### PR TITLE
feat(tabs): frontend — tab bar, add/close/switch within a session

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -430,9 +430,7 @@
         display: none;
         position: relative;
       }
-      /* Each tab gets its own pane stacked in the same container; we toggle
-         visibility rather than remount xterm so switching tabs is instant
-         and background tabs keep receiving output. */
+      /* Panes stack absolutely; toggling .active avoids remounting xterm. */
       .tab-pane {
         position: absolute;
         inset: 4px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -379,6 +379,9 @@
       .tab-chip-label {
         overflow: hidden;
         text-overflow: ellipsis;
+        /* Flex children default to min-width: auto, which prevents shrink
+           below content width and makes ellipsis dead. */
+        min-width: 0;
       }
       .tab-close {
         background: transparent;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -338,12 +338,108 @@
         background: rgba(139, 148, 158, 0.2);
         color: #8b949e;
       }
+      #terminal-tabs {
+        display: none;
+        align-items: stretch;
+        gap: 4px;
+        padding: 4px 8px 0 8px;
+        background: #0d1117;
+        border-bottom: 1px solid #30363d;
+        overflow-x: auto;
+        scrollbar-width: thin;
+        flex-shrink: 0;
+      }
+      .tab-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.3rem 0.55rem;
+        background: #161b22;
+        border: 1px solid #30363d;
+        border-bottom: none;
+        border-radius: 6px 6px 0 0;
+        color: #8b949e;
+        font-size: 0.78rem;
+        cursor: pointer;
+        white-space: nowrap;
+        user-select: none;
+        max-width: 200px;
+      }
+      .tab-chip:hover {
+        background: #1c222b;
+        color: #e6edf3;
+      }
+      .tab-chip.active {
+        background: #0d1117;
+        color: #e6edf3;
+        border-color: #30363d;
+        position: relative;
+        top: 1px;
+      }
+      .tab-chip-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .tab-close {
+        background: transparent;
+        border: none;
+        color: #8b949e;
+        font-size: 0.9rem;
+        line-height: 1;
+        cursor: pointer;
+        padding: 2px 4px;
+        border-radius: 4px;
+        opacity: 0;
+      }
+      .tab-chip:hover .tab-close,
+      .tab-chip.active .tab-close {
+        opacity: 1;
+      }
+      .tab-close:hover {
+        background: rgba(248, 81, 73, 0.2);
+        color: #f85149;
+      }
+      .tab-close:disabled {
+        cursor: not-allowed;
+        opacity: 0.2 !important;
+      }
+      #tab-add {
+        background: transparent;
+        border: 1px dashed #30363d;
+        border-bottom: none;
+        border-radius: 6px 6px 0 0;
+        color: #8b949e;
+        font-size: 0.9rem;
+        padding: 0.2rem 0.55rem;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+      #tab-add:hover {
+        border-color: #58a6ff;
+        color: #58a6ff;
+      }
+      #tab-add:disabled {
+        cursor: progress;
+        opacity: 0.6;
+      }
       #terminal-container {
         flex: 1;
         overflow: hidden;
         padding: 4px;
         background: #0d1117;
         display: none;
+        position: relative;
+      }
+      /* Each tab gets its own pane stacked in the same container; we toggle
+         visibility rather than remount xterm so switching tabs is instant
+         and background tabs keep receiving output. */
+      .tab-pane {
+        position: absolute;
+        inset: 4px;
+        display: none;
+      }
+      .tab-pane.active {
+        display: block;
       }
       #terminal-container .xterm {
         height: 100%;
@@ -458,6 +554,7 @@
             <span id="terminal-session-name"></span>
             <span id="terminal-status-badge"></span>
           </div>
+          <div id="terminal-tabs"></div>
           <div id="terminal-container"></div>
         </section>
       </main>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -180,7 +180,7 @@ export async function deleteTab(sessionId: string, tabId: string): Promise<void>
         if (res.status === 409) {
                 throw new LastTabError();
         }
-        if (!res.ok && res.status !== 204) {
+        if (!res.ok) {
                 const body = await res.json().catch(() => ({}));
                 throw new Error(body.error ?? "Failed to close tab");
         }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -146,6 +146,53 @@ export async function updateEnvVars(id: string, envVars: Record<string, string>)
         return res.json();
 }
 
+// ── Tabs API ────────────────────────────────────────────────────────────────
+
+export interface Tab {
+        tabId: string;
+        label: string;
+        createdAt: number;
+}
+
+export async function listTabs(sessionId: string): Promise<Tab[]> {
+        const res = await apiFetch(`/sessions/${sessionId}/tabs`);
+        if (!res.ok) throw new Error("Failed to list tabs");
+        return res.json();
+}
+
+export async function createTab(sessionId: string, label?: string): Promise<Tab> {
+        const res = await apiFetch(`/sessions/${sessionId}/tabs`, {
+                method: "POST",
+                body: JSON.stringify(label ? { label } : {}),
+        });
+        if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error ?? "Failed to create tab");
+        }
+        return res.json();
+}
+
+/** Close a tab. Throws `LastTabError` if the backend refuses because this is
+ *  the session's only remaining tab — callers should surface that to the user
+ *  rather than retrying. */
+export async function deleteTab(sessionId: string, tabId: string): Promise<void> {
+        const res = await apiFetch(`/sessions/${sessionId}/tabs/${tabId}`, { method: "DELETE" });
+        if (res.status === 409) {
+                throw new LastTabError();
+        }
+        if (!res.ok && res.status !== 204) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error ?? "Failed to close tab");
+        }
+}
+
+export class LastTabError extends Error {
+        constructor() {
+                super("Can't close the last tab of a session");
+                this.name = "LastTabError";
+        }
+}
+
 // ── Fetch wrapper ───────────────────────────────────────────────────────────
 
 async function apiFetch(path: string, init?: RequestInit): Promise<Response> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -108,15 +108,7 @@ export async function getSession(id: string): Promise<SessionInfo> {
         return res.json();
 }
 
-/**
- * Delete a session.
- *
- * - Soft delete (default): stops and removes the Docker container, marks the
- *   session as `terminated`. Workspace files on disk are kept so the session
- *   can later be restored via `startSession`.
- * - Hard delete (`hard = true`): same as soft delete, then also wipes the
- *   workspace directory and removes the session record entirely.
- */
+/** Soft delete stops the container and keeps the workspace; `hard` also wipes files + row. */
 export async function deleteSession(id: string, hard = false): Promise<void> {
         const qs = hard ? "?hard=true" : "";
         const res = await apiFetch(`/sessions/${id}${qs}`, { method: "DELETE" });
@@ -172,9 +164,7 @@ export async function createTab(sessionId: string, label?: string): Promise<Tab>
         return res.json();
 }
 
-/** Close a tab. Throws `LastTabError` if the backend refuses because this is
- *  the session's only remaining tab — callers should surface that to the user
- *  rather than retrying. */
+/** Throws `LastTabError` (HTTP 409) when the tab is the last one — callers should surface, not retry. */
 export async function deleteTab(sessionId: string, tabId: string): Promise<void> {
         const res = await apiFetch(`/sessions/${sessionId}/tabs/${tabId}`, { method: "DELETE" });
         if (res.status === 409) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -153,9 +153,11 @@ export async function listTabs(sessionId: string): Promise<Tab[]> {
 }
 
 export async function createTab(sessionId: string, label?: string): Promise<Tab> {
+        // JSON.stringify drops undefined props, so this serialises to `{}` when
+        // no label is supplied — backend `req.body ?? {}` handles either form.
         const res = await apiFetch(`/sessions/${sessionId}/tabs`, {
                 method: "POST",
-                body: JSON.stringify(label ? { label } : {}),
+                body: JSON.stringify({ label }),
         });
         if (!res.ok) {
                 const body = await res.json().catch(() => ({}));

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -396,6 +396,11 @@ function openTab(tabId: string) {
                 return;
         }
 
+        // Capture the previously-active tab before stripping .active so we can
+        // restore the UI if openTerminalSession throws below — otherwise the
+        // prev pane stays invisible AND the `tabId === currentActiveTabId`
+        // guard above prevents the user from re-clicking its chip.
+        const prevActiveTabId = currentActiveTabId;
         if (currentActiveTabId) {
                 currentTerminals.get(currentActiveTabId)?.pane.classList.remove("active");
         }
@@ -435,8 +440,10 @@ function openTab(tabId: string) {
                         entry = { pane, term };
                         currentTerminals.set(tabId, entry);
                 } catch (err) {
-                        // Avoid orphaning the already-appended pane.
                         pane.remove();
+                        if (prevActiveTabId) {
+                                currentTerminals.get(prevActiveTabId)?.pane.classList.add("active");
+                        }
                         throw err;
                 }
         }
@@ -469,7 +476,20 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                         return;
                 }
                 currentTabs.push(tab);
-                openTab(tab.tabId);
+                try {
+                        openTab(tab.tabId);
+                } catch (err) {
+                        // Roll back the push so the chip doesn't linger pointing at a
+                        // tab with no currentTerminals entry, and clean up the backend
+                        // tab fire-and-forget since it was never actually shown.
+                        currentTabs = currentTabs.filter((t) => t.tabId !== tab.tabId);
+                        void deleteTab(sessionId, tab.tabId).catch((cleanupErr) => {
+                                console.warn(`[tabs] rollback cleanup failed for ${tab.tabId}:`, cleanupErr);
+                                showToast(`Orphan tab left on server: ${(cleanupErr as Error).message}`, true);
+                        });
+                        renderTabBar();
+                        throw err;
+                }
         } catch (err) {
                 showToast((err as Error).message, true);
         } finally {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -295,17 +295,31 @@ async function openSession(sessionId: string) {
 
         // Pull tabs from the backend. An empty list is unusual (the entrypoint
         // always creates tab-default) but we auto-create one so the user can
-        // keep working instead of being stuck.
+        // keep working instead of being stuck. `sessionId` is captured here so
+        // a second rapid click on another session doesn't let this resolution
+        // clobber the newer one's state — each `await` re-checks identity.
         try {
                 const tabs = await listTabs(sessionId);
+                if (activeSessionId !== sessionId) return; // superseded by another click
                 // tmux list-sessions emits alphabetical order; show creation order
                 // instead so the +-added tabs stay on the right.
                 currentTabs = tabs.sort((a, b) => a.createdAt - b.createdAt);
                 if (currentTabs.length === 0) {
                         const created = await createTab(sessionId);
+                        if (activeSessionId !== sessionId) return;
                         currentTabs = [created];
                 }
         } catch (err) {
+                // If nothing else claimed the slot in the meantime, drop back to
+                // the empty state — otherwise the toolbar/container would stay
+                // visible with no tabs rendered. Toast is always shown so the
+                // user knows what happened.
+                if (activeSessionId === sessionId) {
+                        activeSessionId = null;
+                        currentTabs = [];
+                        renderSessionList();
+                        updateToolbar();
+                }
                 showToast((err as Error).message, true);
                 return;
         }
@@ -377,6 +391,16 @@ function openTab(tabId: string) {
         if (!activeSessionId) return;
         if (!currentTabs.some((t) => t.tabId === tabId)) return;
 
+        // Mirror the sidebar's rule: we only spin up a terminal for a running
+        // session. If the user clicked a tab chip while the session was
+        // stopped/terminated/disconnected, bail with a toast instead of
+        // opening a WS that would immediately fail.
+        const s = sessions.find((x) => x.sessionId === activeSessionId);
+        if (s && s.status !== "running") {
+                showToast("Session isn't running — start it first", true);
+                return;
+        }
+
         // Hide the current pane (don't dispose).
         if (currentActiveTabId) {
                 currentTerminals.get(currentActiveTabId)?.pane.classList.remove("active");
@@ -417,12 +441,14 @@ function openTab(tabId: string) {
 
 async function addTab(triggeredBy?: HTMLButtonElement) {
         if (!activeSessionId) return;
+        const sessionId = activeSessionId;
         if (triggeredBy) triggeredBy.disabled = true;
         try {
-                // Default label is "Tab N" where N is the next slot, since the
-                // backend's tabId (`tab-<uuid8>`) is not user-friendly to display.
-                const label = `Tab ${currentTabs.length + 1}`;
-                const tab = await createTab(activeSessionId, label);
+                // Default label: smallest "Tab N" not already in use. Using
+                // `currentTabs.length + 1` would collide after a middle tab
+                // was closed (e.g. [Tab 1, Tab 3] + add → another "Tab 3").
+                const tab = await createTab(sessionId, nextDefaultLabel());
+                if (activeSessionId !== sessionId) return;
                 currentTabs.push(tab);
                 renderTabBar();
                 openTab(tab.tabId);
@@ -433,15 +459,23 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
         }
 }
 
+function nextDefaultLabel(): string {
+        const used = new Set(currentTabs.map((t) => t.label));
+        let n = 1;
+        while (used.has(`Tab ${n}`)) n++;
+        return `Tab ${n}`;
+}
+
 async function closeTab(tabId: string) {
         if (!activeSessionId) return;
+        const sessionId = activeSessionId;
         if (currentTabs.length <= 1) {
                 showToast("Can't close the last tab", true);
                 return;
         }
 
         try {
-                await deleteTab(activeSessionId, tabId);
+                await deleteTab(sessionId, tabId);
         } catch (err) {
                 if (err instanceof LastTabError) {
                         showToast("Can't close the last tab", true);
@@ -450,6 +484,10 @@ async function closeTab(tabId: string) {
                 }
                 return;
         }
+        // Guard against the user switching sessions during the DELETE — the
+        // session we closed the tab on is no longer the active one, so our
+        // in-memory state has already been torn down by openSession().
+        if (activeSessionId !== sessionId) return;
 
         const entry = currentTerminals.get(tabId);
         if (entry) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -384,7 +384,10 @@ function renderTabBar() {
                 close.className = "tab-close";
                 close.textContent = "×";
                 close.title = "Close tab";
-                close.disabled = currentTabs.length <= 1;
+                // Mirror the closeTab guard so the × doesn't render enabled
+                // while a concurrent close is in flight — clicking would just
+                // produce a misleading "Can't close the last tab" toast.
+                close.disabled = currentTabs.length - closingTabs.size <= 1;
                 close.addEventListener("click", (e) => {
                         e.stopPropagation();
                         void closeTab(tab.tabId, close);
@@ -511,6 +514,11 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                         throw err;
                 }
         } catch (err) {
+                // Two distinct failure modes funnel here: (a) createTab itself
+                // rejected — backend state is clean; (b) the inner openTab
+                // rollback re-threw — backend cleanup is already in flight
+                // fire-and-forget. Today both just surface the same toast, but
+                // future retry logic should branch on these two paths.
                 showToast((err as Error).message, true);
         } finally {
                 if (triggeredBy) triggeredBy.disabled = false;
@@ -537,13 +545,16 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
                 return;
         }
         closingTabs.add(tabId);
-        // Disable the × so a double-click doesn't fire a second DELETE mid-flight.
+        // Re-render so sibling chips' × reflects the in-flight close (their
+        // disabled state mirrors the same guard).
+        renderTabBar();
         if (triggeredBy) triggeredBy.disabled = true;
 
         try {
                 await deleteTab(sessionId, tabId);
         } catch (err) {
                 closingTabs.delete(tabId);
+                renderTabBar();
                 if (err instanceof LastTabError) {
                         showToast("Can't close the last tab", true);
                 } else {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -62,6 +62,7 @@ function disposeAllCurrentTerminals() {
         currentActiveTabId = null;
         terminalTabs.innerHTML = "";
         terminalTabs.style.display = "none";
+        terminalContainer.style.display = "none";
 }
 
 // ── Auth flow ───────────────────────────────────────────────────────────────
@@ -335,10 +336,9 @@ function updateToolbar() {
                 return;
         }
         terminalToolbar.style.display = "flex";
-        // Tab bar visibility is owned by renderTabBar — it flips display:flex
-        // only after tabs have actually been populated, avoiding the empty-bar
-        // flash during the listTabs round-trip.
-        terminalContainer.style.display = "block";
+        // #terminal-tabs is owned by renderTabBar, #terminal-container by
+        // openTab — both flip to visible only once real content is ready,
+        // avoiding empty-bar/empty-pane flashes during the listTabs round-trip.
         emptyState.style.display = "none";
         terminalSessionName.textContent = s.name;
         terminalStatusBadge.textContent = s.status;
@@ -436,6 +436,7 @@ function openTab(tabId: string) {
         }
 
         entry.pane.classList.add("active");
+        terminalContainer.style.display = "block";
         currentActiveTabId = tabId;
         renderTabBar();
 }
@@ -503,7 +504,14 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
 
         if (currentActiveTabId === tabId) {
                 currentActiveTabId = null;
-                if (currentTabs.length > 0) openTab(currentTabs[0]!.tabId);
+                // Only fall through to a neighbour if the session is still
+                // running (closeTab's await can race the session going stopped).
+                // openTab will call renderTabBar itself on success.
+                const s = sessions.find((x) => x.sessionId === activeSessionId);
+                if (currentTabs.length > 0 && s?.status === "running") {
+                        openTab(currentTabs[0]!.tabId);
+                        return;
+                }
         }
         renderTabBar();
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -394,7 +394,15 @@ function renderTabBar() {
                 });
                 chip.appendChild(close);
 
-                chip.addEventListener("click", () => openTab(tab.tabId));
+                chip.addEventListener("click", () => {
+                        // Click handlers eat synchronous throws — surface them as
+                        // a toast instead of letting the UI silently revert.
+                        try {
+                                openTab(tab.tabId);
+                        } catch (err) {
+                                showToast((err as Error).message, true);
+                        }
+                });
                 terminalTabs.appendChild(chip);
         }
 
@@ -491,9 +499,11 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
         const sessionId = activeSessionId;
         const sessionName = sessions.find((x) => x.sessionId === sessionId)?.name ?? sessionId.slice(0, 8);
         // Pre-check: don't create a backend tab we can't attach to. Matches
-        // openTab's own guard so this short-circuits before the POST.
+        // openTab's own guard so this short-circuits before the POST. Treat
+        // "session missing from local list" as not-running too, matching both
+        // openTab and the post-check below.
         const statusBefore = sessions.find((x) => x.sessionId === sessionId)?.status;
-        if (statusBefore && statusBefore !== "running") {
+        if (!statusBefore || statusBefore !== "running") {
                 showToast("Session isn't running — start it first", true);
                 return;
         }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -46,11 +46,7 @@ let sessions: SessionInfo[] = [];
 let activeSessionId: string | null = null;
 let isRegisterMode = false;
 
-// Tab state — only for the CURRENTLY active session. Switching sessions
-// disposes these terminals (tmux keeps the tabs alive server-side, so
-// reconnecting replays from the ring buffer). Switching tabs WITHIN the
-// active session keeps every tab's xterm + WS live so background work
-// (e.g. a dev server running in a closed tab) isn't interrupted.
+// Active session's tabs only; switching sessions tears these down.
 interface ActiveTerminal { pane: HTMLDivElement; term: TerminalSession }
 let currentTabs: Tab[] = [];
 let currentActiveTabId: string | null = null;
@@ -65,6 +61,7 @@ function disposeAllCurrentTerminals() {
         currentTabs = [];
         currentActiveTabId = null;
         terminalTabs.innerHTML = "";
+        terminalTabs.style.display = "none";
 }
 
 // ── Auth flow ───────────────────────────────────────────────────────────────
@@ -338,7 +335,9 @@ function updateToolbar() {
                 return;
         }
         terminalToolbar.style.display = "flex";
-        terminalTabs.style.display = "flex";
+        // Tab bar visibility is owned by renderTabBar — it flips display:flex
+        // only after tabs have actually been populated, avoiding the empty-bar
+        // flash during the listTabs round-trip.
         terminalContainer.style.display = "block";
         emptyState.style.display = "none";
         terminalSessionName.textContent = s.name;
@@ -350,7 +349,11 @@ function updateToolbar() {
 
 function renderTabBar() {
         terminalTabs.innerHTML = "";
-        if (!activeSessionId) return;
+        if (!activeSessionId || currentTabs.length === 0) {
+                terminalTabs.style.display = "none";
+                return;
+        }
+        terminalTabs.style.display = "flex";
 
         for (const tab of currentTabs) {
                 const chip = document.createElement("div");
@@ -370,7 +373,7 @@ function renderTabBar() {
                 close.disabled = currentTabs.length <= 1;
                 close.addEventListener("click", (e) => {
                         e.stopPropagation();
-                        void closeTab(tab.tabId);
+                        void closeTab(tab.tabId, close);
                 });
                 chip.appendChild(close);
 
@@ -389,12 +392,10 @@ function renderTabBar() {
 
 function openTab(tabId: string) {
         if (!activeSessionId) return;
+        if (tabId === currentActiveTabId) return;
         if (!currentTabs.some((t) => t.tabId === tabId)) return;
 
-        // Mirror the sidebar's rule: we only spin up a terminal for a running
-        // session. If the user clicked a tab chip while the session was
-        // stopped/terminated/disconnected, bail with a toast instead of
-        // opening a WS that would immediately fail.
+        // Only spin up a terminal for a running session — matches the sidebar.
         const s = sessions.find((x) => x.sessionId === activeSessionId);
         if (s && s.status !== "running") {
                 showToast("Session isn't running — start it first", true);
@@ -466,13 +467,16 @@ function nextDefaultLabel(): string {
         return `Tab ${n}`;
 }
 
-async function closeTab(tabId: string) {
+async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
         if (!activeSessionId) return;
         const sessionId = activeSessionId;
         if (currentTabs.length <= 1) {
                 showToast("Can't close the last tab", true);
                 return;
         }
+        // Disable the × so a double-click doesn't fire a second DELETE mid-flight
+        // (the second would race to a 409 and produce a spurious toast).
+        if (triggeredBy) triggeredBy.disabled = true;
 
         try {
                 await deleteTab(sessionId, tabId);
@@ -482,11 +486,11 @@ async function closeTab(tabId: string) {
                 } else {
                         showToast((err as Error).message, true);
                 }
+                if (triggeredBy?.isConnected) triggeredBy.disabled = false;
                 return;
         }
-        // Guard against the user switching sessions during the DELETE — the
-        // session we closed the tab on is no longer the active one, so our
-        // in-memory state has already been torn down by openSession().
+        // Stale-session guard: renderTabBar() below rebuilds chips anyway, so
+        // the old `triggeredBy` becomes detached — no need to re-enable it.
         if (activeSessionId !== sessionId) return;
 
         const entry = currentTerminals.get(tabId);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -282,35 +282,31 @@ function renderSessionList() {
 async function openSession(sessionId: string) {
         if (activeSessionId === sessionId) return;
 
-        // Tear down the previous session's terminals. (Switching tabs within
-        // a session keeps them alive; switching sessions doesn't.)
+        // Tabs stay alive across tab-switch, but are torn down on session-switch.
         disposeAllCurrentTerminals();
 
         activeSessionId = sessionId;
         renderSessionList();
         updateToolbar();
 
-        // Pull tabs from the backend. An empty list is unusual (the entrypoint
-        // always creates tab-default) but we auto-create one so the user can
-        // keep working instead of being stuck. `sessionId` is captured here so
-        // a second rapid click on another session doesn't let this resolution
-        // clobber the newer one's state — each `await` re-checks identity.
+        // Capturing `sessionId` guards against a rapid second openSession call
+        // clobbering this one — each `await` re-checks identity.
         try {
                 const tabs = await listTabs(sessionId);
-                if (activeSessionId !== sessionId) return; // superseded by another click
-                // tmux list-sessions emits alphabetical order; show creation order
-                // instead so the +-added tabs stay on the right.
+                if (activeSessionId !== sessionId) return;
+                // Sort by creation order so +-added tabs stay on the right
+                // (listTabs returns alphabetical from tmux list-sessions).
                 currentTabs = tabs.sort((a, b) => a.createdAt - b.createdAt);
                 if (currentTabs.length === 0) {
+                        // Unusual (entrypoint creates tab-default) but recover instead
+                        // of leaving the user stuck with no tabs.
                         const created = await createTab(sessionId);
                         if (activeSessionId !== sessionId) return;
                         currentTabs = [created];
                 }
         } catch (err) {
-                // If nothing else claimed the slot in the meantime, drop back to
-                // the empty state — otherwise the toolbar/container would stay
-                // visible with no tabs rendered. Toast is always shown so the
-                // user knows what happened.
+                // Drop back to empty state so the toolbar/container don't linger
+                // visible with no tabs.
                 if (activeSessionId === sessionId) {
                         activeSessionId = null;
                         currentTabs = [];
@@ -321,7 +317,6 @@ async function openSession(sessionId: string) {
                 return;
         }
 
-        // openTab renders the bar; no need for an extra pre-render here.
         if (currentTabs.length > 0) openTab(currentTabs[0]!.tabId);
 }
 
@@ -335,9 +330,9 @@ function updateToolbar() {
                 return;
         }
         terminalToolbar.style.display = "flex";
-        // #terminal-tabs is owned by renderTabBar, #terminal-container by
-        // openTab — both flip to visible only once real content is ready,
-        // avoiding empty-bar/empty-pane flashes during the listTabs round-trip.
+        // #terminal-tabs and #terminal-container are flipped to visible only
+        // by renderTabBar/openTab — avoids an empty-bar flash before listTabs
+        // resolves.
         emptyState.style.display = "none";
         terminalSessionName.textContent = s.name;
         terminalStatusBadge.textContent = s.status;
@@ -401,13 +396,12 @@ function openTab(tabId: string) {
                 return;
         }
 
-        // Hide the current pane (don't dispose).
         if (currentActiveTabId) {
                 currentTerminals.get(currentActiveTabId)?.pane.classList.remove("active");
         }
 
-        // Lazily spin up the xterm+WS for this tab. Subsequent re-opens of the
-        // same tab just toggle .active without reconnecting.
+        // Lazily spin up the xterm+WS; re-opens of the same tab just toggle
+        // .active without reconnecting.
         let entry = currentTerminals.get(tabId);
         if (!entry) {
                 const pane = document.createElement("div");
@@ -425,10 +419,12 @@ function openTab(tabId: string) {
                                 sessionId: ownSessionId,
                                 tabId,
                                 onStatus: (status: SessionStatus) => {
-                                        // Ignore events from terminals that aren't currently active —
-                                        // they're either disposing (post session switch) or backgrounded.
-                                        // In those cases the status is local to the tab, not the session.
+                                        // Only the active tab drives the shared session status. A
+                                        // background tab's WS drop (idle TCP teardown) must not mark
+                                        // the whole session "disconnected" while the foreground tab
+                                        // is still live.
                                         if (activeSessionId !== ownSessionId) return;
+                                        if (tabId !== currentActiveTabId) return;
                                         const s = sessions.find((x) => x.sessionId === ownSessionId);
                                         if (s) s.status = status as SessionInfo["status"];
                                         updateToolbar();
@@ -439,8 +435,7 @@ function openTab(tabId: string) {
                         entry = { pane, term };
                         currentTerminals.set(tabId, entry);
                 } catch (err) {
-                        // Clean up the pane we already appended so it doesn't orphan
-                        // in the container. Re-throw so callers see the failure.
+                        // Avoid orphaning the already-appended pane.
                         pane.remove();
                         throw err;
                 }
@@ -464,10 +459,12 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                 if (activeSessionId !== sessionId) {
                         // User switched away before the POST resolved. The backend tab
                         // exists but was never shown; clean it up so it doesn't resurface
-                        // on the next listTabs for that session. Fire-and-forget, but log
-                        // if the cleanup itself fails so the orphan is at least traceable.
+                        // on the next listTabs for that session. Fire-and-forget, but if
+                        // the cleanup fails surface a toast so the user knows backend
+                        // state drifted from what the UI shows.
                         void deleteTab(sessionId, tab.tabId).catch((err) => {
                                 console.warn(`[tabs] orphan cleanup failed for ${tab.tabId}:`, err);
+                                showToast(`Orphan tab left on server: ${(err as Error).message}`, true);
                         });
                         return;
                 }
@@ -539,6 +536,9 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
                                 return;
                         }
                 }
+                // No running sibling to switch to — hide the container so we
+                // don't leave an empty block sitting where the terminal was.
+                terminalContainer.style.display = "none";
         }
         renderTabBar();
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -322,7 +322,7 @@ async function openSession(sessionId: string) {
                 return;
         }
 
-        renderTabBar();
+        // openTab renders the bar; no need for an extra pre-render here.
         if (currentTabs.length > 0) openTab(currentTabs[0]!.tabId);
 }
 
@@ -416,17 +416,19 @@ function openTab(tabId: string) {
                 pane.dataset.tabId = tabId;
                 terminalContainer.appendChild(pane);
 
+                // Capture the sessionId for this terminal — if the user switches
+                // sessions while this WS is closing, `onStatus("disconnected")`
+                // mustn't write to whatever session happens to be active *now*.
+                const ownSessionId = activeSessionId;
                 const term = openTerminalSession({
                         container: pane,
-                        sessionId: activeSessionId,
+                        sessionId: ownSessionId,
                         tabId,
                         onStatus: (status: SessionStatus) => {
-                                // Session status travels via the tab's WS too. We still
-                                // update the session-level indicator so the sidebar is
-                                // honest about "disconnected".
-                                const s = sessions.find((x) => x.sessionId === activeSessionId);
+                                const s = sessions.find((x) => x.sessionId === ownSessionId);
                                 if (s) s.status = status as SessionInfo["status"];
-                                updateToolbar();
+                                // Only repaint the toolbar if this terminal still owns it.
+                                if (activeSessionId === ownSessionId) updateToolbar();
                                 renderSessionList();
                         },
                         onError: (msg: string) => showToast(msg, true),
@@ -450,9 +452,15 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                 // `currentTabs.length + 1` would collide after a middle tab
                 // was closed (e.g. [Tab 1, Tab 3] + add → another "Tab 3").
                 const tab = await createTab(sessionId, nextDefaultLabel());
-                if (activeSessionId !== sessionId) return;
+                if (activeSessionId !== sessionId) {
+                        // User switched away before the POST resolved. The backend tab
+                        // exists but was never shown; clean it up so it doesn't resurface
+                        // on the next listTabs for that session. Fire-and-forget: any
+                        // failure (container gone, etc.) is tolerable noise here.
+                        void deleteTab(sessionId, tab.tabId).catch(() => { /* ignored */ });
+                        return;
+                }
                 currentTabs.push(tab);
-                renderTabBar();
                 openTab(tab.tabId);
         } catch (err) {
                 showToast((err as Error).message, true);
@@ -494,6 +502,7 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
         // the old `triggeredBy` becomes detached — no need to re-enable it.
         if (activeSessionId !== sessionId) return;
 
+        const closedIndex = currentTabs.findIndex((t) => t.tabId === tabId);
         const entry = currentTerminals.get(tabId);
         if (entry) {
                 entry.term.dispose();
@@ -504,12 +513,14 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
 
         if (currentActiveTabId === tabId) {
                 currentActiveTabId = null;
-                // Only fall through to a neighbour if the session is still
-                // running (closeTab's await can race the session going stopped).
-                // openTab will call renderTabBar itself on success.
+                // Nearest surviving neighbour: what was at the same index is now
+                // the next sibling; clamp to the new last tab when we closed the
+                // rightmost one. Matches standard browser-tab behaviour — better
+                // than always jumping back to the first tab.
                 const s = sessions.find((x) => x.sessionId === activeSessionId);
                 if (currentTabs.length > 0 && s?.status === "running") {
-                        openTab(currentTabs[0]!.tabId);
+                        const next = currentTabs[Math.min(closedIndex, currentTabs.length - 1)]!;
+                        openTab(next.tabId);
                         return;
                 }
         }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -285,6 +285,7 @@ async function openSession(sessionId: string) {
         // Tear down the previous session's terminals. (Switching tabs within
         // a session keeps them alive; switching sessions doesn't.)
         disposeAllCurrentTerminals();
+        // Belt-and-suspenders: catches any pane created before openTerminalSession threw.
         terminalContainer.innerHTML = "";
 
         activeSessionId = sessionId;
@@ -455,9 +456,11 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                 if (activeSessionId !== sessionId) {
                         // User switched away before the POST resolved. The backend tab
                         // exists but was never shown; clean it up so it doesn't resurface
-                        // on the next listTabs for that session. Fire-and-forget: any
-                        // failure (container gone, etc.) is tolerable noise here.
-                        void deleteTab(sessionId, tab.tabId).catch(() => { /* ignored */ });
+                        // on the next listTabs for that session. Fire-and-forget, but log
+                        // if the cleanup itself fails so the orphan is at least traceable.
+                        void deleteTab(sessionId, tab.tabId).catch((err) => {
+                                console.warn(`[tabs] orphan cleanup failed for ${tab.tabId}:`, err);
+                        });
                         return;
                 }
                 currentTabs.push(tab);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -285,8 +285,6 @@ async function openSession(sessionId: string) {
         // Tear down the previous session's terminals. (Switching tabs within
         // a session keeps them alive; switching sessions doesn't.)
         disposeAllCurrentTerminals();
-        // Belt-and-suspenders: catches any pane created before openTerminalSession threw.
-        terminalContainer.innerHTML = "";
 
         activeSessionId = sessionId;
         renderSessionList();
@@ -421,21 +419,31 @@ function openTab(tabId: string) {
                 // sessions while this WS is closing, `onStatus("disconnected")`
                 // mustn't write to whatever session happens to be active *now*.
                 const ownSessionId = activeSessionId;
-                const term = openTerminalSession({
-                        container: pane,
-                        sessionId: ownSessionId,
-                        tabId,
-                        onStatus: (status: SessionStatus) => {
-                                const s = sessions.find((x) => x.sessionId === ownSessionId);
-                                if (s) s.status = status as SessionInfo["status"];
-                                // Only repaint the toolbar if this terminal still owns it.
-                                if (activeSessionId === ownSessionId) updateToolbar();
-                                renderSessionList();
-                        },
-                        onError: (msg: string) => showToast(msg, true),
-                });
-                entry = { pane, term };
-                currentTerminals.set(tabId, entry);
+                try {
+                        const term = openTerminalSession({
+                                container: pane,
+                                sessionId: ownSessionId,
+                                tabId,
+                                onStatus: (status: SessionStatus) => {
+                                        // Ignore events from terminals that aren't currently active —
+                                        // they're either disposing (post session switch) or backgrounded.
+                                        // In those cases the status is local to the tab, not the session.
+                                        if (activeSessionId !== ownSessionId) return;
+                                        const s = sessions.find((x) => x.sessionId === ownSessionId);
+                                        if (s) s.status = status as SessionInfo["status"];
+                                        updateToolbar();
+                                        renderSessionList();
+                                },
+                                onError: (msg: string) => showToast(msg, true),
+                        });
+                        entry = { pane, term };
+                        currentTerminals.set(tabId, entry);
+                } catch (err) {
+                        // Clean up the pane we already appended so it doesn't orphan
+                        // in the container. Re-throw so callers see the failure.
+                        pane.remove();
+                        throw err;
+                }
         }
 
         entry.pane.classList.add("active");
@@ -518,13 +526,18 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
                 currentActiveTabId = null;
                 // Nearest surviving neighbour: what was at the same index is now
                 // the next sibling; clamp to the new last tab when we closed the
-                // rightmost one. Matches standard browser-tab behaviour — better
-                // than always jumping back to the first tab.
+                // rightmost one. If the tab wasn't in currentTabs at findIndex
+                // time (state drifted from under us), fall back to index 0.
                 const s = sessions.find((x) => x.sessionId === activeSessionId);
                 if (currentTabs.length > 0 && s?.status === "running") {
-                        const next = currentTabs[Math.min(closedIndex, currentTabs.length - 1)]!;
-                        openTab(next.tabId);
-                        return;
+                        const idx = closedIndex < 0
+                                ? 0
+                                : Math.min(closedIndex, currentTabs.length - 1);
+                        const next = currentTabs[idx];
+                        if (next) {
+                                openTab(next.tabId);
+                                return;
+                        }
                 }
         }
         renderTabBar();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -51,6 +51,10 @@ interface ActiveTerminal { pane: HTMLDivElement; term: TerminalSession }
 let currentTabs: Tab[] = [];
 let currentActiveTabId: string | null = null;
 const currentTerminals = new Map<string, ActiveTerminal>();
+// Tabs whose DELETE is in flight. Used so the last-tab guard accounts for
+// concurrent closes — two × clicks on two different chips would each see
+// currentTabs.length == 2 and race, with the second eating a spurious 409.
+const closingTabs = new Set<string>();
 
 function disposeAllCurrentTerminals() {
         for (const { term, pane } of currentTerminals.values()) {
@@ -60,6 +64,7 @@ function disposeAllCurrentTerminals() {
         currentTerminals.clear();
         currentTabs = [];
         currentActiveTabId = null;
+        closingTabs.clear();
         terminalTabs.innerHTML = "";
         terminalTabs.style.display = "none";
         terminalContainer.style.display = "none";
@@ -317,7 +322,22 @@ async function openSession(sessionId: string) {
                 return;
         }
 
-        if (currentTabs.length > 0) openTab(currentTabs[0]!.tabId);
+        // openTab can throw synchronously (openTerminalSession init failure) —
+        // openSession is called with `void`, so an unhandled throw here would
+        // become an unhandled rejection with no toast and the UI left mid-switch.
+        if (currentTabs.length > 0) {
+                try {
+                        openTab(currentTabs[0]!.tabId);
+                } catch (err) {
+                        if (activeSessionId === sessionId) {
+                                activeSessionId = null;
+                                currentTabs = [];
+                                renderSessionList();
+                                updateToolbar();
+                        }
+                        showToast((err as Error).message, true);
+                }
+        }
 }
 
 function updateToolbar() {
@@ -507,17 +527,23 @@ function nextDefaultLabel(): string {
 async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
         if (!activeSessionId) return;
         const sessionId = activeSessionId;
-        if (currentTabs.length <= 1) {
+        if (closingTabs.has(tabId)) return; // duplicate invocation for same tab
+        // Subtract in-flight closes so two × clicks on different chips can't
+        // both pass the last-tab check — without this, each would see length=2
+        // and the second DELETE would get a 409 from the backend's last-tab
+        // guard and surface a spurious "can't close" toast.
+        if (currentTabs.length - closingTabs.size <= 1) {
                 showToast("Can't close the last tab", true);
                 return;
         }
-        // Disable the × so a double-click doesn't fire a second DELETE mid-flight
-        // (the second would race to a 409 and produce a spurious toast).
+        closingTabs.add(tabId);
+        // Disable the × so a double-click doesn't fire a second DELETE mid-flight.
         if (triggeredBy) triggeredBy.disabled = true;
 
         try {
                 await deleteTab(sessionId, tabId);
         } catch (err) {
+                closingTabs.delete(tabId);
                 if (err instanceof LastTabError) {
                         showToast("Can't close the last tab", true);
                 } else {
@@ -526,6 +552,7 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
                 if (triggeredBy?.isConnected) triggeredBy.disabled = false;
                 return;
         }
+        closingTabs.delete(tabId);
         // Stale-session guard: renderTabBar() below rebuilds chips anyway, so
         // the old `triggeredBy` becomes detached — no need to re-enable it.
         if (activeSessionId !== sessionId) return;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -486,6 +486,14 @@ function openTab(tabId: string) {
 async function addTab(triggeredBy?: HTMLButtonElement) {
         if (!activeSessionId) return;
         const sessionId = activeSessionId;
+        const sessionName = sessions.find((x) => x.sessionId === sessionId)?.name ?? sessionId.slice(0, 8);
+        // Pre-check: don't create a backend tab we can't attach to. Matches
+        // openTab's own guard so this short-circuits before the POST.
+        const statusBefore = sessions.find((x) => x.sessionId === sessionId)?.status;
+        if (statusBefore && statusBefore !== "running") {
+                showToast("Session isn't running — start it first", true);
+                return;
+        }
         if (triggeredBy) triggeredBy.disabled = true;
         try {
                 // Default label: smallest "Tab N" not already in use. Using
@@ -496,12 +504,26 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                         // User switched away before the POST resolved. The backend tab
                         // exists but was never shown; clean it up so it doesn't resurface
                         // on the next listTabs for that session. Fire-and-forget, but if
-                        // the cleanup fails surface a toast so the user knows backend
-                        // state drifted from what the UI shows.
+                        // the cleanup fails surface a toast — include the owning session
+                        // name so the user knows WHICH session has the orphan, not just
+                        // whichever session happens to be active now.
                         void deleteTab(sessionId, tab.tabId).catch((err) => {
                                 console.warn(`[tabs] orphan cleanup failed for ${tab.tabId}:`, err);
-                                showToast(`Orphan tab left on server: ${(err as Error).message}`, true);
+                                showToast(`Orphan tab left on "${sessionName}": ${(err as Error).message}`, true);
                         });
+                        return;
+                }
+                // Post-check: session may have stopped during the POST round-trip.
+                // openTab returns early (silent toast + return) on non-running
+                // sessions, which would otherwise leave us with currentTabs and
+                // a backend tab both pointing at an unattachable tmux session.
+                const statusAfter = sessions.find((x) => x.sessionId === sessionId)?.status;
+                if (!statusAfter || statusAfter !== "running") {
+                        void deleteTab(sessionId, tab.tabId).catch((err) => {
+                                console.warn(`[tabs] post-stop cleanup failed for ${tab.tabId}:`, err);
+                                showToast(`Orphan tab left on "${sessionName}": ${(err as Error).message}`, true);
+                        });
+                        showToast("Session stopped — tab discarded", true);
                         return;
                 }
                 currentTabs.push(tab);
@@ -514,7 +536,7 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                         currentTabs = currentTabs.filter((t) => t.tabId !== tab.tabId);
                         void deleteTab(sessionId, tab.tabId).catch((cleanupErr) => {
                                 console.warn(`[tabs] rollback cleanup failed for ${tab.tabId}:`, cleanupErr);
-                                showToast(`Orphan tab left on server: ${(cleanupErr as Error).message}`, true);
+                                showToast(`Orphan tab left on "${sessionName}": ${(cleanupErr as Error).message}`, true);
                         });
                         renderTabBar();
                         throw err;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -413,8 +413,11 @@ function openTab(tabId: string) {
         if (!currentTabs.some((t) => t.tabId === tabId)) return;
 
         // Only spin up a terminal for a running session — matches the sidebar.
+        // Treat a missing sessions[] entry as not-running too; if the list is
+        // stale or the session was deleted externally, attaching would just
+        // fail via the WS and leave a blank pane mounted as the active tab.
         const s = sessions.find((x) => x.sessionId === activeSessionId);
-        if (s && s.status !== "running") {
+        if (!s || s.status !== "running") {
                 showToast("Session isn't running — start it first", true);
                 return;
         }
@@ -542,14 +545,11 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                         throw err;
                 }
         } catch (err) {
-                // Two distinct failure modes funnel here: (a) createTab itself
-                // rejected — backend state is clean; (b) the inner openTab
-                // rollback re-threw — backend cleanup is already in flight
-                // fire-and-forget. Today both just surface the same toast, but
-                // future retry logic should branch on these two paths.
                 showToast((err as Error).message, true);
         } finally {
-                if (triggeredBy) triggeredBy.disabled = false;
+                // The inner-catch renderTabBar() rebuilds the + button, so the
+                // original triggeredBy may be detached by the time we get here.
+                if (triggeredBy?.isConnected) triggeredBy.disabled = false;
         }
 }
 
@@ -626,7 +626,9 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
                                         openTab(next.tabId);
                                         return;
                                 } catch (err) {
-                                        showToast((err as Error).message, true);
+                                        // Spell out the connection — the user sees a blank
+                                        // panel otherwise with no hint why.
+                                        showToast(`Couldn't switch to "${next.label}": ${(err as Error).message}`, true);
                                         terminalContainer.style.display = "none";
                                         renderTabBar();
                                         return;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -579,8 +579,19 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
                                 : Math.min(closedIndex, currentTabs.length - 1);
                         const next = currentTabs[idx];
                         if (next) {
-                                openTab(next.tabId);
-                                return;
+                                // closeTab runs as `void`, so a sync throw from openTab
+                                // (openTerminalSession init failure) would be swallowed.
+                                // openTab's own prevActiveTabId restore is a no-op here
+                                // since the prev tab was just removed — recover directly.
+                                try {
+                                        openTab(next.tabId);
+                                        return;
+                                } catch (err) {
+                                        showToast((err as Error).message, true);
+                                        terminalContainer.style.display = "none";
+                                        renderTabBar();
+                                        return;
+                                }
                         }
                 }
                 // No running sibling to switch to — hide the container so we

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -458,7 +458,13 @@ function openTab(tabId: string) {
                                         updateToolbar();
                                         renderSessionList();
                                 },
-                                onError: (msg: string) => showToast(msg, true),
+                                onError: (msg: string) => {
+                                        // Same identity guard as onStatus: background tabs
+                                        // and post-session-switch WS errors must not surface
+                                        // toasts attributed to whatever session is current now.
+                                        if (activeSessionId !== ownSessionId) return;
+                                        showToast(msg, true);
+                                },
                         });
                         entry = { pane, term };
                         currentTerminals.set(tabId, entry);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,7 +8,8 @@
 import {
         isLoggedIn, login, register, logout, checkAuthStatus,
         listSessions, createSession, deleteSession, stopSession, startSession,
-        type SessionInfo,
+        listTabs, createTab, deleteTab, LastTabError,
+        type SessionInfo, type Tab,
 } from "./api.js";
 import { openTerminalSession, type TerminalSession, type SessionStatus } from "./terminal.js";
 
@@ -34,6 +35,7 @@ const showTerminatedToggle = document.getElementById("show-terminated-toggle") a
 const terminalToolbar = document.getElementById("terminal-toolbar")!;
 const terminalSessionName = document.getElementById("terminal-session-name")!;
 const terminalStatusBadge = document.getElementById("terminal-status-badge")!;
+const terminalTabs = document.getElementById("terminal-tabs")!;
 const terminalContainer = document.getElementById("terminal-container")!;
 const emptyState = document.getElementById("empty-state")!;
 const toast = document.getElementById("toast")!;
@@ -42,8 +44,28 @@ const toast = document.getElementById("toast")!;
 
 let sessions: SessionInfo[] = [];
 let activeSessionId: string | null = null;
-let activeTerminal: TerminalSession | null = null;
 let isRegisterMode = false;
+
+// Tab state — only for the CURRENTLY active session. Switching sessions
+// disposes these terminals (tmux keeps the tabs alive server-side, so
+// reconnecting replays from the ring buffer). Switching tabs WITHIN the
+// active session keeps every tab's xterm + WS live so background work
+// (e.g. a dev server running in a closed tab) isn't interrupted.
+interface ActiveTerminal { pane: HTMLDivElement; term: TerminalSession }
+let currentTabs: Tab[] = [];
+let currentActiveTabId: string | null = null;
+const currentTerminals = new Map<string, ActiveTerminal>();
+
+function disposeAllCurrentTerminals() {
+        for (const { term, pane } of currentTerminals.values()) {
+                term.dispose();
+                pane.remove();
+        }
+        currentTerminals.clear();
+        currentTabs = [];
+        currentActiveTabId = null;
+        terminalTabs.innerHTML = "";
+}
 
 // ── Auth flow ───────────────────────────────────────────────────────────────
 
@@ -123,8 +145,7 @@ authForm.addEventListener("submit", async (e) => {
 
 logoutBtn.addEventListener("click", () => {
         logout();
-        activeTerminal?.dispose();
-        activeTerminal = null;
+        disposeAllCurrentTerminals();
         activeSessionId = null;
         sessions = [];
         showAuth();
@@ -237,8 +258,7 @@ function renderSessionList() {
                         try {
                                 await deleteSession(s.sessionId, hard);
                                 if (activeSessionId === s.sessionId) {
-                                        activeTerminal?.dispose();
-                                        activeTerminal = null;
+                                        disposeAllCurrentTerminals();
                                         activeSessionId = null;
                                         updateToolbar();
                                 }
@@ -251,7 +271,7 @@ function renderSessionList() {
                 // Click to open session
                 item.addEventListener("click", () => {
                         if (s.status === "running") {
-                                openSession(s.sessionId);
+                                void openSession(s.sessionId);
                         } else if (s.status === "stopped") {
                                 showToast("Start the session first", true);
                         }
@@ -261,44 +281,189 @@ function renderSessionList() {
         }
 }
 
-function openSession(sessionId: string) {
+async function openSession(sessionId: string) {
         if (activeSessionId === sessionId) return;
 
-        activeTerminal?.dispose();
-        activeTerminal = null;
+        // Tear down the previous session's terminals. (Switching tabs within
+        // a session keeps them alive; switching sessions doesn't.)
+        disposeAllCurrentTerminals();
         terminalContainer.innerHTML = "";
 
         activeSessionId = sessionId;
         renderSessionList();
         updateToolbar();
 
-        activeTerminal = openTerminalSession({
-                container: terminalContainer,
-                sessionId,
-                onStatus: (status: SessionStatus) => {
-                        const s = sessions.find((x) => x.sessionId === sessionId);
-                        if (s) s.status = status as SessionInfo["status"];
-                        updateToolbar();
-                        renderSessionList();
-                },
-                onError: (msg: string) => showToast(msg, true),
-        });
+        // Pull tabs from the backend. An empty list is unusual (the entrypoint
+        // always creates tab-default) but we auto-create one so the user can
+        // keep working instead of being stuck.
+        try {
+                const tabs = await listTabs(sessionId);
+                // tmux list-sessions emits alphabetical order; show creation order
+                // instead so the +-added tabs stay on the right.
+                currentTabs = tabs.sort((a, b) => a.createdAt - b.createdAt);
+                if (currentTabs.length === 0) {
+                        const created = await createTab(sessionId);
+                        currentTabs = [created];
+                }
+        } catch (err) {
+                showToast((err as Error).message, true);
+                return;
+        }
+
+        renderTabBar();
+        if (currentTabs.length > 0) openTab(currentTabs[0]!.tabId);
 }
 
 function updateToolbar() {
         const s = sessions.find((x) => x.sessionId === activeSessionId);
         if (!s) {
                 terminalToolbar.style.display = "none";
+                terminalTabs.style.display = "none";
                 terminalContainer.style.display = "none";
                 emptyState.style.display = "flex";
                 return;
         }
         terminalToolbar.style.display = "flex";
+        terminalTabs.style.display = "flex";
         terminalContainer.style.display = "block";
         emptyState.style.display = "none";
         terminalSessionName.textContent = s.name;
         terminalStatusBadge.textContent = s.status;
         terminalStatusBadge.className = s.status;
+}
+
+// ── Tabs within the active session ──────────────────────────────────────────
+
+function renderTabBar() {
+        terminalTabs.innerHTML = "";
+        if (!activeSessionId) return;
+
+        for (const tab of currentTabs) {
+                const chip = document.createElement("div");
+                chip.className = `tab-chip${tab.tabId === currentActiveTabId ? " active" : ""}`;
+                chip.dataset.tabId = tab.tabId;
+                chip.title = tab.label;
+
+                const label = document.createElement("span");
+                label.className = "tab-chip-label";
+                label.textContent = tab.label;
+                chip.appendChild(label);
+
+                const close = document.createElement("button");
+                close.className = "tab-close";
+                close.textContent = "×";
+                close.title = "Close tab";
+                close.disabled = currentTabs.length <= 1;
+                close.addEventListener("click", (e) => {
+                        e.stopPropagation();
+                        void closeTab(tab.tabId);
+                });
+                chip.appendChild(close);
+
+                chip.addEventListener("click", () => openTab(tab.tabId));
+                terminalTabs.appendChild(chip);
+        }
+
+        const addBtn = document.createElement("button");
+        addBtn.id = "tab-add";
+        addBtn.type = "button";
+        addBtn.textContent = "+";
+        addBtn.title = "Open a new tab (runs services independently; close to SIGHUP them)";
+        addBtn.addEventListener("click", () => void addTab(addBtn));
+        terminalTabs.appendChild(addBtn);
+}
+
+function openTab(tabId: string) {
+        if (!activeSessionId) return;
+        if (!currentTabs.some((t) => t.tabId === tabId)) return;
+
+        // Hide the current pane (don't dispose).
+        if (currentActiveTabId) {
+                currentTerminals.get(currentActiveTabId)?.pane.classList.remove("active");
+        }
+
+        // Lazily spin up the xterm+WS for this tab. Subsequent re-opens of the
+        // same tab just toggle .active without reconnecting.
+        let entry = currentTerminals.get(tabId);
+        if (!entry) {
+                const pane = document.createElement("div");
+                pane.className = "tab-pane";
+                pane.dataset.tabId = tabId;
+                terminalContainer.appendChild(pane);
+
+                const term = openTerminalSession({
+                        container: pane,
+                        sessionId: activeSessionId,
+                        tabId,
+                        onStatus: (status: SessionStatus) => {
+                                // Session status travels via the tab's WS too. We still
+                                // update the session-level indicator so the sidebar is
+                                // honest about "disconnected".
+                                const s = sessions.find((x) => x.sessionId === activeSessionId);
+                                if (s) s.status = status as SessionInfo["status"];
+                                updateToolbar();
+                                renderSessionList();
+                        },
+                        onError: (msg: string) => showToast(msg, true),
+                });
+                entry = { pane, term };
+                currentTerminals.set(tabId, entry);
+        }
+
+        entry.pane.classList.add("active");
+        currentActiveTabId = tabId;
+        renderTabBar();
+}
+
+async function addTab(triggeredBy?: HTMLButtonElement) {
+        if (!activeSessionId) return;
+        if (triggeredBy) triggeredBy.disabled = true;
+        try {
+                // Default label is "Tab N" where N is the next slot, since the
+                // backend's tabId (`tab-<uuid8>`) is not user-friendly to display.
+                const label = `Tab ${currentTabs.length + 1}`;
+                const tab = await createTab(activeSessionId, label);
+                currentTabs.push(tab);
+                renderTabBar();
+                openTab(tab.tabId);
+        } catch (err) {
+                showToast((err as Error).message, true);
+        } finally {
+                if (triggeredBy) triggeredBy.disabled = false;
+        }
+}
+
+async function closeTab(tabId: string) {
+        if (!activeSessionId) return;
+        if (currentTabs.length <= 1) {
+                showToast("Can't close the last tab", true);
+                return;
+        }
+
+        try {
+                await deleteTab(activeSessionId, tabId);
+        } catch (err) {
+                if (err instanceof LastTabError) {
+                        showToast("Can't close the last tab", true);
+                } else {
+                        showToast((err as Error).message, true);
+                }
+                return;
+        }
+
+        const entry = currentTerminals.get(tabId);
+        if (entry) {
+                entry.term.dispose();
+                entry.pane.remove();
+                currentTerminals.delete(tabId);
+        }
+        currentTabs = currentTabs.filter((t) => t.tabId !== tabId);
+
+        if (currentActiveTabId === tabId) {
+                currentActiveTabId = null;
+                if (currentTabs.length > 0) openTab(currentTabs[0]!.tabId);
+        }
+        renderTabBar();
 }
 
 // ── New session ─────────────────────────────────────────────────────────────
@@ -313,7 +478,7 @@ newSessionForm.addEventListener("submit", async (e) => {
                 const session = await createSession(name);
                 sessions.unshift(session);
                 renderSessionList();
-                openSession(session.sessionId);
+                void openSession(session.sessionId);
                 showToast(`Session "${name}" created`);
         } catch (err) {
                 showToast((err as Error).message, true);

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -59,6 +59,11 @@ export function openTerminalSession(opts: {
         term.loadAddon(fitAddon);
         term.open(container);
         fitAddon.fit();
+        // Suppress the browser context menu over the terminal so tmux mouse
+        // mode (enabled in session-image/tmux.conf) actually receives the
+        // right-click as an SGR mouse event instead of the OS menu eating it.
+        const suppressContextMenu = (e: Event) => e.preventDefault();
+        container.addEventListener("contextmenu", suppressContextMenu);
         // Cmd/Ctrl + C copies the current xterm selection to the clipboard.
         // Without this, Cmd-C falls through to the terminal (Claude Code
         // intercepts it as SIGINT) and nothing gets copied.
@@ -173,6 +178,7 @@ export function openTerminalSession(opts: {
         function dispose() {
                 if (heartbeatInterval !== null) clearInterval(heartbeatInterval);
                 ro.disconnect();
+                container.removeEventListener("contextmenu", suppressContextMenu);
                 inputDisposable.dispose();
                 linkProviderDisposable.dispose();
                 ws.close(1000, "User navigated away");

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -357,6 +357,9 @@ function buildWsUrl(sessionId: string, token: string, tabId?: string): string {
         const base = `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
         const params = new URLSearchParams();
         if (token) params.set("token", token);
+        // tabId is server-issued. Backend re-validates against
+        // /^[a-zA-Z0-9._-]{1,64}$/ in wsHandler.ts — colons and `@` would
+        // otherwise let this inject tmux target syntax into `tmux attach -t`.
         if (tabId) params.set("tab", tabId);
         const qs = params.toString();
         return qs ? `${base}?${qs}` : base;

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -19,10 +19,11 @@ export type ErrorCallback = (message: string) => void;
 export function openTerminalSession(opts: {
         container: HTMLElement;
         sessionId: string;
+        tabId?: string;
         onStatus: StatusCallback;
         onError: ErrorCallback;
 }): TerminalSession {
-        const { container, sessionId, onStatus, onError } = opts;
+        const { container, sessionId, tabId, onStatus, onError } = opts;
 
         // ── xterm.js setup ──────────────────────────────────────────────────────
         const term = new Terminal({
@@ -93,7 +94,7 @@ export function openTerminalSession(opts: {
         // though, so we also include the token as a `?token=` query param as a
         // fallback — the backend accepts either.
         const token = getToken() ?? "";
-        const wsUrl = buildWsUrl(sessionId, token);
+        const wsUrl = buildWsUrl(sessionId, token, tabId);
         const ws = new WebSocket(wsUrl, [`auth.bearer.${token}`]);
 
         ws.onopen = () => {
@@ -342,11 +343,15 @@ class MultilineUrlLinkProvider implements ILinkProvider {
 
 // ── URL builder ─────────────────────────────────────────────────────────────
 
-function buildWsUrl(sessionId: string, token: string): string {
+function buildWsUrl(sessionId: string, token: string, tabId?: string): string {
         // Use VITE_API_URL to derive the WebSocket URL
         const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
         const url = new URL(apiUrl);
         const wsProto = url.protocol === "https:" ? "wss:" : "ws:";
         const base = `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
-        return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+        const params = new URLSearchParams();
+        if (token) params.set("token", token);
+        if (tabId) params.set("tab", tabId);
+        const qs = params.toString();
+        return qs ? `${base}?${qs}` : base;
 }

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -357,9 +357,11 @@ function buildWsUrl(sessionId: string, token: string, tabId?: string): string {
         const base = `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
         const params = new URLSearchParams();
         if (token) params.set("token", token);
-        // tabId is server-issued. Backend re-validates against
-        // /^[a-zA-Z0-9._-]{1,64}$/ in wsHandler.ts — colons and `@` would
-        // otherwise let this inject tmux target syntax into `tmux attach -t`.
+        // tabId is server-issued and re-validated on the backend before any
+        // `tmux attach -t` — see backend/src/wsHandler.ts (rawTab regex
+        // /^[a-zA-Z0-9._-]{1,64}$/). Excluding `:` is the load-bearing part:
+        // tmux target syntax needs a colon to parse `session:window.pane`, so
+        // `.` alone can't escalate a tabId into a different tmux target.
         if (tabId) params.set("tab", tabId);
         const qs = params.toString();
         return qs ? `${base}?${qs}` : base;


### PR DESCRIPTION
Completes the tabs feature started in #36. This is the UI half — backend API is already shipped.

## What's in the UI
- **Tab bar** between the session toolbar and the xterm. Chips for each tab, an active highlight, and a \`+\` at the end.
- **\`+\`** → \`POST /api/sessions/:id/tabs\` with a default label \`Tab N\`; tab gets mounted, xterm + WS spun up, auto-switched to.
- **\`×\`** on a chip → \`DELETE /api/sessions/:id/tabs/:tabId\`. The local terminal for that tab is disposed (WS closed, xterm destroyed). Backend's 409 on the last-tab case is surfaced as a toast (\"Can't close the last tab\").
- **Click to switch** → just toggles a CSS class; the background tabs' xterm + WS keep running, so services (\`claude\`, dev server, etc.) aren't interrupted.
- **Session switch or logout** → disposes all terminals for the previous session. Tmux keeps the server-side tabs alive, so reopening the session replays recent output from the ring buffer.

## Key decisions
- **One xterm + one WS per tab**, held alive until the tab is closed. You asked \"can this be improved later?\" in the last round — a future refactor to multiplex all tabs over one WS is a localised change (add a \`tabId\` discriminator to WS messages, demux in wsHandler); the backend keyed everything on \`targetKey\` in #33 to make both options viable.
- **Per-session state, not per-(session,tab)**: switching sessions tears down the previous session's terminals. This bounds memory for the solo-user use case. Keeping every session's tabs alive across session switches would need a small fan-out of the Map keys; happy to do it in a follow-up if you want \"switch away from a long-running Claude tab, come back, it's still going\" behaviour WITHOUT relying on the ring-buffer replay.
- **Tab labels**: backend uses the tmux user-option \`@tab-label\`. The UI names new tabs \`Tab N\` because the backend-assigned \`tabId\` (\`tab-<uuid8>\`) isn't user-friendly. Inline rename can land in a follow-up (would need a backend \`PATCH /tabs/:tabId\` and a double-click handler).

## Tab-pane layout
\`.tab-pane\` uses \`position: absolute; inset: 4px\` inside \`#terminal-container\` (which has \`position: relative\` and \`padding: 4px\`). This is the same visible area xterm filled before; switching tabs toggles \`.active\` display, not remount. Inactive panes stay in the DOM, so their xterm instance and WebSocket keep running.

## Test plan
- [x] \`cd frontend && npm run build\` — clean (tsc + vite)
- [x] \`cd backend && npm test\` — 13/13 still pass (no backend changes)

Manual (stack required — Docker + D1 creds):
- [ ] Fresh session → sidebar shows single \"main\" tab chip; xterm renders as before.
- [ ] \`+\` → \"Tab 2\" chip appears at the right, auto-activates. Run \`ping -c 100 1.1.1.1\` inside.
- [ ] Switch back to \"main\" → no lag; switch to Tab 2 → ping output has accumulated (process kept running in the background).
- [ ] \`×\` on Tab 2 → toast is not shown; \`docker exec <c> ps auxf\` inside the container confirms ping is gone (SIGHUP from \`tmux kill-session\`).
- [ ] \`×\` on the last tab → toast says \"Can't close the last tab\"; tab stays; backend returned 409.
- [ ] Hard delete the session → all terminals disposed cleanly, sidebar empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)