### PR TITLE
feat(frontend): responsive sidebar with menu toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -190,6 +190,12 @@
         min-width: 0;
       }
       #sidebar-backdrop {
+        /* Pulled out of flow unconditionally so a future style edit can't
+           accidentally let the backdrop occupy a grid track and collapse
+           the terminal to a second row of zero height. The mobile rule
+           below only flips `display`, never `position`. */
+        position: absolute;
+        inset: 0;
         display: none;
       }
       #sidebar-header {
@@ -537,9 +543,10 @@
           transform: translateX(0);
         }
         main.sidebar-open #sidebar-backdrop {
+          /* `position: absolute; inset: 0` lives on the base #sidebar-backdrop
+             rule so the element is unconditionally out of grid flow — the
+             only mobile-specific bit here is paint + stacking. */
           display: block;
-          position: absolute;
-          inset: 0;
           background: rgba(0, 0, 0, 0.5);
           z-index: 15;
         }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -106,7 +106,7 @@
       header {
         display: flex;
         align-items: center;
-        gap: 1rem;
+        gap: 0.75rem;
         padding: 0.75rem 1.25rem;
         background: #161b22;
         border-bottom: 1px solid #30363d;
@@ -116,6 +116,26 @@
         font-size: 1rem;
         font-weight: 600;
         color: #58a6ff;
+      }
+      #sidebar-toggle {
+        background: transparent;
+        border: 1px solid #30363d;
+        border-radius: 6px;
+        color: #8b949e;
+        padding: 0.3rem 0.55rem;
+        font-size: 1rem;
+        line-height: 1;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #sidebar-toggle:hover {
+        border-color: #58a6ff;
+        color: #58a6ff;
+      }
+      #sidebar-toggle svg {
+        display: block;
       }
       .header-right {
         margin-left: auto;
@@ -144,8 +164,13 @@
       main {
         flex: 1;
         display: grid;
-        grid-template-columns: 260px 1fr;
+        grid-template-columns: 0 1fr;
         overflow: hidden;
+        transition: grid-template-columns 0.2s ease;
+        position: relative;
+      }
+      main.sidebar-open {
+        grid-template-columns: 260px 1fr;
       }
 
       /* ── Sidebar ────────────────────────────────────────────────── */
@@ -155,6 +180,10 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
+        min-width: 0;
+      }
+      #sidebar-backdrop {
+        display: none;
       }
       #sidebar-header {
         padding: 0.75rem 1rem;
@@ -478,12 +507,33 @@
       }
 
       /* ── Mobile ─────────────────────────────────────────────────── */
-      @media (max-width: 640px) {
-        main {
+      @media (max-width: 768px) {
+        /* Drop the grid column entirely on mobile — the sidebar floats
+           over the terminal as a drawer instead of pushing it. */
+        main,
+        main.sidebar-open {
           grid-template-columns: 1fr;
         }
         #sidebar {
-          display: none;
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          width: min(280px, 85vw);
+          z-index: 20;
+          transform: translateX(-100%);
+          transition: transform 0.2s ease;
+          box-shadow: 4px 0 16px rgba(0, 0, 0, 0.4);
+        }
+        main.sidebar-open #sidebar {
+          transform: translateX(0);
+        }
+        main.sidebar-open #sidebar-backdrop {
+          display: block;
+          position: absolute;
+          inset: 0;
+          background: rgba(0, 0, 0, 0.5);
+          z-index: 15;
         }
       }
     </style>
@@ -518,6 +568,29 @@
     <!-- App view -->
     <div id="app-view">
       <header>
+        <button
+          id="sidebar-toggle"
+          type="button"
+          aria-label="Toggle sessions sidebar"
+          aria-expanded="true"
+          aria-controls="sidebar"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="3" y1="6" x2="21" y2="6"></line>
+            <line x1="3" y1="12" x2="21" y2="12"></line>
+            <line x1="3" y1="18" x2="21" y2="18"></line>
+          </svg>
+        </button>
         <h1>⬛ Shared Terminal</h1>
         <div class="header-right">
           <span id="user-display"></span>
@@ -525,6 +598,7 @@
         </div>
       </header>
       <main>
+        <div id="sidebar-backdrop" aria-hidden="true"></div>
         <aside id="sidebar">
           <div id="sidebar-header">
             <h2>Sessions</h2>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -172,6 +172,13 @@
       main.sidebar-open {
         grid-template-columns: 260px 1fr;
       }
+      /* Suppress the column transition during the JS-driven init pass so
+         desktop doesn't see a 0→260px expand on every page load. main.ts
+         removes this attribute after applying the initial state. */
+      main:not([data-sidebar-ready]),
+      main:not([data-sidebar-ready]) #sidebar {
+        transition: none !important;
+      }
 
       /* ── Sidebar ────────────────────────────────────────────────── */
       #sidebar {
@@ -507,6 +514,7 @@
       }
 
       /* ── Mobile ─────────────────────────────────────────────────── */
+      /* Breakpoint mirrored in main.ts as MOBILE_BREAKPOINT_PX — keep in sync. */
       @media (max-width: 768px) {
         /* Drop the grid column entirely on mobile — the sidebar floats
            over the terminal as a drawer instead of pushing it. */
@@ -572,7 +580,7 @@
           id="sidebar-toggle"
           type="button"
           aria-label="Toggle sessions sidebar"
-          aria-expanded="true"
+          aria-expanded="false"
           aria-controls="sidebar"
         >
           <svg

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -31,6 +31,9 @@ const sessionList = document.getElementById("session-list")!;
 const newSessionForm = document.getElementById("new-session-form") as HTMLFormElement;
 const newSessionInput = document.getElementById("new-session-input") as HTMLInputElement;
 const showTerminatedToggle = document.getElementById("show-terminated-toggle") as HTMLInputElement;
+const mainEl = document.querySelector("main")!;
+const sidebarToggleBtn = document.getElementById("sidebar-toggle") as HTMLButtonElement;
+const sidebarBackdrop = document.getElementById("sidebar-backdrop")!;
 
 const terminalToolbar = document.getElementById("terminal-toolbar")!;
 const terminalSessionName = document.getElementById("terminal-session-name")!;
@@ -690,6 +693,39 @@ showTerminatedToggle.addEventListener("change", () => {
         console.debug(`[sessions] show-terminated toggled → ${showTerminatedToggle.checked}`);
         refreshSessions();
 });
+
+// ── Sidebar toggle ──────────────────────────────────────────────────────────
+
+const MOBILE_BREAKPOINT_PX = 768;
+const isMobile = () => window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX}px)`).matches;
+
+function setSidebarOpen(open: boolean) {
+        mainEl.classList.toggle("sidebar-open", open);
+        sidebarToggleBtn.setAttribute("aria-expanded", String(open));
+}
+
+sidebarToggleBtn.addEventListener("click", () => {
+        setSidebarOpen(!mainEl.classList.contains("sidebar-open"));
+});
+
+sidebarBackdrop.addEventListener("click", () => setSidebarOpen(false));
+
+// On mobile, picking a session should dismiss the drawer so the user can
+// see the terminal — desktop keeps it pinned. Capture phase so we run
+// before the session-item click handler triggers any layout reflow.
+sessionList.addEventListener("click", (e) => {
+        if (!isMobile()) return;
+        // Ignore clicks on action buttons (start/stop/delete) — those don't
+        // switch the active session, so dismissing the drawer is jarring.
+        const target = e.target as HTMLElement;
+        if (target.closest(".session-actions")) return;
+        if (target.closest(".session-item")) setSidebarOpen(false);
+});
+
+// Default state: open on desktop, closed on mobile. We set this on first
+// app render rather than on script load so the auth view doesn't briefly
+// show a sidebar drawer animation on narrow screens.
+setSidebarOpen(!isMobile());
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -696,8 +696,12 @@ showTerminatedToggle.addEventListener("change", () => {
 
 // ── Sidebar toggle ──────────────────────────────────────────────────────────
 
+// Mirrored in index.html `@media (max-width: 768px)` — keep in sync. The CSS
+// query is the source of truth for visual behaviour; this constant exists so
+// the JS-side default (open on desktop, closed on mobile) matches.
 const MOBILE_BREAKPOINT_PX = 768;
-const isMobile = () => window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX}px)`).matches;
+const mobileMql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX}px)`);
+const isMobile = () => mobileMql.matches;
 
 function setSidebarOpen(open: boolean) {
         mainEl.classList.toggle("sidebar-open", open);
@@ -711,8 +715,7 @@ sidebarToggleBtn.addEventListener("click", () => {
 sidebarBackdrop.addEventListener("click", () => setSidebarOpen(false));
 
 // On mobile, picking a session should dismiss the drawer so the user can
-// see the terminal — desktop keeps it pinned. Capture phase so we run
-// before the session-item click handler triggers any layout reflow.
+// see the terminal — desktop keeps it pinned.
 sessionList.addEventListener("click", (e) => {
         if (!isMobile()) return;
         // Ignore clicks on action buttons (start/stop/delete) — those don't
@@ -722,10 +725,19 @@ sessionList.addEventListener("click", (e) => {
         if (target.closest(".session-item")) setSidebarOpen(false);
 });
 
-// Default state: open on desktop, closed on mobile. We set this on first
-// app render rather than on script load so the auth view doesn't briefly
-// show a sidebar drawer animation on narrow screens.
+// Crossing the breakpoint resets to the default state for that mode —
+// otherwise a desktop user who shrinks the window would have the drawer
+// already slid in (sidebar-open class still set, mobile CSS reads it as
+// "show drawer"), and a mobile user who widens the window would find the
+// sidebar column pinned at 0 with no visible trigger to recover.
+mobileMql.addEventListener("change", () => setSidebarOpen(!isMobile()));
+
+// Default state: open on desktop, closed on mobile. The HTML+CSS start in
+// the closed state with transitions suppressed via `[data-sidebar-ready]`,
+// so this synchronous flip-then-enable avoids the 0→260px expand animation
+// that would otherwise fire on every desktop page load.
 setSidebarOpen(!isMobile());
+mainEl.setAttribute("data-sidebar-ready", "");
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -32,6 +32,7 @@ const newSessionForm = document.getElementById("new-session-form") as HTMLFormEl
 const newSessionInput = document.getElementById("new-session-input") as HTMLInputElement;
 const showTerminatedToggle = document.getElementById("show-terminated-toggle") as HTMLInputElement;
 const mainEl = document.querySelector("main")!;
+const sidebarEl = document.getElementById("sidebar")!;
 const sidebarToggleBtn = document.getElementById("sidebar-toggle") as HTMLButtonElement;
 const sidebarBackdrop = document.getElementById("sidebar-backdrop")!;
 
@@ -704,8 +705,26 @@ const mobileMql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX}px)`);
 const isMobile = () => mobileMql.matches;
 
 function setSidebarOpen(open: boolean) {
+        const wasOpen = mainEl.classList.contains("sidebar-open");
         mainEl.classList.toggle("sidebar-open", open);
         sidebarToggleBtn.setAttribute("aria-expanded", String(open));
+
+        // Focus management is only meaningful on mobile, where the sidebar
+        // is a modal-style drawer — keyboard users opening it expect focus
+        // to land inside, and closing it should return focus to the toggle
+        // (only when focus was inside the drawer; otherwise the user has
+        // already moved on and we'd be stealing their focus).
+        if (!isMobile()) return;
+        if (open && !wasOpen) {
+                const firstFocusable = sidebarEl.querySelector<HTMLElement>(
+                        'input, button, a, [tabindex]:not([tabindex="-1"])',
+                );
+                firstFocusable?.focus();
+        } else if (!open && wasOpen) {
+                if (sidebarEl.contains(document.activeElement)) {
+                        sidebarToggleBtn.focus();
+                }
+        }
 }
 
 sidebarToggleBtn.addEventListener("click", () => {
@@ -713,6 +732,16 @@ sidebarToggleBtn.addEventListener("click", () => {
 });
 
 sidebarBackdrop.addEventListener("click", () => setSidebarOpen(false));
+
+// Escape closes the mobile drawer, matching the WAI-ARIA modal-dialog
+// expectation. Desktop ignores this — the sidebar is always part of the
+// layout there and Escape conflicts with terminal/xterm key handling.
+document.addEventListener("keydown", (e) => {
+        if (e.key !== "Escape") return;
+        if (!isMobile()) return;
+        if (!mainEl.classList.contains("sidebar-open")) return;
+        setSidebarOpen(false);
+});
 
 // On mobile, picking a session should dismiss the drawer so the user can
 // see the terminal — desktop keeps it pinned.


### PR DESCRIPTION
## Summary
- Adds a hamburger menu button in the header that toggles the sessions sidebar at any viewport size.
- **Desktop (> 768px):** sidebar is part of the grid layout; toggling animates the column width between `0` and `260px` (0.2s ease).
- **Mobile (≤ 768px):** sidebar becomes a fixed drawer sliding in from the left over the terminal, with a click-to-dismiss backdrop. Selecting a session also auto-dismisses; clicks on the per-session start/stop/delete action buttons do **not** dismiss, since those don't switch the active session.
- Default state: open on desktop, closed on mobile (decided via `matchMedia` at app init, so the auth view doesn't briefly flash a sidebar drawer animation on narrow screens).
- The previous mobile CSS at `≤ 640px` just hid the sidebar with no way to bring it back — this replaces that with the drawer.

## Notes
- xterm already runs a `ResizeObserver` on its container (`terminal.ts:156`), so the terminal refits automatically when the sidebar column width changes — no extra wiring needed.
- The toggle button uses an inline SVG hamburger and has `aria-expanded` / `aria-controls` so it announces correctly to screen readers.
- Toggle state is **not** persisted across reloads. Happy to add `localStorage` persistence in a follow-up if desired.

## Test plan
- [ ] Desktop: verify the menu icon collapses/expands the sidebar with a smooth column transition; the terminal width adjusts and xterm refits.
- [ ] Mobile (≤ 768px, e.g. devtools at 375px): verify the sidebar starts hidden, slides in from the left when the menu is tapped, shows the backdrop, dismisses on backdrop tap, dismisses on session-item tap, and does **not** dismiss on start/stop/delete action button taps.
- [ ] Resize from desktop → mobile (and back) and verify nothing gets stuck — the drawer/grid behaviour follows the breakpoint.
- [ ] Auth view at narrow widths: verify no sidebar drawer or backdrop is visible before login.
- [ ] Verify the menu button has a visible focus ring and that `aria-expanded` flips between `"true"` and `"false"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)