### PR TITLE
feat(tabs): backend — one tmux session per tab, REST API, WS ?tab routing

### DIFF
--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -33,8 +33,10 @@ function makeFakeSessions(containerId: string | null = "container-123"): Session
 interface FakeExec {
 	start: ReturnType<typeof vi.fn>;
 	resize: ReturnType<typeof vi.fn>;
+	inspect: ReturnType<typeof vi.fn>;
 	_resizes: Array<{ h: number; w: number }>;
 	_stream: PassThrough;
+	_cmd: string[];
 }
 
 interface FakeContainer {
@@ -43,22 +45,49 @@ interface FakeContainer {
 	_execs: FakeExec[];
 }
 
-function makeFakeContainer(): FakeContainer {
+// Optional per-test hook that lets the test script one-shot `tmux …` calls.
+// The hook receives the cmd and returns the stdout to emit plus an exit code.
+type OneShotHook = (cmd: string[]) => { stdout: string; exitCode: number } | undefined;
+
+function makeFakeContainer(oneShot?: OneShotHook): FakeContainer {
 	const streams: PassThrough[] = [];
 	const execs: FakeExec[] = [];
 
 	const container = {
-		exec: vi.fn(async () => {
+		exec: vi.fn(async (opts: { Cmd: string[]; Tty?: boolean }) => {
 			const stream = new PassThrough();
 			const resizes: Array<{ h: number; w: number }> = [];
 			streams.push(stream);
+
+			// One-shot tmux commands (list-sessions, new-session, set-option,
+			// kill-session, has-session) don't hijack the stream. If a test
+			// supplied a hook, let it decide the stdout + exit code. `tmux attach`
+			// is explicitly NOT a one-shot — it keeps a long-lived stream open.
+			const isAttach = opts.Cmd[0] === "tmux" && opts.Cmd[1] === "attach";
+			const oneShotResult =
+				!isAttach && opts.Cmd[0] === "tmux" && opts.Tty === true && oneShot
+					? oneShot(opts.Cmd)
+					: undefined;
+
 			const exec: FakeExec = {
-				start: vi.fn(async () => stream),
+				start: vi.fn(async () => {
+					if (oneShotResult) {
+						setImmediate(() => {
+							stream.write(oneShotResult.stdout);
+							stream.end();
+						});
+					}
+					return stream;
+				}),
 				resize: vi.fn(async ({ h, w }: { h: number; w: number }) => {
 					resizes.push({ h, w });
 				}),
+				inspect: vi.fn(async () => ({
+					ExitCode: oneShotResult?.exitCode ?? 0,
+				})),
 				_resizes: resizes,
 				_stream: stream,
+				_cmd: opts.Cmd,
 			};
 			execs.push(exec);
 			return exec;
@@ -74,8 +103,9 @@ function makeFakeDocker(container: FakeContainer) {
 	return { getContainer: vi.fn(() => container) };
 }
 
-function makeDocker(sessions = makeFakeSessions()) {
-	const container = makeFakeContainer();
+function makeDocker(opts?: { sessions?: SessionManager; oneShot?: OneShotHook }) {
+	const sessions = opts?.sessions ?? makeFakeSessions();
+	const container = makeFakeContainer(opts?.oneShot);
 	const dm = new DockerManager(sessions);
 	// Swap in the fake Dockerode. The constructor already instantiated a real
 	// one against /var/run/docker.sock but we never touch it before this.
@@ -112,7 +142,7 @@ describe("DockerManager shared-exec multiplexing", () => {
 		expect(a2).toHaveBeenCalledWith("hello");
 
 		// Ring buffer holds one copy of the output, not N.
-		const buffer = (dm as unknown as { buffers: Map<string, { byteLength: number }> }).buffers.get("s1");
+		const buffer = (dm as unknown as { buffers: Map<string, { byteLength: number }> }).buffers.get("s1:tab-default");
 		expect(buffer?.byteLength).toBe(5);
 	});
 
@@ -196,7 +226,7 @@ describe("DockerManager shared-exec multiplexing", () => {
 
 		expect(container._streams[0]!.destroyed).toBe(true);
 		const shared = (dm as unknown as { shared: Map<string, unknown> }).shared;
-		expect(shared.has("s1")).toBe(false);
+		expect(shared.has("s1:tab-default")).toBe(false);
 
 		// Re-attach: new exec, replay still contains the earlier output.
 		const a2 = vi.fn();
@@ -225,5 +255,118 @@ describe("DockerManager shared-exec multiplexing", () => {
 
 		await dm.attach("s1", "a2", 80, 24, () => { /* noop */ });
 		expect(container.exec).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("DockerManager tabs", () => {
+	it("attaches to different tabs on separate execs and doesn't cross-fan-out", async () => {
+		const { dm, container } = makeDocker();
+		const aListener = vi.fn();
+		const bListener = vi.fn();
+
+		await dm.attach("s1", "a1", 80, 24, aListener, "tab-a");
+		await dm.attach("s1", "b1", 80, 24, bListener, "tab-b");
+
+		// Two separate `tmux attach -t <tabId>` calls.
+		expect(container.exec).toHaveBeenCalledTimes(2);
+		const attachCmds = container._execs.map((e) => e._cmd.join(" "));
+		expect(attachCmds).toContain("tmux attach -t tab-a");
+		expect(attachCmds).toContain("tmux attach -t tab-b");
+
+		// tab-a's stream emits — only tab-a's listener fires.
+		const execA = container._execs.find((e) => e._cmd.includes("tab-a"))!;
+		const execB = container._execs.find((e) => e._cmd.includes("tab-b"))!;
+		execA._stream.write("hello-a");
+		execB._stream.write("hello-b");
+		await tick();
+
+		expect(aListener).toHaveBeenCalledTimes(1);
+		expect(aListener).toHaveBeenCalledWith("hello-a");
+		expect(bListener).toHaveBeenCalledTimes(1);
+		expect(bListener).toHaveBeenCalledWith("hello-b");
+	});
+
+	it("listTabs parses tab-separated tmux list-sessions output", async () => {
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				if (cmd[1] === "list-sessions") {
+					return {
+						stdout: "tab-default\tmain\t1700000000\ntab-abc12345\tclaude\t1700000050\n",
+						exitCode: 0,
+					};
+				}
+				return undefined;
+			},
+		});
+
+		const tabs = await dm.listTabs("s1");
+		expect(tabs).toEqual([
+			{ tabId: "tab-default", label: "main", createdAt: 1700000000 },
+			{ tabId: "tab-abc12345", label: "claude", createdAt: 1700000050 },
+		]);
+	});
+
+	it("listTabs returns [] when tmux reports no server running", async () => {
+		const { dm } = makeDocker({
+			oneShot: () => ({ stdout: "no server running on /tmp/tmux-.../default\n", exitCode: 1 }),
+		});
+		expect(await dm.listTabs("s1")).toEqual([]);
+	});
+
+	it("createTab runs new-session + set-option and returns the created Tab", async () => {
+		const calls: string[][] = [];
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				calls.push(cmd);
+				return { stdout: "", exitCode: 0 };
+			},
+		});
+
+		const tab = await dm.createTab("s1", "git");
+
+		expect(tab.tabId).toMatch(/^tab-[0-9a-f]{8}$/);
+		expect(tab.label).toBe("git");
+		expect(tab.createdAt).toBeGreaterThan(0);
+
+		// tmux new-session then set-option @tab-label
+		expect(calls[0]?.slice(0, 3)).toEqual(["tmux", "new-session", "-d"]);
+		expect(calls[0]).toContain(tab.tabId);
+		expect(calls[1]?.slice(0, 2)).toEqual(["tmux", "set-option"]);
+		expect(calls[1]).toContain("@tab-label");
+		expect(calls[1]).toContain("git");
+	});
+
+	it("deleteTab kills the tmux session and clears in-memory state for that tab", async () => {
+		// Pre-populate an attach on tab-x so we can verify teardown.
+		const { dm, container } = makeDocker({
+			oneShot: () => ({ stdout: "", exitCode: 0 }),
+		});
+
+		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-x");
+
+		const bufKey = "s1:tab-x";
+		expect((dm as unknown as { buffers: Map<string, unknown> }).buffers.has(bufKey)).toBe(true);
+		expect((dm as unknown as { shared: Map<string, unknown> }).shared.has(bufKey)).toBe(true);
+
+		await dm.deleteTab("s1", "tab-x");
+		await tick();
+
+		// tmux kill-session got called with the right target.
+		const killCmd = container._execs.find((e) => e._cmd.includes("kill-session"))!;
+		expect(killCmd._cmd).toEqual(["tmux", "kill-session", "-t", "tab-x"]);
+
+		// The shared exec slot and ring buffer for that tab are gone.
+		expect((dm as unknown as { shared: Map<string, unknown> }).shared.has(bufKey)).toBe(false);
+		expect((dm as unknown as { buffers: Map<string, unknown> }).buffers.has(bufKey)).toBe(false);
+		// keyOf mapping for the detached attach is cleared.
+		expect((dm as unknown as { keyOf: Map<string, string> }).keyOf.has("a1")).toBe(false);
+	});
+
+	it("attach without tabId uses DEFAULT_TAB_ID, yielding key `${sessionId}:tab-default`", async () => {
+		const { dm } = makeDocker();
+		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ });
+
+		const buffers = (dm as unknown as { buffers: Map<string, unknown> }).buffers;
+		expect(buffers.has("s1:tab-default")).toBe(true);
 	});
 });

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -9,6 +9,7 @@ import Dockerode from "dockerode";
 import { Duplex } from "stream";
 import { promises as fs } from "fs";
 import path from "path";
+import { randomBytes } from "crypto";
 import { SessionManager } from "./sessionManager.js";
 import { RingBuffer } from "./ringBuffer.js";
 import { d1Query } from "./db.js";
@@ -25,10 +26,16 @@ export interface ExecHandle {
 
 export type OutputListener = (data: string) => void;
 
+export interface Tab {
+        tabId: string;      // tmux session name inside the container (e.g. "tab-default", "tab-abc12345")
+        label: string;      // display label (tmux user-option @tab-label)
+        createdAt: number;  // unix seconds
+}
+
 // One shared `tmux attach` exec per target key. All WS clients pointing at the
-// same session (later: same session+window) multiplex over this single exec —
-// tmux already mirrors output to every attached client, so if we made one exec
-// per client, each byte would fan out N times.
+// same session+tab multiplex over this single exec — tmux already mirrors
+// output to every attached client, so if we made one exec per client, each
+// byte would fan out N times.
 interface SharedExec {
         execId: string;
         stream: Duplex;
@@ -50,12 +57,16 @@ export class DockerManager {
                 this.sessions = sessions;
         }
 
-        // Today one target per session (the default tmux window). When per-tab
-        // windows land this will return `${sessionId}:${windowId}` — callers stay
-        // the same; only the key-construction changes.
-        private targetKey(sessionId: string /*, windowId?: string*/): string {
-                return sessionId;
+        // Each tab inside a session is its own tmux session in the container and
+        // gets its own shared exec + ring buffer. The targetKey is the join key.
+        private targetKey(sessionId: string, tabId: string): string {
+                return `${sessionId}:${tabId}`;
         }
+
+        // Default tab name that the session-image entrypoint creates on first boot.
+        // Used as the fallback when a WS connects without a `tab` query param so
+        // we keep a sensible experience for single-tab users.
+        static readonly DEFAULT_TAB_ID = "tab-default";
 
         // ── Container lifecycle ─────────────────────────────────────────────────
 
@@ -225,15 +236,16 @@ export class DockerManager {
                 cols: number,
                 rows: number,
                 onOutput: OutputListener,
+                tabId: string = DockerManager.DEFAULT_TAB_ID,
         ): Promise<{ handle: ExecHandle; replay: string | null }> {
-                const key = this.targetKey(sessionId);
+                const key = this.targetKey(sessionId, tabId);
 
                 // Reuse the shared exec if one already exists (or is being spawned).
                 // Concurrent first-attach calls await the same promise → exactly one
                 // `container.exec` on the wire.
                 let pending = this.shared.get(key);
                 if (!pending) {
-                        pending = this.spawnSharedExec(sessionId, key);
+                        pending = this.spawnSharedExec(sessionId, key, tabId);
                         // Clear the slot on rejection so the next attach retries.
                         // `.catch` here doesn't consume the rejection — awaiters on the
                         // original promise still see it; this handler exists so Node
@@ -321,13 +333,13 @@ export class DockerManager {
 
         // ── Shared exec internals ──────────────────────────────────────────────
 
-        private async spawnSharedExec(sessionId: string, key: string): Promise<SharedExec> {
+        private async spawnSharedExec(sessionId: string, key: string, tabId: string): Promise<SharedExec> {
                 const meta = await this.sessions.getOrThrow(sessionId);
                 if (!meta.containerId) throw new Error("No container for this session");
 
                 const container = this.docker.getContainer(meta.containerId);
                 const exec = await container.exec({
-                        Cmd: ["tmux", "attach", "-t", "main"],
+                        Cmd: ["tmux", "attach", "-t", tabId],
                         AttachStdin: true,
                         AttachStdout: true,
                         AttachStderr: true,
@@ -385,6 +397,117 @@ export class DockerManager {
 
                 console.log(`[docker] spawned shared exec for ${key}`);
                 return s;
+        }
+
+        // ── Tabs (tmux session per tab) ────────────────────────────────────────
+
+        async listTabs(sessionId: string): Promise<Tab[]> {
+                const { stdout, exitCode } = await this.execOneShot(sessionId, [
+                        "tmux", "list-sessions", "-F",
+                        "#{session_name}\t#{?@tab-label,#{@tab-label},#{session_name}}\t#{session_created}",
+                ]);
+                // tmux returns 1 with "no server running" when the server died. That is
+                // an unusable container for us — surface as empty so callers can recover.
+                if (exitCode !== 0) return [];
+                return stdout
+                        .split("\n")
+                        .map((line) => line.trim())
+                        .filter((line) => line.length > 0)
+                        .map((line): Tab => {
+                                const [tabId = "", label = "", createdAt = "0"] = line.split("\t");
+                                return { tabId, label, createdAt: Number(createdAt) || 0 };
+                        });
+        }
+
+        async createTab(sessionId: string, label?: string): Promise<Tab> {
+                const tabId = `tab-${randomBytes(4).toString("hex")}`;
+                const displayLabel = (label ?? "").trim() || tabId;
+
+                const create = await this.execOneShot(sessionId, [
+                        "tmux", "new-session", "-d", "-s", tabId, "-x", "120", "-y", "36",
+                ]);
+                if (create.exitCode !== 0) {
+                        throw new Error(`tmux new-session failed (exit ${create.exitCode}): ${create.stdout}`);
+                }
+
+                // User-option stays with the tmux session for its lifetime — survives
+                // backend restarts, doesn't need a D1 table.
+                await this.execOneShot(sessionId, [
+                        "tmux", "set-option", "-t", tabId, "@tab-label", displayLabel,
+                ]);
+
+                const now = Math.floor(Date.now() / 1000);
+                console.log(`[docker] created tab ${tabId} (${displayLabel}) in session ${sessionId}`);
+                return { tabId, label: displayLabel, createdAt: now };
+        }
+
+        async deleteTab(sessionId: string, tabId: string): Promise<void> {
+                // Tear down any shared exec + buffer for this tab first so we don't
+                // leave dangling handles pointing at a dead tmux session.
+                const key = this.targetKey(sessionId, tabId);
+                const pending = this.shared.get(key);
+                if (pending) {
+                        this.shared.delete(key);
+                        pending.then(
+                                (s) => { try { s.stream.destroy(); } catch { /* already destroyed */ } },
+                                () => { /* spawn rejected — nothing to destroy */ },
+                        );
+                }
+                this.buffers.delete(key);
+                for (const [attachId, k] of this.keyOf) {
+                        if (k === key) this.keyOf.delete(attachId);
+                }
+
+                const { exitCode } = await this.execOneShot(sessionId, ["tmux", "kill-session", "-t", tabId]);
+                if (exitCode !== 0) {
+                        // kill-session returns non-zero if the target doesn't exist — OK for
+                        // the idempotent case; caller has already validated it existed.
+                        console.warn(`[docker] kill-session ${tabId} exited ${exitCode}`);
+                }
+                console.log(`[docker] deleted tab ${tabId} from session ${sessionId}`);
+        }
+
+        /** Resolve a sane default when a caller didn't specify a tabId. Returns the
+         *  first tab from `listTabs`, falling back to DEFAULT_TAB_ID if we can't
+         *  reach the container (e.g. reconcile race). */
+        async getDefaultTabId(sessionId: string): Promise<string> {
+                try {
+                        const tabs = await this.listTabs(sessionId);
+                        if (tabs.length > 0) return tabs[0]!.tabId;
+                } catch { /* fall through to static default */ }
+                return DockerManager.DEFAULT_TAB_ID;
+        }
+
+        private async execOneShot(
+                sessionId: string,
+                cmd: string[],
+        ): Promise<{ stdout: string; exitCode: number }> {
+                const meta = await this.sessions.getOrThrow(sessionId);
+                if (!meta.containerId) throw new Error("No container for this session");
+                const container = this.docker.getContainer(meta.containerId);
+
+                const exec = await container.exec({
+                        Cmd: cmd,
+                        AttachStdin: false,
+                        AttachStdout: true,
+                        AttachStderr: true,
+                        // Tty:true merges stdout/stderr onto a single stream so we don't
+                        // need the docker frame demuxer for these short-lived tmux calls.
+                        Tty: true,
+                });
+                const stream = await exec.start({ hijack: false, stdin: false });
+                const chunks: Buffer[] = [];
+                stream.on("data", (c: Buffer) => chunks.push(c));
+                await new Promise<void>((resolve, reject) => {
+                        stream.on("end", () => resolve());
+                        stream.on("close", () => resolve());
+                        stream.on("error", reject);
+                });
+                const info = await exec.inspect();
+                return {
+                        stdout: Buffer.concat(chunks).toString("utf-8").replace(/\r/g, ""),
+                        exitCode: info.ExitCode ?? 0,
+                };
         }
 
         private async recomputeSize(s: SharedExec): Promise<void> {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -165,6 +165,59 @@ export function buildRouter(sessions: SessionManager, docker: DockerManager): Ro
                 }
         });
 
+        // ── Tabs within a session ──────────────────────────────────────────────
+        // Each tab is a tmux session inside the container. The backend owns the
+        // tabId → tmux session name mapping; the UI treats tabId as an opaque
+        // string. Deleting a tab SIGHUPs everything inside it.
+
+        router.get("/sessions/:id/tabs", async (req: Request, res: Response) => {
+                const { userId } = req as AuthedRequest;
+                try {
+                        await sessions.assertOwnership(req.params.id, userId);
+                        const tabs = await docker.listTabs(req.params.id);
+                        res.json(tabs);
+                } catch (err) {
+                        handleSessionError(err, res);
+                }
+        });
+
+        router.post("/sessions/:id/tabs", async (req: Request, res: Response) => {
+                const { userId } = req as AuthedRequest;
+                const { label } = (req.body ?? {}) as { label?: string };
+                try {
+                        await sessions.assertOwnership(req.params.id, userId);
+                        const tab = await docker.createTab(req.params.id, label);
+                        res.status(201).json(tab);
+                } catch (err) {
+                        handleSessionError(err, res);
+                }
+        });
+
+        router.delete("/sessions/:id/tabs/:tabId", async (req: Request, res: Response) => {
+                const { userId } = req as AuthedRequest;
+                const { id, tabId } = req.params;
+                try {
+                        await sessions.assertOwnership(id, userId);
+
+                        // Enforce "always at least one tab per session" — refuse the close
+                        // and let the client decide whether to create a new tab first.
+                        const tabs = await docker.listTabs(id);
+                        if (!tabs.some((t) => t.tabId === tabId)) {
+                                res.status(404).json({ error: "tab not found" });
+                                return;
+                        }
+                        if (tabs.length <= 1) {
+                                res.status(409).json({ error: "cannot close the last tab" });
+                                return;
+                        }
+
+                        await docker.deleteTab(id, tabId);
+                        res.status(204).send();
+                } catch (err) {
+                        handleSessionError(err, res);
+                }
+        });
+
         return router;
 }
 

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -23,7 +23,21 @@ export function handleWsConnection(
                 ws.close(1008, "Invalid path");
                 return;
         }
-        const sessionId = match[1];
+        const sessionId = match[1]!;
+
+        // Optional ?tab=<tabId>. If absent, we resolve to the first tab in the
+        // container below so clients that predate the tabs feature keep working.
+        // Strict charset: tmux session names + our own prefix; no shell metas
+        // (docker exec takes argv, not a shell line, but a defensive allowlist
+        // keeps surprising tmux targets like "main:1" out of the path).
+        const tabQueryMatch = url.match(/[?&]tab=([^&#]+)/);
+        const rawTab = tabQueryMatch ? decodeURIComponent(tabQueryMatch[1]!) : null;
+        if (rawTab !== null && !/^[a-zA-Z0-9._-]{1,64}$/.test(rawTab)) {
+                sendError(ws, "Invalid tab id");
+                ws.close(1008, "Invalid tab");
+                return;
+        }
+        const requestedTabId = rawTab;
 
         const payload = verifyWsToken(req.headers["sec-websocket-protocol"], req.url);
         if (!payload) {
@@ -44,6 +58,12 @@ export function handleWsConnection(
                         return;
                 }
 
+                // Resolve tab: explicit ?tab=… wins; otherwise pick the first tab
+                // the container actually has. That lets existing clients (no tab
+                // query) land on a sensible default regardless of whether the
+                // container was created pre- or post-tabs.
+                const tabId = requestedTabId ?? (await docker.getDefaultTabId(sessionId));
+
                 // Attach to Docker container
                 const attachId = `${sessionId}:${uuidv4().slice(0, 8)}`;
                 const outputListener = (data: string) => {
@@ -51,7 +71,7 @@ export function handleWsConnection(
                 };
 
                 const { replay } = await docker.attach(
-                        sessionId, attachId, session.cols, session.rows, outputListener,
+                        sessionId, attachId, session.cols, session.rows, outputListener, tabId,
                 );
 
                 sendMsg(ws, { type: "status", status: "running" });
@@ -59,7 +79,7 @@ export function handleWsConnection(
                         sendMsg(ws, { type: "output", data: replay });
                 }
 
-                console.log(`[ws] user=${userId} attached to session=${sessionId} (exec=${attachId})`);
+                console.log(`[ws] user=${userId} attached to session=${sessionId} tab=${tabId} (exec=${attachId})`);
 
                 // Message handler
                 ws.on("message", (raw) => {

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -2,20 +2,24 @@
 # ──────────────────────────────────────────────────────────────────────────────
 # Session container entrypoint.
 #
-# Starts a detached tmux session named "main" and then waits forever so the
-# container stays alive.  The backend attaches via:
-#   docker exec -it <container> tmux attach -t main
+# Each tmux session inside the container is ONE browser tab. We boot with a
+# single default tab (`tab-default`); additional tabs are created by the
+# backend via `tmux new-session`, and closed via `tmux kill-session`. The
+# container stays alive as long as any tmux session exists.
 # ──────────────────────────────────────────────────────────────────────────────
 set -e
 
 # Navigate to workspace
 cd /home/developer/workspace
 
-# Create the detached tmux session
-tmux new-session -d -s main -x 120 -y 36
+# Create the detached default tab. Named deterministically so the backend
+# can address it without an extra round-trip on first attach.
+tmux new-session -d -s tab-default -x 120 -y 36
+tmux set-option -t tab-default @tab-label "main"
 
-echo "[entrypoint] tmux session 'main' started — waiting for connections…"
+echo "[entrypoint] tmux session 'tab-default' started — waiting for connections…"
 
-# Keep the container alive.  Use `wait` on tmux server so the container
-# exits if tmux dies (e.g., last window closed).
+# Keep the container alive. Tmux server exits when its last session closes,
+# which bubbles out here and terminates the container — matching "always at
+# least one tab per session" enforced by the backend kill-last guard.
 exec tmux wait-for exit-signal


### PR DESCRIPTION
First of three PRs delivering per-session tabs (\"claude in one tab, git in another\"). This one lands the backend only — no UI yet.

## Model
- Each **tab = one tmux session inside the container**.
- Backend generates tabIds like \`tab-<uuid8>\` (entrypoint creates \`tab-default\` on boot).
- Display name stored as the tmux user-option \`@tab-label\` on that session, so it survives backend restarts without a new D1 table.
- Closing a tab \`tmux kill-session\`s the whole tmux session, SIGHUPping every process in it — matches the requirement that \"if I close a tab, services running on it should terminate.\"
- The REST DELETE refuses when only one tab remains (409), enforcing \"always ≥1 tab per session.\"

## API
| Method | Path                              | Description                                     |
| ------ | --------------------------------- | ----------------------------------------------- |
| GET    | /api/sessions/:id/tabs            | List tabs: \`[{ tabId, label, createdAt }]\`    |
| POST   | /api/sessions/:id/tabs            | Create tab; body \`{ label? }\`; returns Tab   |
| DELETE | /api/sessions/:id/tabs/:tabId     | Close tab (409 if last)                         |

WS: \`/ws/sessions/:id?tab=<tabId>\` — optional; defaults to the first tab.

## How the shared-exec refactor from #33 paid off
That PR parameterised all of attach/detach/write/resize/kill on an opaque \`targetKey\`. All this PR had to do was change the helper from \`targetKey(sessionId)\` → \`targetKey(sessionId, tabId)\`. Fan-out, ring-buffer, smallest-wins resize, and last-detach teardown kept working without touching those code paths.

## Tests
13 passing vitest cases (was 7; + 6 new):
- Multi-tab attaches go through separate \`tmux attach -t <tabId>\` execs and don't cross-fan-out.
- \`listTabs\` parses tab-separated \`tmux list-sessions\` output; returns \`[]\` when tmux reports no server.
- \`createTab\` runs \`new-session\` + \`set-option @tab-label\` and returns the created \`Tab\`.
- \`deleteTab\` kills the tmux session and clears the shared-exec slot, ring buffer, and \`keyOf\` entries for that tab.
- Omitting the tabId falls back to \`DEFAULT_TAB_ID\`.
- Plus seven previous tests, with \`s1\` → \`s1:tab-default\` keys.

## Security note
\`?tab=<tabId>\` is validated against \`^[a-zA-Z0-9._-]{1,64}$\` before reaching \`tmux attach -t …\`. \`container.exec\` uses argv (not a shell line), so this is defense in depth — keeps surprising tmux targets like \`main:1\` out of the path.

## Test plan
- [x] \`cd backend && npm run build\` passes
- [x] \`cd backend && npm test\` passes (13/13)
- [x] \`cd frontend && npm run build\` passes (no frontend changes)
- [ ] Manual: \`docker build -t shared-terminal-session ./session-image\` produces an image that boots with session \`tab-default\`.
- [ ] Manual: \`POST /api/sessions/:id/tabs\` creates a new tmux session visible in \`docker exec … tmux list-sessions\`; \`DELETE\` kills it; \`DELETE\` on the last tab returns 409.

## Follow-ups
1. **Frontend tab UI** (separate PR): tab bar above the xterm, \`+\` button, \`×\` per tab, click-to-switch.
2. Optional WS protocol addition: \`resize\`-only events when switching tabs (no-op today since each tab has its own WS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)