### PR TITLE
feat(sessions): soft/hard delete with restore

### DIFF
--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -7,6 +7,8 @@
 
 import Dockerode from "dockerode";
 import { Duplex } from "stream";
+import { promises as fs } from "fs";
+import path from "path";
 import { SessionManager } from "./sessionManager.js";
 import { RingBuffer } from "./ringBuffer.js";
 import { d1Query } from "./db.js";
@@ -72,14 +74,25 @@ export class DockerManager {
 
         async kill(sessionId: string): Promise<void> {
                 const meta = await this.sessions.get(sessionId);
-                if (!meta?.containerId) return;
 
-                try {
-                        const container = this.docker.getContainer(meta.containerId);
-                        try { await container.stop({ t: 5 }); } catch { /* already stopped */ }
-                        try { await container.remove({ force: true }); } catch { /* already removed */ }
-                } catch (err) {
-                        console.error(`[docker] error killing container for session ${sessionId}:`, (err as Error).message);
+                if (meta?.containerId) {
+                        try {
+                                const container = this.docker.getContainer(meta.containerId);
+                                try { await container.stop({ t: 5 }); } catch { /* already stopped */ }
+                                // `v: true` also removes any anonymous volumes attached to the
+                                // container (bind mounts are unaffected — those are cleaned by
+                                // purgeWorkspace on hard delete).
+                                try { await container.remove({ force: true, v: true }); } catch { /* already removed */ }
+                        } catch (err) {
+                                console.error(`[docker] error killing container for session ${sessionId}:`, (err as Error).message);
+                        }
+                        // The container no longer exists in Docker — reflect that in D1 so any
+                        // later lookup doesn't chase a dead container id.
+                        try {
+                                await this.sessions.setContainerId(sessionId, null);
+                        } catch (err) {
+                                console.error(`[docker] failed to null container_id for session ${sessionId}:`, (err as Error).message);
+                        }
                 }
 
                 for (const [key, handle] of this.execs) {
@@ -91,6 +104,33 @@ export class DockerManager {
                 this.buffers.delete(sessionId);
                 this.listeners.delete(sessionId);
                 console.log(`[docker] killed container for session ${sessionId}`);
+        }
+
+        /**
+         * Delete the bind-mounted workspace directory for a session.
+         *
+         * This is intentionally strict about the path it will remove: it refuses
+         * to touch anything that does not resolve to a child of WORKSPACE_ROOT.
+         * Missing directories are a no-op (idempotent hard delete).
+         */
+        async purgeWorkspace(sessionId: string): Promise<void> {
+                const rootAbs = path.resolve(WORKSPACE_ROOT);
+                const sessionAbs = path.resolve(path.join(WORKSPACE_ROOT, sessionId));
+
+                // Safety: the resolved session dir must be a strict child of rootAbs.
+                if (!sessionAbs.startsWith(rootAbs + path.sep)) {
+                        throw new Error(
+                                `[docker] refusing to purge workspace outside root (root=${rootAbs}, target=${sessionAbs})`,
+                        );
+                }
+
+                try {
+                        await fs.rm(sessionAbs, { recursive: true, force: true });
+                        console.log(`[docker] purged workspace dir ${sessionAbs}`);
+                } catch (err) {
+                        console.error(`[docker] failed to purge workspace ${sessionAbs}:`, (err as Error).message);
+                        throw err;
+                }
         }
 
         async isAlive(sessionId: string): Promise<boolean> {
@@ -106,10 +146,33 @@ export class DockerManager {
 
         async startContainer(sessionId: string): Promise<void> {
                 const meta = await this.sessions.getOrThrow(sessionId);
-                if (!meta.containerId) throw new Error("No container ID for this session");
-                await this.docker.getContainer(meta.containerId).start();
-                await this.sessions.updateStatus(sessionId, "running");
-                console.log(`[docker] restarted container for session ${sessionId}`);
+
+                // Case 1: no container exists (terminated session, or one whose container
+                // was removed out-of-band). Spawn a fresh container reusing the existing
+                // container name + workspace bind mount.
+                if (!meta.containerId) {
+                        await this.spawn(sessionId);
+                        await this.sessions.updateStatus(sessionId, "running");
+                        console.log(`[docker] respawned container for session ${sessionId}`);
+                        return;
+                }
+
+                // Case 2: container id is on file. Check it still exists in Docker; if it
+                // does, just start it. If Docker has no record of it, forget the stale id
+                // and spawn a replacement.
+                try {
+                        const info = await this.docker.getContainer(meta.containerId).inspect();
+                        if (!info.State.Running) {
+                                await this.docker.getContainer(meta.containerId).start();
+                        }
+                        await this.sessions.updateStatus(sessionId, "running");
+                        console.log(`[docker] restarted container for session ${sessionId}`);
+                } catch {
+                        console.log(`[docker] stale container_id for session ${sessionId}, respawning`);
+                        await this.sessions.setContainerId(sessionId, null);
+                        await this.spawn(sessionId);
+                        await this.sessions.updateStatus(sessionId, "running");
+                }
         }
 
         async stopContainer(sessionId: string): Promise<void> {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -90,10 +90,34 @@ export function buildRouter(sessions: SessionManager, docker: DockerManager): Ro
 
         router.delete("/sessions/:id", async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
+                // `?hard=true` turns this into a hard delete: container is killed,
+                // workspace files are wiped from disk, and the D1 row is removed.
+                // Without it, we do a soft delete — container goes away but the row
+                // stays (status=terminated) and the workspace dir is preserved so
+                // the user can later restore the session.
+                const hard = req.query.hard === "true" || req.query.hard === "1";
+
                 try {
-                        await sessions.assertOwnership(req.params.id, userId);
-                        await docker.kill(req.params.id);
-                        await sessions.terminate(req.params.id);
+                        const meta = await sessions.assertOwnership(req.params.id, userId);
+
+                        // Idempotent path: only tear down the container + flip to
+                        // terminated the first time. Subsequent calls skip this.
+                        if (meta.status !== "terminated") {
+                                await docker.kill(req.params.id);
+                                await sessions.terminate(req.params.id);
+                        }
+
+                        if (hard) {
+                                // Wipe workspace files and drop the row entirely.
+                                try {
+                                        await docker.purgeWorkspace(req.params.id);
+                                } catch (err) {
+                                        console.error(`[routes] purgeWorkspace failed for ${req.params.id}:`, (err as Error).message);
+                                        // Fall through — we still want to remove the row.
+                                }
+                                await sessions.deleteRow(req.params.id);
+                        }
+
                         res.status(204).send();
                 } catch (err) {
                         handleSessionError(err, res);

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -111,7 +111,7 @@ export class SessionManager {
                 return result.results.map(rowToMeta);
         }
 
-        async setContainerId(sessionId: string, containerId: string): Promise<void> {
+        async setContainerId(sessionId: string, containerId: string | null): Promise<void> {
                 await d1Query("UPDATE sessions SET container_id = ? WHERE session_id = ?", [containerId, sessionId]);
         }
 
@@ -135,5 +135,14 @@ export class SessionManager {
 
         async terminate(sessionId: string): Promise<void> {
                 await this.updateStatus(sessionId, "terminated");
+        }
+
+        /**
+         * Permanently delete the session row (hard delete). Caller is responsible
+         * for having already killed any running container and for cleaning up any
+         * workspace data on disk.
+         */
+        async deleteRow(sessionId: string): Promise<void> {
+                await d1Query("DELETE FROM sessions WHERE session_id = ?", [sessionId]);
         }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -159,6 +159,10 @@
       #sidebar-header {
         padding: 0.75rem 1rem;
         border-bottom: 1px solid #30363d;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
       }
       #sidebar-header h2 {
         font-size: 0.75rem;
@@ -166,6 +170,19 @@
         text-transform: uppercase;
         letter-spacing: 0.05em;
         color: #8b949e;
+      }
+      #show-terminated-label {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.7rem;
+        color: #8b949e;
+        cursor: pointer;
+        user-select: none;
+      }
+      #show-terminated-label input {
+        accent-color: #58a6ff;
+        cursor: pointer;
       }
       #new-session-form {
         padding: 0.75rem 1rem;
@@ -220,6 +237,10 @@
       }
       .session-item.active {
         background: #1f3348;
+      }
+      .session-item.terminated .session-name {
+        color: #8b949e;
+        font-style: italic;
       }
       .session-dot {
         width: 8px;
@@ -408,7 +429,16 @@
       </header>
       <main>
         <aside id="sidebar">
-          <div id="sidebar-header"><h2>Sessions</h2></div>
+          <div id="sidebar-header">
+            <h2>Sessions</h2>
+            <label
+              id="show-terminated-label"
+              title="Include terminated sessions so you can restore them"
+            >
+              <input type="checkbox" id="show-terminated-toggle" />
+              Show terminated
+            </label>
+          </div>
           <form id="new-session-form">
             <input
               id="new-session-input"

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -95,8 +95,9 @@ export async function createSession(
         return res.json();
 }
 
-export async function listSessions(): Promise<SessionInfo[]> {
-        const res = await apiFetch("/sessions");
+export async function listSessions(includeTerminated = false): Promise<SessionInfo[]> {
+        const path = includeTerminated ? "/sessions?all=true" : "/sessions";
+        const res = await apiFetch(path);
         if (!res.ok) throw new Error("Failed to list sessions");
         return res.json();
 }
@@ -107,8 +108,18 @@ export async function getSession(id: string): Promise<SessionInfo> {
         return res.json();
 }
 
-export async function deleteSession(id: string): Promise<void> {
-        const res = await apiFetch(`/sessions/${id}`, { method: "DELETE" });
+/**
+ * Delete a session.
+ *
+ * - Soft delete (default): stops and removes the Docker container, marks the
+ *   session as `terminated`. Workspace files on disk are kept so the session
+ *   can later be restored via `startSession`.
+ * - Hard delete (`hard = true`): same as soft delete, then also wipes the
+ *   workspace directory and removes the session record entirely.
+ */
+export async function deleteSession(id: string, hard = false): Promise<void> {
+        const qs = hard ? "?hard=true" : "";
+        const res = await apiFetch(`/sessions/${id}${qs}`, { method: "DELETE" });
         if (!res.ok && res.status !== 204) {
                 throw new Error("Failed to delete session");
         }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -29,6 +29,7 @@ const logoutBtn = document.getElementById("logout-btn")!;
 const sessionList = document.getElementById("session-list")!;
 const newSessionForm = document.getElementById("new-session-form") as HTMLFormElement;
 const newSessionInput = document.getElementById("new-session-input") as HTMLInputElement;
+const showTerminatedToggle = document.getElementById("show-terminated-toggle") as HTMLInputElement;
 
 const terminalToolbar = document.getElementById("terminal-toolbar")!;
 const terminalSessionName = document.getElementById("terminal-session-name")!;
@@ -43,6 +44,7 @@ let sessions: SessionInfo[] = [];
 let activeSessionId: string | null = null;
 let activeTerminal: TerminalSession | null = null;
 let isRegisterMode = false;
+let showTerminated = false;
 
 // ── Auth flow ───────────────────────────────────────────────────────────────
 
@@ -133,7 +135,7 @@ logoutBtn.addEventListener("click", () => {
 
 async function refreshSessions() {
         try {
-                sessions = await listSessions();
+                sessions = await listSessions(showTerminated);
                 renderSessionList();
         } catch (err) {
                 showToast((err as Error).message, true);
@@ -144,7 +146,8 @@ function renderSessionList() {
         sessionList.innerHTML = "";
         for (const s of sessions) {
                 const item = document.createElement("div");
-                item.className = `session-item${s.sessionId === activeSessionId ? " active" : ""}`;
+                const terminatedCls = s.status === "terminated" ? " terminated" : "";
+                item.className = `session-item${s.sessionId === activeSessionId ? " active" : ""}${terminatedCls}`;
 
                 const dot = document.createElement("span");
                 dot.className = `session-dot ${s.status}`;
@@ -185,17 +188,48 @@ function renderSessionList() {
                                 } catch (err) { showToast((err as Error).message, true); }
                         });
                         actions.appendChild(stopBtn);
+                } else if (s.status === "terminated") {
+                        // Restore — spawns a fresh container reusing the original
+                        // container name + workspace bind mount. Files are preserved.
+                        const restoreBtn = document.createElement("button");
+                        restoreBtn.className = "session-action-btn start";
+                        restoreBtn.textContent = "↻";
+                        restoreBtn.title = "Restore (respawn container with existing workspace files)";
+                        restoreBtn.addEventListener("click", async (e) => {
+                                e.stopPropagation();
+                                try {
+                                        showToast(`Restoring "${s.name}"…`);
+                                        await startSession(s.sessionId);
+                                        await refreshSessions();
+                                        showToast(`Session "${s.name}" restored`);
+                                } catch (err) { showToast((err as Error).message, true); }
+                        });
+                        actions.appendChild(restoreBtn);
                 }
 
                 const killBtn = document.createElement("button");
                 killBtn.className = "session-kill";
                 killBtn.textContent = "✕";
-                killBtn.title = "Terminate";
+                // Shift-click enables hard delete — also wipes workspace files and
+                // removes the session record entirely. Plain click is a soft delete,
+                // which keeps the workspace files so the session can be restored.
+                killBtn.title = s.status === "terminated"
+                        ? "Delete permanently (wipes workspace files)"
+                        : "Terminate (Shift-click to also wipe workspace files)";
                 killBtn.addEventListener("click", async (e) => {
                         e.stopPropagation();
-                        if (!confirm(`Terminate "${s.name}"? Container will be removed.`)) return;
+                        const mouseEvent = e as MouseEvent;
+                        // If the session is already terminated, the only meaningful action
+                        // is hard delete — otherwise there's nothing to do.
+                        const hard = s.status === "terminated" || mouseEvent.shiftKey;
+
+                        const prompt = hard
+                                ? `Permanently delete "${s.name}"?\n\nThis stops and removes the container, wipes workspace files from disk, and removes the session record. This cannot be undone.`
+                                : `Terminate "${s.name}"?\n\nContainer will be stopped and removed. Workspace files are preserved — you can restore the session later.`;
+                        if (!confirm(prompt)) return;
+
                         try {
-                                await deleteSession(s.sessionId);
+                                await deleteSession(s.sessionId, hard);
                                 if (activeSessionId === s.sessionId) {
                                         activeTerminal?.dispose();
                                         activeTerminal = null;
@@ -292,6 +326,13 @@ function showToast(message: string, isError = false) {
                 toast.className = "";
         }, 4000);
 }
+
+// ── Show terminated toggle ──────────────────────────────────────────────────
+
+showTerminatedToggle.addEventListener("change", () => {
+        showTerminated = showTerminatedToggle.checked;
+        refreshSessions();
+});
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Adds a soft-vs-hard distinction to session deletion and a first-class restore flow for soft-deleted sessions.

### Soft delete — DELETE /api/sessions/:id (default)
- Stops and force-removes the Docker container (`v:true` so any anonymous volumes go too).
- Nulls `container_id` in D1 — the row no longer references a dead Docker id.
- Sets `status = 'terminated'`.
- **Keeps** the workspace bind mount under `WORKSPACE_ROOT/<sessionId>/` on disk so the session can be restored later.

### Hard delete — DELETE /api/sessions/:id?hard=true
- Does the full soft-delete path, then:
- Wipes the workspace directory with `fs.rm`, behind a strict path guard that refuses to touch anything that doesn't resolve inside `WORKSPACE_ROOT`.
- Removes the D1 row entirely. The session is as if it never existed.

### Idempotent
A second DELETE on an already-terminated session is a no-op for the soft path and only performs the filesystem + row cleanup for the hard path — no stack of noisy 'already stopped' errors on replay.

### Restore
`POST /api/sessions/:id/start` now does the right thing no matter the state:
- Container id is null (terminated, or cleaned out of band) → spawn a new container, reusing the original `container_name` and workspace bind mount.
- Container id is stale (Docker has no record) → drop the stale id, spawn fresh.
- Container exists and is stopped → plain `container.start()`.
- Container exists and is running → just flip DB status to running.

### Frontend
- `deleteSession(id, hard?: boolean)` + `listSessions(includeTerminated?: boolean)`.
- Sidebar gets a 'Show terminated' toggle so users can actually see what to restore.
- Terminated rows show a ↻ restore button that calls `startSession` (same endpoint, smarter backend).
- ✕ is soft delete by default; Shift-click does the hard delete, with a confirm dialog that spells out exactly what's about to be lost. Terminated rows only expose hard delete (soft is already done).
- Terminated items are styled dimmed + italic so they don't blend in with live sessions.

## Why

Before this change, `DELETE` already removed the container — but the workspace files on the host accumulated forever, the D1 row kept pointing at a dead Docker id, and there was no way to come back to a terminated session short of creating a new one from scratch. Users asked for both 'get rid of it completely' and 'I changed my mind, give me back my files'.

## Safety notes

- Workspace purge is guarded: the resolved target must be a strict child of the resolved `WORKSPACE_ROOT`. No path traversal, no accidental `fs.rm('/')`.
- `fs.rm({ force: true, recursive: true })` swallows ENOENT — hard delete on a session whose workspace is already gone still succeeds.
- Type-checks pass in both `backend/` and `frontend/`.

## How to test

1. Create a session, touch a file in the workspace.
2. Soft delete it from the UI (✕). Confirm the container disappears (`docker ps -a`) and the workspace dir is still on disk.
3. Tick 'Show terminated', then click ↻. A new container spawns; the file from step 1 is still there.
4. Hard delete (Shift-click ✕, or hit a terminated row's ✕). Confirm the workspace dir is gone and the session is removed from the list entirely.