### PR TITLE
fix(tabs): new tabs land in the workspace bind mount

### DIFF
--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -331,6 +331,11 @@ describe("DockerManager tabs", () => {
 		// tmux new-session then set-option @tab-label
 		expect(calls[0]?.slice(0, 3)).toEqual(["tmux", "new-session", "-d"]);
 		expect(calls[0]).toContain(tab.tabId);
+		// New tabs must start in the workspace bind mount, not the image's
+		// /home/developer WORKDIR — otherwise the user lands next to
+		// entrypoint.sh instead of in their project files.
+		expect(calls[0]).toContain("-c");
+		expect(calls[0]).toContain("/home/developer/workspace");
 		expect(calls[1]?.slice(0, 2)).toEqual(["tmux", "set-option"]);
 		expect(calls[1]).toContain("@tab-label");
 		expect(calls[1]).toContain("git");

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -423,8 +423,14 @@ export class DockerManager {
                 const tabId = `tab-${randomBytes(4).toString("hex")}`;
                 const displayLabel = (label ?? "").trim() || tabId;
 
+                // `-c` pins the new tab's starting directory to the bind-mounted
+                // workspace. Without it, tmux inherits cwd from docker exec, which
+                // uses the image's WORKDIR (/home/developer) and dumps the user
+                // next to entrypoint.sh instead of in their project files.
                 const create = await this.execOneShot(sessionId, [
-                        "tmux", "new-session", "-d", "-s", tabId, "-x", "120", "-y", "36",
+                        "tmux", "new-session", "-d", "-s", tabId,
+                        "-c", "/home/developer/workspace",
+                        "-x", "120", "-y", "36",
                 ]);
                 if (create.exitCode !== 0) {
                         throw new Error(`tmux new-session failed (exit ${create.exitCode}): ${create.stdout}`);

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -14,7 +14,7 @@ cd /home/developer/workspace
 
 # Create the detached default tab. Named deterministically so the backend
 # can address it without an extra round-trip on first attach.
-tmux new-session -d -s tab-default -x 120 -y 36
+tmux new-session -d -s tab-default -c /home/developer/workspace -x 120 -y 36
 tmux set-option -t tab-default @tab-label "main"
 
 echo "[entrypoint] tmux session 'tab-default' started — waiting for connections…"


### PR DESCRIPTION
## Summary
- `tmux new-session` inside `createTab` now passes `-c /home/developer/workspace` so new tabs start in the bind-mounted project dir instead of the image's `/home/developer` WORKDIR (next to `entrypoint.sh`).
- `entrypoint.sh`'s default tab gets the same `-c` flag for consistency (previously relied on the surrounding `cd`, which worked but was implicit).
- Extended the existing `createTab` test to assert the `-c` flag.

## Not addressed here
The reported *"first tab named main fails with 1008 tab id unauthorized"* issue is **not** fixed in this PR — no code path in `wsHandler.ts` reproduces a 1008 that hits only the first tab (both `main` and `tab-default` pass the tab-id regex, and all tabs share the same JWT). Needs DevTools output (Console + WS close code/reason) to pin down the real cause; recommended workaround for now is hard-deleting and recreating the affected session.

## Test plan
- [x] `cd backend && npx vitest run` — all 13 tests pass
- [x] `cd backend && npm run build` — clean
- [ ] Rebuild session image (`docker build -t shared-terminal-session ./session-image`)
- [ ] Create a new session + new tab, confirm `pwd` is `/home/developer/workspace`
- [ ] Confirm existing containers are unaffected (old cwd until rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)