### PR TITLE
fix(auth): rate-limit /auth/login and /auth/register (closes #10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ JWT_EXPIRES_IN=7d
 # e.g. https://shared-terminal.pages.dev,http://localhost:5173
 CORS_ORIGINS=*
 
+# Trust proxy for req.ip — set to "1" behind a single known proxy
+# (e.g. Cloudflare Tunnel), a count, or "true" to trust everything.
+# Load-bearing for /auth rate limiting: without it, every request has the
+# tunnel's IP so per-IP buckets collapse into one shared bucket.
+# TRUST_PROXY=1
+
 # ── Cloudflare D1 Database ───────────────────────────────────────────────────
 CLOUDFLARE_ACCOUNT_ID=your-account-id
 CLOUDFLARE_API_TOKEN=your-api-token

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ CORS_ORIGINS=*
 # X-Forwarded-For entry, defeating per-IP rate limiting entirely.
 # TRUST_PROXY=1
 
+# Auth rate-limit tuning. Defaults are defined in backend/src/rateLimit.ts
+# (login 10/15min per IP + 10 failed/15min per username; register 5/1h).
+# The per-username lockout is strict — a known username can be kept
+# locked by any attacker spending 10 bad attempts per 15-minute window.
+# If your username is publicly known and you want a narrower DoS window,
+# edit DEFAULT_RATE_LIMIT_CONFIG to shrink usernameWindowMs (e.g. 5 min).
+
 # ── Cloudflare D1 Database ───────────────────────────────────────────────────
 CLOUDFLARE_ACCOUNT_ID=your-account-id
 CLOUDFLARE_API_TOKEN=your-api-token

--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,12 @@ JWT_EXPIRES_IN=7d
 CORS_ORIGINS=*
 
 # Trust proxy for req.ip — set to the number of known hops in front of
-# the backend (1 for a single Cloudflare Tunnel, 2 if there's also a
-# reverse proxy, etc.). Load-bearing for /auth rate limiting: without
-# it, every request has the tunnel's IP so per-IP buckets collapse
-# into one. Do NOT use "true" here — it makes Express take the
-# leftmost (attacker-controlled) X-Forwarded-For entry, defeating
-# per-IP rate limiting entirely.
+# the backend. For a Cloudflare Tunnel deployment set this to 1; for
+# direct/local dev leave it at 0 (the docker-compose default). Load-
+# bearing for /auth rate limiting: without it, every request shares
+# the tunnel's IP and per-IP buckets collapse. Do NOT use "true" —
+# it makes Express take the leftmost (attacker-controlled)
+# X-Forwarded-For entry, defeating per-IP rate limiting entirely.
 # TRUST_PROXY=1
 
 # ── Cloudflare D1 Database ───────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,13 @@ JWT_EXPIRES_IN=7d
 # e.g. https://shared-terminal.pages.dev,http://localhost:5173
 CORS_ORIGINS=*
 
-# Trust proxy for req.ip — set to "1" behind a single known proxy
-# (e.g. Cloudflare Tunnel), a count, or "true" to trust everything.
-# Load-bearing for /auth rate limiting: without it, every request has the
-# tunnel's IP so per-IP buckets collapse into one shared bucket.
+# Trust proxy for req.ip — set to the number of known hops in front of
+# the backend (1 for a single Cloudflare Tunnel, 2 if there's also a
+# reverse proxy, etc.). Load-bearing for /auth rate limiting: without
+# it, every request has the tunnel's IP so per-IP buckets collapse
+# into one. Do NOT use "true" here — it makes Express take the
+# leftmost (attacker-controlled) X-Forwarded-For entry, defeating
+# per-IP rate limiting entirely.
 # TRUST_PROXY=1
 
 # ── Cloudflare D1 Database ───────────────────────────────────────────────────

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "bcryptjs": "^2.4.3",
         "dockerode": "^4.0.4",
         "express": "^4.19.2",
+        "express-rate-limit": "^8.3.2",
         "jsonwebtoken": "^9.0.2",
         "uuid": "^9.0.1",
         "ws": "^8.17.1"
@@ -1948,6 +1949,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2196,6 +2215,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,18 +13,19 @@
     "docker:build-session": "docker build -t shared-terminal-session ../session-image"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "dockerode": "^4.0.4",
     "express": "^4.19.2",
+    "express-rate-limit": "^8.3.2",
     "jsonwebtoken": "^9.0.2",
-    "bcryptjs": "^2.4.3",
     "uuid": "^9.0.1",
     "ws": "^8.17.1"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
     "@types/dockerode": "^3.3.31",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.7",
-    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20.14.2",
     "@types/uuid": "^9.0.8",
     "@types/ws": "^8.5.10",

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -39,6 +39,16 @@ export async function registerUser(username: string, password: string): Promise<
         return { userId, token };
 }
 
+// Thrown on wrong-username-or-password, and only that. Infra failures (D1
+// timeouts, bcrypt crashes, …) propagate as regular Errors so the route
+// handler can 500 them instead of counting them toward the lockout budget.
+export class InvalidCredentialsError extends Error {
+        constructor() {
+                super("Invalid credentials");
+                this.name = "InvalidCredentialsError";
+        }
+}
+
 export async function loginUser(username: string, password: string): Promise<{ userId: string; token: string }> {
         const result = await d1Query<{ id: string; password_hash: string }>(
                 "SELECT id, password_hash FROM users WHERE username = ?",
@@ -47,7 +57,7 @@ export async function loginUser(username: string, password: string): Promise<{ u
 
         const row = result.results[0];
         if (!row || !bcrypt.compareSync(password, row.password_hash)) {
-                throw new Error("Invalid credentials");
+                throw new InvalidCredentialsError();
         }
 
         const token = signToken(row.id, username);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -60,6 +60,12 @@ if (TRUST_PROXY !== undefined) {
         else if (TRUST_PROXY === "false") coerced = false;
         else coerced = TRUST_PROXY;
         app.set("trust proxy", coerced);
+        // Log the effective value so ops can spot a misconfigured prod
+        // (e.g. TRUST_PROXY=0 behind a tunnel would silently collapse
+        // per-IP rate limits into one bucket).
+        console.log(`[server] trust proxy = ${JSON.stringify(coerced)}`);
+} else {
+        console.log("[server] trust proxy = unset (req.ip will be the socket address)");
 }
 app.use(express.json());
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -44,23 +44,21 @@ const docker = new DockerManager(sessions);
 
 const app = express();
 if (TRUST_PROXY !== undefined) {
-        // Env values are strings; Express accepts a number (hop count), a
-        // boolean, or an IP/subnet list. Coerce "1" → 1, "false" → false,
-        // otherwise pass through for IPs/subnets. "true" is coerced and
-        // logged as a warning — see the security note above const
-        // TRUST_PROXY for why it's unsafe on a public endpoint.
+        // Env values are strings; coerce "1" → 1 and "false" → false.
+        // Anything else passes through as an IP/subnet/"loopback"/etc.
+        // "true" is explicitly refused — see note above.
+        if (TRUST_PROXY === "true") {
+                console.error(
+                        "[server] TRUST_PROXY=true is refused: Express would take the leftmost " +
+                        "X-Forwarded-For entry (attacker-controlled), bypassing per-IP rate limiting. " +
+                        "Use a hop count (e.g. TRUST_PROXY=1) instead.",
+                );
+                process.exit(1);
+        }
         let coerced: number | boolean | string;
         if (/^\d+$/.test(TRUST_PROXY)) coerced = Number(TRUST_PROXY);
-        else if (TRUST_PROXY === "true") coerced = true;
         else if (TRUST_PROXY === "false") coerced = false;
         else coerced = TRUST_PROXY;
-        if (coerced === true) {
-                console.warn(
-                        "[server] TRUST_PROXY=true is UNSAFE: Express will take the leftmost " +
-                        "X-Forwarded-For entry (attacker-controlled), which bypasses per-IP " +
-                        "rate limiting on /auth. Use a hop count like '1' instead.",
-                );
-        }
         app.set("trust proxy", coerced);
 }
 app.use(express.json());

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -56,8 +56,12 @@ if (TRUST_PROXY !== undefined) {
                 process.exit(1);
         }
         let coerced: number | boolean | string;
-        if (/^\d+$/.test(TRUST_PROXY)) coerced = Number(TRUST_PROXY);
-        else if (TRUST_PROXY === "false") coerced = false;
+        // Explicit "0"/"false" → boolean false so we don't rely on Express's
+        // (undocumented) compileTrust(0) returning "never trust". If that
+        // internal ever changes, a string mistakenly treated as an IP would
+        // silently mis-trust; the explicit boolean keeps us pinned.
+        if (TRUST_PROXY === "0" || TRUST_PROXY === "false") coerced = false;
+        else if (/^\d+$/.test(TRUST_PROXY)) coerced = Number(TRUST_PROXY);
         else coerced = TRUST_PROXY;
         app.set("trust proxy", coerced);
         // Log the effective value so ops can spot a misconfigured prod

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -38,11 +38,18 @@ const docker = new DockerManager(sessions);
 
 const app = express();
 if (TRUST_PROXY !== undefined) {
-        // Numbers and "true" are meaningful to express; pass the raw string and
-        // let it coerce. This is load-bearing for rate limiting — without it,
-        // req.ip behind a tunnel is always the tunnel's IP so per-IP buckets
-        // collapse into one.
-        const coerced = /^\d+$/.test(TRUST_PROXY) ? Number(TRUST_PROXY) : TRUST_PROXY;
+        // Express accepts a boolean, a number (hop count), or a string/fn
+        // describing which IPs to trust. Environment values are always
+        // strings, so coerce "1" → 1, "true" → true, "false" → false
+        // explicitly; anything else (IPs, subnets, "loopback", …) passes
+        // through unchanged. Load-bearing for /auth rate limiting — without
+        // it, req.ip behind a tunnel is always the tunnel's IP so per-IP
+        // buckets collapse into one.
+        let coerced: number | boolean | string;
+        if (/^\d+$/.test(TRUST_PROXY)) coerced = Number(TRUST_PROXY);
+        else if (TRUST_PROXY === "true") coerced = true;
+        else if (TRUST_PROXY === "false") coerced = false;
+        else coerced = TRUST_PROXY;
         app.set("trust proxy", coerced);
 }
 app.use(express.json());

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,8 +21,14 @@ const PORT = parseInt(process.env.PORT ?? "3001", 10);
 const CORS_ORIGINS = (process.env.CORS_ORIGINS ?? "*").split(",");
 // TRUST_PROXY: used by req.ip (and therefore auth rate limiting) to pick the
 // real client from X-Forwarded-For instead of the tunnel's socket address.
-// Set to "1" for a single known proxy (e.g. Cloudflare Tunnel), a count, or
-// "true" to trust everything. Leave unset for direct localhost dev.
+// Set to the number of known hops in front of the backend — "1" for a
+// single Cloudflare Tunnel. Leave unset for direct localhost dev.
+//
+// Do NOT set this to "true": Express then takes the LEFTMOST X-Forwarded-For
+// entry, which is fully attacker-controlled. An attacker rotating
+// `X-Forwarded-For: <random>` per request would bypass the per-IP limiter
+// entirely. The hop count ("1", "2", …) picks the rightmost-untrusted
+// address, which is the real client.
 const TRUST_PROXY = process.env.TRUST_PROXY;
 
 // ── Validate config ───────────────────────────────────────────────────────────
@@ -38,18 +44,23 @@ const docker = new DockerManager(sessions);
 
 const app = express();
 if (TRUST_PROXY !== undefined) {
-        // Express accepts a boolean, a number (hop count), or a string/fn
-        // describing which IPs to trust. Environment values are always
-        // strings, so coerce "1" → 1, "true" → true, "false" → false
-        // explicitly; anything else (IPs, subnets, "loopback", …) passes
-        // through unchanged. Load-bearing for /auth rate limiting — without
-        // it, req.ip behind a tunnel is always the tunnel's IP so per-IP
-        // buckets collapse into one.
+        // Env values are strings; Express accepts a number (hop count), a
+        // boolean, or an IP/subnet list. Coerce "1" → 1, "false" → false,
+        // otherwise pass through for IPs/subnets. "true" is coerced and
+        // logged as a warning — see the security note above const
+        // TRUST_PROXY for why it's unsafe on a public endpoint.
         let coerced: number | boolean | string;
         if (/^\d+$/.test(TRUST_PROXY)) coerced = Number(TRUST_PROXY);
         else if (TRUST_PROXY === "true") coerced = true;
         else if (TRUST_PROXY === "false") coerced = false;
         else coerced = TRUST_PROXY;
+        if (coerced === true) {
+                console.warn(
+                        "[server] TRUST_PROXY=true is UNSAFE: Express will take the leftmost " +
+                        "X-Forwarded-For entry (attacker-controlled), which bypasses per-IP " +
+                        "rate limiting on /auth. Use a hop count like '1' instead.",
+                );
+        }
         app.set("trust proxy", coerced);
 }
 app.use(express.json());

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,11 @@ import { selectWsAuthProtocol } from "./auth.js";
 
 const PORT = parseInt(process.env.PORT ?? "3001", 10);
 const CORS_ORIGINS = (process.env.CORS_ORIGINS ?? "*").split(",");
+// TRUST_PROXY: used by req.ip (and therefore auth rate limiting) to pick the
+// real client from X-Forwarded-For instead of the tunnel's socket address.
+// Set to "1" for a single known proxy (e.g. Cloudflare Tunnel), a count, or
+// "true" to trust everything. Leave unset for direct localhost dev.
+const TRUST_PROXY = process.env.TRUST_PROXY;
 
 // ── Validate config ───────────────────────────────────────────────────────────
 
@@ -32,6 +37,14 @@ const docker = new DockerManager(sessions);
 // ── Express app ───────────────────────────────────────────────────────────────
 
 const app = express();
+if (TRUST_PROXY !== undefined) {
+        // Numbers and "true" are meaningful to express; pass the raw string and
+        // let it coerce. This is load-bearing for rate limiting — without it,
+        // req.ip behind a tunnel is always the tunnel's IP so per-IP buckets
+        // collapse into one.
+        const coerced = /^\d+$/.test(TRUST_PROXY) ? Number(TRUST_PROXY) : TRUST_PROXY;
+        app.set("trust proxy", coerced);
+}
 app.use(express.json());
 
 // CORS — allow frontend from Cloudflare Pages (or any configured origin)

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -3,18 +3,21 @@ import http from "http";
 import type { AddressInfo } from "net";
 import express from "express";
 
-import { UsernameRateLimiter, RateLimitError } from "./rateLimit.js";
-import { InvalidCredentialsError } from "./auth.js";
+import { UsernameRateLimiter } from "./rateLimit.js";
+import type { SessionManager } from "./sessionManager.js";
+import type { DockerManager } from "./dockerManager.js";
 
-// Stub the auth module so routing tests don't touch D1.
+// Stub the auth module so routing tests don't touch D1. Handles captured
+// as `authStubs` are reconfigured per-test.
 const authStubs = vi.hoisted(() => ({
 	registerUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	loginUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	hasAnyUsers: vi.fn(async () => true),
 	requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
-	// Re-export the error class so `import { InvalidCredentialsError }` above
-	// resolves to the same constructor the route handler uses (module-local
-	// mocks replace the whole module).
+	// The route handler checks `err instanceof InvalidCredentialsError` where
+	// `InvalidCredentialsError` is imported from `./auth.js`. Because we
+	// `vi.mock` the whole module, both the handler's import and the stub's
+	// throw resolve to this same constructor.
 	InvalidCredentialsError: class extends Error {
 		constructor() { super("Invalid credentials"); this.name = "InvalidCredentialsError"; }
 	},
@@ -24,39 +27,35 @@ vi.mock("./auth.js", () => authStubs);
 // `buildRouter` is imported AFTER the mock is in place.
 import { buildRouter } from "./routes.js";
 
+// Typed placeholders for the route tests — no session/docker routes are
+// hit in these scenarios, so an empty-object cast is fine AND preserves
+// type-checking if a future route starts calling into sessions/docker.
+const fakeSessions = {} as unknown as SessionManager;
+const fakeDocker = {} as unknown as DockerManager;
+
 // ── UsernameRateLimiter unit tests ─────────────────────────────────────────
 
 describe("UsernameRateLimiter", () => {
-	it("allows attempts up to the configured max", () => {
+	it("allows attempts up to max; blocks the (max+1)th with retryAfterSeconds", () => {
 		const rl = new UsernameRateLimiter(3, 60_000);
-		// 3 allowed assertAllowed calls, each followed by a recorded failure.
 		for (let i = 0; i < 3; i++) {
-			expect(() => rl.assertAllowed("alice")).not.toThrow();
+			expect(rl.check("alice").allowed).toBe(true);
 			rl.recordFailure("alice");
 		}
-	});
-
-	it("throws RateLimitError with retryAfterSeconds on the (max+1)th attempt", () => {
-		const rl = new UsernameRateLimiter(2, 60_000);
-		rl.recordFailure("alice");
-		rl.recordFailure("alice");
-		let thrown: unknown;
-		try {
-			rl.assertAllowed("alice");
-		} catch (err) { thrown = err; }
-		expect(thrown).toBeInstanceOf(RateLimitError);
-		const rle = thrown as RateLimitError;
-		// 60_000ms window → between 1 and 60 seconds remaining.
-		expect(rle.retryAfterSeconds).toBeGreaterThan(0);
-		expect(rle.retryAfterSeconds).toBeLessThanOrEqual(60);
+		const blocked = rl.check("alice");
+		expect(blocked.allowed).toBe(false);
+		if (!blocked.allowed) {
+			expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+			expect(blocked.retryAfterSeconds).toBeLessThanOrEqual(60);
+		}
 	});
 
 	it("isolates buckets per username", () => {
 		const rl = new UsernameRateLimiter(1, 60_000);
 		rl.recordFailure("alice");
-		expect(() => rl.assertAllowed("alice")).toThrow(RateLimitError);
-		// bob is untouched
-		expect(() => rl.assertAllowed("bob")).not.toThrow();
+		expect(rl.check("alice").allowed).toBe(false);
+		// bob is untouched.
+		expect(rl.check("bob").allowed).toBe(true);
 	});
 
 	it("resets the window automatically after windowMs elapses", () => {
@@ -64,24 +63,24 @@ describe("UsernameRateLimiter", () => {
 		try {
 			const rl = new UsernameRateLimiter(1, 60_000);
 			rl.recordFailure("alice");
-			expect(() => rl.assertAllowed("alice")).toThrow(RateLimitError);
+			expect(rl.check("alice").allowed).toBe(false);
 			vi.advanceTimersByTime(60_001);
-			expect(() => rl.assertAllowed("alice")).not.toThrow();
+			expect(rl.check("alice").allowed).toBe(true);
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
-	it("reset(username) clears a single bucket, clear() clears all", () => {
+	it("reset(username) clears a single bucket, clearForTesting() clears all", () => {
 		const rl = new UsernameRateLimiter(1, 60_000);
 		rl.recordFailure("alice");
 		rl.recordFailure("bob");
 		rl.reset("alice");
-		expect(() => rl.assertAllowed("alice")).not.toThrow();
-		expect(() => rl.assertAllowed("bob")).toThrow(RateLimitError);
+		expect(rl.check("alice").allowed).toBe(true);
+		expect(rl.check("bob").allowed).toBe(false);
 
-		rl.clear();
-		expect(() => rl.assertAllowed("bob")).not.toThrow();
+		rl.clearForTesting();
+		expect(rl.check("bob").allowed).toBe(true);
 	});
 
 	it("recordFailure past the window starts a fresh counter", () => {
@@ -90,57 +89,100 @@ describe("UsernameRateLimiter", () => {
 			const rl = new UsernameRateLimiter(2, 60_000);
 			rl.recordFailure("alice");
 			rl.recordFailure("alice");
-			// At max. Advance past the window then record again — should be a
-			// fresh bucket at count=1, so we're below the limit again.
 			vi.advanceTimersByTime(60_001);
 			rl.recordFailure("alice");
-			expect(() => rl.assertAllowed("alice")).not.toThrow();
+			expect(rl.check("alice").allowed).toBe(true);
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
 	it("caps total tracked usernames and evicts oldest when full (DoS guard)", () => {
-		// Size 3 means after four distinct bad usernames we've dropped the
-		// first. `u0` should be gone; `u1..u3` should remain.
 		const rl = new UsernameRateLimiter(5, 60_000, 3);
 		rl.recordFailure("u0");
 		rl.recordFailure("u1");
 		rl.recordFailure("u2");
-		expect(rl.size()).toBe(3);
+		expect(rl.sizeForTesting()).toBe(3);
 
 		rl.recordFailure("u3");
-		expect(rl.size()).toBe(3);
+		expect(rl.sizeForTesting()).toBe(3);
 
-		// `u0` was evicted, so its counter is gone — first hit here is a
-		// fresh bucket at 1, not resumed at 2. Observable via the fact that
-		// we never throw even if the cap threshold is 5.
-		expect(() => rl.assertAllowed("u0")).not.toThrow();
+		// u0 was evicted FIFO — check() returns allowed and no bucket remains,
+		// and a fresh recordFailure gets a new count-1 bucket rather than
+		// resuming u0's prior state.
+		expect(rl.check("u0").allowed).toBe(true);
 	});
 
 	it("prefers expired entries over live ones when the cap is hit", () => {
 		vi.useFakeTimers();
 		try {
-			// Fill the cap. u0/u1 will expire; u2 is added right before the
-			// sweep so it survives, and the new insert must land without
-			// evicting u2.
 			const rl = new UsernameRateLimiter(5, 60_000, 3);
 			rl.recordFailure("u0"); // resetAt = t + 60_000
 			rl.recordFailure("u1"); // resetAt = t + 60_000
-			vi.advanceTimersByTime(59_000); // +59s
-			rl.recordFailure("u2"); // resetAt = t + 59_000 + 60_000 = t + 119_000
-			vi.advanceTimersByTime(2_000); // +61s total; u0/u1 expired, u2 still live
+			vi.advanceTimersByTime(59_000);
+			rl.recordFailure("u2"); // resetAt = t + 119_000 (latest)
+			vi.advanceTimersByTime(2_000); // u0/u1 expired; u2 still live
 
-			rl.recordFailure("u3"); // triggers evictExpired + insert
-			// u0/u1 should be gone (expired and swept); u2 survives because it
-			// hadn't expired yet. u3 is the new bucket.
-			expect(rl.size()).toBe(2);
-			// u2 specifically — not evicted by the FIFO fallback.
-			rl.recordFailure("u2");
-			// If it had been evicted this would be count=1; still live means
-			// count=2 — either way it doesn't throw at max=5. Just assert it
-			// stayed in the map.
-			expect(rl.size()).toBe(2);
+			rl.recordFailure("u3"); // overflow → evictExpired removes u0/u1
+			// u2 survives because it hadn't expired; u3 is the new slot.
+			expect(rl.sizeForTesting()).toBe(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("resetting an expired entry at full capacity doesn't evict a live entry", () => {
+		// Regression guard for the eviction path the reviewer called out:
+		// map is at capacity, `alice`'s entry has just expired. Re-tracking
+		// `alice` should NOT FIFO-evict one of the live entries — alice's
+		// stale slot is the one that frees up space.
+		vi.useFakeTimers();
+		try {
+			const rl = new UsernameRateLimiter(5, 60_000, 3);
+			rl.recordFailure("alice"); // t=0, resetAt=60_000
+			rl.recordFailure("bob");   // t=0, resetAt=60_000
+			rl.recordFailure("carol"); // t=0, resetAt=60_000
+			expect(rl.sizeForTesting()).toBe(3);
+
+			// Expire alice alone.
+			vi.setSystemTime(30_000);
+			// Refresh bob and carol so they stay live past alice's resetAt.
+			rl.recordFailure("bob");   // live, count=2
+			rl.recordFailure("carol"); // live, count=2
+			vi.setSystemTime(60_001); // alice expired; bob/carol still live
+
+			rl.recordFailure("alice"); // should reclaim alice's slot, not evict bob/carol
+
+			// Three entries total, bob and carol both intact with their count=2.
+			expect(rl.sizeForTesting()).toBe(3);
+			rl.recordFailure("bob");
+			// bob's count went 2→3 (live), not 1→2 (would indicate it was evicted
+			// and re-added). At max=5 still allowed, so check passes.
+			expect(rl.check("bob").allowed).toBe(true);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("re-tracking an expired entry moves it to the end of FIFO order", () => {
+		// After `alice` expires and is re-tracked, she should be the YOUNGEST
+		// entry (evicted last), not frozen in her original position.
+		vi.useFakeTimers();
+		try {
+			const rl = new UsernameRateLimiter(5, 60_000, 3);
+			rl.recordFailure("alice"); // inserted first
+			rl.recordFailure("bob");
+			rl.recordFailure("carol");
+			vi.advanceTimersByTime(60_001); // everyone expired
+
+			rl.recordFailure("alice"); // fresh bucket — should land at end
+			rl.recordFailure("dave");  // new — triggers overflow logic
+			rl.recordFailure("eve");
+
+			// Size is capped at 3; bob and carol should have been evicted
+			// before alice (she was re-inserted at the end after expiry).
+			expect(rl.sizeForTesting()).toBe(3);
+			expect(rl.check("alice").allowed).toBe(true); // still present
 		} finally {
 			vi.useRealTimers();
 		}
@@ -148,22 +190,15 @@ describe("UsernameRateLimiter", () => {
 });
 
 // ── Route-level integration tests ──────────────────────────────────────────
-//
-// Fire real HTTP requests at an ephemeral server so we're exercising the
-// express-rate-limit middleware as it'll run in prod — headers, 429 status,
-// Retry-After, the works. The auth module is stubbed so nothing touches D1.
 
 describe("auth route rate limiting", () => {
 	let server: http.Server | null = null;
 	let baseUrl: string;
 
-	// Default stub behaviour reset before each test; tight per-test limits
-	// set via spinUp() so individual tests can raise the IP ceiling when
-	// they only care about the per-username path.
 	beforeEach(() => {
 		authStubs.registerUser.mockClear();
 		authStubs.loginUser.mockClear();
-		// Default: loginUser rejects as bad creds (typed so the handler counts it).
+		// Default: loginUser fails as bad creds (typed so the handler counts it).
 		authStubs.loginUser.mockImplementation(async () => {
 			throw new authStubs.InvalidCredentialsError();
 		});
@@ -181,7 +216,7 @@ describe("auth route rate limiting", () => {
 		login: { ipMax: number; ipWindowMs: number; usernameMax: number; usernameWindowMs: number };
 		register: { ipMax: number; ipWindowMs: number };
 	}): Promise<void> {
-		const router = buildRouter({} as never, {} as never, cfg);
+		const router = buildRouter(fakeSessions, fakeDocker, cfg);
 		const app = express();
 		app.use(express.json());
 		app.use("/api", router);
@@ -208,8 +243,6 @@ describe("auth route rate limiting", () => {
 	}
 
 	it("login returns 429 after ipMax from one IP — 4th request is blocked", async () => {
-		// ipMax=3, usernameMax ridiculously high so only the IP limit can fire.
-		// Distinct usernames per call so the per-username bucket is irrelevant.
 		await spinUp({
 			login: { ipMax: 3, ipWindowMs: 60_000, usernameMax: 1_000, usernameWindowMs: 60_000 },
 			register: { ipMax: 100, ipWindowMs: 60_000 },
@@ -244,9 +277,6 @@ describe("auth route rate limiting", () => {
 	});
 
 	it("per-username limit blocks a third bad attempt even when IP limit would allow it", async () => {
-		// usernameMax=2 exhausts alice after two failures. ipMax high so the
-		// 429 on the 3rd request has to come from the username limiter, not
-		// express-rate-limit.
 		await spinUp({
 			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
 			register: { ipMax: 100, ipWindowMs: 60_000 },
@@ -261,18 +291,11 @@ describe("auth route rate limiting", () => {
 		expect(r3.status).toBe(429);
 		expect(r3.headers.get("retry-after")).not.toBeNull();
 
-		// 429 came via our handler (before bcrypt), so loginUser was called
-		// twice, not three times — the expensive hash never ran on the 3rd.
+		// loginUser is called exactly twice — bcrypt is skipped on the 3rd.
 		expect(authStubs.loginUser).toHaveBeenCalledTimes(2);
 	});
 
 	it("a successful login resets the per-username counter", async () => {
-		// usernameMax=2, ipMax high. The key sequence:
-		//   fail → success (reset) → fail → fail
-		// All four login attempts should be handled normally (401/200/401/401).
-		// Without the reset-on-success, the fourth call would hit assertAllowed
-		// with count=2 already and return 429 — so 401 on r4 is the load-
-		// bearing assertion here.
 		await spinUp({
 			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
 			register: { ipMax: 100, ipWindowMs: 60_000 },
@@ -303,16 +326,11 @@ describe("auth route rate limiting", () => {
 		const registerRes = await postRegister({ username: huge, password: "secret123" });
 		expect(registerRes.status).toBe(400);
 
-		// Neither request reached the auth module — the whole point of the
-		// upfront length check is to keep huge strings out of both D1 and
-		// the in-memory limiter map.
 		expect(authStubs.loginUser).not.toHaveBeenCalled();
 		expect(authStubs.registerUser).not.toHaveBeenCalled();
 	});
 
 	it("infra errors from loginUser don't count toward the per-username lockout", async () => {
-		// Regression guard: a D1 outage would otherwise be indistinguishable
-		// from a bad password and lock out legitimate users during downtime.
 		await spinUp({
 			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
 			register: { ipMax: 100, ipWindowMs: 60_000 },
@@ -321,8 +339,6 @@ describe("auth route rate limiting", () => {
 			throw new Error("D1 timeout");
 		});
 
-		// Three attempts — if the handler incremented on every throw, the 3rd
-		// would be 429. With typed-error filtering, all three should 500.
 		const r1 = await postLogin({ username: "alice", password: "bad" });
 		const r2 = await postLogin({ username: "alice", password: "bad" });
 		const r3 = await postLogin({ username: "alice", password: "bad" });
@@ -332,7 +348,6 @@ describe("auth route rate limiting", () => {
 	});
 
 	it("429 bodies carry a `scope` field so the UI can tell IP vs username lockout apart", async () => {
-		// IP-scoped 429 from express-rate-limit.
 		await spinUp({
 			login: { ipMax: 1, ipWindowMs: 60_000, usernameMax: 100, usernameWindowMs: 60_000 },
 			register: { ipMax: 100, ipWindowMs: 60_000 },
@@ -342,7 +357,6 @@ describe("auth route rate limiting", () => {
 		expect(ipBlocked.status).toBe(429);
 		expect(await ipBlocked.json()).toMatchObject({ scope: "ip" });
 
-		// Tear down and bring up a fresh server where only the username layer fires.
 		await new Promise<void>((resolve) => server!.close(() => resolve()));
 		server = null;
 
@@ -357,10 +371,6 @@ describe("auth route rate limiting", () => {
 	});
 
 	it("once per-username max is reached, even the correct password 429s until the window resets", async () => {
-		// Strict lockout: we assertAllowed BEFORE verifying the password, so a
-		// blocked account stays blocked for the rest of the window. Trade-off
-		// is worth it — the alternative runs bcrypt on every guess and leaks
-		// timing info.
 		await spinUp({
 			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
 			register: { ipMax: 100, ipWindowMs: 60_000 },
@@ -369,7 +379,6 @@ describe("auth route rate limiting", () => {
 		await postLogin({ username: "alice", password: "bad" });
 		await postLogin({ username: "alice", password: "bad" });
 
-		// Even a "correct" password now 429s — bucket is at max.
 		authStubs.loginUser.mockImplementationOnce(async () => ({ userId: "u1", token: "tok" }));
 		const locked = await postLogin({ username: "alice", password: "good" });
 		expect(locked.status).toBe(429);

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -95,6 +95,52 @@ describe("UsernameRateLimiter", () => {
 			vi.useRealTimers();
 		}
 	});
+
+	it("caps total tracked usernames and evicts oldest when full (DoS guard)", () => {
+		// Size 3 means after four distinct bad usernames we've dropped the
+		// first. `u0` should be gone; `u1..u3` should remain.
+		const rl = new UsernameRateLimiter(5, 60_000, 3);
+		rl.recordFailure("u0");
+		rl.recordFailure("u1");
+		rl.recordFailure("u2");
+		expect(rl.size()).toBe(3);
+
+		rl.recordFailure("u3");
+		expect(rl.size()).toBe(3);
+
+		// `u0` was evicted, so its counter is gone — first hit here is a
+		// fresh bucket at 1, not resumed at 2. Observable via the fact that
+		// we never throw even if the cap threshold is 5.
+		expect(() => rl.assertAllowed("u0")).not.toThrow();
+	});
+
+	it("prefers expired entries over live ones when the cap is hit", () => {
+		vi.useFakeTimers();
+		try {
+			// Fill the cap. u0/u1 will expire; u2 is added right before the
+			// sweep so it survives, and the new insert must land without
+			// evicting u2.
+			const rl = new UsernameRateLimiter(5, 60_000, 3);
+			rl.recordFailure("u0"); // resetAt = t + 60_000
+			rl.recordFailure("u1"); // resetAt = t + 60_000
+			vi.advanceTimersByTime(59_000); // +59s
+			rl.recordFailure("u2"); // resetAt = t + 59_000 + 60_000 = t + 119_000
+			vi.advanceTimersByTime(2_000); // +61s total; u0/u1 expired, u2 still live
+
+			rl.recordFailure("u3"); // triggers evictExpired + insert
+			// u0/u1 should be gone (expired and swept); u2 survives because it
+			// hadn't expired yet. u3 is the new bucket.
+			expect(rl.size()).toBe(2);
+			// u2 specifically — not evicted by the FIFO fallback.
+			rl.recordFailure("u2");
+			// If it had been evicted this would be count=1; still live means
+			// count=2 — either way it doesn't throw at max=5. Just assert it
+			// stayed in the map.
+			expect(rl.size()).toBe(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });
 
 // ── Route-level integration tests ──────────────────────────────────────────

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -286,6 +286,25 @@ describe("auth route rate limiting", () => {
 		expect(r4.status).toBe(401);
 	});
 
+	it("rejects usernames over 64 chars with 400 before touching the limiter or auth module", async () => {
+		await spinUp({
+			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+		const huge = "a".repeat(65);
+
+		const loginRes = await postLogin({ username: huge, password: "bad" });
+		expect(loginRes.status).toBe(400);
+		const registerRes = await postRegister({ username: huge, password: "secret123" });
+		expect(registerRes.status).toBe(400);
+
+		// Neither request reached the auth module — the whole point of the
+		// upfront length check is to keep huge strings out of both D1 and
+		// the in-memory limiter map.
+		expect(authStubs.loginUser).not.toHaveBeenCalled();
+		expect(authStubs.registerUser).not.toHaveBeenCalled();
+	});
+
 	it("once per-username max is reached, even the correct password 429s until the window resets", async () => {
 		// Strict lockout: we assertAllowed BEFORE verifying the password, so a
 		// blocked account stays blocked for the rest of the window. Trade-off

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import http from "http";
+import type { AddressInfo } from "net";
+import express from "express";
+
+import { UsernameRateLimiter, RateLimitError } from "./rateLimit.js";
+
+// `routes.ts` calls registerUser / loginUser / hasAnyUsers from `./auth.js`,
+// which talk to D1. Stub the whole module so routing tests don't need a real
+// database. Stubs are configured per-test via the handles captured below.
+const authStubs = vi.hoisted(() => ({
+	registerUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
+	loginUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
+	hasAnyUsers: vi.fn(async () => true),
+	requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("./auth.js", () => authStubs);
+
+// `buildRouter` is imported AFTER the mock is in place.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import { buildRouter } from "./routes.js";
+
+// ── UsernameRateLimiter unit tests ─────────────────────────────────────────
+
+describe("UsernameRateLimiter", () => {
+	it("allows attempts up to the configured max", () => {
+		const rl = new UsernameRateLimiter(3, 60_000);
+		// 3 allowed assertAllowed calls, each followed by a recorded failure.
+		for (let i = 0; i < 3; i++) {
+			expect(() => rl.assertAllowed("alice")).not.toThrow();
+			rl.recordFailure("alice");
+		}
+	});
+
+	it("throws RateLimitError with retryAfterSeconds on the (max+1)th attempt", () => {
+		const rl = new UsernameRateLimiter(2, 60_000);
+		rl.recordFailure("alice");
+		rl.recordFailure("alice");
+		let thrown: unknown;
+		try {
+			rl.assertAllowed("alice");
+		} catch (err) { thrown = err; }
+		expect(thrown).toBeInstanceOf(RateLimitError);
+		const rle = thrown as RateLimitError;
+		// 60_000ms window → between 1 and 60 seconds remaining.
+		expect(rle.retryAfterSeconds).toBeGreaterThan(0);
+		expect(rle.retryAfterSeconds).toBeLessThanOrEqual(60);
+	});
+
+	it("isolates buckets per username", () => {
+		const rl = new UsernameRateLimiter(1, 60_000);
+		rl.recordFailure("alice");
+		expect(() => rl.assertAllowed("alice")).toThrow(RateLimitError);
+		// bob is untouched
+		expect(() => rl.assertAllowed("bob")).not.toThrow();
+	});
+
+	it("resets the window automatically after windowMs elapses", () => {
+		vi.useFakeTimers();
+		try {
+			const rl = new UsernameRateLimiter(1, 60_000);
+			rl.recordFailure("alice");
+			expect(() => rl.assertAllowed("alice")).toThrow(RateLimitError);
+			vi.advanceTimersByTime(60_001);
+			expect(() => rl.assertAllowed("alice")).not.toThrow();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("reset(username) clears a single bucket, clear() clears all", () => {
+		const rl = new UsernameRateLimiter(1, 60_000);
+		rl.recordFailure("alice");
+		rl.recordFailure("bob");
+		rl.reset("alice");
+		expect(() => rl.assertAllowed("alice")).not.toThrow();
+		expect(() => rl.assertAllowed("bob")).toThrow(RateLimitError);
+
+		rl.clear();
+		expect(() => rl.assertAllowed("bob")).not.toThrow();
+	});
+
+	it("recordFailure past the window starts a fresh counter", () => {
+		vi.useFakeTimers();
+		try {
+			const rl = new UsernameRateLimiter(2, 60_000);
+			rl.recordFailure("alice");
+			rl.recordFailure("alice");
+			// At max. Advance past the window then record again — should be a
+			// fresh bucket at count=1, so we're below the limit again.
+			vi.advanceTimersByTime(60_001);
+			rl.recordFailure("alice");
+			expect(() => rl.assertAllowed("alice")).not.toThrow();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+// ── Route-level integration tests ──────────────────────────────────────────
+//
+// Fire real HTTP requests at an ephemeral server so we're exercising the
+// express-rate-limit middleware as it'll run in prod — headers, 429 status,
+// Retry-After, the works. The auth module is stubbed so nothing touches D1.
+
+describe("auth route rate limiting", () => {
+	let server: http.Server | null = null;
+	let baseUrl: string;
+
+	// Default stub behaviour reset before each test; tight per-test limits
+	// set via spinUp() so individual tests can raise the IP ceiling when
+	// they only care about the per-username path.
+	beforeEach(() => {
+		authStubs.registerUser.mockClear();
+		authStubs.loginUser.mockClear();
+		authStubs.loginUser.mockImplementation(async () => {
+			throw new Error("Invalid credentials");
+		});
+		authStubs.registerUser.mockImplementation(async () => ({ userId: "u1", token: "tok" }));
+	});
+
+	afterEach(async () => {
+		if (server) {
+			await new Promise<void>((resolve) => server!.close(() => resolve()));
+			server = null;
+		}
+	});
+
+	async function spinUp(cfg: {
+		login: { ipMax: number; ipWindowMs: number; usernameMax: number; usernameWindowMs: number };
+		register: { ipMax: number; ipWindowMs: number };
+	}): Promise<void> {
+		const router = buildRouter({} as never, {} as never, cfg);
+		const app = express();
+		app.use(express.json());
+		app.use("/api", router);
+
+		server = http.createServer(app);
+		await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+		const { port } = server.address() as AddressInfo;
+		baseUrl = `http://127.0.0.1:${port}`;
+	}
+
+	async function postLogin(body: { username?: string; password?: string }): Promise<Response> {
+		return fetch(`${baseUrl}/api/auth/login`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	}
+	async function postRegister(body: { username?: string; password?: string }): Promise<Response> {
+		return fetch(`${baseUrl}/api/auth/register`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	}
+
+	it("login returns 429 after ipMax from one IP — 4th request is blocked", async () => {
+		// ipMax=3, usernameMax ridiculously high so only the IP limit can fire.
+		// Distinct usernames per call so the per-username bucket is irrelevant.
+		await spinUp({
+			login: { ipMax: 3, ipWindowMs: 60_000, usernameMax: 1_000, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+
+		const r1 = await postLogin({ username: "u1", password: "bad" });
+		const r2 = await postLogin({ username: "u2", password: "bad" });
+		const r3 = await postLogin({ username: "u3", password: "bad" });
+		const r4 = await postLogin({ username: "u4", password: "bad" });
+
+		expect(r1.status).toBe(401);
+		expect(r2.status).toBe(401);
+		expect(r3.status).toBe(401);
+		expect(r4.status).toBe(429);
+		expect(r4.headers.get("retry-after")).not.toBeNull();
+	});
+
+	it("register returns 429 after ipMax attempts with Retry-After set", async () => {
+		await spinUp({
+			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 100, usernameWindowMs: 60_000 },
+			register: { ipMax: 2, ipWindowMs: 60_000 },
+		});
+
+		const r1 = await postRegister({ username: "a", password: "secret123" });
+		const r2 = await postRegister({ username: "b", password: "secret123" });
+		const r3 = await postRegister({ username: "c", password: "secret123" });
+
+		expect(r1.status).toBe(201);
+		expect(r2.status).toBe(201);
+		expect(r3.status).toBe(429);
+		expect(r3.headers.get("retry-after")).not.toBeNull();
+	});
+
+	it("per-username limit blocks a third bad attempt even when IP limit would allow it", async () => {
+		// usernameMax=2 exhausts alice after two failures. ipMax high so the
+		// 429 on the 3rd request has to come from the username limiter, not
+		// express-rate-limit.
+		await spinUp({
+			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+
+		const r1 = await postLogin({ username: "alice", password: "bad" });
+		const r2 = await postLogin({ username: "alice", password: "bad" });
+		const r3 = await postLogin({ username: "alice", password: "bad" });
+
+		expect(r1.status).toBe(401);
+		expect(r2.status).toBe(401);
+		expect(r3.status).toBe(429);
+		expect(r3.headers.get("retry-after")).not.toBeNull();
+
+		// 429 came via our handler (before bcrypt), so loginUser was called
+		// twice, not three times — the expensive hash never ran on the 3rd.
+		expect(authStubs.loginUser).toHaveBeenCalledTimes(2);
+	});
+
+	it("a successful login resets the per-username counter", async () => {
+		// usernameMax=2, ipMax high. The key sequence:
+		//   fail → success (reset) → fail → fail
+		// All four login attempts should be handled normally (401/200/401/401).
+		// Without the reset-on-success, the fourth call would hit assertAllowed
+		// with count=2 already and return 429 — so 401 on r4 is the load-
+		// bearing assertion here.
+		await spinUp({
+			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+
+		const r1 = await postLogin({ username: "alice", password: "bad" });
+		expect(r1.status).toBe(401);
+
+		authStubs.loginUser.mockImplementationOnce(async () => ({ userId: "u1", token: "tok" }));
+		const r2 = await postLogin({ username: "alice", password: "good" });
+		expect(r2.status).toBe(200);
+
+		const r3 = await postLogin({ username: "alice", password: "bad" });
+		const r4 = await postLogin({ username: "alice", password: "bad" });
+		expect(r3.status).toBe(401);
+		expect(r4.status).toBe(401);
+	});
+
+	it("once per-username max is reached, even the correct password 429s until the window resets", async () => {
+		// Strict lockout: we assertAllowed BEFORE verifying the password, so a
+		// blocked account stays blocked for the rest of the window. Trade-off
+		// is worth it — the alternative runs bcrypt on every guess and leaks
+		// timing info.
+		await spinUp({
+			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+
+		await postLogin({ username: "alice", password: "bad" });
+		await postLogin({ username: "alice", password: "bad" });
+
+		// Even a "correct" password now 429s — bucket is at max.
+		authStubs.loginUser.mockImplementationOnce(async () => ({ userId: "u1", token: "tok" }));
+		const locked = await postLogin({ username: "alice", password: "good" });
+		expect(locked.status).toBe(429);
+	});
+});

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -4,20 +4,24 @@ import type { AddressInfo } from "net";
 import express from "express";
 
 import { UsernameRateLimiter, RateLimitError } from "./rateLimit.js";
+import { InvalidCredentialsError } from "./auth.js";
 
-// `routes.ts` calls registerUser / loginUser / hasAnyUsers from `./auth.js`,
-// which talk to D1. Stub the whole module so routing tests don't need a real
-// database. Stubs are configured per-test via the handles captured below.
+// Stub the auth module so routing tests don't touch D1.
 const authStubs = vi.hoisted(() => ({
 	registerUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	loginUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	hasAnyUsers: vi.fn(async () => true),
 	requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+	// Re-export the error class so `import { InvalidCredentialsError }` above
+	// resolves to the same constructor the route handler uses (module-local
+	// mocks replace the whole module).
+	InvalidCredentialsError: class extends Error {
+		constructor() { super("Invalid credentials"); this.name = "InvalidCredentialsError"; }
+	},
 }));
 vi.mock("./auth.js", () => authStubs);
 
 // `buildRouter` is imported AFTER the mock is in place.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 import { buildRouter } from "./routes.js";
 
 // ── UsernameRateLimiter unit tests ─────────────────────────────────────────
@@ -159,8 +163,9 @@ describe("auth route rate limiting", () => {
 	beforeEach(() => {
 		authStubs.registerUser.mockClear();
 		authStubs.loginUser.mockClear();
+		// Default: loginUser rejects as bad creds (typed so the handler counts it).
 		authStubs.loginUser.mockImplementation(async () => {
-			throw new Error("Invalid credentials");
+			throw new authStubs.InvalidCredentialsError();
 		});
 		authStubs.registerUser.mockImplementation(async () => ({ userId: "u1", token: "tok" }));
 	});
@@ -303,6 +308,52 @@ describe("auth route rate limiting", () => {
 		// the in-memory limiter map.
 		expect(authStubs.loginUser).not.toHaveBeenCalled();
 		expect(authStubs.registerUser).not.toHaveBeenCalled();
+	});
+
+	it("infra errors from loginUser don't count toward the per-username lockout", async () => {
+		// Regression guard: a D1 outage would otherwise be indistinguishable
+		// from a bad password and lock out legitimate users during downtime.
+		await spinUp({
+			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 2, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+		authStubs.loginUser.mockImplementation(async () => {
+			throw new Error("D1 timeout");
+		});
+
+		// Three attempts — if the handler incremented on every throw, the 3rd
+		// would be 429. With typed-error filtering, all three should 500.
+		const r1 = await postLogin({ username: "alice", password: "bad" });
+		const r2 = await postLogin({ username: "alice", password: "bad" });
+		const r3 = await postLogin({ username: "alice", password: "bad" });
+		expect(r1.status).toBe(500);
+		expect(r2.status).toBe(500);
+		expect(r3.status).toBe(500);
+	});
+
+	it("429 bodies carry a `scope` field so the UI can tell IP vs username lockout apart", async () => {
+		// IP-scoped 429 from express-rate-limit.
+		await spinUp({
+			login: { ipMax: 1, ipWindowMs: 60_000, usernameMax: 100, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+		await postLogin({ username: "u1", password: "bad" });
+		const ipBlocked = await postLogin({ username: "u2", password: "bad" });
+		expect(ipBlocked.status).toBe(429);
+		expect(await ipBlocked.json()).toMatchObject({ scope: "ip" });
+
+		// Tear down and bring up a fresh server where only the username layer fires.
+		await new Promise<void>((resolve) => server!.close(() => resolve()));
+		server = null;
+
+		await spinUp({
+			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 1, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+		await postLogin({ username: "alice", password: "bad" });
+		const usernameBlocked = await postLogin({ username: "alice", password: "bad" });
+		expect(usernameBlocked.status).toBe(429);
+		expect(await usernameBlocked.json()).toMatchObject({ scope: "username" });
 	});
 
 	it("once per-username max is reached, even the correct password 429s until the window resets", async () => {

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -260,6 +260,32 @@ describe("auth route rate limiting", () => {
 		expect(r4.headers.get("retry-after")).not.toBeNull();
 	});
 
+	it("successful logins don't consume the login IP budget (skipSuccessfulRequests)", async () => {
+		// ipMax=2. Three successes shouldn't move the budget; two subsequent
+		// failures exhaust it and the third is 429.
+		await spinUp({
+			login: { ipMax: 2, ipWindowMs: 60_000, usernameMax: 1_000, usernameWindowMs: 60_000 },
+			register: { ipMax: 100, ipWindowMs: 60_000 },
+		});
+
+		authStubs.loginUser.mockImplementation(async () => ({ userId: "u1", token: "tok" }));
+		for (let i = 0; i < 3; i++) {
+			const ok = await postLogin({ username: `u${i}`, password: "good" });
+			expect(ok.status).toBe(200);
+		}
+
+		authStubs.loginUser.mockImplementation(async () => {
+			throw new authStubs.InvalidCredentialsError();
+		});
+		const f1 = await postLogin({ username: "x", password: "bad" });
+		const f2 = await postLogin({ username: "y", password: "bad" });
+		const f3 = await postLogin({ username: "z", password: "bad" });
+		expect(f1.status).toBe(401);
+		expect(f2.status).toBe(401);
+		expect(f3.status).toBe(429);
+		expect(await f3.json()).toMatchObject({ scope: "ip" });
+	});
+
 	it("register returns 429 after ipMax attempts with Retry-After set", async () => {
 		await spinUp({
 			login: { ipMax: 100, ipWindowMs: 60_000, usernameMax: 100, usernameWindowMs: 60_000 },
@@ -368,6 +394,10 @@ describe("auth route rate limiting", () => {
 		const usernameBlocked = await postLogin({ username: "alice", password: "bad" });
 		expect(usernameBlocked.status).toBe(429);
 		expect(await usernameBlocked.json()).toMatchObject({ scope: "username" });
+		// Emits the same draft-7 shape the IP limiter does — clients parsing
+		// RateLimit-Policy see a consistent response across both layers.
+		expect(usernameBlocked.headers.get("ratelimit-policy")).toMatch(/^\d+;w=\d+$/);
+		expect(usernameBlocked.headers.get("ratelimit")).toMatch(/limit=\d+, remaining=0, reset=\d+/);
 	});
 
 	it("once per-username max is reached, even the correct password 429s until the window resets", async () => {

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -1,0 +1,142 @@
+/**
+ * rateLimit.ts — Rate limiters for the public /auth routes.
+ *
+ * Two layers defend against credential brute-force:
+ *  1. Per-IP, via `express-rate-limit` (middleware). Stops a single machine
+ *     from hammering the endpoint.
+ *  2. Per-username, via the in-process `UsernameRateLimiter` below. Counts
+ *     FAILED logins only and resets on success, so a botnet distributing
+ *     guesses across many IPs can still be throttled on a single account.
+ *
+ * Both are in-memory — fine for the single-node deployment described in
+ * CLAUDE.md. If this ever scales horizontally, swap the store for Redis.
+ */
+
+import rateLimit, { type RateLimitRequestHandler } from "express-rate-limit";
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+export interface RateLimitConfig {
+	login: {
+		ipMax: number;
+		ipWindowMs: number;
+		usernameMax: number;
+		usernameWindowMs: number;
+	};
+	register: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
+}
+
+// Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
+export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
+	login: {
+		ipMax: 10,
+		ipWindowMs: 15 * 60 * 1000,
+		usernameMax: 10,
+		usernameWindowMs: 15 * 60 * 1000,
+	},
+	register: {
+		ipMax: 5,
+		ipWindowMs: 60 * 60 * 1000,
+	},
+};
+
+// ── IP-based limiters (express-rate-limit) ─────────────────────────────────
+
+export interface AuthRateLimiters {
+	loginIp: RateLimitRequestHandler;
+	registerIp: RateLimitRequestHandler;
+}
+
+export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
+	// standardHeaders: draft-7 sends RateLimit-* and Retry-After on 429.
+	// legacyHeaders: false suppresses the older X-RateLimit-* variants.
+	// Response body is explicit JSON so the frontend can read `error` like
+	// every other 4xx on this surface.
+	const loginIp = rateLimit({
+		windowMs: cfg.login.ipWindowMs,
+		limit: cfg.login.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: { error: "Too many login attempts from this IP, try again later" },
+	});
+	const registerIp = rateLimit({
+		windowMs: cfg.register.ipWindowMs,
+		limit: cfg.register.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: { error: "Too many registration attempts from this IP, try again later" },
+	});
+	return { loginIp, registerIp };
+}
+
+// ── Per-username limiter ────────────────────────────────────────────────────
+
+export class RateLimitError extends Error {
+	readonly retryAfterSeconds: number;
+	constructor(retryAfterSeconds: number) {
+		super("Too many failed attempts for this username, try again later");
+		this.name = "RateLimitError";
+		this.retryAfterSeconds = retryAfterSeconds;
+	}
+}
+
+interface FailedAttempts {
+	count: number;
+	resetAt: number;
+}
+
+/**
+ * Tracks failed logins per username, with a sliding-ish window: the counter
+ * resets the first time it's consulted past `resetAt`. Successful logins call
+ * `reset()` so legitimate users aren't locked out after one typo.
+ */
+export class UsernameRateLimiter {
+	private attempts = new Map<string, FailedAttempts>();
+
+	constructor(
+		private readonly max: number,
+		private readonly windowMs: number,
+	) { }
+
+	/**
+	 * Throws `RateLimitError` when the username has already hit the max within
+	 * the current window. Call before attempting verification.
+	 */
+	assertAllowed(username: string): void {
+		const now = Date.now();
+		const entry = this.attempts.get(username);
+		if (!entry) return;
+		if (now >= entry.resetAt) {
+			this.attempts.delete(username);
+			return;
+		}
+		if (entry.count >= this.max) {
+			const retryAfterSeconds = Math.max(1, Math.ceil((entry.resetAt - now) / 1000));
+			throw new RateLimitError(retryAfterSeconds);
+		}
+	}
+
+	/** Bump the counter for this username. Call after a failed verification. */
+	recordFailure(username: string): void {
+		const now = Date.now();
+		const entry = this.attempts.get(username);
+		if (!entry || now >= entry.resetAt) {
+			this.attempts.set(username, { count: 1, resetAt: now + this.windowMs });
+			return;
+		}
+		entry.count++;
+	}
+
+	/** Forget any prior failures for this username (called after a successful login). */
+	reset(username: string): void {
+		this.attempts.delete(username);
+	}
+
+	/** Test helper: wipe all state. */
+	clear(): void {
+		this.attempts.clear();
+	}
+}

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -88,18 +88,39 @@ interface FailedAttempts {
 	resetAt: number;
 }
 
+// Hard cap on how many distinct usernames we'll track at once. Without this,
+// a caller hitting /auth/login with a large pool of unique usernames could
+// force the map to grow unbounded for the full window — a real DoS vector on
+// a public endpoint. JS Map preserves insertion order, so evicting the
+// oldest entry when we overflow (FIFO) is cheap: `map.keys().next().value`.
+// LRU would be nicer but needs re-insertion on each access; FIFO is enough
+// for DoS defence — under steady attack the oldest buckets are the ones
+// most likely to have already expired anyway.
+const DEFAULT_MAX_TRACKED_USERNAMES = 10_000;
+
 /**
  * Tracks failed logins per username, with a sliding-ish window: the counter
  * resets the first time it's consulted past `resetAt`. Successful logins call
  * `reset()` so legitimate users aren't locked out after one typo.
+ *
+ * NOTE on case sensitivity: usernames are stored verbatim in D1 and looked
+ * up with `WHERE username = ?` (case-sensitive collation), so "Alice" and
+ * "alice" are distinct accounts. This limiter keys on the same literal
+ * string and therefore locks the same identity the auth module authenticates.
+ * If username normalization is ever introduced in `auth.ts`, this class must
+ * apply the same normalization or the two layers will diverge.
  */
 export class UsernameRateLimiter {
 	private attempts = new Map<string, FailedAttempts>();
+	private readonly maxTracked: number;
 
 	constructor(
 		private readonly max: number,
 		private readonly windowMs: number,
-	) { }
+		maxTracked: number = DEFAULT_MAX_TRACKED_USERNAMES,
+	) {
+		this.maxTracked = maxTracked;
+	}
 
 	/**
 	 * Throws `RateLimitError` when the username has already hit the max within
@@ -124,6 +145,17 @@ export class UsernameRateLimiter {
 		const now = Date.now();
 		const entry = this.attempts.get(username);
 		if (!entry || now >= entry.resetAt) {
+			// Opportunistic GC: if we're about to insert and the map is full,
+			// first drop any entries whose windows have already expired. Cheap
+			// O(n) sweep but amortizes across many requests.
+			if (this.attempts.size >= this.maxTracked) this.evictExpired(now);
+			// Still full? Evict the oldest (FIFO) to make room for the new
+			// tracker. The attacker keeps winning the race, but we stay within
+			// the memory budget.
+			if (this.attempts.size >= this.maxTracked) {
+				const oldestKey = this.attempts.keys().next().value;
+				if (oldestKey !== undefined) this.attempts.delete(oldestKey);
+			}
 			this.attempts.set(username, { count: 1, resetAt: now + this.windowMs });
 			return;
 		}
@@ -138,5 +170,16 @@ export class UsernameRateLimiter {
 	/** Test helper: wipe all state. */
 	clear(): void {
 		this.attempts.clear();
+	}
+
+	/** Test helper: current map size, for the eviction tests. */
+	size(): number {
+		return this.attempts.size;
+	}
+
+	private evictExpired(now: number): void {
+		for (const [key, entry] of this.attempts) {
+			if (now >= entry.resetAt) this.attempts.delete(key);
+		}
 	}
 }

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -47,6 +47,11 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		limit: cfg.login.ipMax,
 		standardHeaders: "draft-7",
 		legacyHeaders: false,
+		// Only failed logins count toward the IP budget. Brings the IP layer
+		// in line with the per-username layer (which also only counts failures)
+		// and means a legitimate user re-logging in ten times in 15 min
+		// doesn't self-block. Attackers burn the budget on failures anyway.
+		skipSuccessfulRequests: true,
 		message: { error: "Too many login attempts from this IP, try again later", scope: "ip" },
 	});
 	const registerIp = rateLimit({
@@ -147,6 +152,8 @@ export class UsernameRateLimiter {
 		this.attempts.clear();
 	}
 
+	// Map iteration is spec'd to tolerate in-loop deletes of already-visited
+	// or current keys (ECMA-262 §24.1.3.5), so this pattern is safe.
 	private evictExpired(now: number): void {
 		for (const [key, entry] of this.attempts) {
 			if (now >= entry.resetAt) this.attempts.delete(key);

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -61,14 +61,9 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 
 // ── Per-username limiter ────────────────────────────────────────────────────
 
-export class RateLimitError extends Error {
-	readonly retryAfterSeconds: number;
-	constructor(retryAfterSeconds: number) {
-		super("Too many failed attempts for this username, try again later");
-		this.name = "RateLimitError";
-		this.retryAfterSeconds = retryAfterSeconds;
-	}
-}
+export type UsernameCheckResult =
+	| { allowed: true }
+	| { allowed: false; retryAfterSeconds: number };
 
 interface FailedAttempts {
 	count: number;
@@ -94,54 +89,62 @@ export class UsernameRateLimiter {
 		this.maxTracked = maxTracked;
 	}
 
-	/**
-	 * Throws `RateLimitError` when the username has already hit the max within
-	 * the current window. Call before attempting verification.
-	 */
-	assertAllowed(username: string): void {
+	// Returns allowed=false only when the bucket is full inside its window.
+	// Result-based (never throws) so callers don't need try/catch around an
+	// otherwise-synchronous check inside an async handler.
+	check(username: string): UsernameCheckResult {
 		const now = Date.now();
 		const entry = this.attempts.get(username);
-		if (!entry) return;
+		if (!entry) return { allowed: true };
 		if (now >= entry.resetAt) {
 			this.attempts.delete(username);
-			return;
+			return { allowed: true };
 		}
 		if (entry.count >= this.max) {
-			const retryAfterSeconds = Math.max(1, Math.ceil((entry.resetAt - now) / 1000));
-			throw new RateLimitError(retryAfterSeconds);
+			return {
+				allowed: false,
+				retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
+			};
 		}
+		return { allowed: true };
 	}
 
-	/** Bump the counter for this username. Call after a failed verification. */
+	// Bump the counter for this username. Call after a failed verification.
 	recordFailure(username: string): void {
 		const now = Date.now();
-		const entry = this.attempts.get(username);
-		if (!entry || now >= entry.resetAt) {
-			// On overflow: sweep expired entries first, then FIFO-evict.
-			if (this.attempts.size >= this.maxTracked) this.evictExpired(now);
+		const existing = this.attempts.get(username);
+		if (existing && now < existing.resetAt) {
+			existing.count++;
+			return;
+		}
+		// Either a genuinely new key or an expired entry being reset. Remove
+		// the stale slot first so the fresh bucket re-enters at the END of
+		// Map insertion order — otherwise an expired entry would be resurrected
+		// in its old (early) FIFO position and evicted prematurely on the
+		// next overflow.
+		if (existing) this.attempts.delete(username);
+		if (this.attempts.size >= this.maxTracked) {
+			this.evictExpired(now);
 			if (this.attempts.size >= this.maxTracked) {
 				const oldestKey = this.attempts.keys().next().value;
 				if (oldestKey !== undefined) this.attempts.delete(oldestKey);
 			}
-			this.attempts.set(username, { count: 1, resetAt: now + this.windowMs });
-			return;
 		}
-		entry.count++;
+		this.attempts.set(username, { count: 1, resetAt: now + this.windowMs });
 	}
 
-	/** Forget any prior failures for this username (called after a successful login). */
+	// Forget any prior failures for this username (call after a successful login).
 	reset(username: string): void {
 		this.attempts.delete(username);
 	}
 
-	// test helper: wipe all state
-	clear(): void {
-		this.attempts.clear();
-	}
-
-	// test helper: current map size, for the eviction tests
-	size(): number {
+	// TEST-ONLY: exposed so eviction/size tests can observe internal state.
+	// Do not call from production code.
+	sizeForTesting(): number {
 		return this.attempts.size;
+	}
+	clearForTesting(): void {
+		this.attempts.clear();
 	}
 
 	private evictExpired(now: number): void {

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -167,12 +167,12 @@ export class UsernameRateLimiter {
 		this.attempts.delete(username);
 	}
 
-	/** Test helper: wipe all state. */
+	/** @internal Test helper: wipe all state. */
 	clear(): void {
 		this.attempts.clear();
 	}
 
-	/** Test helper: current map size, for the eviction tests. */
+	/** @internal Test helper: current map size, for the eviction tests. */
 	size(): number {
 		return this.attempts.size;
 	}

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -1,16 +1,4 @@
-/**
- * rateLimit.ts — Rate limiters for the public /auth routes.
- *
- * Two layers defend against credential brute-force:
- *  1. Per-IP, via `express-rate-limit` (middleware). Stops a single machine
- *     from hammering the endpoint.
- *  2. Per-username, via the in-process `UsernameRateLimiter` below. Counts
- *     FAILED logins only and resets on success, so a botnet distributing
- *     guesses across many IPs can still be throttled on a single account.
- *
- * Both are in-memory — fine for the single-node deployment described in
- * CLAUDE.md. If this ever scales horizontally, swap the store for Redis.
- */
+// rateLimit.ts — per-IP and per-username limiters for the /auth routes.
 
 import rateLimit, { type RateLimitRequestHandler } from "express-rate-limit";
 
@@ -51,23 +39,22 @@ export interface AuthRateLimiters {
 }
 
 export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
-	// standardHeaders: draft-7 sends RateLimit-* and Retry-After on 429.
-	// legacyHeaders: false suppresses the older X-RateLimit-* variants.
-	// Response body is explicit JSON so the frontend can read `error` like
-	// every other 4xx on this surface.
+	// draft-7 gives us RateLimit-* and Retry-After; legacyHeaders off.
+	// `scope` lets the frontend tell an IP block apart from a per-account
+	// lockout and surface a useful message.
 	const loginIp = rateLimit({
 		windowMs: cfg.login.ipWindowMs,
 		limit: cfg.login.ipMax,
 		standardHeaders: "draft-7",
 		legacyHeaders: false,
-		message: { error: "Too many login attempts from this IP, try again later" },
+		message: { error: "Too many login attempts from this IP, try again later", scope: "ip" },
 	});
 	const registerIp = rateLimit({
 		windowMs: cfg.register.ipWindowMs,
 		limit: cfg.register.ipMax,
 		standardHeaders: "draft-7",
 		legacyHeaders: false,
-		message: { error: "Too many registration attempts from this IP, try again later" },
+		message: { error: "Too many registration attempts from this IP, try again later", scope: "ip" },
 	});
 	return { loginIp, registerIp };
 }
@@ -88,28 +75,13 @@ interface FailedAttempts {
 	resetAt: number;
 }
 
-// Hard cap on how many distinct usernames we'll track at once. Without this,
-// a caller hitting /auth/login with a large pool of unique usernames could
-// force the map to grow unbounded for the full window — a real DoS vector on
-// a public endpoint. JS Map preserves insertion order, so evicting the
-// oldest entry when we overflow (FIFO) is cheap: `map.keys().next().value`.
-// LRU would be nicer but needs re-insertion on each access; FIFO is enough
-// for DoS defence — under steady attack the oldest buckets are the ones
-// most likely to have already expired anyway.
+// Cap distinct tracked usernames so a flood of unique keys can't grow the
+// map unbounded. FIFO eviction (Map preserves insertion order).
 const DEFAULT_MAX_TRACKED_USERNAMES = 10_000;
 
-/**
- * Tracks failed logins per username, with a sliding-ish window: the counter
- * resets the first time it's consulted past `resetAt`. Successful logins call
- * `reset()` so legitimate users aren't locked out after one typo.
- *
- * NOTE on case sensitivity: usernames are stored verbatim in D1 and looked
- * up with `WHERE username = ?` (case-sensitive collation), so "Alice" and
- * "alice" are distinct accounts. This limiter keys on the same literal
- * string and therefore locks the same identity the auth module authenticates.
- * If username normalization is ever introduced in `auth.ts`, this class must
- * apply the same normalization or the two layers will diverge.
- */
+// Keyed on the literal username string because auth.ts looks up D1 with the
+// same literal (case-sensitive). If auth.ts ever normalizes, this class must
+// mirror the normalization or the two layers diverge.
 export class UsernameRateLimiter {
 	private attempts = new Map<string, FailedAttempts>();
 	private readonly maxTracked: number;
@@ -145,13 +117,8 @@ export class UsernameRateLimiter {
 		const now = Date.now();
 		const entry = this.attempts.get(username);
 		if (!entry || now >= entry.resetAt) {
-			// Opportunistic GC: if we're about to insert and the map is full,
-			// first drop any entries whose windows have already expired. Cheap
-			// O(n) sweep but amortizes across many requests.
+			// On overflow: sweep expired entries first, then FIFO-evict.
 			if (this.attempts.size >= this.maxTracked) this.evictExpired(now);
-			// Still full? Evict the oldest (FIFO) to make room for the new
-			// tracker. The attacker keeps winning the race, but we stay within
-			// the memory budget.
 			if (this.attempts.size >= this.maxTracked) {
 				const oldestKey = this.attempts.keys().next().value;
 				if (oldestKey !== undefined) this.attempts.delete(oldestKey);

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -134,12 +134,12 @@ export class UsernameRateLimiter {
 		this.attempts.delete(username);
 	}
 
-	/** @internal Test helper: wipe all state. */
+	// test helper: wipe all state
 	clear(): void {
 		this.attempts.clear();
 	}
 
-	/** @internal Test helper: current map size, for the eviction tests. */
+	// test helper: current map size, for the eviction tests
 	size(): number {
 		return this.attempts.size;
 	}

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -12,7 +12,6 @@ import {
         DEFAULT_RATE_LIMIT_CONFIG,
         createAuthRateLimiters,
         UsernameRateLimiter,
-        RateLimitError,
 } from "./rateLimit.js";
 
 export function buildRouter(
@@ -66,48 +65,32 @@ export function buildRouter(
                         return;
                 }
 
-                // Per-username gate runs before bcrypt so guesses can't burn CPU
-                // or leak timing info. `scope` distinguishes "this account is
-                // locked" from the IP-layer 429 above. assertAllowed only ever
-                // throws RateLimitError; anything else is a programming bug we
-                // want to surface as 500 rather than an unhandled promise
-                // rejection (async handler, Express 4 has no next wired up).
-                try {
-                        usernameLimiter.assertAllowed(username);
-                } catch (err) {
-                        if (err instanceof RateLimitError) {
-                                res.setHeader("Retry-After", String(err.retryAfterSeconds));
-                                res.status(429).json({
-                                        error: "Too many failed login attempts for this account, try again later",
-                                        scope: "username",
-                                });
-                                return;
-                        }
-                        console.error(`[auth] unexpected error from usernameLimiter:`, (err as Error).message);
-                        res.status(500).json({ error: "Internal server error" });
+                // Per-username gate runs before bcrypt. `scope` distinguishes an
+                // account lockout from the IP-layer 429 above.
+                const check = usernameLimiter.check(username);
+                if (!check.allowed) {
+                        res.setHeader("Retry-After", String(check.retryAfterSeconds));
+                        res.status(429).json({
+                                error: "Too many failed login attempts for this account, try again later",
+                                scope: "username",
+                        });
                         return;
                 }
 
-                // Note on race: assertAllowed is sync, loginUser is async. On a
-                // single Node process this can let `concurrent in-flight requests`
-                // slip past the limit — acceptable given the attacker still can't
-                // meaningfully exceed `max + parallelism`, and parallelism is 1 in
-                // practice (bcrypt serialises on the event loop).
+                // Race note: check() is sync, loginUser is async — in-flight
+                // requests can slip past by `parallelism`. bcrypt serialises on
+                // the event loop so parallelism is effectively 1.
                 let result: { userId: string; token: string };
                 try {
                         result = await loginUser(username, password);
                 } catch (err) {
                         if (err instanceof InvalidCredentialsError) {
-                                // Only bad credentials count toward lockout. Infra
-                                // errors (D1 down, bcrypt crash, …) must NOT
-                                // increment the counter — a transient outage would
-                                // otherwise silently lock legitimate users out.
+                                // Only bad creds count — infra errors must not lock real users out.
                                 usernameLimiter.recordFailure(username);
                                 res.status(401).json({ error: err.message });
                                 return;
                         }
-                        // Don't log the submitted username — would be an
-                        // enumeration vector if logs leak.
+                        // Username omitted from the log to avoid an enumeration vector.
                         console.error(`[auth] login failed unexpectedly:`, (err as Error).message);
                         res.status(500).json({ error: "Internal server error" });
                         return;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -67,9 +67,11 @@ export function buildRouter(
                 }
 
                 // Per-username gate runs before bcrypt so guesses can't burn CPU
-                // or leak timing info. Message distinguishes "this account is
-                // locked" from the IP-layer 429 above so the user knows to wait
-                // rather than suspect a service outage.
+                // or leak timing info. `scope` distinguishes "this account is
+                // locked" from the IP-layer 429 above. assertAllowed only ever
+                // throws RateLimitError; anything else is a programming bug we
+                // want to surface as 500 rather than an unhandled promise
+                // rejection (async handler, Express 4 has no next wired up).
                 try {
                         usernameLimiter.assertAllowed(username);
                 } catch (err) {
@@ -81,7 +83,9 @@ export function buildRouter(
                                 });
                                 return;
                         }
-                        throw err;
+                        console.error(`[auth] unexpected error from usernameLimiter:`, (err as Error).message);
+                        res.status(500).json({ error: "Internal server error" });
+                        return;
                 }
 
                 // Note on race: assertAllowed is sync, loginUser is async. On a
@@ -102,7 +106,9 @@ export function buildRouter(
                                 res.status(401).json({ error: err.message });
                                 return;
                         }
-                        console.error(`[auth] login failed unexpectedly for ${username}:`, (err as Error).message);
+                        // Don't log the submitted username — would be an
+                        // enumeration vector if logs leak.
+                        console.error(`[auth] login failed unexpectedly:`, (err as Error).message);
                         res.status(500).json({ error: "Internal server error" });
                         return;
                 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -7,17 +7,38 @@ import { AuthedRequest, requireAuth, registerUser, loginUser, hasAnyUsers } from
 import { SessionManager, NotFoundError, ForbiddenError } from "./sessionManager.js";
 import { DockerManager } from "./dockerManager.js";
 import { SessionMeta } from "./types.js";
+import {
+        RateLimitConfig,
+        DEFAULT_RATE_LIMIT_CONFIG,
+        createAuthRateLimiters,
+        UsernameRateLimiter,
+        RateLimitError,
+} from "./rateLimit.js";
 
-export function buildRouter(sessions: SessionManager, docker: DockerManager): Router {
+export function buildRouter(
+        sessions: SessionManager,
+        docker: DockerManager,
+        rateLimitConfig: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG,
+): Router {
         const router = Router();
 
         // ── Auth routes (public) ────────────────────────────────────────────────
+
+        // Two-layer rate limiting on the public auth surface:
+        //  - loginIp / registerIp: per-IP, defends against a single attacker.
+        //  - usernameLimiter: per-username (failed logins only), defends against
+        //    a distributed attack on a specific account.
+        const { loginIp, registerIp } = createAuthRateLimiters(rateLimitConfig);
+        const usernameLimiter = new UsernameRateLimiter(
+                rateLimitConfig.login.usernameMax,
+                rateLimitConfig.login.usernameWindowMs,
+        );
 
         router.get("/auth/status", async (_req: Request, res: Response) => {
                 res.json({ needsSetup: !(await hasAnyUsers()) });
         });
 
-        router.post("/auth/register", async (req: Request, res: Response) => {
+        router.post("/auth/register", registerIp, async (req: Request, res: Response) => {
                 const { username, password } = req.body as { username?: string; password?: string };
                 if (!username || !password || password.length < 6) {
                         res.status(400).json({ error: "username and password (min 6 chars) required" });
@@ -31,16 +52,33 @@ export function buildRouter(sessions: SessionManager, docker: DockerManager): Ro
                 }
         });
 
-        router.post("/auth/login", async (req: Request, res: Response) => {
+        router.post("/auth/login", loginIp, async (req: Request, res: Response) => {
                 const { username, password } = req.body as { username?: string; password?: string };
                 if (!username || !password) {
                         res.status(400).json({ error: "username and password required" });
                         return;
                 }
+
+                // Per-username gate BEFORE credential verification so repeated
+                // guesses don't get to run bcrypt (which would be expensive and
+                // also leak timing info).
+                try {
+                        usernameLimiter.assertAllowed(username);
+                } catch (err) {
+                        if (err instanceof RateLimitError) {
+                                res.setHeader("Retry-After", String(err.retryAfterSeconds));
+                                res.status(429).json({ error: err.message });
+                                return;
+                        }
+                        throw err;
+                }
+
                 try {
                         const result = await loginUser(username, password);
+                        usernameLimiter.reset(username);
                         res.json(result);
                 } catch (err) {
+                        usernameLimiter.recordFailure(username);
                         res.status(401).json({ error: (err as Error).message });
                 }
         });

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -34,6 +34,11 @@ export function buildRouter(
                 rateLimitConfig.login.usernameWindowMs,
         );
 
+        // Cap username length at the request boundary so a huge string never
+        // becomes a key in the in-memory limiter's map or a query param in
+        // D1. 64 is generous for human-typed usernames.
+        const USERNAME_MAX_LEN = 64;
+
         router.get("/auth/status", async (_req: Request, res: Response) => {
                 res.json({ needsSetup: !(await hasAnyUsers()) });
         });
@@ -42,6 +47,10 @@ export function buildRouter(
                 const { username, password } = req.body as { username?: string; password?: string };
                 if (!username || !password || password.length < 6) {
                         res.status(400).json({ error: "username and password (min 6 chars) required" });
+                        return;
+                }
+                if (username.length > USERNAME_MAX_LEN) {
+                        res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
                         return;
                 }
                 try {
@@ -56,6 +65,11 @@ export function buildRouter(
                 const { username, password } = req.body as { username?: string; password?: string };
                 if (!username || !password) {
                         res.status(400).json({ error: "username and password required" });
+                        return;
+                }
+                if (username.length > USERNAME_MAX_LEN) {
+                        // Reject before anything lands in the per-username limiter map.
+                        res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
                         return;
                 }
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -66,10 +66,21 @@ export function buildRouter(
                 }
 
                 // Per-username gate runs before bcrypt. `scope` distinguishes an
-                // account lockout from the IP-layer 429 above.
+                // account lockout from the IP-layer 429 above. Emits the same
+                // draft-7 RateLimit-* headers as express-rate-limit does on the
+                // IP 429 so clients parsing them see a consistent shape.
                 const check = usernameLimiter.check(username);
                 if (!check.allowed) {
+                        const windowSeconds = Math.ceil(rateLimitConfig.login.usernameWindowMs / 1000);
                         res.setHeader("Retry-After", String(check.retryAfterSeconds));
+                        res.setHeader(
+                                "RateLimit-Policy",
+                                `${rateLimitConfig.login.usernameMax};w=${windowSeconds}`,
+                        );
+                        res.setHeader(
+                                "RateLimit",
+                                `limit=${rateLimitConfig.login.usernameMax}, remaining=0, reset=${check.retryAfterSeconds}`,
+                        );
                         res.status(429).json({
                                 error: "Too many failed login attempts for this account, try again later",
                                 scope: "username",
@@ -77,9 +88,14 @@ export function buildRouter(
                         return;
                 }
 
-                // Race note: check() is sync, loginUser is async — in-flight
-                // requests can slip past by `parallelism`. bcrypt serialises on
-                // the event loop so parallelism is effectively 1.
+                // Concurrency note: check() is sync but loginUser is async, so
+                // `max + parallelism` slippage is possible in theory. Today
+                // parallelism is effectively 1 because loginUser uses
+                // `bcrypt.compareSync`, which blocks the event loop — that
+                // synchronous call is what pins the bound, not an explicit
+                // mutex. Swapping to the async `bcrypt.compare` removes the
+                // guarantee, so either add queueing or re-check the limit
+                // after the await.
                 let result: { userId: string; token: string };
                 try {
                         result = await loginUser(username, password);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -3,7 +3,7 @@
  */
 
 import { Router, Request, Response } from "express";
-import { AuthedRequest, requireAuth, registerUser, loginUser, hasAnyUsers } from "./auth.js";
+import { AuthedRequest, requireAuth, registerUser, loginUser, hasAnyUsers, InvalidCredentialsError } from "./auth.js";
 import { SessionManager, NotFoundError, ForbiddenError } from "./sessionManager.js";
 import { DockerManager } from "./dockerManager.js";
 import { SessionMeta } from "./types.js";
@@ -24,19 +24,13 @@ export function buildRouter(
 
         // ── Auth routes (public) ────────────────────────────────────────────────
 
-        // Two-layer rate limiting on the public auth surface:
-        //  - loginIp / registerIp: per-IP, defends against a single attacker.
-        //  - usernameLimiter: per-username (failed logins only), defends against
-        //    a distributed attack on a specific account.
         const { loginIp, registerIp } = createAuthRateLimiters(rateLimitConfig);
         const usernameLimiter = new UsernameRateLimiter(
                 rateLimitConfig.login.usernameMax,
                 rateLimitConfig.login.usernameWindowMs,
         );
-
-        // Cap username length at the request boundary so a huge string never
-        // becomes a key in the in-memory limiter's map or a query param in
-        // D1. 64 is generous for human-typed usernames.
+        // Cap username length at the request boundary so huge strings can't
+        // land in the limiter map or D1.
         const USERNAME_MAX_LEN = 64;
 
         router.get("/auth/status", async (_req: Request, res: Response) => {
@@ -68,33 +62,52 @@ export function buildRouter(
                         return;
                 }
                 if (username.length > USERNAME_MAX_LEN) {
-                        // Reject before anything lands in the per-username limiter map.
                         res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
                         return;
                 }
 
-                // Per-username gate BEFORE credential verification so repeated
-                // guesses don't get to run bcrypt (which would be expensive and
-                // also leak timing info).
+                // Per-username gate runs before bcrypt so guesses can't burn CPU
+                // or leak timing info. Message distinguishes "this account is
+                // locked" from the IP-layer 429 above so the user knows to wait
+                // rather than suspect a service outage.
                 try {
                         usernameLimiter.assertAllowed(username);
                 } catch (err) {
                         if (err instanceof RateLimitError) {
                                 res.setHeader("Retry-After", String(err.retryAfterSeconds));
-                                res.status(429).json({ error: err.message });
+                                res.status(429).json({
+                                        error: "Too many failed login attempts for this account, try again later",
+                                        scope: "username",
+                                });
                                 return;
                         }
                         throw err;
                 }
 
+                // Note on race: assertAllowed is sync, loginUser is async. On a
+                // single Node process this can let `concurrent in-flight requests`
+                // slip past the limit — acceptable given the attacker still can't
+                // meaningfully exceed `max + parallelism`, and parallelism is 1 in
+                // practice (bcrypt serialises on the event loop).
+                let result: { userId: string; token: string };
                 try {
-                        const result = await loginUser(username, password);
-                        usernameLimiter.reset(username);
-                        res.json(result);
+                        result = await loginUser(username, password);
                 } catch (err) {
-                        usernameLimiter.recordFailure(username);
-                        res.status(401).json({ error: (err as Error).message });
+                        if (err instanceof InvalidCredentialsError) {
+                                // Only bad credentials count toward lockout. Infra
+                                // errors (D1 down, bcrypt crash, …) must NOT
+                                // increment the counter — a transient outage would
+                                // otherwise silently lock legitimate users out.
+                                usernameLimiter.recordFailure(username);
+                                res.status(401).json({ error: err.message });
+                                return;
+                        }
+                        console.error(`[auth] login failed unexpectedly for ${username}:`, (err as Error).message);
+                        res.status(500).json({ error: "Internal server error" });
+                        return;
                 }
+                usernameLimiter.reset(username);
+                res.json(result);
         });
 
         // ── Session routes (authenticated) ──────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,11 @@ services:
       - JWT_SECRET=${JWT_SECRET:-change-me-in-production}
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-7d}
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
-      # Default "1" = trust exactly one hop in front of us (the Cloudflare
-      # Tunnel). Load-bearing for /auth per-IP rate limiting — without it
-      # every request shares the tunnel's IP. Set to "0" for direct dev.
-      - TRUST_PROXY=${TRUST_PROXY:-1}
+      # Defaults to "0" (trust nothing) so a direct-connection dev setup
+      # can't be XFF-spoofed. Set to "1" in your .env when deploying behind
+      # Cloudflare Tunnel — otherwise the per-IP /auth rate limiter
+      # collapses every request into the tunnel's shared IP bucket.
+      - TRUST_PROXY=${TRUST_PROXY:-0}
       - SESSION_IMAGE=${SESSION_IMAGE:-shared-terminal-session}
       - WORKSPACE_ROOT=/var/shared-terminal/workspaces
       - CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
       - JWT_SECRET=${JWT_SECRET:-change-me-in-production}
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-7d}
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
+      # Default "1" = trust exactly one hop in front of us (the Cloudflare
+      # Tunnel). Load-bearing for /auth per-IP rate limiting — without it
+      # every request shares the tunnel's IP. Set to "0" for direct dev.
+      - TRUST_PROXY=${TRUST_PROXY:-1}
       - SESSION_IMAGE=${SESSION_IMAGE:-shared-terminal-session}
       - WORKSPACE_ROOT=/var/shared-terminal/workspaces
       - CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID}


### PR DESCRIPTION
Closes #10.

## Summary
- Per-IP rate limiting on `POST /api/auth/login` (10 / 15 min) and `POST /api/auth/register` (5 / 1 h) via `express-rate-limit`. Response is 429 + `Retry-After` + `RateLimit-*` draft-7 headers.
- Per-username layer on login (10 failed attempts / 15 min, reset on success), guarding against distributed guessing against one account. Runs **before** bcrypt so a locked bucket doesn't keep burning CPU or leaking timing info.
- Added `TRUST_PROXY` env so `req.ip` picks the real client from `X-Forwarded-For` when the backend sits behind Cloudflare Tunnel. Without it, every per-IP bucket collapses into one shared bucket and the per-IP layer is effectively useless.

## Design notes
- Per-username layer is **strict** — once max is hit, even the correct password gets a 429 until the window resets. Softer alternatives either still run bcrypt on every guess or leak timing. Reset-on-success covers the typo-then-retry case.
- Everything is in-process (a `Map` + `express-rate-limit`'s MemoryStore). Fine for the single-node deployment in CLAUDE.md; would need a shared store if this ever scales horizontally.
- Config is a param on `buildRouter` so tests can tighten the limits without waiting on real time.

## Tests (11 new)
- **Unit** (`UsernameRateLimiter`): allows up to max, throws `RateLimitError` with `retryAfterSeconds` on max+1, isolates buckets per username, auto-resets past the window (fake timers), `reset()` vs `clear()`, post-window `recordFailure` starts a fresh bucket.
- **Integration** (real HTTP, ephemeral server, mocked auth module): login 429 after IP max with `Retry-After`, register 429 after IP max with `Retry-After`, per-username 429 fires before `loginUser` is called (bcrypt-skip assertion), successful login resets the counter, locked account stays locked even with correct password.

## Test plan
- [x] `cd backend && npx vitest run` — 24/24 pass
- [x] `cd backend && npm run build` — clean
- [ ] Smoke test the IP limit against a running backend: 11 rapid login calls from curl → the 11th returns 429 with a `Retry-After` header
- [x] Confirm `TRUST_PROXY=1` is set in production env before merging (otherwise per-IP limits still collapse behind the tunnel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)