### PR TITLE
feat(mobile): WebGL renderer + touch scroll + visibility refresh

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,12 @@
         font-family: system-ui, sans-serif;
         background: #0d1117;
         color: #e6edf3;
-        height: 100dvh;
+        /* --app-vh is pinned by main.ts off visualViewport.height so the
+           terminal fits between the status/address bar and the soft
+           keyboard on mobile — dvh alone doesn't account for iOS's
+           keyboard overlay. Falls back to 100dvh on browsers without
+           visualViewport. */
+        height: var(--app-vh, 100dvh);
         display: flex;
         flex-direction: column;
       }
@@ -539,6 +544,21 @@
         background: rgba(139, 148, 158, 0.2);
         color: #8b949e;
       }
+      #font-size-btn {
+        margin-left: auto;
+        background: transparent;
+        border: 1px solid #30363d;
+        border-radius: 6px;
+        color: #8b949e;
+        font-size: 0.75rem;
+        padding: 0.2rem 0.55rem;
+        cursor: pointer;
+        line-height: 1;
+      }
+      #font-size-btn:hover {
+        border-color: #58a6ff;
+        color: #58a6ff;
+      }
       #terminal-tabs {
         display: none;
         align-items: stretch;
@@ -645,6 +665,15 @@
       }
       #terminal-container .xterm {
         height: 100%;
+      }
+      /* Stop the OS from claiming vertical drags as page-scroll — our
+         touch handler in terminal.ts routes them to term.scrollLines or
+         synthetic arrow keys. touch-action has to be on xterm's own
+         layers, not just the wrapping container. */
+      #terminal-container .xterm,
+      #terminal-container .xterm-viewport,
+      #terminal-container .xterm-screen {
+        touch-action: none;
       }
       #empty-state {
         display: flex;
@@ -811,6 +840,14 @@
             <span>Session:</span>
             <span id="terminal-session-name"></span>
             <span id="terminal-status-badge"></span>
+            <button
+              id="font-size-btn"
+              type="button"
+              title="Cycle terminal font size"
+              aria-label="Change terminal font size"
+            >
+              Aa
+            </button>
           </div>
           <div id="terminal-tabs"></div>
           <div id="terminal-container"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0"
       },
       "devDependencies": {
@@ -172,9 +173,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -192,9 +190,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -212,9 +207,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -232,9 +224,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -252,9 +241,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -272,9 +258,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -376,6 +359,15 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
       "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
+      "integrity": "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==",
       "license": "MIT",
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
@@ -573,9 +565,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -597,9 +586,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -621,9 +607,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -645,9 +628,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0"
   },
   "devDependencies": {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -48,7 +48,37 @@ const terminalStatusBadge = document.getElementById("terminal-status-badge")!;
 const terminalTabs = document.getElementById("terminal-tabs")!;
 const terminalContainer = document.getElementById("terminal-container")!;
 const emptyState = document.getElementById("empty-state")!;
+const fontSizeBtn = document.getElementById("font-size-btn") as HTMLButtonElement;
 const toast = document.getElementById("toast")!;
+
+// ── Viewport height ─────────────────────────────────────────────────────────
+// iOS Safari's soft keyboard overlays the layout viewport without resizing
+// it, so `100dvh` on <body> leaves the terminal partially behind the
+// keyboard. VisualViewport fires resize events as the keyboard opens/closes
+// and as the URL bar shows/hides — we mirror its height into --app-vh so the
+// xterm host container refits to the space actually visible to the user.
+function syncViewportHeight() {
+	const vv = window.visualViewport;
+	const h = vv ? vv.height : window.innerHeight;
+	document.documentElement.style.setProperty("--app-vh", `${h}px`);
+}
+syncViewportHeight();
+window.visualViewport?.addEventListener("resize", syncViewportHeight);
+window.visualViewport?.addEventListener("scroll", syncViewportHeight);
+window.addEventListener("resize", syncViewportHeight);
+
+// ── Font size ───────────────────────────────────────────────────────────────
+// Persisted across reloads via localStorage. Mobile users want ~16 px on a
+// 6" phone, desktop users typically 13–15 px — let them pick once and stick.
+const FONT_SIZE_STEPS = [11, 12, 13, 14, 15, 16, 18];
+const DEFAULT_FONT_SIZE = 14;
+const FONT_SIZE_KEY = "shared-terminal:font-size";
+function readFontSize(): number {
+	const raw = localStorage.getItem(FONT_SIZE_KEY);
+	const n = raw ? Number.parseInt(raw, 10) : DEFAULT_FONT_SIZE;
+	return FONT_SIZE_STEPS.includes(n) ? n : DEFAULT_FONT_SIZE;
+}
+let currentFontSize = readFontSize();
 
 // ── State ───────────────────────────────────────────────────────────────────
 
@@ -838,6 +868,26 @@ mobileMql.addEventListener("change", () => setSidebarOpen(!isMobile()));
 // that would otherwise fire on every desktop page load.
 setSidebarOpen(!isMobile());
 mainEl.setAttribute("data-sidebar-ready", "");
+
+// ── Font size cycle button ──────────────────────────────────────────────────
+
+function nextFontSize(current: number): number {
+	const i = FONT_SIZE_STEPS.indexOf(current);
+	if (i === -1) return DEFAULT_FONT_SIZE;
+	return FONT_SIZE_STEPS[(i + 1) % FONT_SIZE_STEPS.length]!;
+}
+
+fontSizeBtn.addEventListener("click", () => {
+	currentFontSize = nextFontSize(currentFontSize);
+	localStorage.setItem(FONT_SIZE_KEY, String(currentFontSize));
+	fontSizeBtn.textContent = `Aa ${currentFontSize}`;
+	for (const { term } of currentTerminals.values()) {
+		term.setFontSize(currentFontSize);
+	}
+});
+// Reflect the persisted size in the label on load so users see e.g. "Aa 16"
+// rather than a generic "Aa" after they've picked their size once.
+fontSizeBtn.textContent = `Aa ${currentFontSize}`;
 
 // ── Invites modal ───────────────────────────────────────────────────────────
 

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -4,6 +4,7 @@
 
 import { Terminal, ILink, ILinkProvider, IDisposable } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 import { getToken } from "./api.js";
 
@@ -11,6 +12,7 @@ export type SessionStatus = "running" | "stopped" | "terminated" | "disconnected
 
 export interface TerminalSession {
         dispose(): void;
+        setFontSize(px: number): void;
 }
 
 export type StatusCallback = (status: SessionStatus) => void;
@@ -20,10 +22,11 @@ export function openTerminalSession(opts: {
         container: HTMLElement;
         sessionId: string;
         tabId?: string;
+        fontSize?: number;
         onStatus: StatusCallback;
         onError: ErrorCallback;
 }): TerminalSession {
-        const { container, sessionId, tabId, onStatus, onError } = opts;
+        const { container, sessionId, tabId, fontSize, onStatus, onError } = opts;
 
         // ── xterm.js setup ──────────────────────────────────────────────────────
         const term = new Terminal({
@@ -34,7 +37,7 @@ export function openTerminalSession(opts: {
                         selectionBackground: "#264f78",
                 },
                 fontFamily: '"Cascadia Code", "Fira Code", "JetBrains Mono", monospace',
-                fontSize: 14,
+                fontSize: fontSize ?? 14,
                 lineHeight: 1.2,
                 cursorBlink: true,
                 convertEol: true,
@@ -49,21 +52,37 @@ export function openTerminalSession(opts: {
                         },
                         allowNonHttpProtocols: false,
                 },
-                // Auto-copy selected text to the clipboard — avoids the xterm quirk
-                // where Cmd-C doesn't copy unless a custom key handler intercepts.
-                // Works on secure contexts (https + localhost).
                 scrollback: 5000,
         });
 
         const fitAddon = new FitAddon();
         term.loadAddon(fitAddon);
         term.open(container);
+
+        // Touch-action none so the OS doesn't eat vertical drags as page-scroll
+        // — our touch handler below routes them into terminal scroll instead.
+        container.style.touchAction = "none";
+
+        // ── WebGL renderer ──────────────────────────────────────────────────────
+        // WebGL avoids the DOM renderer's visibility-loss glitches (rows written
+        // while a tab is hidden drop out of the paint). Activate after open so
+        // the canvas exists. If the GPU driver revokes the context we dispose
+        // the addon and xterm silently falls back to the DOM renderer.
+        let webgl: WebglAddon | null = null;
+        try {
+                webgl = new WebglAddon();
+                webgl.onContextLoss(() => {
+                        webgl?.dispose();
+                        webgl = null;
+                });
+                term.loadAddon(webgl);
+        } catch (err) {
+                console.warn("[terminal] WebGL renderer unavailable, falling back to DOM:", err);
+                webgl = null;
+        }
+
         fitAddon.fit();
-        // Suppress the browser context menu over the terminal so tmux mouse
-        // mode (enabled in session-image/tmux.conf) actually receives the
-        // right-click as an SGR mouse event instead of the OS menu eating it.
-        const suppressContextMenu = (e: Event) => e.preventDefault();
-        container.addEventListener("contextmenu", suppressContextMenu);
+
         // Cmd/Ctrl + C copies the current xterm selection to the clipboard.
         // Without this, Cmd-C falls through to the terminal (Claude Code
         // intercepts it as SIGINT) and nothing gets copied.
@@ -91,6 +110,12 @@ export function openTerminalSession(opts: {
         const linkProviderDisposable = term.registerLinkProvider(
                 new MultilineUrlLinkProvider(term),
         );
+
+        // Mobile: tapping the terminal should move the keyboard caret here so
+        // the user can actually type. xterm only auto-focuses on mouse clicks,
+        // not on touch taps inside its helper textarea layout.
+        const focusOnPointer = () => term.focus();
+        container.addEventListener("pointerdown", focusOnPointer);
 
         // ── WebSocket connection ────────────────────────────────────────────────
         // Prefer passing the JWT as a subprotocol (`auth.bearer.<jwt>`) so the
@@ -152,12 +177,105 @@ export function openTerminalSession(opts: {
                 send({ type: "input", data });
         });
 
+        // ── Touch scroll ────────────────────────────────────────────────────────
+        // On mobile there are no wheel events, and `mouse on` in tmux means
+        // finger drags aren't forwarded as anything useful. We translate the
+        // drag into terminal scroll:
+        //
+        //  - Main buffer (shell prompt, command output): scroll xterm's own
+        //    scrollback with `scrollLines`. Users expect to pull older lines
+        //    back into view; we don't involve tmux at all, so there's no weird
+        //    copy-mode dance.
+        //  - Alt buffer (vim, less, Claude Code, htop, …): synthesise
+        //    up/down arrow keys. Every TUI app responds to arrows, so the
+        //    user can navigate without needing mouse-wheel support in the app
+        //    or tmux copy-mode.
+        //
+        // Direction follows iOS/Android convention — content tracks the
+        // finger: drag up → view moves up → scroll toward newer (bottom).
+        let lastTouchY: number | null = null;
+        const getCellHeight = () => (term.rows > 0 ? container.clientHeight / term.rows : 20);
+
+        const onTouchStart = (ev: TouchEvent) => {
+                if (ev.touches.length !== 1) { lastTouchY = null; return; }
+                lastTouchY = ev.touches[0]!.clientY;
+        };
+        const onTouchMove = (ev: TouchEvent) => {
+                if (lastTouchY === null || ev.touches.length !== 1) return;
+                const y = ev.touches[0]!.clientY;
+                const cellH = getCellHeight();
+                const deltaPx = lastTouchY - y;
+                const lines = Math.trunc(deltaPx / cellH);
+                if (lines === 0) return;
+
+                if (term.buffer.active.type === "alternate") {
+                        // Cap the burst so a fast flick doesn't fire 100+ arrows
+                        // at the app in one frame.
+                        const n = Math.min(Math.abs(lines), 20);
+                        const key = lines > 0 ? "\x1b[B" : "\x1b[A";
+                        send({ type: "input", data: key.repeat(n) });
+                } else {
+                        term.scrollLines(lines);
+                }
+                lastTouchY -= lines * cellH;
+        };
+        const onTouchEnd = () => { lastTouchY = null; };
+
+        container.addEventListener("touchstart", onTouchStart, { passive: true });
+        container.addEventListener("touchmove", onTouchMove, { passive: true });
+        container.addEventListener("touchend", onTouchEnd, { passive: true });
+        container.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
         // ── Resize ──────────────────────────────────────────────────────────────
-        const ro = new ResizeObserver(() => {
-                fitAddon.fit();
-                send({ type: "resize", cols: term.cols, rows: term.rows });
-        });
+        // ResizeObserver fires continuously during mobile viewport churn (URL
+        // bar show/hide, soft-keyboard open/close, rotation). Coalescing to
+        // one fit per frame avoids overlapping tmux redraws that leave
+        // half-painted cells on screen.
+        //
+        // We also only emit the `resize` WS message when cols/rows actually
+        // changed — ResizeObserver fires on every pixel change, but tmux only
+        // cares about cell-count changes.
+        let lastCols = term.cols;
+        let lastRows = term.rows;
+        let fitScheduled = false;
+        const scheduleFit = () => {
+                if (fitScheduled) return;
+                fitScheduled = true;
+                requestAnimationFrame(() => {
+                        fitScheduled = false;
+                        try { fitAddon.fit(); } catch { /* container detached mid-resize */ }
+                        if (term.cols !== lastCols || term.rows !== lastRows) {
+                                lastCols = term.cols;
+                                lastRows = term.rows;
+                                send({ type: "resize", cols: term.cols, rows: term.rows });
+                        }
+                });
+        };
+        const ro = new ResizeObserver(scheduleFit);
         ro.observe(container);
+
+        // ── Visibility / focus refresh ──────────────────────────────────────────
+        // Backgrounded tabs get rAF throttled, so xterm's renderer stops
+        // flushing dirty cells while the user is away. Output still streams
+        // in and lands in the internal buffer, but the painted DOM/canvas
+        // can end up several screens stale by the time the tab returns.
+        //
+        // On return, re-fit (viewport may have resized while hidden), wipe
+        // the WebGL texture atlas (fonts render sharp again after DPR change
+        // or OS font-smoothing toggles), and force a full refresh so every
+        // row repaints.
+        const onVisibilityChange = () => {
+                if (document.hidden) return;
+                scheduleFit();
+                webgl?.clearTextureAtlas();
+                term.refresh(0, term.rows - 1);
+        };
+        const onWindowFocus = () => {
+                scheduleFit();
+                term.refresh(0, term.rows - 1);
+        };
+        document.addEventListener("visibilitychange", onVisibilityChange);
+        window.addEventListener("focus", onWindowFocus);
 
         // ── Heartbeat ───────────────────────────────────────────────────────────
         let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
@@ -174,18 +292,30 @@ export function openTerminalSession(opts: {
                 }
         }
 
+        function setFontSize(px: number) {
+                term.options.fontSize = px;
+                scheduleFit();
+        }
+
         // ── Dispose ─────────────────────────────────────────────────────────────
         function dispose() {
                 if (heartbeatInterval !== null) clearInterval(heartbeatInterval);
                 ro.disconnect();
-                container.removeEventListener("contextmenu", suppressContextMenu);
+                document.removeEventListener("visibilitychange", onVisibilityChange);
+                window.removeEventListener("focus", onWindowFocus);
+                container.removeEventListener("pointerdown", focusOnPointer);
+                container.removeEventListener("touchstart", onTouchStart);
+                container.removeEventListener("touchmove", onTouchMove);
+                container.removeEventListener("touchend", onTouchEnd);
+                container.removeEventListener("touchcancel", onTouchEnd);
                 inputDisposable.dispose();
                 linkProviderDisposable.dispose();
+                webgl?.dispose();
                 ws.close(1000, "User navigated away");
                 term.dispose();
         }
 
-        return { dispose };
+        return { dispose, setFontSize };
 }
 
 // ── Multiline URL link provider ─────────────────────────────────────────────
@@ -261,12 +391,12 @@ class MultilineUrlLinkProvider implements ILinkProvider {
 
                 // "Terminators" that can't appear inside a URL. Includes whitespace,
                 // common quote/bracket chars, and the Unicode Box Drawing block
-                // (\u2500-\u257F — covers │ ─ ╭ ╮ etc. that ink/React TUIs draw
+                // (─-╿ — covers │ ─ ╭ ╮ etc. that ink/React TUIs draw
                 // around their panels). This lets us treat a row's URL "zone" as
                 // the contiguous run of URL-safe chars between the left and right
                 // borders/padding of the row.
-                const NON_URL = /[\s<>"'`{}()[\]\u2500-\u257F|]/;
-                const URL_RE = /https?:\/\/[^\s<>"'`{}()[\]\u2500-\u257F|]+/g;
+                const NON_URL = /[\s<>"'`{}()[\]─-╿|]/;
+                const URL_RE = /https?:\/\/[^\s<>"'`{}()[\]─-╿|]+/g;
 
                 // Phase 1 — for every row in the buffer, strip leading/trailing
                 // non-URL chars (borders, padding) and record where the interior

--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -17,6 +17,18 @@ set -sg escape-time 10
 # Enable mouse (for scrolling / clicking in xterm.js)
 set -g mouse on
 
+# Disable tmux's right-click popup menus. In a browser-hosted terminal the
+# menus flicker and dismiss on any pointer movement (xterm reports every
+# mouse-move to tmux, and touch positions jump), so they're unusable. The
+# frontend drops its preventDefault on `contextmenu` in tandem, which lets
+# the browser's own Copy/Paste menu show up instead — behaviour users
+# actually expect in a web page.
+unbind -n MouseDown3Pane
+unbind -n MouseDown3Status
+unbind -n MouseDown3StatusLeft
+unbind -n MouseDown3StatusRight
+unbind -n M-MouseDown3Pane
+
 # Status bar styling
 set -g status-style "bg=#1e1e2e,fg=#cdd6f4"
 set -g status-left "#[fg=#89b4fa,bold] #S "


### PR DESCRIPTION
## Summary

Makes the web terminal actually usable on phones and steadies the desktop render. Four interlinked fixes land together because they share the same renderer/event plumbing:

- **WebGL renderer** (`@xterm/addon-webgl`) with silent DOM fallback on context loss. Kills the stale-row glitches that appeared after the tab had been backgrounded. ResizeObserver now coalesces fits to one per `requestAnimationFrame` and only emits the `resize` WS message when cols/rows actually change — iOS URL-bar / soft-keyboard churn no longer fights an in-flight tmux redraw. `visibilitychange` + `focus` refit, clear the WebGL atlas, and force a full refresh so output streamed in while hidden shows up on return.
- **Mobile touch scroll** — finger drag on the main buffer scrolls xterm's own scrollback via `scrollLines`; in the alt buffer (vim / less / Claude Code / htop) it synthesises up/down arrow keys so every TUI responds naturally. `touch-action: none` on the xterm layers stops the OS from swallowing vertical drags as page-scroll. `pointerdown → term.focus()` so tapping pops the soft keyboard.
- **Viewport / font size** — `visualViewport` drives `--app-vh` from `main.ts`, so the terminal sits above the iOS keyboard instead of behind it. A font-size cycle button (11/12/13/14/15/16/18 px, persisted in `localStorage`) in the toolbar live-applies to every open tab's terminal.
- **Right-click menu** — `tmux.conf` unbinds `MouseDown3{Pane,Status,StatusLeft,StatusRight}` (and `M-MouseDown3Pane`) so tmux stops popping its right-click menu — it dismissed on every mouse-motion report and was unusable in a browser context. Frontend drops its `preventDefault` on `contextmenu` in tandem, so the browser's own Copy/Paste menu shows up instead.

## Base branch

Stacked on top of `feat/invite-only-registration` (PR #45) because it branched from there. Re-target to `main` once #45 merges.

## Deploy notes

Rebuild the session image for the tmux.conf change to land on new containers (`docker build -t shared-terminal-session ./session-image`). Existing running containers keep their baked-in tmux config until replaced.

## Test plan

- [ ] `cd frontend && npm run build` — tsc + vite clean
- [ ] Desktop: open a session, confirm right-click now shows the **browser** menu (not tmux's popup)
- [ ] Desktop: backgrounded tab for a minute with output streaming — on return the latest rows are painted, no stale gaps
- [ ] Mobile (real device): one-finger drag up/down inside a plain shell — scrolls xterm scrollback
- [ ] Mobile: inside `vim` / `htop` — one-finger drag navigates with arrow keys
- [ ] Mobile: soft keyboard opens on tap, terminal stays above it (not behind)
- [ ] Toolbar font-size button cycles and persists across reload
- [ ] Session image rebuild + new session — right-click menu comes from browser, not tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)