### PR TITLE
feat(terminal): suppress browser context menu so tmux gets right-clicks

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -58,6 +58,11 @@ export function openTerminalSession(opts: {
         term.loadAddon(fitAddon);
         term.open(container);
         fitAddon.fit();
+        // Suppress the browser context menu over the terminal so tmux mouse
+        // mode (enabled in session-image/tmux.conf) actually receives the
+        // right-click as an SGR mouse event instead of the OS menu eating it.
+        const suppressContextMenu = (e: Event) => e.preventDefault();
+        container.addEventListener("contextmenu", suppressContextMenu);
         // Cmd/Ctrl + C copies the current xterm selection to the clipboard.
         // Without this, Cmd-C falls through to the terminal (Claude Code
         // intercepts it as SIGINT) and nothing gets copied.
@@ -172,6 +177,7 @@ export function openTerminalSession(opts: {
         function dispose() {
                 if (heartbeatInterval !== null) clearInterval(heartbeatInterval);
                 ro.disconnect();
+                container.removeEventListener("contextmenu", suppressContextMenu);
                 inputDisposable.dispose();
                 linkProviderDisposable.dispose();
                 ws.close(1000, "User navigated away");


### PR DESCRIPTION
## Why
tmux mouse mode is already on (\`session-image/tmux.conf: set -g mouse on\`), so right-click inside the terminal should be forwarded to tmux as an SGR mouse event — either showing tmux's popup menu (3.2+) or letting the running TUI (Claude, vim, etc.) handle it.

Today the browser's own context menu eats the right-click before xterm gets to send it. Everything else in mouse mode works (scroll, pane click) but right-click is silently swallowed by the OS menu.

## Fix
\`preventDefault\` on \`contextmenu\` over the xterm container. Left-click text selection still works; \`Cmd/Ctrl+C\` clipboard copy still works (the existing \`attachCustomKeyEventHandler\` path). The handler is removed on \`dispose\`.

## Test plan
- [x] \`cd frontend && npm run build\` passes
- [ ] Manual: run tmux inside the container, right-click the xterm → tmux pops its own menu (or the inner TUI handles it) instead of the browser's.
- [ ] Manual: left-click drag still selects text; \`Cmd-C\` still copies.

## Note
This branches from main (not #37) so it merges cleanly whether or not the tabs frontend lands first. #37 also touches terminal.ts (adds \`tabId\` to \`openTerminalSession\`), but the changes don't overlap — the contextmenu bits live right after \`fitAddon.fit()\`, #37's changes are on the function signature and \`buildWsUrl\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)