### PR TITLE
ci: add Claude-powered PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,63 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# If a PR gets pushed to rapidly, cancel the in-flight review.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Claude Max / Pro subscription (OAuth). For pay-as-you-go API billing instead,
+          # comment the line below and use: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: --model claude-sonnet-4-6
+          prompt: |
+            You are reviewing a pull request on the shared-terminal repo
+            (public TypeScript/Node project: Cloudflare Pages frontend,
+            Proxmox + Cloudflare Tunnel backend). This is a solo repo with
+            no human reviewer, so be direct and actionable.
+
+            Produce ONE review comment with the headings below. Skip any
+            section that has nothing real to say — do not pad.
+
+            ## Summary
+            2-4 sentences describing what this PR actually changes and why,
+            so a future skim of the PR list makes sense.
+
+            ## Bugs & correctness
+            Logic errors, off-by-ones, unhandled errors, race conditions,
+            wrong types, broken or missing tests. Cite file:line.
+
+            ## Security
+            Secrets in code, command/shell injection, unsafe exec paths,
+            auth/authz gaps, unsanitized input reaching the terminal
+            backend or tunnel, overly permissive CORS. This repo exposes
+            a terminal — treat command-exec paths with extra skepticism.
+
+            ## Style & conventions
+            Only things that hurt readability or deviate from patterns
+            already in the repo. Do not nitpick what a linter would catch.
+
+            ## Verdict
+            One of: LGTM / Minor nits / Needs changes.
+
+            Be terse. No emojis. No praise. No trailing summary.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,5 +1,19 @@
 name: Claude PR Review
 
+# Security notes:
+# - Uses `pull_request` (NOT pull_request_target): fork PRs run without repo
+#   secrets, so an attacker who opens a PR cannot invoke Claude or post as it.
+# - Permissions are the minimum needed. No `contents: write` — the bot cannot
+#   push code. No `issues: write` — it's PR-only.
+# - `id-token: write` is required: the action uses GitHub's OIDC to mint a
+#   short-lived, scoped GitHub App installation token for posting comments.
+#   This is NOT equivalent to `contents: write` — it does not grant code-push
+#   rights; the resulting token is bounded by the Claude GitHub App's own
+#   install permissions on this repo.
+# - `--max-turns 5` caps iteration blast radius if prompt injection occurs.
+# - Action is pinned to major version `@v1`. Consider pinning to a commit SHA
+#   for stricter supply-chain hygiene.
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -15,13 +29,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
-      actions: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Claude review
         uses: anthropics/claude-code-action@v1
@@ -29,7 +43,7 @@ jobs:
           # Claude Max / Pro subscription (OAuth). For pay-as-you-go API billing instead,
           # comment the line below and use: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --model claude-sonnet-4-6
+          claude_args: --model claude-sonnet-4-6 --max-turns 5
           prompt: |
             You are reviewing a pull request on the shared-terminal repo
             (public TypeScript/Node project: Cloudflare Pages frontend,

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 # Local-only review artifacts (security findings — don't publish until fixed)
 .issues/
 REVIEW.md
+
+# Claude Code worktrees / local agent state — never commit
+.claude/


### PR DESCRIPTION
## What

Adds `.github/workflows/claude-review.yml` — a GitHub Action that runs `anthropics/claude-code-action@v1` on every PR (`opened`, `synchronize`, `reopened`) and posts a single structured review comment.

## Why

This is a solo repo with no human reviewer. A consistent automated second pair of eyes catches obvious bugs, forgotten error handling, and security mistakes before merge — especially important because the service exposes a terminal over a Cloudflare tunnel, so command-exec / auth regressions matter.

## Review prompt

Produces one comment with headings:
- **Summary** — 2-4 sentences so the PR list is skimmable later.
- **Bugs & correctness** — logic errors, unhandled errors, race conditions, missing tests. Must cite `file:line`.
- **Security** — secrets, shell/command injection, auth/authz gaps, CORS, anything reaching the terminal backend or tunnel.
- **Style & conventions** — only things that hurt readability or break repo patterns (no linter-grade nits).
- **Verdict** — `LGTM` / `Minor nits` / `Needs changes`.

Tuned to be terse: no emojis, no praise, no trailing summary.

## Config notes

- Auth via `CLAUDE_CODE_OAUTH_TOKEN` (Claude Max/Pro). A comment in the YAML documents the `ANTHROPIC_API_KEY` alternative for pay-as-you-go billing — swap the two lines if needed.
- `concurrency.group: claude-review-${{ github.event.pull_request.number }}` with `cancel-in-progress: true` means rapid pushes cancel the in-flight review instead of piling up runs.
- Permissions scoped to the minimum needed to post the review: `contents: read`, `pull-requests: write`, `issues: write`, `actions: read`.

## Prerequisite

Repo secret `CLAUDE_CODE_OAUTH_TOKEN` must be set in **Settings → Secrets and variables → Actions** before this workflow can run successfully.