### PR TITLE
docs: add CLAUDE.md and sync README with D1 + Cloudflare Pages stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+All commands are run from within `backend/` or `frontend/`.
+
+```bash
+# Backend (Node 22+, TypeScript, CommonJS output)
+cd backend
+npm install
+npm run dev        # tsx watch — auto-restarts on source changes
+npm run build      # tsc → dist/
+npm start          # node dist/index.js
+npm run db:migrate # runs migrateDb() against D1 (requires dist/)
+
+# Frontend (Vite + vanilla TS — no framework)
+cd frontend
+npm install
+npm run dev        # vite on :5173, proxies /api and /ws to VITE_API_URL (default http://localhost:3001)
+npm run build      # tsc && vite build
+
+# Session container image (required before creating a session)
+docker build -t shared-terminal-session ./session-image
+# or: cd backend && npm run docker:build-session
+
+# Backend deploy (frontend is deployed separately to Cloudflare Pages)
+docker compose up -d --build
+```
+
+There is no test suite and no linter configured — verify changes by running `npm run build` in both workspaces and exercising the feature in a browser.
+
+## Required environment
+
+Backend refuses to start without `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, and `D1_DATABASE_ID` (see `validateD1Config` in `backend/src/db.ts`). `JWT_SECRET` should also be set for anything past local experimentation. `.env.example` is the source of truth.
+
+`WORKSPACE_ROOT` (default `/var/shared-terminal/workspaces`) must exist on the host and be writable by the backend — each session gets a `<WORKSPACE_ROOT>/<sessionId>` bind mount.
+
+The frontend needs `VITE_API_URL` at build time (Cloudflare Pages env var) so `vite.config.ts` can rewrite the CSP meta tag to allow connections back to the backend.
+
+## Architecture
+
+Three pieces cooperate:
+
+1. **Backend** (`backend/src/`) — Express REST + `ws` WebSocket on the same HTTP server (`index.ts`). Stateless; all persistence is in Cloudflare D1. Deployed on a self-hosted Linux box, typically behind Cloudflare Tunnel.
+2. **Frontend** (`frontend/src/`) — vanilla TS SPA with xterm.js. Deployed to Cloudflare Pages in production; `vite.config.ts` rewrites the CSP meta tag based on `VITE_API_URL` so dev and prod agree.
+3. **Session containers** — one Docker container per session, built from `session-image/Dockerfile` (Ubuntu 24.04 + Node 22 + Claude CLI + tmux). Each container runs `entrypoint.sh` which starts a detached tmux session named `main` and sleeps forever.
+
+### The terminal data path
+
+`wsHandler.ts` → `DockerManager.attach()` runs `docker exec … tmux attach -t main` with `Tty: true`. The hijacked stream is piped both ways:
+
+- bytes from tmux → pushed into a per-session `RingBuffer` (128 KB) **and** broadcast to all listeners for that session;
+- bytes from the browser → `docker.write(attachId, …)` back into the exec stdin.
+
+On reconnect, the ring buffer is drained and sent as a single `output` message so the user sees recent scrollback. Multiple browser tabs can attach to the same session — they all share the same tmux and see the same stream (each with its own `attachId`, listener, and resize).
+
+### Persistence model
+
+- **Container state is ephemeral** — killed by `stopContainer` / `kill`. The bind-mounted workspace at `/home/developer/workspace` inside the container is what survives.
+- **D1 is the source of truth** for session metadata (`session_id`, `container_id`, `status`, `env_vars`, `cols/rows`).
+- **`DockerManager.reconcile()`** runs on startup and flips the D1 `status` to `stopped` for any session whose container is missing or not running — handles the case where the host rebooted but D1 still thinks sessions are live.
+
+### Delete semantics
+
+`DELETE /api/sessions/:id` is a **soft delete** by default: container is killed, row flips to `status=terminated`, workspace files are preserved so the user can later `POST /start` to respawn. Pass `?hard=true` to also purge the workspace dir and drop the row. `purgeWorkspace` refuses any path that does not resolve under `WORKSPACE_ROOT`.
+
+### Auth
+
+- REST: `Authorization: Bearer <jwt>` via `requireAuth` middleware. First visit shows `needsSetup: true` from `/api/auth/status` and the frontend drives user creation.
+- WebSocket: token is passed via the `Sec-WebSocket-Protocol` header as `auth.bearer.<jwt>` (preferred — keeps it out of URLs/access logs), with a `?token=<jwt>` query-param fallback for proxies that strip the subprotocol header. `selectWsAuthProtocol` echoes the chosen subprotocol back in the handshake (RFC 6455 requires this).
+- `sessions.assertOwnership(sessionId, userId)` is the single choke point for authorization on REST and WebSocket paths.
+
+### Notes on D1
+
+All `db.ts` calls are HTTP round-trips to Cloudflare. Keep query counts low on hot paths — the WebSocket attach already does multiple lookups per connection and there is no local cache.
+
+## Code style
+
+- **TypeScript strict mode** everywhere (both workspaces).
+- **Tabs** for indentation.
+- Section dividers in the form `// ── Section ───` are used throughout the backend — preserve them when editing.
+- Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, …).
+- Frontend deliberately has no framework — do not add React/Vue/etc. without discussion.

--- a/README.md
+++ b/README.md
@@ -5,26 +5,29 @@ A self-hosted web-based terminal that runs on an always-on Linux server at home.
 ## Architecture
 
 ```
-[Any Device] ←HTTPS→ [Cloudflare Tunnel] ←HTTP/WS→ [Linux Server]
-                                                          ├── Backend (Node.js + Express + WebSocket)
-                                                          ├── Frontend (Vite + TypeScript + xterm.js)
-                                                          └── Docker Engine
-                                                               ├── Container: project-acme  (tmux + claude CLI)
-                                                               ├── Container: project-beta  (tmux + claude CLI)
-                                                               └── ...
+[Any Device] ──HTTPS──▶ [Cloudflare Pages] ── static frontend (Vite + xterm.js)
+                                 │
+                                 ├──────────────▶ [Cloudflare D1] ── session + user metadata
+                                 │
+                                 └──HTTPS/WSS──▶ [Cloudflare Tunnel] ──▶ [Linux Server]
+                                                                                ├── Backend (Node.js + Express + WebSocket)
+                                                                                └── Docker Engine
+                                                                                     ├── Container: project-acme  (tmux + claude CLI)
+                                                                                     ├── Container: project-beta  (tmux + claude CLI)
+                                                                                     └── ...
 ```
 
 ### Key Features
 
 - **Docker-isolated sessions** — each session runs in its own container with dev tools pre-installed
 - **Persistent sessions** — tmux inside each container keeps your terminal alive across disconnects
-- **Persistent workspaces** — each session gets a Docker volume mounted at `/home/developer/workspace`
+- **Persistent workspaces** — each session gets a bind-mounted host directory at `/home/developer/workspace`
 - **JWT authentication** — secure login with bcrypt-hashed passwords
 - **Per-session environment variables** — configure API keys, secrets per project
 - **Real terminal emulation** — xterm.js in the browser with 256-color support, mouse, resize
 - **Reconnect replay** — ring buffer replays recent output when you reconnect
-- **SQLite storage** — session metadata survives server restarts
-- **Docker Compose deployment** — one command to build and run everything
+- **Cloudflare D1 storage** — serverless SQLite on Cloudflare; session metadata survives server restarts and is accessible from anywhere
+- **Docker Compose deployment** — one command to build and run the backend
 
 ## Quick Start (Development)
 
@@ -33,6 +36,7 @@ A self-hosted web-based terminal that runs on an always-on Linux server at home.
 - Node.js 22+
 - Docker
 - Git
+- A Cloudflare account with a D1 database provisioned (you'll need the account ID, an API token with D1 write permission, and the database ID)
 
 ### 1. Clone and install
 
@@ -47,23 +51,30 @@ cd backend && npm install && cd ..
 cd frontend && npm install && cd ..
 ```
 
-### 2. Build the session image
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+# Fill in CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, D1_DATABASE_ID, and JWT_SECRET
+```
+
+### 3. Build the session image
 
 ```bash
 docker build -t shared-terminal-session ./session-image
 ```
 
-### 3. Create workspace directory
+### 4. Create workspace directory
 
 ```bash
 sudo mkdir -p /var/shared-terminal/workspaces
 sudo chown $USER /var/shared-terminal/workspaces
 ```
 
-### 4. Start dev servers
+### 5. Start dev servers
 
 ```bash
-# Terminal 1: Backend
+# Terminal 1: Backend — will run migrateDb() against D1 on first start
 cd backend && npm run dev
 
 # Terminal 2: Frontend
@@ -74,23 +85,27 @@ Open http://localhost:5173 — on first visit you'll be prompted to create an ac
 
 ## Production Deployment
 
-### Using Docker Compose
+### Backend (Docker Compose)
 
 ```bash
 # Copy and edit environment variables
 cp .env.example .env
-# IMPORTANT: Change JWT_SECRET to a random string!
+# IMPORTANT: change JWT_SECRET and fill in CLOUDFLARE_* / D1_DATABASE_ID
 nano .env
 
 # Build and start
 docker compose up -d --build
 ```
 
-The app will be available at `http://localhost:3001`.
+The backend will be available at `http://localhost:3001`.
+
+### Frontend (Cloudflare Pages)
+
+The frontend is a static Vite build. Deploy `frontend/dist` to Cloudflare Pages and set the `VITE_API_URL` env var in the Pages dashboard to your backend's public URL (e.g. `https://api.terminal.yourdomain.com`). `vite.config.ts` rewrites the CSP meta tag from that value so the browser allows connections back to your backend.
 
 ### With Cloudflare Tunnel
 
-To access from outside your local network:
+To expose the backend from your home server without opening ports:
 
 ```bash
 # Install cloudflared
@@ -100,7 +115,7 @@ To access from outside your local network:
 cloudflared tunnel create shared-terminal
 
 # Route DNS
-cloudflared tunnel route dns shared-terminal terminal.yourdomain.com
+cloudflared tunnel route dns shared-terminal api.terminal.yourdomain.com
 
 # Run the tunnel
 cloudflared tunnel --url http://localhost:3001 run shared-terminal
@@ -118,15 +133,16 @@ cloudflared tunnel --url http://localhost:3001 run shared-terminal
 
 ### Sessions (require `Authorization: Bearer <token>`)
 
-| Method | Path                    | Description                         |
-| ------ | ----------------------- | ----------------------------------- |
-| POST   | /api/sessions           | Create session + Docker container   |
-| GET    | /api/sessions           | List active sessions                |
-| GET    | /api/sessions/:id       | Get session details                 |
-| DELETE | /api/sessions/:id       | Terminate (stop + remove container) |
-| POST   | /api/sessions/:id/stop  | Stop container (preservable)        |
-| POST   | /api/sessions/:id/start | Restart stopped container           |
-| PATCH  | /api/sessions/:id/env   | Update environment variables        |
+| Method | Path                          | Description                                                   |
+| ------ | ----------------------------- | ------------------------------------------------------------- |
+| POST   | /api/sessions                 | Create session + Docker container                             |
+| GET    | /api/sessions                 | List active sessions (append `?all=true` to include terminated) |
+| GET    | /api/sessions/:id             | Get session details                                           |
+| DELETE | /api/sessions/:id             | Soft delete (container killed, workspace kept, row→terminated) |
+| DELETE | /api/sessions/:id?hard=true   | Hard delete (also purge workspace dir + drop the D1 row)      |
+| POST   | /api/sessions/:id/stop        | Stop container (preservable)                                  |
+| POST   | /api/sessions/:id/start       | Restart or respawn stopped container                          |
+| PATCH  | /api/sessions/:id/env         | Update environment variables                                  |
 
 ### WebSocket
 
@@ -134,6 +150,8 @@ cloudflared tunnel --url http://localhost:3001 run shared-terminal
 ws://host/ws/sessions/:id
 Sec-WebSocket-Protocol: auth.bearer.<jwt>
 ```
+
+The token may also be passed as `?token=<jwt>` as a fallback for proxies that strip the `Sec-WebSocket-Protocol` header.
 
 **Client → Server:** `input`, `resize`, `ping`
 **Server → Client:** `output`, `status`, `pong`, `error`
@@ -145,21 +163,22 @@ Each session runs in a Docker container based on `session-image/Dockerfile`:
 - **OS:** Ubuntu 24.04
 - **Dev tools:** git, curl, build-essential, python3, Node.js 22, vim, nano, htop, jq
 - **Claude CLI:** `@anthropic-ai/claude-code` (globally installed)
-- **Terminal:** tmux with catppuccin-inspired theme, 50k scrollback, mouse support
+- **Terminal:** tmux with a session named `main`, 50k scrollback, mouse support
 - **User:** `developer` (sudo, no password)
-- **Workspace:** `/home/developer/workspace` (persistent Docker volume)
-- **Resources:** 2 GB RAM, 2 CPUs per container (configurable)
+- **Workspace:** `/home/developer/workspace` (bind-mounted from `<WORKSPACE_ROOT>/<sessionId>` on the host)
+- **Resources:** 2 GB RAM, 2 CPUs per container (configurable in `dockerManager.ts`)
 
 ## Tech Stack
 
-| Layer      | Technology                       |
-| ---------- | -------------------------------- |
-| Frontend   | TypeScript, Vite, xterm.js       |
-| Backend    | TypeScript, Node.js, Express, ws |
-| Auth       | JWT (jsonwebtoken), bcrypt       |
-| Database   | SQLite (better-sqlite3)          |
-| Containers | Docker (dockerode), tmux         |
-| Tunnel     | Cloudflare Tunnel                |
+| Layer      | Technology                        |
+| ---------- | --------------------------------- |
+| Frontend   | TypeScript, Vite, xterm.js        |
+| Backend    | TypeScript, Node.js, Express, ws  |
+| Auth       | JWT (jsonwebtoken), bcryptjs      |
+| Database   | Cloudflare D1 (accessed via HTTP) |
+| Containers | Docker (dockerode), tmux          |
+| Tunnel     | Cloudflare Tunnel                 |
+| Hosting    | Cloudflare Pages (frontend), self-hosted (backend) |
 
 ## Project Structure
 
@@ -167,17 +186,18 @@ Each session runs in a Docker container based on `session-image/Dockerfile`:
 shared-terminal/
 ├── backend/
 │   └── src/
-│       ├── index.ts          # Server entry point
-│       ├── db.ts             # SQLite database layer
-│       ├── auth.ts           # JWT auth + user management
-│       ├── sessionManager.ts # Session metadata (CRUD)
-│       ├── dockerManager.ts  # Docker container lifecycle
-│       ├── wsHandler.ts      # WebSocket → Docker exec bridge
+│       ├── index.ts          # Server entry point (Express + ws on one HTTP server)
+│       ├── db.ts             # Cloudflare D1 client (HTTP API) + migrations
+│       ├── auth.ts           # JWT auth + user management (REST + WS subprotocol)
+│       ├── sessionManager.ts # Session metadata (D1-backed CRUD)
+│       ├── dockerManager.ts  # Docker container lifecycle + exec/attach
+│       ├── wsHandler.ts      # WebSocket → docker exec tmux bridge
 │       ├── routes.ts         # REST API routes
-│       ├── ringBuffer.ts     # Circular buffer for replay
-│       └── types.ts          # Shared types
+│       ├── ringBuffer.ts     # Circular buffer for reconnect replay
+│       └── types.ts          # Shared types + WS protocol messages
 ├── frontend/
 │   ├── index.html            # SPA shell (auth + terminal UI)
+│   ├── vite.config.ts        # Rewrites CSP from VITE_API_URL
 │   └── src/
 │       ├── main.ts           # App entry (auth flow, session sidebar)
 │       ├── api.ts            # REST client with JWT
@@ -186,7 +206,7 @@ shared-terminal/
 │   ├── Dockerfile            # Session container image
 │   ├── entrypoint.sh         # tmux startup script
 │   └── tmux.conf             # tmux theme & settings
-├── Dockerfile                # Multi-stage build (app)
-├── docker-compose.yml        # Full deployment
+├── Dockerfile                # Backend-only image (frontend ships via Pages)
+├── docker-compose.yml        # Backend + session image build
 └── .env.example              # Environment template
 ```


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` documenting commands, required env, architecture (terminal data path, persistence model, delete semantics, auth), and code style conventions for Claude Code agents.
- Update `README.md` to reflect the current stack: Cloudflare Pages frontend, Cloudflare D1 metadata store, bind-mounted workspaces (replacing the earlier SQLite + Docker-volume description).
- Add a `.env` / D1 configuration step to the Quick Start and split production deployment into backend (Docker Compose) and frontend (Cloudflare Pages).

## Test plan
- [ ] `npm run build` in `backend/` still succeeds
- [ ] `npm run build` in `frontend/` still succeeds
- [ ] README renders correctly on GitHub
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)