### PR TITLE
ci: allow gh pr comment so Claude actually posts reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,15 +43,28 @@ jobs:
           # Claude Max / Pro subscription (OAuth). For pay-as-you-go API billing instead,
           # comment the line below and use: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --model claude-sonnet-4-6 --max-turns 10
+          # The action doesn't auto-post Claude's text — Claude has to actively
+          # call a tool. We allowlist just the read-only PR tools + `gh pr comment`
+          # so the review lands as a top-level PR comment.
+          claude_args: >
+            --model claude-sonnet-4-6
+            --max-turns 10
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
           prompt: |
+            REPO: ${{ github.repository }}
+            PR: #${{ github.event.pull_request.number }}
+
             You are reviewing a pull request on the shared-terminal repo
             (public TypeScript/Node project: Cloudflare Pages frontend,
             Proxmox + Cloudflare Tunnel backend). This is a solo repo with
             no human reviewer, so be direct and actionable.
 
             Produce ONE review comment with the headings below. Skip any
-            section that has nothing real to say — do not pad.
+            section that has nothing real to say — do not pad. Post it as
+            a top-level PR comment via
+              gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<'EOF' … EOF)"
+            Do not reply with the review as an assistant message — only the
+            `gh pr comment` call produces user-visible output.
 
             ## Summary
             2-4 sentences describing what this PR actually changes and why,


### PR DESCRIPTION
## Summary
- Allowlists `gh pr view`, `gh pr diff`, and `gh pr comment` in `claude_args --allowedTools`.
- Updates the prompt to inject \`REPO\` / \`PR\` context and tell Claude to post the review via \`gh pr comment <n> --body …\` (not via the assistant message text).

## Why
Looking at the PR #33 review run (success, 128s, 12 turns, 1 permission denial, and the telling \`No buffered inline comments\` log line): the v1 action does NOT auto-post Claude's output. Claude has to explicitly call a tool. Without the allowlist, Claude tried and got denied; the action exited successfully having posted nothing.

Per the action's \`docs/solutions.md\` PR-review template, the correct wiring is \`--allowedTools \"Bash(gh pr comment:*), …\"\` plus a prompt that directs Claude to use those tools.

## Test plan
- [ ] After merging to main, re-running the workflow on a PR (or opening a new one) results in a top-level comment from the bot with the expected sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)