### PR TITLE
security: move WS JWT out of URL query into Sec-WebSocket-Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ cloudflared tunnel --url http://localhost:3001 run shared-terminal
 ### WebSocket
 
 ```
-ws://host/ws/sessions/:id?token=<jwt>
+ws://host/ws/sessions/:id
+Sec-WebSocket-Protocol: auth.bearer.<jwt>
 ```
 
 **Client → Server:** `input`, `resize`, `ping`

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -81,16 +81,37 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
 
 // ── WebSocket auth ──────────────────────────────────────────────────────────
 
-export function verifyWsToken(url: string | undefined): JwtPayload | null {
-        if (!url) return null;
+const WS_AUTH_PROTOCOL_PREFIX = "auth.bearer.";
+
+/**
+ * Extract the bearer token from the Sec-WebSocket-Protocol header and verify it.
+ * The header is a comma-separated list of subprotocols; the client should
+ * include `auth.bearer.<jwt>`.
+ */
+export function verifyWsToken(protocolHeader: string | string[] | undefined): JwtPayload | null {
+        if (!protocolHeader) return null;
+        const header = Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader;
+        const protocols = header.split(",").map((s) => s.trim());
+        const authProto = protocols.find((p) => p.startsWith(WS_AUTH_PROTOCOL_PREFIX));
+        if (!authProto) return null;
+        const token = authProto.slice(WS_AUTH_PROTOCOL_PREFIX.length);
+        if (!token) return null;
         try {
-                const parsed = new URL(url, "http://localhost");
-                const token = parsed.searchParams.get("token");
-                if (!token) return null;
                 return jwt.verify(token, JWT_SECRET) as JwtPayload;
         } catch {
                 return null;
         }
+}
+
+/**
+ * Pick the `auth.bearer.<jwt>` subprotocol from an offered set so the server
+ * can echo it back in the handshake response (required by RFC 6455).
+ */
+export function selectWsAuthProtocol(protocols: Set<string>): string | false {
+        for (const p of protocols) {
+                if (p.startsWith(WS_AUTH_PROTOCOL_PREFIX)) return p;
+        }
+        return false;
 }
 
 export async function hasAnyUsers(): Promise<boolean> {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,7 @@ import { SessionManager } from "./sessionManager.js";
 import { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
 import { handleWsConnection } from "./wsHandler.js";
+import { selectWsAuthProtocol } from "./auth.js";
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -54,7 +55,10 @@ app.get("/health", (_req, res) => res.json({ ok: true }));
 // ── HTTP + WebSocket server ───────────────────────────────────────────────────
 
 const server = http.createServer(app);
-const wss = new WebSocketServer({ noServer: true });
+const wss = new WebSocketServer({
+        noServer: true,
+        handleProtocols: (protocols) => selectWsAuthProtocol(protocols),
+});
 
 server.on("upgrade", (req, socket, head) => {
         const url = req.url ?? "";

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -25,7 +25,7 @@ export function handleWsConnection(
         }
         const sessionId = match[1];
 
-        const payload = verifyWsToken(req.url);
+        const payload = verifyWsToken(req.headers["sec-websocket-protocol"]);
         if (!payload) {
                 sendError(ws, "Missing or invalid token");
                 ws.close(1008, "Unauthorized");

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -46,8 +46,12 @@ export function openTerminalSession(opts: {
         fitAddon.fit();
 
         // ── WebSocket connection ────────────────────────────────────────────────
+        // Pass the JWT as a subprotocol (`auth.bearer.<jwt>`) so it never hits
+        // the URL — and therefore never ends up in server/tunnel access logs,
+        // browser history, or Referer headers.
         const wsUrl = buildWsUrl(sessionId);
-        const ws = new WebSocket(wsUrl);
+        const token = getToken() ?? "";
+        const ws = new WebSocket(wsUrl, [`auth.bearer.${token}`]);
 
         ws.onopen = () => {
                 send({ type: "ping" });
@@ -136,12 +140,9 @@ export function openTerminalSession(opts: {
 // ── URL builder ─────────────────────────────────────────────────────────────
 
 function buildWsUrl(sessionId: string): string {
-        const token = getToken() ?? "";
-        const params = `?token=${encodeURIComponent(token)}`;
-
         // Use VITE_API_URL to derive the WebSocket URL
         const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
         const url = new URL(apiUrl);
         const wsProto = url.protocol === "https:" ? "wss:" : "ws:";
-        return `${wsProto}//${url.host}/ws/sessions/${sessionId}${params}`;
+        return `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
 }


### PR DESCRIPTION
## Summary

Fixes #2. The previous `ws://…/ws/sessions/:id?token=<jwt>` scheme leaked the full JWT into Cloudflare Tunnel / web-server access logs, browser history, and any Referer headers.

This PR implements Option A from the issue: the client sends the token as an `auth.bearer.<jwt>` WebSocket subprotocol, which is carried in request headers only and is not logged by default.

## Changes

- **backend/src/auth.ts** — `verifyWsToken` now parses the `Sec-WebSocket-Protocol` header (comma-split, looks for `auth.bearer.<jwt>`) instead of the URL query. Added `selectWsAuthProtocol` helper.
- **backend/src/index.ts** — `WebSocketServer` gets a `handleProtocols` option so the server echoes the client's chosen subprotocol back in the handshake response. Without this, browsers abort the upgrade per RFC 6455.
- **backend/src/wsHandler.ts** — reads the header instead of `req.url`.
- **frontend/src/terminal.ts** — `new WebSocket(wsUrl, [\`auth.bearer.\${token}\`])`; `buildWsUrl` no longer appends `?token=…`.
- **README.md** — updated WS example.

## Reviewer notes

- Backend and frontend both type-check cleanly.
- JWT characters (`[A-Za-z0-9_-]` plus `.` separators) are all valid RFC 7230 token chars, so no escaping is needed for the subprotocol value.
- Acceptance criterion "access logs on a test run do not contain the token" should be verified manually against a real Cloudflare Tunnel deployment before closing.

## Test plan

- [ ] Run backend + frontend locally, confirm a session attaches and streams I/O end-to-end.
- [ ] Tail backend access logs and the tunnel access log during a test attach — confirm neither contains the JWT.
- [ ] Reject paths: try connecting with no subprotocol → expect 1008 Unauthorized; with a malformed `auth.bearer.` prefix and garbage → expect 1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)