### PR TITLE
feat(terminal): make URLs in terminal output clickable

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0"
       },
       "devDependencies": {
@@ -768,6 +769,15 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
       "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz",
+      "integrity": "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==",
       "license": "MIT",
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0"
   },
   "devDependencies": {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -4,6 +4,7 @@
 
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { getToken } from "./api.js";
 
@@ -42,6 +43,15 @@ export function openTerminalSession(opts: {
 
         const fitAddon = new FitAddon();
         term.loadAddon(fitAddon);
+        // URLs in terminal output become clickable — opens in a new tab, which
+        // matters for OAuth flows (e.g. `claude` login) where the container
+        // can't open a browser itself.
+        term.loadAddon(
+                new WebLinksAddon((event, uri) => {
+                        event.preventDefault();
+                        window.open(uri, "_blank", "noopener,noreferrer");
+                }),
+        );
         term.open(container);
         fitAddon.fit();
 


### PR DESCRIPTION
## What

Loads `@xterm/addon-web-links` into every terminal session with a custom click handler that opens matched URIs in a new tab via `window.open(uri, '_blank', 'noopener,noreferrer')`.

Before this change, URLs printed by CLIs inside the container were plain text — you had to highlight and copy them out manually. The default `WebLinksAddon` behavior (navigate the current tab) would also kill the active WebSocket and drop you out of the app, so we override it.

## Why

The motivating case is OAuth-style login flows that print a URL and expect the user to open it in a browser:
- `claude` login
- GitHub device flow
- `gcloud auth login`
- `az login`
- etc.

The container has no browser of its own, so the *only* place that URL can be opened is the user's host browser — which is exactly the window the shared-terminal frontend is already running in. Making those links one-click resolves the awkward copy/paste dance.

## Safety

- `window.open` with `_blank` keeps the main app view (and its live WebSocket) untouched — switching tabs/panes is a user-initiated action, not a side effect of clicking a link.
- `noopener,noreferrer` means the newly-opened tab can't reach back into our window via `window.opener` and can't leak the Referer of the shared-terminal page.

## Files

- `frontend/package.json` + `frontend/package-lock.json` — add `@xterm/addon-web-links@^0.11.0`.
- `frontend/src/terminal.ts` — import and load the addon with the custom handler.

Type-check passes in `frontend/`.