### PR TITLE
ci: bump Claude review --max-turns from 5 to 10

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,7 +10,7 @@ name: Claude PR Review
 #   This is NOT equivalent to `contents: write` — it does not grant code-push
 #   rights; the resulting token is bounded by the Claude GitHub App's own
 #   install permissions on this repo.
-# - `--max-turns 5` caps iteration blast radius if prompt injection occurs.
+# - `--max-turns 10` caps iteration blast radius if prompt injection occurs.
 # - Action is pinned to major version `@v1`. Consider pinning to a commit SHA
 #   for stricter supply-chain hygiene.
 
@@ -43,7 +43,7 @@ jobs:
           # Claude Max / Pro subscription (OAuth). For pay-as-you-go API billing instead,
           # comment the line below and use: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --model claude-sonnet-4-6 --max-turns 5
+          claude_args: --model claude-sonnet-4-6 --max-turns 10
           prompt: |
             You are reviewing a pull request on the shared-terminal repo
             (public TypeScript/Node project: Cloudflare Pages frontend,


### PR DESCRIPTION
## Summary
- Bumps `--max-turns` in `.github/workflows/claude-review.yml` from 5 to 10 and updates the security-notes comment to match.

## Why
PR #33 exhausted the 5-turn limit mid-review. The diff on that PR was 1.8k insertions (new Vitest setup, \`package-lock.json\` bump, full \`dockerManager\` rewrite) — the reviewer burned turns just reading the diff and never produced a comment.

10 still bounds blast radius for the prompt-injection scenarios the limit was designed for, and leaves headroom for PRs that touch dependencies or add new files.

## Test plan
- [ ] This PR itself triggers the workflow and the review completes within the new limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)