### PR TITLE
feat(auth): invite-only registration (closes #7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,17 @@ CORS_ORIGINS=*
 # If your username is publicly known and you want a narrower DoS window,
 # edit DEFAULT_RATE_LIMIT_CONFIG to shrink usernameWindowMs (e.g. 5 min).
 
+# ── Invite-only registration ─────────────────────────────────────────────────
+# Registration after the first (bootstrap) account requires an invite code
+# minted by an existing user. Codes are stored in the D1 invite_codes table
+# in PLAINTEXT — they're single-use and short-lived, but anyone with D1
+# read access (a backup leak, an admin token compromise) sees every unused
+# code. Rotate them via the Invites modal if you suspect exposure.
+#
+# How long an unredeemed invite stays valid (decimal days). 1-minute floor
+# is enforced internally to prevent burst-cycle quota bypass. Default 30.
+# INVITE_EXPIRY_DAYS=30
+
 # ── Cloudflare D1 Database ───────────────────────────────────────────────────
 CLOUDFLARE_ACCOUNT_ID=your-account-id
 CLOUDFLARE_API_TOKEN=your-api-token

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -221,7 +221,7 @@ const INVITE_EXPIRY_DAYS = Number(process.env.INVITE_EXPIRY_DAYS) || 30;
 
 export class InviteQuotaExceededError extends Error {
         constructor() {
-                super(`You already have ${MAX_UNUSED_INVITES_PER_USER} unused invite codes — revoke or wait for some to be used before minting more`);
+                super(`You already have ${MAX_UNUSED_INVITES_PER_USER} active invite codes — revoke some, or wait for them to be used or expire, before minting more`);
                 this.name = "InviteQuotaExceededError";
         }
 }
@@ -258,10 +258,18 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
         // < MAX and both insert. The WHERE clause is evaluated as part of the
         // INSERT, so SQLite serialises the read+write. Same changes-based
         // pattern as the bootstrap and invite-claim paths above.
+        //
+        // Expired codes are excluded from the count: the cap exists to bound
+        // *concurrently redeemable* invites (blast radius), and an expired
+        // code is no more redeemable than a used one. Without this filter, a
+        // forgetful user silently hits the cap 30 days after their last mint
+        // and an attacker could just wait out the expiry instead of revoking.
         const insert = await d1Query(
                 "INSERT INTO invite_codes (code, created_by, created_at, expires_at) " +
                         "SELECT ?, ?, ?, ? WHERE (" +
-                        "SELECT COUNT(*) FROM invite_codes WHERE created_by = ? AND used_at IS NULL" +
+                        "SELECT COUNT(*) FROM invite_codes " +
+                        "WHERE created_by = ? AND used_at IS NULL " +
+                        "AND (expires_at IS NULL OR expires_at > datetime('now'))" +
                         ") < ?",
                 [code, creatorUserId, createdAt, expiresAt, creatorUserId, MAX_UNUSED_INVITES_PER_USER],
         );

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -288,11 +288,17 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
         return { code, createdBy: creatorUserId, createdAt, usedBy: null, usedAt: null, expiresAt };
 }
 
+// LIMIT bounds the response size so historical used/expired rows can't
+// silently grow the payload over time. 100 is 5x the active quota — enough
+// headroom that a user always sees their full active set plus a long tail
+// of recent history. The UI doesn't paginate.
+const INVITE_LIST_LIMIT = 100;
+
 export async function listInvites(creatorUserId: string): Promise<Invite[]> {
         const result = await d1Query<InviteRow>(
                 "SELECT code, created_by, created_at, used_by, used_at, expires_at FROM invite_codes " +
-                        "WHERE created_by = ? ORDER BY created_at DESC",
-                [creatorUserId],
+                        "WHERE created_by = ? ORDER BY created_at DESC LIMIT ?",
+                [creatorUserId, INVITE_LIST_LIMIT],
         );
         return result.results.map(rowToInvite);
 }

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -106,14 +106,22 @@ export async function registerUser(
         // Bootstrap exception: the very first account doesn't need an invite,
         // since there's nobody to issue one. Every subsequent register must
         // claim an unused invite_codes row atomically.
-        const isBootstrap = !(await hasAnyUsers());
-
-        if (isBootstrap) {
+        //
+        // Only call hasAnyUsers() when no inviteCode was provided — the
+        // steady-state register-with-invite path doesn't need to know whether
+        // bootstrap is open, so skipping the round-trip cuts D1 chatter on
+        // the hot path. When the caller did supply a code, they couldn't be
+        // a bootstrap anyway (no codes exist yet), so skipping is also
+        // semantically correct.
+        if (!inviteCode) {
+                const isBootstrap = !(await hasAnyUsers());
+                if (!isBootstrap) {
+                        throw new InviteRequiredError("Invite code required");
+                }
                 // INSERT … WHERE NOT EXISTS closes the bootstrap TOCTOU window:
                 // hasAnyUsers() and INSERT are separate D1 round-trips, so two
                 // simultaneous first-ever registers could both observe zero users
-                // without this guard. Only one of them gets `meta.changes === 1`;
-                // the loser falls through to the invite-required path below.
+                // without this guard. Only one of them gets `meta.changes === 1`.
                 //
                 // Bootstrap is the one path where we hash before validating an
                 // invite — there's nothing to validate, and we need the hash for
@@ -128,11 +136,9 @@ export async function registerUser(
                 if (insert.meta.changes === 1) {
                         return { userId, token: signToken(userId, username) };
                 }
-                // Race loser: a concurrent bootstrap got there first. Require an
-                // invite from this point on, just like the steady-state path.
-        }
-
-        if (!inviteCode) {
+                // Race loser: a concurrent bootstrap got there first and we have
+                // no invite to fall back on. Match the steady-state response so
+                // the user can retry once they've been given a code.
                 throw new InviteRequiredError("Invite code required");
         }
         // Atomic claim: the WHERE used_at IS NULL clause prevents two concurrent
@@ -222,7 +228,11 @@ const MAX_UNUSED_INVITES_PER_USER = 20;
 const INVITE_EXPIRY_MIN_DAYS = 1 / 1440; // 1 minute
 const INVITE_EXPIRY_DAYS = ((): number => {
         const raw = process.env.INVITE_EXPIRY_DAYS;
-        if (raw === undefined) return 30;
+        // Treat blank ("" or whitespace-only) the same as unset. Without this
+        // Number("") === 0 would slip past the finite/non-negative check and
+        // land at the 1-minute floor — an operator who blanks the variable in
+        // a secrets manager would silently get near-zero TTL.
+        if (raw === undefined || raw.trim() === "") return 30;
         const n = Number(raw);
         if (!Number.isFinite(n) || n < 0) return 30;
         return Math.max(n, INVITE_EXPIRY_MIN_DAYS);

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -216,8 +216,17 @@ const MAX_UNUSED_INVITES_PER_USER = 20;
 // which a stolen JWT's pre-minted codes remain useful — the attacker has 20
 // quota slots, but anything they minted before losing the JWT becomes inert
 // after this window. Override via INVITE_EXPIRY_DAYS env var if a deployment
-// needs longer-lived invites.
-const INVITE_EXPIRY_DAYS = Number(process.env.INVITE_EXPIRY_DAYS) || 30;
+// needs longer-lived invites; "0" is a valid override (immediate expiry,
+// useful for tests) which `Number(x) || 30` would silently coerce to 30.
+const INVITE_EXPIRY_DAYS = ((): number => {
+        const raw = process.env.INVITE_EXPIRY_DAYS;
+        if (raw === undefined) return 30;
+        const n = Number(raw);
+        // Reject NaN / -Infinity / negative inputs by falling back to the
+        // default rather than producing nonsense expiry timestamps. `0` is
+        // explicitly allowed so a test can mint already-expired invites.
+        return Number.isFinite(n) && n >= 0 ? n : 30;
+})();
 
 export class InviteQuotaExceededError extends Error {
         constructor() {

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -107,33 +107,47 @@ export async function registerUser(
         }
 
         const userId = uuidv4();
+        const passwordHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
 
         // Bootstrap exception: the very first account doesn't need an invite,
         // since there's nobody to issue one. Every subsequent register must
         // claim an unused invite_codes row atomically.
         const isBootstrap = !(await hasAnyUsers());
 
-        if (!isBootstrap) {
-                if (!inviteCode) {
-                        throw new InviteRequiredError("Invite code required");
-                }
-                // Atomic claim: the WHERE used_at IS NULL clause prevents two
-                // concurrent registers from redeeming the same code. The race
-                // loser sees changes === 0 and is rejected. If the user INSERT
-                // below fails (e.g. concurrent username-uniqueness collision),
-                // we best-effort release the claim so the invite isn't burned
-                // by a register that never produced an account.
-                const claim = await d1Query(
-                        "UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
-                                "WHERE code = ? AND used_at IS NULL",
-                        [userId, inviteCode],
+        if (isBootstrap) {
+                // INSERT … WHERE NOT EXISTS closes the bootstrap TOCTOU window:
+                // hasAnyUsers() and INSERT are separate D1 round-trips, so two
+                // simultaneous first-ever registers could both observe zero users
+                // without this guard. Only one of them gets `meta.changes === 1`;
+                // the loser falls through to the invite-required path below.
+                const insert = await d1Query(
+                        "INSERT INTO users (id, username, password_hash) " +
+                                "SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
+                        [userId, username, passwordHash],
                 );
-                if (claim.meta.changes !== 1) {
-                        throw new InviteRequiredError("Invite code is invalid or already used");
+                if (insert.meta.changes === 1) {
+                        return { userId, token: signToken(userId, username) };
                 }
+                // Race loser: a concurrent bootstrap got there first. Require an
+                // invite from this point on, just like the steady-state path.
         }
 
-        const passwordHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
+        if (!inviteCode) {
+                throw new InviteRequiredError("Invite code required");
+        }
+        // Atomic claim: the WHERE used_at IS NULL clause prevents two concurrent
+        // registers from redeeming the same code. The race loser sees changes
+        // === 0 and is rejected. If the user INSERT below fails (e.g. concurrent
+        // username-uniqueness collision), we best-effort release the claim so
+        // the invite isn't burned by a register that never produced an account.
+        const claim = await d1Query(
+                "UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
+                        "WHERE code = ? AND used_at IS NULL",
+                [userId, inviteCode],
+        );
+        if (claim.meta.changes !== 1) {
+                throw new InviteRequiredError("Invite code is invalid or already used");
+        }
 
         try {
                 await d1Query("INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)", [
@@ -142,31 +156,42 @@ export async function registerUser(
                         passwordHash,
                 ]);
         } catch (err) {
-                if (!isBootstrap && inviteCode) {
-                        // Best-effort release. We scope by `used_by = userId` so we
-                        // can't accidentally un-claim a code that some other concurrent
-                        // register has since legitimately consumed.
-                        try {
-                                await d1Query(
-                                        "UPDATE invite_codes SET used_by = NULL, used_at = NULL " +
-                                                "WHERE code = ? AND used_by = ?",
-                                        [inviteCode, userId],
-                                );
-                        } catch (releaseErr) {
-                                console.error(
-                                        "[auth] invite release after failed user insert errored:",
-                                        (releaseErr as Error).message,
-                                );
-                        }
+                // Best-effort release. We scope by `used_by = userId` so we can't
+                // accidentally un-claim a code that some other concurrent register
+                // has since legitimately consumed.
+                try {
+                        await d1Query(
+                                "UPDATE invite_codes SET used_by = NULL, used_at = NULL " +
+                                        "WHERE code = ? AND used_by = ?",
+                                [inviteCode, userId],
+                        );
+                } catch (releaseErr) {
+                        console.error(
+                                "[auth] invite release after failed user insert errored:",
+                                (releaseErr as Error).message,
+                        );
                 }
                 throw err;
         }
 
-        const token = signToken(userId, username);
-        return { userId, token };
+        return { userId, token: signToken(userId, username) };
 }
 
 // ── Invites ────────────────────────────────────────────────────────────────
+
+// Caps the number of *outstanding* (unused) invites a single account can mint.
+// Bounds the blast radius if an account is compromised: even with a stolen
+// JWT the attacker can issue at most this many fresh invites before the cap
+// trips. Used codes don't count — revoking or seeing a redemption frees a
+// slot. Tune up if a legitimate workflow needs more concurrent invites.
+const MAX_UNUSED_INVITES_PER_USER = 20;
+
+export class InviteQuotaExceededError extends Error {
+        constructor() {
+                super(`You already have ${MAX_UNUSED_INVITES_PER_USER} unused invite codes — revoke or wait for some to be used before minting more`);
+                this.name = "InviteQuotaExceededError";
+        }
+}
 
 export interface Invite {
         code: string;
@@ -177,16 +202,27 @@ export interface Invite {
 }
 
 export async function createInvite(creatorUserId: string): Promise<Invite> {
+        const countResult = await d1Query<{ count: number }>(
+                "SELECT COUNT(*) as count FROM invite_codes WHERE created_by = ? AND used_at IS NULL",
+                [creatorUserId],
+        );
+        if ((countResult.results[0]?.count ?? 0) >= MAX_UNUSED_INVITES_PER_USER) {
+                throw new InviteQuotaExceededError();
+        }
+
         // 16 hex chars = 64 bits of entropy — plenty for a single-use,
         // typically short-lived invite code, and short enough to paste.
         const code = randomBytes(8).toString("hex");
-        await d1Query("INSERT INTO invite_codes (code, created_by) VALUES (?, ?)", [code, creatorUserId]);
-        // Round-trip the row so callers see the server-generated created_at.
-        const row = await d1Query<InviteRow>(
-                "SELECT code, created_by, created_at, used_by, used_at FROM invite_codes WHERE code = ?",
-                [code],
+        // Pass created_at explicitly so we can return it without a follow-up
+        // SELECT that could orphan a valid invite row on read failure. Format
+        // matches D1's `datetime('now')` output (UTC, no fractional seconds)
+        // so existing rows and new ones sort/compare consistently.
+        const createdAt = new Date().toISOString().replace("T", " ").slice(0, 19);
+        await d1Query(
+                "INSERT INTO invite_codes (code, created_by, created_at) VALUES (?, ?, ?)",
+                [code, creatorUserId, createdAt],
         );
-        return rowToInvite(row.results[0]!);
+        return { code, createdBy: creatorUserId, createdAt, usedBy: null, usedAt: null };
 }
 
 export async function listInvites(creatorUserId: string): Promise<Invite[]> {
@@ -198,12 +234,10 @@ export async function listInvites(creatorUserId: string): Promise<Invite[]> {
         return result.results.map(rowToInvite);
 }
 
-/**
- * Revoke an unused invite. Returns true if a row was removed, false if the
- * invite was missing, already used, or owned by a different user. We don't
- * distinguish those cases on the wire — keeping the surface intentionally
- * vague so a caller can't enumerate codes belonging to other users.
- */
+// Revoke an unused invite. Returns true if a row was removed, false if the
+// invite was missing, already used, or owned by a different user. The wire
+// surface is intentionally vague so a caller can't enumerate codes belonging
+// to other users.
 export async function revokeInvite(creatorUserId: string, code: string): Promise<boolean> {
         const result = await d1Query(
                 "DELETE FROM invite_codes WHERE code = ? AND created_by = ? AND used_at IS NULL",

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -101,11 +101,6 @@ export async function registerUser(
         password: string,
         inviteCode: string | undefined,
 ): Promise<{ userId: string; token: string }> {
-        const existing = await d1Query<{ id: string }>("SELECT id FROM users WHERE username = ?", [username]);
-        if (existing.results.length > 0) {
-                throw new UsernameTakenError();
-        }
-
         const userId = uuidv4();
         const passwordHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
 
@@ -120,13 +115,19 @@ export async function registerUser(
                 // simultaneous first-ever registers could both observe zero users
                 // without this guard. Only one of them gets `meta.changes === 1`;
                 // the loser falls through to the invite-required path below.
-                const insert = await d1Query(
-                        "INSERT INTO users (id, username, password_hash) " +
-                                "SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
-                        [userId, username, passwordHash],
-                );
-                if (insert.meta.changes === 1) {
-                        return { userId, token: signToken(userId, username) };
+                try {
+                        const insert = await d1Query(
+                                "INSERT INTO users (id, username, password_hash) " +
+                                        "SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
+                                [userId, username, passwordHash],
+                        );
+                        if (insert.meta.changes === 1) {
+                                return { userId, token: signToken(userId, username) };
+                        }
+                } catch (err) {
+                        // UNIQUE collision can't happen here (no users yet by definition),
+                        // so any error from this INSERT is infra, not a duplicate username.
+                        throw err;
                 }
                 // Race loser: a concurrent bootstrap got there first. Require an
                 // invite from this point on, just like the steady-state path.
@@ -137,9 +138,12 @@ export async function registerUser(
         }
         // Atomic claim: the WHERE used_at IS NULL clause prevents two concurrent
         // registers from redeeming the same code. The race loser sees changes
-        // === 0 and is rejected. If the user INSERT below fails (e.g. concurrent
-        // username-uniqueness collision), we best-effort release the claim so
-        // the invite isn't burned by a register that never produced an account.
+        // === 0 and is rejected. The claim happens BEFORE any check on the
+        // username so an unauthenticated caller without a valid invite always
+        // sees 403 — never a 409 that would let them probe for existing
+        // usernames. If the user INSERT below fails (UNIQUE collision), we
+        // best-effort release the claim so the invite isn't burned by a
+        // register that never produced an account.
         const claim = await d1Query(
                 "UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
                         "WHERE code = ? AND used_at IS NULL",
@@ -170,6 +174,13 @@ export async function registerUser(
                                 "[auth] invite release after failed user insert errored:",
                                 (releaseErr as Error).message,
                         );
+                }
+                // SQLite UNIQUE-constraint violation → username already taken.
+                // D1 surfaces the SQLite error message in the d1Query throw, so
+                // we sniff for it rather than introducing a typed-error layer
+                // around the whole D1 client.
+                if (/UNIQUE constraint failed: users\.username/i.test((err as Error).message)) {
+                        throw new UsernameTakenError();
                 }
                 throw err;
         }
@@ -202,26 +213,35 @@ export interface Invite {
 }
 
 export async function createInvite(creatorUserId: string): Promise<Invite> {
-        const countResult = await d1Query<{ count: number }>(
-                "SELECT COUNT(*) as count FROM invite_codes WHERE created_by = ? AND used_at IS NULL",
-                [creatorUserId],
-        );
-        if ((countResult.results[0]?.count ?? 0) >= MAX_UNUSED_INVITES_PER_USER) {
-                throw new InviteQuotaExceededError();
-        }
-
         // 16 hex chars = 64 bits of entropy — plenty for a single-use,
         // typically short-lived invite code, and short enough to paste.
+        //
+        // Codes are stored in plaintext rather than hashed: they are
+        // single-use, expected to be short-lived, and the user needs to read
+        // them back from the UI to share with invitees. A D1 breach would
+        // expose unused codes immediately — an acceptable trade-off given
+        // those properties, but flagged here so it's a conscious choice.
         const code = randomBytes(8).toString("hex");
         // Pass created_at explicitly so we can return it without a follow-up
         // SELECT that could orphan a valid invite row on read failure. Format
         // matches D1's `datetime('now')` output (UTC, no fractional seconds)
         // so existing rows and new ones sort/compare consistently.
         const createdAt = new Date().toISOString().replace("T", " ").slice(0, 19);
-        await d1Query(
-                "INSERT INTO invite_codes (code, created_by, created_at) VALUES (?, ?, ?)",
-                [code, creatorUserId, createdAt],
+        // Atomic quota check: collapse the count + insert into one statement
+        // so two concurrent POST /invites requests can't both observe count
+        // < MAX and both insert. The WHERE clause is evaluated as part of the
+        // INSERT, so SQLite serialises the read+write. Same changes-based
+        // pattern as the bootstrap and invite-claim paths above.
+        const insert = await d1Query(
+                "INSERT INTO invite_codes (code, created_by, created_at) " +
+                        "SELECT ?, ?, ? WHERE (" +
+                        "SELECT COUNT(*) FROM invite_codes WHERE created_by = ? AND used_at IS NULL" +
+                        ") < ?",
+                [code, creatorUserId, createdAt, creatorUserId, MAX_UNUSED_INVITES_PER_USER],
         );
+        if (insert.meta.changes !== 1) {
+                throw new InviteQuotaExceededError();
+        }
         return { code, createdBy: creatorUserId, createdAt, usedBy: null, usedAt: null };
 }
 

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -6,6 +6,7 @@ import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 import bcrypt from "bcryptjs";
 import { v4 as uuidv4 } from "uuid";
+import { randomBytes } from "node:crypto";
 import { d1Query } from "./db.js";
 import { JwtPayload } from "./types.js";
 
@@ -79,23 +80,154 @@ export interface AuthedRequest extends Request {
 
 // ── User management ─────────────────────────────────────────────────────────
 
-export async function registerUser(username: string, password: string): Promise<{ userId: string; token: string }> {
+// Thrown when register is attempted without an invite code (and an account
+// already exists), or with a code that's invalid / already redeemed.
+export class InviteRequiredError extends Error {
+        constructor(message: string) {
+                super(message);
+                this.name = "InviteRequiredError";
+        }
+}
+
+export class UsernameTakenError extends Error {
+        constructor() {
+                super("Username already taken");
+                this.name = "UsernameTakenError";
+        }
+}
+
+export async function registerUser(
+        username: string,
+        password: string,
+        inviteCode: string | undefined,
+): Promise<{ userId: string; token: string }> {
         const existing = await d1Query<{ id: string }>("SELECT id FROM users WHERE username = ?", [username]);
         if (existing.results.length > 0) {
-                throw new Error("Username already taken");
+                throw new UsernameTakenError();
         }
 
         const userId = uuidv4();
+
+        // Bootstrap exception: the very first account doesn't need an invite,
+        // since there's nobody to issue one. Every subsequent register must
+        // claim an unused invite_codes row atomically.
+        const isBootstrap = !(await hasAnyUsers());
+
+        if (!isBootstrap) {
+                if (!inviteCode) {
+                        throw new InviteRequiredError("Invite code required");
+                }
+                // Atomic claim: the WHERE used_at IS NULL clause prevents two
+                // concurrent registers from redeeming the same code. The race
+                // loser sees changes === 0 and is rejected. If the user INSERT
+                // below fails (e.g. concurrent username-uniqueness collision),
+                // we best-effort release the claim so the invite isn't burned
+                // by a register that never produced an account.
+                const claim = await d1Query(
+                        "UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
+                                "WHERE code = ? AND used_at IS NULL",
+                        [userId, inviteCode],
+                );
+                if (claim.meta.changes !== 1) {
+                        throw new InviteRequiredError("Invite code is invalid or already used");
+                }
+        }
+
         const passwordHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
 
-        await d1Query("INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)", [
-                userId,
-                username,
-                passwordHash,
-        ]);
+        try {
+                await d1Query("INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)", [
+                        userId,
+                        username,
+                        passwordHash,
+                ]);
+        } catch (err) {
+                if (!isBootstrap && inviteCode) {
+                        // Best-effort release. We scope by `used_by = userId` so we
+                        // can't accidentally un-claim a code that some other concurrent
+                        // register has since legitimately consumed.
+                        try {
+                                await d1Query(
+                                        "UPDATE invite_codes SET used_by = NULL, used_at = NULL " +
+                                                "WHERE code = ? AND used_by = ?",
+                                        [inviteCode, userId],
+                                );
+                        } catch (releaseErr) {
+                                console.error(
+                                        "[auth] invite release after failed user insert errored:",
+                                        (releaseErr as Error).message,
+                                );
+                        }
+                }
+                throw err;
+        }
 
         const token = signToken(userId, username);
         return { userId, token };
+}
+
+// ── Invites ────────────────────────────────────────────────────────────────
+
+export interface Invite {
+        code: string;
+        createdBy: string;
+        createdAt: string;
+        usedBy: string | null;
+        usedAt: string | null;
+}
+
+export async function createInvite(creatorUserId: string): Promise<Invite> {
+        // 16 hex chars = 64 bits of entropy — plenty for a single-use,
+        // typically short-lived invite code, and short enough to paste.
+        const code = randomBytes(8).toString("hex");
+        await d1Query("INSERT INTO invite_codes (code, created_by) VALUES (?, ?)", [code, creatorUserId]);
+        // Round-trip the row so callers see the server-generated created_at.
+        const row = await d1Query<InviteRow>(
+                "SELECT code, created_by, created_at, used_by, used_at FROM invite_codes WHERE code = ?",
+                [code],
+        );
+        return rowToInvite(row.results[0]!);
+}
+
+export async function listInvites(creatorUserId: string): Promise<Invite[]> {
+        const result = await d1Query<InviteRow>(
+                "SELECT code, created_by, created_at, used_by, used_at FROM invite_codes " +
+                        "WHERE created_by = ? ORDER BY created_at DESC",
+                [creatorUserId],
+        );
+        return result.results.map(rowToInvite);
+}
+
+/**
+ * Revoke an unused invite. Returns true if a row was removed, false if the
+ * invite was missing, already used, or owned by a different user. We don't
+ * distinguish those cases on the wire — keeping the surface intentionally
+ * vague so a caller can't enumerate codes belonging to other users.
+ */
+export async function revokeInvite(creatorUserId: string, code: string): Promise<boolean> {
+        const result = await d1Query(
+                "DELETE FROM invite_codes WHERE code = ? AND created_by = ? AND used_at IS NULL",
+                [code, creatorUserId],
+        );
+        return result.meta.changes === 1;
+}
+
+interface InviteRow {
+        code: string;
+        created_by: string;
+        created_at: string;
+        used_by: string | null;
+        used_at: string | null;
+}
+
+function rowToInvite(row: InviteRow): Invite {
+        return {
+                code: row.code,
+                createdBy: row.created_by,
+                createdAt: row.created_at,
+                usedBy: row.used_by,
+                usedAt: row.used_at,
+        };
 }
 
 // Thrown on wrong-username-or-password, and only that. Infra failures (D1

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -261,7 +261,19 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
         // consistently.
         const now = new Date();
         const createdAt = formatD1Datetime(now);
-        const expiresAt = formatD1Datetime(new Date(now.getTime() + INVITE_EXPIRY_DAYS * 86400_000));
+        // Enforce a minimum 1-second future expiry, even when INVITE_EXPIRY_DAYS=0.
+        // Without this, expires_at would resolve to the same UTC second as
+        // datetime('now') in the quota subquery's strict `>` filter, so the
+        // freshly inserted row would be classified as already-expired and would
+        // not count toward the cap. The result: every POST /invites would see
+        // COUNT(*)=0 and succeed, letting an attacker fill invite_codes with
+        // garbage. The 1s minimum still satisfies the test-plan scenario where
+        // INVITE_EXPIRY_DAYS=0 is set to verify the Expired UI label.
+        const expiresAtMs = Math.max(
+                now.getTime() + INVITE_EXPIRY_DAYS * 86400_000,
+                now.getTime() + 1000,
+        );
+        const expiresAt = formatD1Datetime(new Date(expiresAtMs));
         // Atomic quota check: collapse the count + insert into one statement
         // so two concurrent POST /invites requests can't both observe count
         // < MAX and both insert. The WHERE clause is evaluated as part of the

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -213,19 +213,19 @@ export async function registerUser(
 const MAX_UNUSED_INVITES_PER_USER = 20;
 
 // How long an unredeemed invite stays valid. 30 days bounds the window in
-// which a stolen JWT's pre-minted codes remain useful — the attacker has 20
-// quota slots, but anything they minted before losing the JWT becomes inert
-// after this window. Override via INVITE_EXPIRY_DAYS env var if a deployment
-// needs longer-lived invites; "0" is a valid override (immediate expiry,
-// useful for tests) which `Number(x) || 30` would silently coerce to 30.
+// which a stolen JWT's pre-minted codes remain useful. Override via
+// INVITE_EXPIRY_DAYS env var (decimal days). A 1-minute floor is enforced —
+// any lower value would let an authenticated user mint unbounded codes by
+// burst-cycling: at very short TTLs, 20 codes drain from the quota count in
+// seconds and another 20 can be minted, repeating without bound. 1 minute
+// caps the steady-state rate at 20/min/user.
+const INVITE_EXPIRY_MIN_DAYS = 1 / 1440; // 1 minute
 const INVITE_EXPIRY_DAYS = ((): number => {
         const raw = process.env.INVITE_EXPIRY_DAYS;
         if (raw === undefined) return 30;
         const n = Number(raw);
-        // Reject NaN / -Infinity / negative inputs by falling back to the
-        // default rather than producing nonsense expiry timestamps. `0` is
-        // explicitly allowed so a test can mint already-expired invites.
-        return Number.isFinite(n) && n >= 0 ? n : 30;
+        if (!Number.isFinite(n) || n < 0) return 30;
+        return Math.max(n, INVITE_EXPIRY_MIN_DAYS);
 })();
 
 export class InviteQuotaExceededError extends Error {
@@ -261,19 +261,7 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
         // consistently.
         const now = new Date();
         const createdAt = formatD1Datetime(now);
-        // Enforce a minimum 1-second future expiry, even when INVITE_EXPIRY_DAYS=0.
-        // Without this, expires_at would resolve to the same UTC second as
-        // datetime('now') in the quota subquery's strict `>` filter, so the
-        // freshly inserted row would be classified as already-expired and would
-        // not count toward the cap. The result: every POST /invites would see
-        // COUNT(*)=0 and succeed, letting an attacker fill invite_codes with
-        // garbage. The 1s minimum still satisfies the test-plan scenario where
-        // INVITE_EXPIRY_DAYS=0 is set to verify the Expired UI label.
-        const expiresAtMs = Math.max(
-                now.getTime() + INVITE_EXPIRY_DAYS * 86400_000,
-                now.getTime() + 1000,
-        );
-        const expiresAt = formatD1Datetime(new Date(expiresAtMs));
+        const expiresAt = formatD1Datetime(new Date(now.getTime() + INVITE_EXPIRY_DAYS * 86400_000));
         // Atomic quota check: collapse the count + insert into one statement
         // so two concurrent POST /invites requests can't both observe count
         // < MAX and both insert. The WHERE clause is evaluated as part of the

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -102,7 +102,6 @@ export async function registerUser(
         inviteCode: string | undefined,
 ): Promise<{ userId: string; token: string }> {
         const userId = uuidv4();
-        const passwordHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
 
         // Bootstrap exception: the very first account doesn't need an invite,
         // since there's nobody to issue one. Every subsequent register must
@@ -115,19 +114,19 @@ export async function registerUser(
                 // simultaneous first-ever registers could both observe zero users
                 // without this guard. Only one of them gets `meta.changes === 1`;
                 // the loser falls through to the invite-required path below.
-                try {
-                        const insert = await d1Query(
-                                "INSERT INTO users (id, username, password_hash) " +
-                                        "SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
-                                [userId, username, passwordHash],
-                        );
-                        if (insert.meta.changes === 1) {
-                                return { userId, token: signToken(userId, username) };
-                        }
-                } catch (err) {
-                        // UNIQUE collision can't happen here (no users yet by definition),
-                        // so any error from this INSERT is infra, not a duplicate username.
-                        throw err;
+                //
+                // Bootstrap is the one path where we hash before validating an
+                // invite — there's nothing to validate, and we need the hash for
+                // the conditional INSERT. The cost is one bcrypt per first-ever
+                // visit, which happens at most once per deployment.
+                const bootstrapHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
+                const insert = await d1Query(
+                        "INSERT INTO users (id, username, password_hash) " +
+                                "SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
+                        [userId, username, bootstrapHash],
+                );
+                if (insert.meta.changes === 1) {
+                        return { userId, token: signToken(userId, username) };
                 }
                 // Race loser: a concurrent bootstrap got there first. Require an
                 // invite from this point on, just like the steady-state path.
@@ -141,17 +140,24 @@ export async function registerUser(
         // === 0 and is rejected. The claim happens BEFORE any check on the
         // username so an unauthenticated caller without a valid invite always
         // sees 403 — never a 409 that would let them probe for existing
-        // usernames. If the user INSERT below fails (UNIQUE collision), we
-        // best-effort release the claim so the invite isn't burned by a
-        // register that never produced an account.
+        // usernames. The expires_at filter rejects stale codes the same way.
+        // If the user INSERT below fails (UNIQUE collision), we best-effort
+        // release the claim so the invite isn't burned by a register that
+        // never produced an account.
         const claim = await d1Query(
                 "UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
-                        "WHERE code = ? AND used_at IS NULL",
+                        "WHERE code = ? AND used_at IS NULL " +
+                        "AND (expires_at IS NULL OR expires_at > datetime('now'))",
                 [userId, inviteCode],
         );
         if (claim.meta.changes !== 1) {
-                throw new InviteRequiredError("Invite code is invalid or already used");
+                throw new InviteRequiredError("Invite code is invalid, expired, or already used");
         }
+
+        // Hash only after the invite is confirmed valid. bcrypt.hashSync blocks
+        // the event loop, so doing it before the claim would let an unauth'd
+        // caller burn server CPU just by spamming bogus codes.
+        const passwordHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
 
         try {
                 await d1Query("INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)", [
@@ -170,8 +176,17 @@ export async function registerUser(
                                 [inviteCode, userId],
                         );
                 } catch (releaseErr) {
+                        // The release UPDATE failed, so the invite is now permanently
+                        // consumed without producing an account. The invitee will see
+                        // a 409 (or 500) response and has no way of knowing the code
+                        // is burned — they'll have to ask whoever issued it for a new
+                        // one. Log loudly with the code so an operator can audit the
+                        // invite_codes table and reissue if needed.
                         console.error(
-                                "[auth] invite release after failed user insert errored:",
+                                "[auth] CRITICAL: invite release failed — code %s is permanently consumed without an account. " +
+                                        "Insert error: %s. Release error: %s",
+                                inviteCode,
+                                (err as Error).message,
                                 (releaseErr as Error).message,
                         );
                 }
@@ -197,6 +212,13 @@ export async function registerUser(
 // slot. Tune up if a legitimate workflow needs more concurrent invites.
 const MAX_UNUSED_INVITES_PER_USER = 20;
 
+// How long an unredeemed invite stays valid. 30 days bounds the window in
+// which a stolen JWT's pre-minted codes remain useful — the attacker has 20
+// quota slots, but anything they minted before losing the JWT becomes inert
+// after this window. Override via INVITE_EXPIRY_DAYS env var if a deployment
+// needs longer-lived invites.
+const INVITE_EXPIRY_DAYS = Number(process.env.INVITE_EXPIRY_DAYS) || 30;
+
 export class InviteQuotaExceededError extends Error {
         constructor() {
                 super(`You already have ${MAX_UNUSED_INVITES_PER_USER} unused invite codes — revoke or wait for some to be used before minting more`);
@@ -210,6 +232,7 @@ export interface Invite {
         createdAt: string;
         usedBy: string | null;
         usedAt: string | null;
+        expiresAt: string | null;
 }
 
 export async function createInvite(creatorUserId: string): Promise<Invite> {
@@ -222,32 +245,35 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
         // expose unused codes immediately — an acceptable trade-off given
         // those properties, but flagged here so it's a conscious choice.
         const code = randomBytes(8).toString("hex");
-        // Pass created_at explicitly so we can return it without a follow-up
-        // SELECT that could orphan a valid invite row on read failure. Format
-        // matches D1's `datetime('now')` output (UTC, no fractional seconds)
-        // so existing rows and new ones sort/compare consistently.
-        const createdAt = new Date().toISOString().replace("T", " ").slice(0, 19);
+        // Pass created_at + expires_at explicitly so we can return them
+        // without a follow-up SELECT that could orphan a valid invite row on
+        // read failure. Format matches D1's `datetime('now')` output (UTC,
+        // no fractional seconds) so existing rows and new ones sort/compare
+        // consistently.
+        const now = new Date();
+        const createdAt = formatD1Datetime(now);
+        const expiresAt = formatD1Datetime(new Date(now.getTime() + INVITE_EXPIRY_DAYS * 86400_000));
         // Atomic quota check: collapse the count + insert into one statement
         // so two concurrent POST /invites requests can't both observe count
         // < MAX and both insert. The WHERE clause is evaluated as part of the
         // INSERT, so SQLite serialises the read+write. Same changes-based
         // pattern as the bootstrap and invite-claim paths above.
         const insert = await d1Query(
-                "INSERT INTO invite_codes (code, created_by, created_at) " +
-                        "SELECT ?, ?, ? WHERE (" +
+                "INSERT INTO invite_codes (code, created_by, created_at, expires_at) " +
+                        "SELECT ?, ?, ?, ? WHERE (" +
                         "SELECT COUNT(*) FROM invite_codes WHERE created_by = ? AND used_at IS NULL" +
                         ") < ?",
-                [code, creatorUserId, createdAt, creatorUserId, MAX_UNUSED_INVITES_PER_USER],
+                [code, creatorUserId, createdAt, expiresAt, creatorUserId, MAX_UNUSED_INVITES_PER_USER],
         );
         if (insert.meta.changes !== 1) {
                 throw new InviteQuotaExceededError();
         }
-        return { code, createdBy: creatorUserId, createdAt, usedBy: null, usedAt: null };
+        return { code, createdBy: creatorUserId, createdAt, usedBy: null, usedAt: null, expiresAt };
 }
 
 export async function listInvites(creatorUserId: string): Promise<Invite[]> {
         const result = await d1Query<InviteRow>(
-                "SELECT code, created_by, created_at, used_by, used_at FROM invite_codes " +
+                "SELECT code, created_by, created_at, used_by, used_at, expires_at FROM invite_codes " +
                         "WHERE created_by = ? ORDER BY created_at DESC",
                 [creatorUserId],
         );
@@ -272,6 +298,7 @@ interface InviteRow {
         created_at: string;
         used_by: string | null;
         used_at: string | null;
+        expires_at: string | null;
 }
 
 function rowToInvite(row: InviteRow): Invite {
@@ -281,7 +308,15 @@ function rowToInvite(row: InviteRow): Invite {
                 createdAt: row.created_at,
                 usedBy: row.used_by,
                 usedAt: row.used_at,
+                expiresAt: row.expires_at,
         };
+}
+
+// "YYYY-MM-DD HH:MM:SS" UTC, matching D1's datetime('now') format so direct
+// SQL comparisons (`expires_at > datetime('now')`) work without timezone
+// surprises.
+function formatD1Datetime(d: Date): string {
+        return d.toISOString().replace("T", " ").slice(0, 19);
 }
 
 // Thrown on wrong-username-or-password, and only that. Infra failures (D1

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -245,11 +245,12 @@ export class InviteQuotaExceededError extends Error {
         }
 }
 
+// Wire shape intentionally omits created_by (always the authenticated caller,
+// so redundant) and used_by (exposes another user's internal UUID for no UI
+// benefit — the frontend derives used/unused from `usedAt !== null`).
 export interface Invite {
         code: string;
-        createdBy: string;
         createdAt: string;
-        usedBy: string | null;
         usedAt: string | null;
         expiresAt: string | null;
 }
@@ -295,7 +296,7 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
         if (insert.meta.changes !== 1) {
                 throw new InviteQuotaExceededError();
         }
-        return { code, createdBy: creatorUserId, createdAt, usedBy: null, usedAt: null, expiresAt };
+        return { code, createdAt, usedAt: null, expiresAt };
 }
 
 // LIMIT bounds the response size so historical used/expired rows can't
@@ -306,7 +307,7 @@ const INVITE_LIST_LIMIT = 100;
 
 export async function listInvites(creatorUserId: string): Promise<Invite[]> {
         const result = await d1Query<InviteRow>(
-                "SELECT code, created_by, created_at, used_by, used_at, expires_at FROM invite_codes " +
+                "SELECT code, created_at, used_at, expires_at FROM invite_codes " +
                         "WHERE created_by = ? ORDER BY created_at DESC LIMIT ?",
                 [creatorUserId, INVITE_LIST_LIMIT],
         );
@@ -327,9 +328,7 @@ export async function revokeInvite(creatorUserId: string, code: string): Promise
 
 interface InviteRow {
         code: string;
-        created_by: string;
         created_at: string;
-        used_by: string | null;
         used_at: string | null;
         expires_at: string | null;
 }
@@ -337,9 +336,7 @@ interface InviteRow {
 function rowToInvite(row: InviteRow): Invite {
         return {
                 code: row.code,
-                createdBy: row.created_by,
                 createdAt: row.created_at,
-                usedBy: row.used_by,
                 usedAt: row.used_at,
                 expiresAt: row.expires_at,
         };

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -98,6 +98,20 @@ export async function migrateDb(): Promise<void> {
                 )`,
                 `CREATE INDEX IF NOT EXISTS idx_sessions_user
                         ON sessions(user_id, status)`,
+                // Invite-only registration. The first user is allowed to register
+                // without an invite (bootstrap); every subsequent register must
+                // claim a row here. Atomic claim is enforced by an UPDATE …
+                // WHERE used_at IS NULL with `meta.changes === 1` check, so two
+                // concurrent registers can't redeem the same code.
+                `CREATE TABLE IF NOT EXISTS invite_codes (
+                        code        TEXT PRIMARY KEY,
+                        created_by  TEXT NOT NULL,
+                        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                        used_by     TEXT,
+                        used_at     TEXT
+                )`,
+                `CREATE INDEX IF NOT EXISTS idx_invite_codes_creator
+                        ON invite_codes(created_by)`,
         ]);
         console.log("[db] migrations complete");
 }

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -102,17 +102,31 @@ export async function migrateDb(): Promise<void> {
                 // without an invite (bootstrap); every subsequent register must
                 // claim a row here. Atomic claim is enforced by an UPDATE …
                 // WHERE used_at IS NULL with `meta.changes === 1` check, so two
-                // concurrent registers can't redeem the same code.
+                // concurrent registers can't redeem the same code. expires_at
+                // bounds how long an unredeemed code stays valid (NULL = never).
                 `CREATE TABLE IF NOT EXISTS invite_codes (
                         code        TEXT PRIMARY KEY,
                         created_by  TEXT NOT NULL,
                         created_at  TEXT NOT NULL DEFAULT (datetime('now')),
                         used_by     TEXT,
-                        used_at     TEXT
+                        used_at     TEXT,
+                        expires_at  TEXT
                 )`,
                 `CREATE INDEX IF NOT EXISTS idx_invite_codes_creator
                         ON invite_codes(created_by)`,
         ]);
+        // ALTER for any table that pre-dates the expires_at column (e.g. a dev
+        // DB that ran the original migration before this column existed). SQLite
+        // has no ADD COLUMN IF NOT EXISTS, so we run it unguarded and swallow
+        // the "duplicate column" error. CREATE TABLE above already includes the
+        // column for fresh deploys, so this is a no-op there.
+        try {
+                await d1Query("ALTER TABLE invite_codes ADD COLUMN expires_at TEXT");
+        } catch (err) {
+                if (!/duplicate column name|already exists/i.test((err as Error).message)) {
+                        throw err;
+                }
+        }
         console.log("[db] migrations complete");
 }
 

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -215,8 +215,12 @@ describe("auth route rate limiting", () => {
 	async function spinUp(cfg: {
 		login: { ipMax: number; ipWindowMs: number; usernameMax: number; usernameWindowMs: number };
 		register: { ipMax: number; ipWindowMs: number };
+		invites?: { ipMax: number; ipWindowMs: number };
 	}): Promise<void> {
-		const router = buildRouter(fakeSessions, fakeDocker, cfg);
+		// invites limiter was added later; supply a permissive default for tests
+		// that pre-date it and only exercise login/register surface.
+		const fullCfg = { invites: { ipMax: 1000, ipWindowMs: 60_000 }, ...cfg };
+		const router = buildRouter(fakeSessions, fakeDocker, fullCfg);
 		const app = express();
 		app.use(express.json());
 		app.use("/api", router);

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -15,9 +15,20 @@ export interface RateLimitConfig {
 		ipMax: number;
 		ipWindowMs: number;
 	};
+	// Caps how often a single IP can mint invite codes. The atomic per-user
+	// quota (20 outstanding) bounds the steady-state surface, but a stolen
+	// JWT could otherwise burst all 20 mints in milliseconds before anyone
+	// notices. Slower than registerIp because legitimate use is "invite a
+	// few friends, then idle for weeks".
+	invites: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
 }
 
 // Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
+// Invites: 10/1h — generous for legitimate inviting bursts, restrictive for
+// JWT-theft pre-mint floods.
 export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 	login: {
 		ipMax: 10,
@@ -29,6 +40,10 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 		ipMax: 5,
 		ipWindowMs: 60 * 60 * 1000,
 	},
+	invites: {
+		ipMax: 10,
+		ipWindowMs: 60 * 60 * 1000,
+	},
 };
 
 // ── IP-based limiters (express-rate-limit) ─────────────────────────────────
@@ -36,6 +51,7 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 export interface AuthRateLimiters {
 	loginIp: RateLimitRequestHandler;
 	registerIp: RateLimitRequestHandler;
+	invitesIp: RateLimitRequestHandler;
 }
 
 export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
@@ -61,7 +77,14 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many registration attempts from this IP, try again later", scope: "ip" },
 	});
-	return { loginIp, registerIp };
+	const invitesIp = rateLimit({
+		windowMs: cfg.invites.ipWindowMs,
+		limit: cfg.invites.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: { error: "Too many invite-mint requests from this IP, try again later", scope: "ip" },
+	});
+	return { loginIp, registerIp, invitesIp };
 }
 
 // ── Per-username limiter ────────────────────────────────────────────────────

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -191,6 +191,13 @@ export function buildRouter(
         router.delete("/invites/:code", async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
                 const { code } = req.params;
+                // Same 64-char ceiling as the inviteCode body field at register —
+                // codes mint at 16 hex chars, anything larger is a probe and
+                // shouldn't reach D1 even as a parameterized arg.
+                if (code.length > 64) {
+                        res.status(400).json({ error: "code must be at most 64 characters" });
+                        return;
+                }
                 try {
                         const removed = await revokeInvite(userId, code);
                         if (!removed) {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -28,7 +28,7 @@ export function buildRouter(
 
         // ── Auth routes (public) ────────────────────────────────────────────────
 
-        const { loginIp, registerIp } = createAuthRateLimiters(rateLimitConfig);
+        const { loginIp, registerIp, invitesIp } = createAuthRateLimiters(rateLimitConfig);
         const usernameLimiter = new UsernameRateLimiter(
                 rateLimitConfig.login.usernameMax,
                 rateLimitConfig.login.usernameWindowMs,
@@ -67,8 +67,22 @@ export function buildRouter(
                         res.status(400).json({ error: "inviteCode must be at most 64 characters" });
                         return;
                 }
+                // Distinguish "field absent" from "field present but whitespace-only".
+                // Without this, `inviteCode = "   "` would trim to "" and `|| undefined`
+                // would coerce it to absent, surfacing as "Invite code required" instead
+                // of "invalid". Whitespace-only is an explicit attempt — treat it as
+                // an invalid code so the user sees the right error.
+                let trimmedInviteCode: string | undefined;
+                if (inviteCode === undefined) {
+                        trimmedInviteCode = undefined;
+                } else if (inviteCode.trim() === "") {
+                        res.status(403).json({ error: "Invite code is invalid, expired, or already used" });
+                        return;
+                } else {
+                        trimmedInviteCode = inviteCode.trim();
+                }
                 try {
-                        const result = await registerUser(username, password, inviteCode?.trim() || undefined);
+                        const result = await registerUser(username, password, trimmedInviteCode);
                         res.status(201).json(result);
                 } catch (err) {
                         if (err instanceof InviteRequiredError) {
@@ -173,7 +187,7 @@ export function buildRouter(
                 }
         });
 
-        router.post("/invites", async (req: Request, res: Response) => {
+        router.post("/invites", invitesIp, async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
                 try {
                         const invite = await createInvite(userId);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -164,9 +164,6 @@ export function buildRouter(
         });
 
         // ── Authenticated route prefixes ────────────────────────────────────────
-        // Grouped so an auth-coverage audit is a single scan rather than a
-        // file-wide search. Order doesn't affect correctness — each `use(path,
-        // middleware)` only runs for routes mounted on that path *afterwards*.
 
         router.use("/invites", requireAuth);
         router.use("/sessions", requireAuth);
@@ -202,7 +199,7 @@ export function buildRouter(
                 }
         });
 
-        router.delete("/invites/:code", async (req: Request, res: Response) => {
+        router.delete("/invites/:code", invitesIp, async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
                 const { code } = req.params;
                 // Same 64-char ceiling as the inviteCode body field at register —

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -53,6 +53,13 @@ export function buildRouter(
                         res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
                         return;
                 }
+                // The frontend always sends a string or omits the field, but a hand-
+                // crafted POST with `inviteCode: 123` would crash `.trim()` and
+                // surface as a 500. Guard at the boundary so callers get a clear 400.
+                if (inviteCode !== undefined && typeof inviteCode !== "string") {
+                        res.status(400).json({ error: "inviteCode must be a string" });
+                        return;
+                }
                 try {
                         const result = await registerUser(username, password, inviteCode?.trim() || undefined);
                         res.status(201).json(result);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -142,12 +142,18 @@ export function buildRouter(
                 res.json(result);
         });
 
-        // ── Invite routes (authenticated) ───────────────────────────────────────
+        // ── Authenticated route prefixes ────────────────────────────────────────
+        // Grouped so an auth-coverage audit is a single scan rather than a
+        // file-wide search. Order doesn't affect correctness — each `use(path,
+        // middleware)` only runs for routes mounted on that path *afterwards*.
+
+        router.use("/invites", requireAuth);
+        router.use("/sessions", requireAuth);
+
+        // ── Invite routes ───────────────────────────────────────────────────────
         // Any authenticated user can mint invites — there is no admin tier yet.
         // If you ever want to gate this to specific accounts, add an is_admin
         // column to users and a middleware check here.
-
-        router.use("/invites", requireAuth);
 
         router.get("/invites", async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
@@ -194,9 +200,7 @@ export function buildRouter(
                 }
         });
 
-        // ── Session routes (authenticated) ──────────────────────────────────────
-
-        router.use("/sessions", requireAuth);
+        // ── Session routes ──────────────────────────────────────────────────────
 
         router.post("/sessions", async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -6,6 +6,7 @@ import { Router, Request, Response } from "express";
 import {
         AuthedRequest, requireAuth, registerUser, loginUser, hasAnyUsers,
         InvalidCredentialsError, InviteRequiredError, UsernameTakenError,
+        InviteQuotaExceededError,
         createInvite, listInvites, revokeInvite,
 } from "./auth.js";
 import { SessionManager, NotFoundError, ForbiddenError } from "./sessionManager.js";
@@ -158,6 +159,10 @@ export function buildRouter(
                         const invite = await createInvite(userId);
                         res.status(201).json(invite);
                 } catch (err) {
+                        if (err instanceof InviteQuotaExceededError) {
+                                res.status(429).json({ error: err.message });
+                                return;
+                        }
                         console.error(`[invites] create failed:`, (err as Error).message);
                         res.status(500).json({ error: "Internal server error" });
                 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -3,7 +3,11 @@
  */
 
 import { Router, Request, Response } from "express";
-import { AuthedRequest, requireAuth, registerUser, loginUser, hasAnyUsers, InvalidCredentialsError } from "./auth.js";
+import {
+        AuthedRequest, requireAuth, registerUser, loginUser, hasAnyUsers,
+        InvalidCredentialsError, InviteRequiredError, UsernameTakenError,
+        createInvite, listInvites, revokeInvite,
+} from "./auth.js";
 import { SessionManager, NotFoundError, ForbiddenError } from "./sessionManager.js";
 import { DockerManager } from "./dockerManager.js";
 import { SessionMeta } from "./types.js";
@@ -37,7 +41,9 @@ export function buildRouter(
         });
 
         router.post("/auth/register", registerIp, async (req: Request, res: Response) => {
-                const { username, password } = req.body as { username?: string; password?: string };
+                const { username, password, inviteCode } = req.body as {
+                        username?: string; password?: string; inviteCode?: string;
+                };
                 if (!username || !password || password.length < 6) {
                         res.status(400).json({ error: "username and password (min 6 chars) required" });
                         return;
@@ -47,10 +53,23 @@ export function buildRouter(
                         return;
                 }
                 try {
-                        const result = await registerUser(username, password);
+                        const result = await registerUser(username, password, inviteCode?.trim() || undefined);
                         res.status(201).json(result);
                 } catch (err) {
-                        res.status(409).json({ error: (err as Error).message });
+                        if (err instanceof InviteRequiredError) {
+                                // 403 — caller authenticated nothing yet, but the action is
+                                // forbidden without a valid invite. Distinct from 409 so the
+                                // frontend can render the invite-code field instead of a
+                                // username-taken message.
+                                res.status(403).json({ error: err.message });
+                                return;
+                        }
+                        if (err instanceof UsernameTakenError) {
+                                res.status(409).json({ error: err.message });
+                                return;
+                        }
+                        console.error(`[auth] register failed unexpectedly:`, (err as Error).message);
+                        res.status(500).json({ error: "Internal server error" });
                 }
         });
 
@@ -113,6 +132,54 @@ export function buildRouter(
                 }
                 usernameLimiter.reset(username);
                 res.json(result);
+        });
+
+        // ── Invite routes (authenticated) ───────────────────────────────────────
+        // Any authenticated user can mint invites — there is no admin tier yet.
+        // If you ever want to gate this to specific accounts, add an is_admin
+        // column to users and a middleware check here.
+
+        router.use("/invites", requireAuth);
+
+        router.get("/invites", async (req: Request, res: Response) => {
+                const { userId } = req as AuthedRequest;
+                try {
+                        const invites = await listInvites(userId);
+                        res.json(invites);
+                } catch (err) {
+                        console.error(`[invites] list failed:`, (err as Error).message);
+                        res.status(500).json({ error: "Internal server error" });
+                }
+        });
+
+        router.post("/invites", async (req: Request, res: Response) => {
+                const { userId } = req as AuthedRequest;
+                try {
+                        const invite = await createInvite(userId);
+                        res.status(201).json(invite);
+                } catch (err) {
+                        console.error(`[invites] create failed:`, (err as Error).message);
+                        res.status(500).json({ error: "Internal server error" });
+                }
+        });
+
+        router.delete("/invites/:code", async (req: Request, res: Response) => {
+                const { userId } = req as AuthedRequest;
+                const { code } = req.params;
+                try {
+                        const removed = await revokeInvite(userId, code);
+                        if (!removed) {
+                                // Vague on purpose: don't distinguish missing / already-used /
+                                // owned-by-someone-else, since that would let a caller probe for
+                                // codes outside their ownership.
+                                res.status(404).json({ error: "Invite not found or already used" });
+                                return;
+                        }
+                        res.status(204).send();
+                } catch (err) {
+                        console.error(`[invites] revoke failed:`, (err as Error).message);
+                        res.status(500).json({ error: "Internal server error" });
+                }
         });
 
         // ── Session routes (authenticated) ──────────────────────────────────────

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -60,6 +60,13 @@ export function buildRouter(
                         res.status(400).json({ error: "inviteCode must be a string" });
                         return;
                 }
+                // Cap length too — invite codes mint at 16 hex chars, so anything
+                // larger is a client bug or a probe. Without this, a megabyte-long
+                // string would still hit D1 as a parameter.
+                if (inviteCode !== undefined && inviteCode.length > 64) {
+                        res.status(400).json({ error: "inviteCode must be at most 64 characters" });
+                        return;
+                }
                 try {
                         const result = await registerUser(username, password, inviteCode?.trim() || undefined);
                         res.status(201).json(result);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -160,6 +160,160 @@
         border-color: #f85149;
         color: #f85149;
       }
+      #invites-btn {
+        background: transparent;
+        border: 1px solid #30363d;
+        border-radius: 6px;
+        color: #8b949e;
+        font-size: 0.75rem;
+        padding: 0.25rem 0.6rem;
+        cursor: pointer;
+      }
+      #invites-btn:hover {
+        border-color: #58a6ff;
+        color: #58a6ff;
+      }
+
+      /* ── Modal (invites) ────────────────────────────────────────── */
+      .modal {
+        display: none;
+        position: fixed;
+        inset: 0;
+        z-index: 100;
+        align-items: center;
+        justify-content: center;
+      }
+      .modal.open {
+        display: flex;
+      }
+      .modal-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.6);
+      }
+      .modal-card {
+        position: relative;
+        background: #161b22;
+        border: 1px solid #30363d;
+        border-radius: 12px;
+        padding: 1.25rem 1.25rem 1rem;
+        width: 480px;
+        max-width: 92vw;
+        max-height: 80vh;
+        display: flex;
+        flex-direction: column;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+      }
+      .modal-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.5rem;
+      }
+      .modal-header h2 {
+        font-size: 1rem;
+        color: #e6edf3;
+        font-weight: 600;
+      }
+      .modal-close {
+        background: transparent;
+        border: none;
+        color: #8b949e;
+        font-size: 1.4rem;
+        line-height: 1;
+        cursor: pointer;
+        padding: 0 0.4rem;
+        border-radius: 4px;
+      }
+      .modal-close:hover {
+        background: rgba(255, 255, 255, 0.08);
+        color: #e6edf3;
+      }
+      .modal-hint {
+        font-size: 0.78rem;
+        color: #8b949e;
+        margin-bottom: 0.85rem;
+        line-height: 1.45;
+      }
+      #invite-create-btn {
+        background: #238636;
+        border: none;
+        border-radius: 6px;
+        padding: 0.45rem 0.75rem;
+        color: #fff;
+        font-size: 0.82rem;
+        cursor: pointer;
+        margin-bottom: 0.85rem;
+        align-self: flex-start;
+      }
+      #invite-create-btn:hover {
+        background: #2ea043;
+      }
+      #invite-create-btn:disabled {
+        opacity: 0.6;
+        cursor: progress;
+      }
+      .invite-list {
+        flex: 1;
+        overflow-y: auto;
+        border-top: 1px solid #21262d;
+        padding-top: 0.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+      }
+      .invite-row {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.45rem 0.6rem;
+        background: #0d1117;
+        border: 1px solid #21262d;
+        border-radius: 6px;
+        font-size: 0.8rem;
+      }
+      .invite-row.used {
+        opacity: 0.55;
+      }
+      .invite-code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: #e6edf3;
+        flex: 1;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+      .invite-status {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #8b949e;
+      }
+      .invite-status.unused {
+        color: #3fb950;
+      }
+      .invite-action-btn {
+        background: transparent;
+        border: 1px solid #30363d;
+        border-radius: 4px;
+        color: #8b949e;
+        padding: 0.2rem 0.5rem;
+        font-size: 0.72rem;
+        cursor: pointer;
+      }
+      .invite-action-btn:hover {
+        color: #e6edf3;
+        border-color: #58a6ff;
+      }
+      .invite-action-btn.revoke:hover {
+        color: #f85149;
+        border-color: #f85149;
+      }
+      .invite-empty {
+        text-align: center;
+        color: #8b949e;
+        font-size: 0.8rem;
+        padding: 1rem 0;
+      }
 
       main {
         flex: 1;
@@ -571,6 +725,14 @@
             placeholder="Password"
             autocomplete="current-password"
           />
+          <input
+            id="auth-invite-code"
+            type="text"
+            placeholder="Invite code"
+            autocomplete="off"
+            spellcheck="false"
+            style="display: none"
+          />
           <div id="auth-error"></div>
           <button type="submit" id="auth-submit">Login</button>
         </form>
@@ -609,6 +771,7 @@
         <h1>⬛ Shared Terminal</h1>
         <div class="header-right">
           <span id="user-display"></span>
+          <button id="invites-btn" title="Manage invite codes">Invites</button>
           <button id="logout-btn">Logout</button>
         </div>
       </header>
@@ -651,6 +814,34 @@
     </div>
 
     <div id="toast"></div>
+
+    <!-- Invites modal -->
+    <div id="invites-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="invites-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="invites-modal-title">Invite codes</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >×</button>
+        </div>
+        <p class="modal-hint">
+          Share an invite code with someone to let them register an account.
+          Each code can only be used once.
+        </p>
+        <button id="invite-create-btn" type="button">+ Generate new invite</button>
+        <div id="invite-list" class="invite-list"></div>
+      </div>
+    </div>
+
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,6 +25,11 @@
         flex-direction: column;
       }
 
+      /* ── Utilities ──────────────────────────────────────────────── */
+      .hidden {
+        display: none !important;
+      }
+
       /* ── Auth view ──────────────────────────────────────────────── */
       #auth-view {
         display: none;
@@ -727,11 +732,11 @@
           />
           <input
             id="auth-invite-code"
+            class="hidden"
             type="text"
             placeholder="Invite code"
             autocomplete="off"
             spellcheck="false"
-            style="display: none"
           />
           <div id="auth-error"></div>
           <button type="submit" id="auth-submit">Login</button>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -216,9 +216,7 @@ export class TabNotFoundError extends Error {
 
 export interface Invite {
         code: string;
-        createdBy: string;
         createdAt: string;
-        usedBy: string | null;
         usedAt: string | null;
         expiresAt: string | null;
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,10 +31,14 @@ export async function checkAuthStatus(): Promise<{ needsSetup: boolean }> {
         return res.json();
 }
 
-export async function register(username: string, password: string): Promise<{ userId: string; token: string }> {
+export async function register(
+        username: string,
+        password: string,
+        inviteCode?: string,
+): Promise<{ userId: string; token: string }> {
         const res = await apiFetch("/auth/register", {
                 method: "POST",
-                body: JSON.stringify({ username, password }),
+                body: JSON.stringify({ username, password, inviteCode }),
         });
         if (!res.ok) {
                 const body = await res.json();
@@ -195,6 +199,39 @@ export class TabNotFoundError extends Error {
         constructor() {
                 super("Tab no longer exists in the session");
                 this.name = "TabNotFoundError";
+        }
+}
+
+// ── Invites API ─────────────────────────────────────────────────────────────
+
+export interface Invite {
+        code: string;
+        createdBy: string;
+        createdAt: string;
+        usedBy: string | null;
+        usedAt: string | null;
+}
+
+export async function listInvites(): Promise<Invite[]> {
+        const res = await apiFetch("/invites");
+        if (!res.ok) throw new Error("Failed to list invites");
+        return res.json();
+}
+
+export async function createInvite(): Promise<Invite> {
+        const res = await apiFetch("/invites", { method: "POST" });
+        if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error ?? "Failed to create invite");
+        }
+        return res.json();
+}
+
+export async function revokeInvite(code: string): Promise<void> {
+        const res = await apiFetch(`/invites/${encodeURIComponent(code)}`, { method: "DELETE" });
+        if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error ?? "Failed to revoke invite");
         }
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -220,6 +220,7 @@ export interface Invite {
         createdAt: string;
         usedBy: string | null;
         usedAt: string | null;
+        expiresAt: string | null;
 }
 
 export async function listInvites(): Promise<Invite[]> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,6 +31,13 @@ export async function checkAuthStatus(): Promise<{ needsSetup: boolean }> {
         return res.json();
 }
 
+export class InviteRequiredError extends Error {
+        constructor(message: string) {
+                super(message);
+                this.name = "InviteRequiredError";
+        }
+}
+
 export async function register(
         username: string,
         password: string,
@@ -41,7 +48,10 @@ export async function register(
                 body: JSON.stringify({ username, password, inviteCode }),
         });
         if (!res.ok) {
-                const body = await res.json();
+                const body = await res.json().catch(() => ({}));
+                if (res.status === 403) {
+                        throw new InviteRequiredError(body.error ?? "Invite code required");
+                }
                 throw new Error(body.error ?? "Registration failed");
         }
         const data = await res.json();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -240,6 +240,12 @@ export async function createInvite(): Promise<Invite> {
 
 export async function revokeInvite(code: string): Promise<void> {
         const res = await apiFetch(`/invites/${encodeURIComponent(code)}`, { method: "DELETE" });
+        // 404 means the row is already gone (concurrent revoke from another
+        // tab, or the invite was redeemed in the interim). The user-visible
+        // outcome — "the code is no longer in the list" — is identical to a
+        // 204, so swallow it. Without this, two tabs racing on the same code
+        // would show one success and one spurious "not found" toast.
+        if (res.status === 404) return;
         if (!res.ok) {
                 const body = await res.json().catch(() => ({}));
                 throw new Error(body.error ?? "Failed to revoke invite");

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -847,8 +847,14 @@ async function renderInvites() {
 
         for (const invite of invites) {
                 const used = invite.usedAt !== null;
+                // expires_at is server-stored as "YYYY-MM-DD HH:MM:SS" UTC. Append
+                // "Z" so Date parses it as UTC instead of local time, otherwise
+                // an invite minted UTC-late could appear expired in a CET browser.
+                const expired = !used && invite.expiresAt !== null
+                        && new Date(`${invite.expiresAt}Z`).getTime() <= Date.now();
+                const inert = used || expired;
                 const row = document.createElement("div");
-                row.className = `invite-row${used ? " used" : ""}`;
+                row.className = `invite-row${inert ? " used" : ""}`;
 
                 const code = document.createElement("span");
                 code.className = "invite-code";
@@ -856,11 +862,15 @@ async function renderInvites() {
                 row.appendChild(code);
 
                 const status = document.createElement("span");
-                status.className = `invite-status ${used ? "used" : "unused"}`;
-                status.textContent = used ? "Used" : "Unused";
+                status.className = `invite-status ${inert ? "used" : "unused"}`;
+                status.textContent = used ? "Used" : expired ? "Expired" : "Unused";
+                if (!used && !expired && invite.expiresAt) {
+                        status.title = `Expires ${invite.expiresAt} UTC`;
+                }
                 row.appendChild(status);
 
-                if (!used) {
+                // Copy is only meaningful while the code can still be redeemed.
+                if (!inert) {
                         const copyBtn = document.createElement("button");
                         copyBtn.type = "button";
                         copyBtn.className = "invite-action-btn";
@@ -875,7 +885,12 @@ async function renderInvites() {
                                 }
                         });
                         row.appendChild(copyBtn);
+                }
 
+                // Revoke is offered for both unused and expired invites — the
+                // backend DELETE matches WHERE used_at IS NULL, so expired-but-
+                // unused codes can still be cleaned up to free a quota slot.
+                if (!used) {
                         const revokeBtn = document.createElement("button");
                         revokeBtn.type = "button";
                         revokeBtn.className = "invite-action-btn revoke";

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -919,7 +919,9 @@ async function renderInvites() {
 
                 // Revoke is offered for both unused and expired invites — the
                 // backend DELETE matches WHERE used_at IS NULL, so expired-but-
-                // unused codes can still be cleaned up to free a quota slot.
+                // unused codes can be cleared from the list. Quota slots are
+                // already auto-freed by the expiry filter on the COUNT subquery,
+                // so this is purely UI hygiene.
                 if (!used) {
                         const revokeBtn = document.createElement("button");
                         revokeBtn.type = "button";

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,7 +9,8 @@ import {
         isLoggedIn, login, register, logout, checkAuthStatus,
         listSessions, createSession, deleteSession, stopSession, startSession,
         listTabs, createTab, deleteTab, LastTabError, TabNotFoundError,
-        type SessionInfo, type Tab,
+        listInvites, createInvite, revokeInvite,
+        type SessionInfo, type Tab, type Invite,
 } from "./api.js";
 import { openTerminalSession, type TerminalSession, type SessionStatus } from "./terminal.js";
 
@@ -23,10 +24,15 @@ const authToggle = document.getElementById("auth-toggle")!;
 const authError = document.getElementById("auth-error")!;
 const authUsername = document.getElementById("auth-username") as HTMLInputElement;
 const authPassword = document.getElementById("auth-password") as HTMLInputElement;
+const authInviteCode = document.getElementById("auth-invite-code") as HTMLInputElement;
 const authSubmitBtn = document.getElementById("auth-submit") as HTMLButtonElement;
 
 const userDisplay = document.getElementById("user-display")!;
 const logoutBtn = document.getElementById("logout-btn")!;
+const invitesBtn = document.getElementById("invites-btn") as HTMLButtonElement;
+const invitesModal = document.getElementById("invites-modal")!;
+const inviteCreateBtn = document.getElementById("invite-create-btn") as HTMLButtonElement;
+const inviteList = document.getElementById("invite-list")!;
 const sessionList = document.getElementById("session-list")!;
 const newSessionForm = document.getElementById("new-session-form") as HTMLFormElement;
 const newSessionInput = document.getElementById("new-session-input") as HTMLInputElement;
@@ -76,6 +82,11 @@ function disposeAllCurrentTerminals() {
 
 // ── Auth flow ───────────────────────────────────────────────────────────────
 
+// True only on the very first ever visit before any account exists. The
+// backend lets the first register go through without an invite (bootstrap);
+// we hide the invite-code field in that case so the screen looks normal.
+let isBootstrapRegister = false;
+
 async function initAuth() {
         if (isLoggedIn()) {
                 showApp();
@@ -86,6 +97,7 @@ async function initAuth() {
                 const { needsSetup } = await checkAuthStatus();
                 if (needsSetup) {
                         isRegisterMode = true;
+                        isBootstrapRegister = true;
                         updateAuthUI();
                 }
         } catch {
@@ -113,10 +125,14 @@ function updateAuthUI() {
                 authTitle.textContent = "Create Account";
                 authSubmitBtn.textContent = "Register";
                 authToggle.innerHTML = 'Already have an account? <a href="#" id="auth-toggle-link">Login</a>';
+                // Invite code is required for every register except the bootstrap
+                // first user — show the field accordingly.
+                authInviteCode.style.display = isBootstrapRegister ? "none" : "block";
         } else {
                 authTitle.textContent = "Login";
                 authSubmitBtn.textContent = "Login";
                 authToggle.innerHTML = 'No account? <a href="#" id="auth-toggle-link">Register</a>';
+                authInviteCode.style.display = "none";
         }
         // Re-bind toggle link
         document.getElementById("auth-toggle-link")?.addEventListener("click", (e) => {
@@ -132,15 +148,20 @@ authForm.addEventListener("submit", async (e) => {
         authError.textContent = "";
         const username = authUsername.value.trim();
         const password = authPassword.value;
+        const inviteCode = authInviteCode.value.trim();
 
         if (!username || !password) {
                 authError.textContent = "Username and password required";
                 return;
         }
+        if (isRegisterMode && !isBootstrapRegister && !inviteCode) {
+                authError.textContent = "Invite code required";
+                return;
+        }
 
         try {
                 if (isRegisterMode) {
-                        await register(username, password);
+                        await register(username, password, inviteCode || undefined);
                 } else {
                         await login(username, password);
                 }
@@ -778,6 +799,120 @@ mobileMql.addEventListener("change", () => setSidebarOpen(!isMobile()));
 // that would otherwise fire on every desktop page load.
 setSidebarOpen(!isMobile());
 mainEl.setAttribute("data-sidebar-ready", "");
+
+// ── Invites modal ───────────────────────────────────────────────────────────
+
+function openInvitesModal() {
+        invitesModal.classList.add("open");
+        invitesModal.setAttribute("aria-hidden", "false");
+        void renderInvites();
+}
+
+function closeInvitesModal() {
+        invitesModal.classList.remove("open");
+        invitesModal.setAttribute("aria-hidden", "true");
+        invitesBtn.focus();
+}
+
+async function renderInvites() {
+        inviteList.textContent = "Loading…";
+        let invites: Invite[];
+        try {
+                invites = await listInvites();
+        } catch (err) {
+                inviteList.textContent = "";
+                showToast((err as Error).message, true);
+                return;
+        }
+
+        inviteList.textContent = "";
+        if (invites.length === 0) {
+                const empty = document.createElement("div");
+                empty.className = "invite-empty";
+                empty.textContent = "No invites yet — generate one above.";
+                inviteList.appendChild(empty);
+                return;
+        }
+
+        for (const invite of invites) {
+                const used = invite.usedAt !== null;
+                const row = document.createElement("div");
+                row.className = `invite-row${used ? " used" : ""}`;
+
+                const code = document.createElement("span");
+                code.className = "invite-code";
+                code.textContent = invite.code;
+                row.appendChild(code);
+
+                const status = document.createElement("span");
+                status.className = `invite-status ${used ? "used" : "unused"}`;
+                status.textContent = used ? "Used" : "Unused";
+                row.appendChild(status);
+
+                if (!used) {
+                        const copyBtn = document.createElement("button");
+                        copyBtn.type = "button";
+                        copyBtn.className = "invite-action-btn";
+                        copyBtn.textContent = "Copy";
+                        copyBtn.addEventListener("click", async () => {
+                                try {
+                                        await navigator.clipboard.writeText(invite.code);
+                                        copyBtn.textContent = "Copied";
+                                        setTimeout(() => { copyBtn.textContent = "Copy"; }, 1500);
+                                } catch {
+                                        showToast("Couldn't copy — select the code manually", true);
+                                }
+                        });
+                        row.appendChild(copyBtn);
+
+                        const revokeBtn = document.createElement("button");
+                        revokeBtn.type = "button";
+                        revokeBtn.className = "invite-action-btn revoke";
+                        revokeBtn.textContent = "Revoke";
+                        revokeBtn.addEventListener("click", async () => {
+                                if (!confirm(`Revoke invite "${invite.code}"?`)) return;
+                                revokeBtn.disabled = true;
+                                try {
+                                        await revokeInvite(invite.code);
+                                        await renderInvites();
+                                } catch (err) {
+                                        revokeBtn.disabled = false;
+                                        showToast((err as Error).message, true);
+                                }
+                        });
+                        row.appendChild(revokeBtn);
+                }
+
+                inviteList.appendChild(row);
+        }
+}
+
+invitesBtn.addEventListener("click", openInvitesModal);
+
+inviteCreateBtn.addEventListener("click", async () => {
+        inviteCreateBtn.disabled = true;
+        try {
+                await createInvite();
+                await renderInvites();
+        } catch (err) {
+                showToast((err as Error).message, true);
+        } finally {
+                inviteCreateBtn.disabled = false;
+        }
+});
+
+// data-close-modal lives on both the backdrop and the × button — one
+// listener handles both rather than wiring two element refs.
+invitesModal.addEventListener("click", (e) => {
+        const target = e.target as HTMLElement;
+        if (target.hasAttribute("data-close-modal")) closeInvitesModal();
+});
+
+document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && invitesModal.classList.contains("open")) {
+                closeInvitesModal();
+        }
+});
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,7 +9,7 @@ import {
         isLoggedIn, login, register, logout, checkAuthStatus,
         listSessions, createSession, deleteSession, stopSession, startSession,
         listTabs, createTab, deleteTab, LastTabError, TabNotFoundError,
-        listInvites, createInvite, revokeInvite,
+        listInvites, createInvite, revokeInvite, InviteRequiredError,
         type SessionInfo, type Tab, type Invite,
 } from "./api.js";
 import { openTerminalSession, type TerminalSession, type SessionStatus } from "./terminal.js";
@@ -167,6 +167,17 @@ authForm.addEventListener("submit", async (e) => {
                 }
                 showApp();
         } catch (err) {
+                // The bootstrap window can close between page load and submit
+                // (a concurrent register sneaks in, or the page sat open after
+                // someone else set up the first account). The backend signals
+                // this with 403 InviteRequired — clear the flag and reveal the
+                // invite-code field so the user can retry without reloading.
+                if (err instanceof InviteRequiredError && isBootstrapRegister) {
+                        isBootstrapRegister = false;
+                        updateAuthUI();
+                        authError.textContent = "An account already exists — enter an invite code to register.";
+                        return;
+                }
                 authError.textContent = (err as Error).message;
         }
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -178,6 +178,23 @@ authForm.addEventListener("submit", async (e) => {
                         authError.textContent = "An account already exists — enter an invite code to register.";
                         return;
                 }
+                // Non-403 failures during bootstrap (transient 500, network blip)
+                // would otherwise leave isBootstrapRegister=true forever — the
+                // invite field stays hidden and every retry re-fires the no-invite
+                // path, which the backend may now reject if a concurrent register
+                // already grabbed the bootstrap slot. Re-fetch the canonical state
+                // so the next submit either retries cleanly or shows the invite
+                // field. checkAuthStatus is cheap and only runs on the rare
+                // bootstrap-error path.
+                if (isRegisterMode && isBootstrapRegister) {
+                        try {
+                                const { needsSetup } = await checkAuthStatus();
+                                if (!needsSetup) {
+                                        isBootstrapRegister = false;
+                                        updateAuthUI();
+                                }
+                        } catch { /* status check itself failed — keep the flag, surface the original error */ }
+                }
                 authError.textContent = (err as Error).message;
         }
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -844,6 +844,10 @@ mainEl.setAttribute("data-sidebar-ready", "");
 function openInvitesModal() {
         invitesModal.classList.add("open");
         invitesModal.setAttribute("aria-hidden", "false");
+        // Move focus into the dialog so a keyboard user activating the Invites
+        // button via Enter doesn't have their first Tab walk through the page
+        // behind the backdrop. Mirrors the invitesBtn.focus() in close.
+        inviteCreateBtn.focus();
         void renderInvites();
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -127,12 +127,12 @@ function updateAuthUI() {
                 authToggle.innerHTML = 'Already have an account? <a href="#" id="auth-toggle-link">Login</a>';
                 // Invite code is required for every register except the bootstrap
                 // first user — show the field accordingly.
-                authInviteCode.style.display = isBootstrapRegister ? "none" : "block";
+                authInviteCode.classList.toggle("hidden", isBootstrapRegister);
         } else {
                 authTitle.textContent = "Login";
                 authSubmitBtn.textContent = "Login";
                 authToggle.innerHTML = 'No account? <a href="#" id="auth-toggle-link">Register</a>';
-                authInviteCode.style.display = "none";
+                authInviteCode.classList.add("hidden");
         }
         // Re-bind toggle link
         document.getElementById("auth-toggle-link")?.addEventListener("click", (e) => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -135,10 +135,21 @@ function updateAuthUI() {
                 authInviteCode.classList.add("hidden");
         }
         // Re-bind toggle link
-        document.getElementById("auth-toggle-link")?.addEventListener("click", (e) => {
+        document.getElementById("auth-toggle-link")?.addEventListener("click", async (e) => {
                 e.preventDefault();
                 isRegisterMode = !isRegisterMode;
                 authError.textContent = "";
+                // Re-fetch the canonical bootstrap state when entering register
+                // mode. Otherwise isBootstrapRegister is whatever it was at page
+                // load — toggling login → register would silently keep the flag
+                // (and the hidden invite field) even if the bootstrap window
+                // closed in the interim. Single GET, only on the toggle click.
+                if (isRegisterMode) {
+                        try {
+                                const { needsSetup } = await checkAuthStatus();
+                                isBootstrapRegister = needsSetup;
+                        } catch { /* status check failed — keep prior flag value */ }
+                }
                 updateAuthUI();
         });
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -875,11 +875,13 @@ async function renderInvites() {
 
         for (const invite of invites) {
                 const used = invite.usedAt !== null;
-                // expires_at is server-stored as "YYYY-MM-DD HH:MM:SS" UTC. Append
-                // "Z" so Date parses it as UTC instead of local time, otherwise
-                // an invite minted UTC-late could appear expired in a CET browser.
+                // expires_at is server-stored as "YYYY-MM-DD HH:MM:SS" UTC. Swap
+                // the space for "T" before appending "Z" so the result is valid
+                // ISO 8601 — Safari rejects the space-separated form and returns
+                // Invalid Date, which would silently misclassify expired invites
+                // as Unused.
                 const expired = !used && invite.expiresAt !== null
-                        && new Date(`${invite.expiresAt}Z`).getTime() <= Date.now();
+                        && new Date(`${invite.expiresAt.replace(" ", "T")}Z`).getTime() <= Date.now();
                 const inert = used || expired;
                 const row = document.createElement("div");
                 row.className = `invite-row${inert ? " used" : ""}`;


### PR DESCRIPTION
Closes #7.

## Summary
Previously `POST /api/auth/register` only checked username uniqueness — anyone who could reach the URL could create an account and spawn containers on the host. The frontend's `needsSetup` flag was a hint only; the endpoint enforced nothing.

This PR gates registration behind invite codes that any authenticated user can mint. The very first ever account can still register without an invite (bootstrap exception), matching the existing first-visit UX.

## Backend
- **New `invite_codes` table** (`code` PK, `created_by`, `created_at`, `used_by`, `used_at`, `expires_at`) + index on `created_by`. `IF NOT EXISTS` migration so no manual D1 step required; `expires_at` added with a guarded `ALTER TABLE` for any pre-existing dev DB.
- **`registerUser`** now takes `inviteCode?` and:
  - On bootstrap (no users yet): registers without an invite via `INSERT … SELECT … WHERE NOT EXISTS (SELECT 1 FROM users)`. Closes the bootstrap TOCTOU; race losers fall through to the invite-required path below.
  - Otherwise: claims an invite atomically with `UPDATE invite_codes SET used_by=?, used_at=… WHERE code=? AND used_at IS NULL AND (expires_at IS NULL OR expires_at > datetime('now'))` and checks `meta.changes === 1`. Two concurrent registers can't redeem the same code; expired codes are rejected the same way as missing/used ones.
  - **Invite is claimed *before* any username check** — by design, so an unauthenticated caller without a valid invite always sees `403`, never a `409` that would let them probe for existing usernames.
  - bcrypt hashing happens **after** the invite is validated, so probing with bogus codes doesn't trigger expensive hash work on every attempt.
  - Username collisions are detected by the final user `INSERT`'s UNIQUE constraint, with a best-effort invite release on failure. If the release itself fails, a CRITICAL log line names the invite so an operator can audit `invite_codes` and reissue.
- **New endpoints** (auth-required):
  - `GET /api/invites` — list invites the caller minted, with status (used / expired / unused).
  - `POST /api/invites` — mint a new code (16 hex chars, `randomBytes(8)`). Per-user cap of 20 outstanding unused invites is enforced atomically inside the INSERT (`INSERT … SELECT … WHERE (SELECT COUNT…) < ?`) so two concurrent mints can't both bypass the cap; cap exceeded → `429`.
  - `DELETE /api/invites/:code` — revoke an unused (or expired) code the caller owns. Backend returns 404 with a vague message on missing/used/foreign codes to prevent enumeration; the frontend swallows that 404 so racing tabs (or already-redeemed codes) feel like silent success in the UI.
- **`POST /api/auth/register`** returns `403 InviteRequired` (distinct from `409 UsernameTaken`) so the frontend can render the right message.

## Frontend
- Register form picks up an **invite code input**, hidden via a `.hidden` utility class when `needsSetup` is true and shown otherwise. If the bootstrap window closes mid-session (the backend returns `403 InviteRequired` on what was meant to be a bootstrap register), the field unhides and the form recovers without a reload.
- New **"Invites" header button** opens a modal listing the user's invites with status (Used / Expired / Unused), **Copy** and **Revoke** actions, plus a button to mint a new code. Modal dismisses on backdrop click, the × button, or Escape.

## Security trade-offs (intentional)
- **Anyone authenticated can mint invites** — no admin tier yet. Per-user quota (20 unused) and 30-day expiry bound the blast radius if a JWT is stolen. Tighten to admin-only later by adding an `is_admin` column + middleware check.
- **Invite codes stored in plaintext.** Single-use, short-lived, needs to be human-readable to share. Documented inline in `createInvite`.
- `DELETE /invites/:code` puts the code in the URL path → it lands in access logs. Logged codes are codes about to be invalidated, so the leak is moot. Documented as known.

## Test plan
- [ ] Fresh DB: visit the app, register without an invite — should succeed (`needsSetup` path), no invite field shown.
- [ ] As that user, open the **Invites** modal, mint a code, verify it appears as Unused with copy/revoke actions.
- [ ] In an incognito window, register with that code + a new username → success; the modal in the original session shows the code as Used.
- [ ] Try to register again with the same code → 403 with "Invite code is invalid, expired, or already used".
- [ ] Try to register without an invite when accounts exist → 403.
- [ ] Mint a code, then revoke it → row disappears; attempting to register with it now fails.
- [ ] Two concurrent registers using the same code (race): only one succeeds; the other gets 403. (Manual via two browsers.)
- [ ] Two concurrent mint requests at quota: only one succeeds; the other gets 429. (Manual via two tabs.)
- [ ] Set `INVITE_EXPIRY_DAYS=0` (or wait), verify expired codes show Expired in the modal and reject on register.
- [ ] All existing backend tests pass: `cd backend && npm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

