### PR TITLE
fix(tabs): allow closing stale "main" tab and confirm before close

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -166,11 +166,17 @@ export async function createTab(sessionId: string, label?: string): Promise<Tab>
         return res.json();
 }
 
-/** Throws `LastTabError` (HTTP 409) when the tab is the last one — callers should surface, not retry. */
+/** Throws `LastTabError` (HTTP 409) when the tab is the last one — callers should surface, not retry.
+ *  Throws `TabNotFoundError` (HTTP 404) when the tab is already gone in the backend (e.g. tmux
+ *  server died and dropped its sessions); callers should treat this as success and drop the
+ *  stale chip from the UI. */
 export async function deleteTab(sessionId: string, tabId: string): Promise<void> {
         const res = await apiFetch(`/sessions/${sessionId}/tabs/${tabId}`, { method: "DELETE" });
         if (res.status === 409) {
                 throw new LastTabError();
+        }
+        if (res.status === 404) {
+                throw new TabNotFoundError();
         }
         if (!res.ok) {
                 const body = await res.json().catch(() => ({}));
@@ -182,6 +188,13 @@ export class LastTabError extends Error {
         constructor() {
                 super("Can't close the last tab of a session");
                 this.name = "LastTabError";
+        }
+}
+
+export class TabNotFoundError extends Error {
+        constructor() {
+                super("Tab no longer exists in the session");
+                this.name = "TabNotFoundError";
         }
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,7 +8,7 @@
 import {
         isLoggedIn, login, register, logout, checkAuthStatus,
         listSessions, createSession, deleteSession, stopSession, startSession,
-        listTabs, createTab, deleteTab, LastTabError,
+        listTabs, createTab, deleteTab, LastTabError, TabNotFoundError,
         type SessionInfo, type Tab,
 } from "./api.js";
 import { openTerminalSession, type TerminalSession, type SessionStatus } from "./terminal.js";
@@ -582,6 +582,10 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
                 showToast("Can't close the last tab", true);
                 return;
         }
+        const tabLabel = currentTabs.find((t) => t.tabId === tabId)?.label ?? tabId;
+        if (!confirm(`Close tab "${tabLabel}"?\n\nAny processes running in this tab will be terminated (SIGHUP).`)) {
+                return;
+        }
         closingTabs.add(tabId);
         // Re-render so sibling chips' × reflects the in-flight close (their
         // disabled state mirrors the same guard).
@@ -591,15 +595,22 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
         try {
                 await deleteTab(sessionId, tabId);
         } catch (err) {
-                closingTabs.delete(tabId);
-                renderTabBar();
-                if (err instanceof LastTabError) {
-                        showToast("Can't close the last tab", true);
+                // 404 means the backend already lost the tab (e.g. tmux server died).
+                // Drop the stale chip from the UI rather than leaving the user stuck
+                // with an unremovable phantom tab.
+                if (err instanceof TabNotFoundError) {
+                        // fall through to the success path below
                 } else {
-                        showToast((err as Error).message, true);
+                        closingTabs.delete(tabId);
+                        renderTabBar();
+                        if (err instanceof LastTabError) {
+                                showToast("Can't close the last tab", true);
+                        } else {
+                                showToast((err as Error).message, true);
+                        }
+                        if (triggeredBy?.isConnected) triggeredBy.disabled = false;
+                        return;
                 }
-                if (triggeredBy?.isConnected) triggeredBy.disabled = false;
-                return;
         }
         closingTabs.delete(tabId);
         // Stale-session guard: renderTabBar() below rebuilds chips anyway, so

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -13,9 +13,10 @@ set -e
 cd /home/developer/workspace
 
 # Create the detached default tab. Named deterministically so the backend
-# can address it without an extra round-trip on first attach.
+# can address it without an extra round-trip on first attach. No `@tab-label`
+# is set — the UI falls back to the tabId, so it shows as "tab-default"
+# rather than a misleading "main" label that read as a special tab.
 tmux new-session -d -s tab-default -c /home/developer/workspace -x 120 -y 36
-tmux set-option -t tab-default @tab-label "main"
 
 echo "[entrypoint] tmux session 'tab-default' started — waiting for connections…"
 


### PR DESCRIPTION
## Summary
- Stop labelling the auto-created tab as `main` in `session-image/entrypoint.sh` — it read as a special, non-removable tab. It now shows as its tabId (`tab-default`).
- Surface HTTP 404 from `DELETE /sessions/:id/tabs/:tabId` as `TabNotFoundError` so the frontend can distinguish "already gone" (e.g. tmux server died) from real failures.
- In `closeTab()`, treat `TabNotFoundError` as success — drop the stale chip from the UI rather than leaving the user stuck with an unremovable phantom tab.
- Add a `confirm()` dialog before closing a tab so a misclick on `×` doesn't SIGHUP a tab full of running processes. Matches the existing pattern used for session deletes.

## Notes
- The entrypoint change only affects **new** containers built from a rebuilt `shared-terminal-session` image. Existing sessions still have `@tab-label "main"` set on their `tab-default` tmux session — they keep showing "main" until killed and respawned, but the 404-handling fix means the user can now actually close the broken chip in either case.
- Used native `confirm()` to match `main.ts:259` (session-delete prompt). Happy to switch to a styled in-app modal if preferred.

## Test plan
- [ ] Rebuild the session image (`docker build -t shared-terminal-session ./session-image`) and create a new session — verify the default tab shows as `tab-default` (not `main`).
- [ ] Click the `×` on a tab — verify the confirm dialog appears with the tab label and that cancelling preserves the tab.
- [ ] Confirm the dialog and verify the tab closes cleanly.
- [ ] Simulate a stale tab (e.g. `tmux kill-session -t tab-default` inside the container, or stop tmux) and verify clicking `×` removes the chip rather than showing "tab not found".
- [ ] Verify the last-tab guard still blocks closing the only remaining tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)