### PR TITLE
feat: dynamic CSP from VITE_API_URL + WS auth error logging

### DIFF
--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -86,9 +86,13 @@ export function verifyWsToken(url: string | undefined): JwtPayload | null {
         try {
                 const parsed = new URL(url, "http://localhost");
                 const token = parsed.searchParams.get("token");
-                if (!token) return null;
+                if (!token) {
+                        console.error("[verifyWsToken] no token in query string");
+                        return null;
+                }
                 return jwt.verify(token, JWT_SECRET) as JwtPayload;
-        } catch {
+        } catch (err) {
+                console.error("[verifyWsToken]", (err as Error).name, (err as Error).message);
                 return null;
         }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -777,8 +777,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "shared-terminal-frontend",
   "version": "1.0.0",
   "description": "Shared terminal service frontend",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,36 +1,62 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 
-export default defineConfig({
-        server: {
-                port: 5173,
-                // Serve a permissive CSP in dev so xterm.js (which uses new Function()
-                // internally) and Vite HMR inline scripts can run without browser errors.
-                // The meta tag in index.html covers production builds.
-                headers: {
-                        "Content-Security-Policy": [
-                                "default-src 'self'",
-                                "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-                                "style-src 'self' 'unsafe-inline'",
-                                "img-src 'self' data: blob:",
-                                "font-src 'self' data:",
-                                // Allow direct WS connection to the backend (bypasses Vite HMR proxy).
-                                "connect-src 'self' ws://localhost:3001 wss://localhost:3001 http://localhost:3001",
-                        ].join("; "),
-                },
-                proxy: {
-                        // Proxy REST calls to the backend so the frontend dev server handles
-                        // them without CORS complexity during local development.
-                        "/api": {
-                                target: "http://localhost:3001",
-                                changeOrigin: true,
-                        },
-                        // WebSocket proxy kept for completeness but not used — the frontend
-                        // connects directly to ws://localhost:3001 to avoid HMR interference.
-                        "/ws": {
-                                target: "ws://localhost:3001",
-                                ws: true,
-                                changeOrigin: true,
-                        },
-                },
-        },
+// CSP and proxy targets are derived from VITE_API_URL so the same config
+// works for:
+//   - local loopback dev (no env var)   → http://localhost:3001
+//   - laptop → LAN VM dev               → http://<vm-ip>:3001 via .env.local
+//   - production build for Pages        → https://api.<your-domain> via Pages env
+//
+// Both the dev-server CSP header and the index.html meta tag are rewritten
+// to match — browsers apply multiple CSPs as an intersection, so they have
+// to agree or the stricter one wins and blocks the connection.
+
+export default defineConfig(({ mode }) => {
+	const env = loadEnv(mode, process.cwd(), "");
+	const apiUrl = env.VITE_API_URL || "http://localhost:3001";
+	const wsUrl = apiUrl.replace(/^http(s?):\/\//, "ws$1://");
+
+	const csp = [
+		"default-src 'self'",
+		"script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' data: blob:",
+		"font-src 'self' data:",
+		`connect-src 'self' ${apiUrl} ${wsUrl}`,
+	].join("; ");
+
+	return {
+		plugins: [
+			{
+				name: "csp-meta-tag",
+				transformIndexHtml(html: string) {
+					// Replace whatever CSP meta tag is in index.html with one
+					// built from VITE_API_URL. Runs for both dev and build.
+					return html.replace(
+						/<meta\s+http-equiv="Content-Security-Policy"[^>]*\/?>/,
+						`<meta http-equiv="Content-Security-Policy" content="${csp}" />`,
+					);
+				},
+			},
+		],
+		server: {
+			port: 5173,
+			headers: {
+				"Content-Security-Policy": csp,
+			},
+			proxy: {
+				// REST proxy so relative /api/* calls in dev hit the real backend.
+				"/api": {
+					target: apiUrl,
+					changeOrigin: true,
+				},
+				// WS proxy; frontend currently connects direct to wsUrl, kept
+				// here for completeness.
+				"/ws": {
+					target: wsUrl,
+					ws: true,
+					changeOrigin: true,
+				},
+			},
+		},
+	};
 });


### PR DESCRIPTION
## Changes

### Frontend: Dynamic CSP configuration
- **vite.config.ts**: CSP and proxy targets derived from VITE_API_URL instead of hardcoded localhost:3001
- Vite plugin rewrites the CSP meta tag in index.html at build time
- Works for local dev, LAN dev, and production Pages builds
- **package.json**: Added type:module for ESM compatibility

### Backend: WS auth error logging
- **auth.ts**: verifyWsToken() now logs specific JWT errors for easier debugging

### Testing
```bash
cd backend && npm run build   # ✅
cd frontend && npm run build  # ✅
```