### PR TITLE
fix(tabs): drop auto-created default tab; container outlives tmux

### DIFF
--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -119,8 +119,8 @@ describe("DockerManager shared-exec multiplexing", () => {
 	it("creates only one shared exec across multiple attaches to the same session", async () => {
 		const { dm, container } = makeDocker();
 
-		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ });
-		await dm.attach("s1", "a2", 80, 24, () => { /* noop */ });
+		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test");
+		await dm.attach("s1", "a2", 80, 24, () => { /* noop */ }, "tab-test");
 
 		expect(container.exec).toHaveBeenCalledTimes(1);
 	});
@@ -130,8 +130,8 @@ describe("DockerManager shared-exec multiplexing", () => {
 		const a1 = vi.fn();
 		const a2 = vi.fn();
 
-		await dm.attach("s1", "a1", 80, 24, a1);
-		await dm.attach("s1", "a2", 80, 24, a2);
+		await dm.attach("s1", "a1", 80, 24, a1, "tab-test");
+		await dm.attach("s1", "a2", 80, 24, a2, "tab-test");
 
 		container._streams[0]!.write("hello");
 		await tick();
@@ -142,7 +142,7 @@ describe("DockerManager shared-exec multiplexing", () => {
 		expect(a2).toHaveBeenCalledWith("hello");
 
 		// Ring buffer holds one copy of the output, not N.
-		const buffer = (dm as unknown as { buffers: Map<string, { byteLength: number }> }).buffers.get("s1:tab-default");
+		const buffer = (dm as unknown as { buffers: Map<string, { byteLength: number }> }).buffers.get("s1:tab-test");
 		expect(buffer?.byteLength).toBe(5);
 	});
 
@@ -165,8 +165,8 @@ describe("DockerManager shared-exec multiplexing", () => {
 			return exec;
 		}) as typeof origExec;
 
-		const p1 = dm.attach("s1", "a1", 80, 24, () => { /* noop */ });
-		const p2 = dm.attach("s1", "a2", 80, 24, () => { /* noop */ });
+		const p1 = dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test");
+		const p2 = dm.attach("s1", "a2", 80, 24, () => { /* noop */ }, "tab-test");
 
 		// Both calls are now awaiting the same spawnSharedExec promise.
 		await tick();
@@ -183,11 +183,11 @@ describe("DockerManager shared-exec multiplexing", () => {
 		const a1 = vi.fn();
 		const a2 = vi.fn();
 
-		await dm.attach("s1", "a1", 80, 24, a1);
+		await dm.attach("s1", "a1", 80, 24, a1, "tab-test");
 		container._streams[0]!.write("abc");
 		await tick();
 
-		const { replay } = await dm.attach("s1", "a2", 80, 24, a2);
+		const { replay } = await dm.attach("s1", "a2", 80, 24, a2, "tab-test");
 
 		expect(replay).toBe("abc");
 		// a1 got "abc" once via fan-out; replay goes back to the caller only.
@@ -198,9 +198,9 @@ describe("DockerManager shared-exec multiplexing", () => {
 	it("resizes the shared exec to min(cols) × min(rows) and recomputes on detach", async () => {
 		const { dm, container } = makeDocker();
 
-		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ });
-		await dm.attach("s1", "a2", 120, 36, () => { /* noop */ });
-		await dm.attach("s1", "a3", 100, 30, () => { /* noop */ });
+		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test");
+		await dm.attach("s1", "a2", 120, 36, () => { /* noop */ }, "tab-test");
+		await dm.attach("s1", "a3", 100, 30, () => { /* noop */ }, "tab-test");
 
 		const resizes = container._execs[0]!._resizes;
 		expect(resizes[resizes.length - 1]).toEqual({ h: 24, w: 80 });
@@ -216,7 +216,7 @@ describe("DockerManager shared-exec multiplexing", () => {
 	it("destroys the shared exec on last detach but preserves the ring buffer", async () => {
 		const { dm, container } = makeDocker();
 
-		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ });
+		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test");
 		container._streams[0]!.write("abc");
 		await tick();
 
@@ -226,11 +226,11 @@ describe("DockerManager shared-exec multiplexing", () => {
 
 		expect(container._streams[0]!.destroyed).toBe(true);
 		const shared = (dm as unknown as { shared: Map<string, unknown> }).shared;
-		expect(shared.has("s1:tab-default")).toBe(false);
+		expect(shared.has("s1:tab-test")).toBe(false);
 
 		// Re-attach: new exec, replay still contains the earlier output.
 		const a2 = vi.fn();
-		const { replay } = await dm.attach("s1", "a2", 80, 24, a2);
+		const { replay } = await dm.attach("s1", "a2", 80, 24, a2, "tab-test");
 		expect(container.exec).toHaveBeenCalledTimes(2);
 		expect(replay).toBe("abc");
 	});
@@ -249,11 +249,11 @@ describe("DockerManager shared-exec multiplexing", () => {
 			return (origExec as (...a: unknown[]) => Promise<FakeExec>).apply(container, args);
 		}) as typeof origExec;
 
-		await expect(dm.attach("s1", "a1", 80, 24, () => { /* noop */ })).rejects.toThrow("kaboom");
+		await expect(dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test")).rejects.toThrow("kaboom");
 		// Let the .catch handler clear the slot.
 		await tick();
 
-		await dm.attach("s1", "a2", 80, 24, () => { /* noop */ });
+		await dm.attach("s1", "a2", 80, 24, () => { /* noop */ }, "tab-test");
 		expect(container.exec).toHaveBeenCalledTimes(2);
 	});
 });
@@ -291,7 +291,7 @@ describe("DockerManager tabs", () => {
 			oneShot: (cmd) => {
 				if (cmd[1] === "list-sessions") {
 					return {
-						stdout: "tab-default\tmain\t1700000000\ntab-abc12345\tclaude\t1700000050\n",
+						stdout: "tab-00000001\tshell\t1700000000\ntab-abc12345\tclaude\t1700000050\n",
 						exitCode: 0,
 					};
 				}
@@ -301,7 +301,7 @@ describe("DockerManager tabs", () => {
 
 		const tabs = await dm.listTabs("s1");
 		expect(tabs).toEqual([
-			{ tabId: "tab-default", label: "main", createdAt: 1700000000 },
+			{ tabId: "tab-00000001", label: "shell", createdAt: 1700000000 },
 			{ tabId: "tab-abc12345", label: "claude", createdAt: 1700000050 },
 		]);
 	});
@@ -367,11 +367,4 @@ describe("DockerManager tabs", () => {
 		expect((dm as unknown as { keyOf: Map<string, string> }).keyOf.has("a1")).toBe(false);
 	});
 
-	it("attach without tabId uses DEFAULT_TAB_ID, yielding key `${sessionId}:tab-default`", async () => {
-		const { dm } = makeDocker();
-		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ });
-
-		const buffers = (dm as unknown as { buffers: Map<string, unknown> }).buffers;
-		expect(buffers.has("s1:tab-default")).toBe(true);
-	});
 });

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -27,7 +27,7 @@ export interface ExecHandle {
 export type OutputListener = (data: string) => void;
 
 export interface Tab {
-        tabId: string;      // tmux session name inside the container (e.g. "tab-default", "tab-abc12345")
+        tabId: string;      // tmux session name inside the container (e.g. "tab-abc12345")
         label: string;      // display label (tmux user-option @tab-label)
         createdAt: number;  // unix seconds
 }
@@ -62,11 +62,6 @@ export class DockerManager {
         private targetKey(sessionId: string, tabId: string): string {
                 return `${sessionId}:${tabId}`;
         }
-
-        // Default tab name that the session-image entrypoint creates on first boot.
-        // Used as the fallback when a WS connects without a `tab` query param so
-        // we keep a sensible experience for single-tab users.
-        static readonly DEFAULT_TAB_ID = "tab-default";
 
         // ── Container lifecycle ─────────────────────────────────────────────────
 
@@ -236,7 +231,7 @@ export class DockerManager {
                 cols: number,
                 rows: number,
                 onOutput: OutputListener,
-                tabId: string = DockerManager.DEFAULT_TAB_ID,
+                tabId: string,
         ): Promise<{ handle: ExecHandle; replay: string | null }> {
                 const key = this.targetKey(sessionId, tabId);
 
@@ -471,17 +466,6 @@ export class DockerManager {
                         console.warn(`[docker] kill-session ${tabId} exited ${exitCode}`);
                 }
                 console.log(`[docker] deleted tab ${tabId} from session ${sessionId}`);
-        }
-
-        /** Resolve a sane default when a caller didn't specify a tabId. Returns the
-         *  first tab from `listTabs`, falling back to DEFAULT_TAB_ID if we can't
-         *  reach the container (e.g. reconcile race). */
-        async getDefaultTabId(sessionId: string): Promise<string> {
-                try {
-                        const tabs = await this.listTabs(sessionId);
-                        if (tabs.length > 0) return tabs[0]!.tabId;
-                } catch { /* fall through to static default */ }
-                return DockerManager.DEFAULT_TAB_ID;
         }
 
         private async execOneShot(

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -269,15 +269,12 @@ export function buildRouter(
                 try {
                         await sessions.assertOwnership(id, userId);
 
-                        // Enforce "always at least one tab per session" — refuse the close
-                        // and let the client decide whether to create a new tab first.
+                        // Closing all tabs is allowed — the container lifecycle is
+                        // independent of tmux now, so a session with zero tabs is a
+                        // valid state (the user creates a new tab from the +).
                         const tabs = await docker.listTabs(id);
                         if (!tabs.some((t) => t.tabId === tabId)) {
                                 res.status(404).json({ error: "tab not found" });
-                                return;
-                        }
-                        if (tabs.length <= 1) {
-                                res.status(409).json({ error: "cannot close the last tab" });
                                 return;
                         }
 

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -25,19 +25,24 @@ export function handleWsConnection(
         }
         const sessionId = match[1]!;
 
-        // Optional ?tab=<tabId>. If absent, we resolve to the first tab in the
-        // container below so clients that predate the tabs feature keep working.
-        // Strict charset: tmux session names + our own prefix; no shell metas
+        // Required ?tab=<tabId>. The container no longer creates a default tab
+        // at boot, so every WS attach must name its target explicitly. Strict
+        // charset: tmux session names + our own prefix; no shell metas
         // (docker exec takes argv, not a shell line, but a defensive allowlist
         // keeps surprising tmux targets like "main:1" out of the path).
         const tabQueryMatch = url.match(/[?&]tab=([^&#]+)/);
         const rawTab = tabQueryMatch ? decodeURIComponent(tabQueryMatch[1]!) : null;
-        if (rawTab !== null && !/^[a-zA-Z0-9._-]{1,64}$/.test(rawTab)) {
+        if (rawTab === null) {
+                sendError(ws, "Missing tab id");
+                ws.close(1008, "Missing tab");
+                return;
+        }
+        if (!/^[a-zA-Z0-9._-]{1,64}$/.test(rawTab)) {
                 sendError(ws, "Invalid tab id");
                 ws.close(1008, "Invalid tab");
                 return;
         }
-        const requestedTabId = rawTab;
+        const tabId = rawTab;
 
         const payload = verifyWsToken(req.headers["sec-websocket-protocol"], req.url);
         if (!payload) {
@@ -57,12 +62,6 @@ export function handleWsConnection(
                         ws.close(1008, "Session terminated");
                         return;
                 }
-
-                // Resolve tab: explicit ?tab=… wins; otherwise pick the first tab
-                // the container actually has. That lets existing clients (no tab
-                // query) land on a sensible default regardless of whether the
-                // container was created pre- or post-tabs.
-                const tabId = requestedTabId ?? (await docker.getDefaultTabId(sessionId));
 
                 // Attach to Docker container
                 const attachId = `${sessionId}:${uuidv4().slice(0, 8)}`;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -166,22 +166,11 @@ export async function createTab(sessionId: string, label?: string): Promise<Tab>
         return res.json();
 }
 
-/** Throws `LastTabError` (HTTP 409) when the tab is the last one — callers should surface, not retry. */
 export async function deleteTab(sessionId: string, tabId: string): Promise<void> {
         const res = await apiFetch(`/sessions/${sessionId}/tabs/${tabId}`, { method: "DELETE" });
-        if (res.status === 409) {
-                throw new LastTabError();
-        }
         if (!res.ok) {
                 const body = await res.json().catch(() => ({}));
                 throw new Error(body.error ?? "Failed to close tab");
-        }
-}
-
-export class LastTabError extends Error {
-        constructor() {
-                super("Can't close the last tab of a session");
-                this.name = "LastTabError";
         }
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,7 +8,7 @@
 import {
         isLoggedIn, login, register, logout, checkAuthStatus,
         listSessions, createSession, deleteSession, stopSession, startSession,
-        listTabs, createTab, deleteTab, LastTabError,
+        listTabs, createTab, deleteTab,
         type SessionInfo, type Tab,
 } from "./api.js";
 import { openTerminalSession, type TerminalSession, type SessionStatus } from "./terminal.js";
@@ -51,9 +51,8 @@ interface ActiveTerminal { pane: HTMLDivElement; term: TerminalSession }
 let currentTabs: Tab[] = [];
 let currentActiveTabId: string | null = null;
 const currentTerminals = new Map<string, ActiveTerminal>();
-// Tabs whose DELETE is in flight. Used so the last-tab guard accounts for
-// concurrent closes — two × clicks on two different chips would each see
-// currentTabs.length == 2 and race, with the second eating a spurious 409.
+// Tabs whose DELETE is in flight. Used so the same × can't fire twice
+// while the request is pending (renderTabBar disables the button).
 const closingTabs = new Set<string>();
 
 function disposeAllCurrentTerminals() {
@@ -302,13 +301,6 @@ async function openSession(sessionId: string) {
                 // Sort by creation order so +-added tabs stay on the right
                 // (listTabs returns alphabetical from tmux list-sessions).
                 currentTabs = tabs.sort((a, b) => a.createdAt - b.createdAt);
-                if (currentTabs.length === 0) {
-                        // Unusual (entrypoint creates tab-default) but recover instead
-                        // of leaving the user stuck with no tabs.
-                        const created = await createTab(sessionId);
-                        if (activeSessionId !== sessionId) return;
-                        currentTabs = [created];
-                }
         } catch (err) {
                 // Drop back to empty state so the toolbar/container don't linger
                 // visible with no tabs.
@@ -322,21 +314,27 @@ async function openSession(sessionId: string) {
                 return;
         }
 
+        // Freshly-spawned session legitimately has zero tabs — the container no
+        // longer creates one at boot. Render just the + so the user can open
+        // their first tab, and keep the terminal pane hidden.
+        if (currentTabs.length === 0) {
+                renderTabBar();
+                return;
+        }
+
         // openTab can throw synchronously (openTerminalSession init failure) —
         // openSession is called with `void`, so an unhandled throw here would
         // become an unhandled rejection with no toast and the UI left mid-switch.
-        if (currentTabs.length > 0) {
-                try {
-                        openTab(currentTabs[0]!.tabId);
-                } catch (err) {
-                        if (activeSessionId === sessionId) {
-                                activeSessionId = null;
-                                currentTabs = [];
-                                renderSessionList();
-                                updateToolbar();
-                        }
-                        showToast((err as Error).message, true);
+        try {
+                openTab(currentTabs[0]!.tabId);
+        } catch (err) {
+                if (activeSessionId === sessionId) {
+                        activeSessionId = null;
+                        currentTabs = [];
+                        renderSessionList();
+                        updateToolbar();
                 }
+                showToast((err as Error).message, true);
         }
 }
 
@@ -363,10 +361,13 @@ function updateToolbar() {
 
 function renderTabBar() {
         terminalTabs.innerHTML = "";
-        if (!activeSessionId || currentTabs.length === 0) {
+        if (!activeSessionId) {
                 terminalTabs.style.display = "none";
                 return;
         }
+        // Render even at currentTabs.length === 0 so the + button is reachable
+        // — a brand-new session starts with no tabs and the user opens the
+        // first one from here.
         terminalTabs.style.display = "flex";
 
         for (const tab of currentTabs) {
@@ -384,10 +385,7 @@ function renderTabBar() {
                 close.className = "tab-close";
                 close.textContent = "×";
                 close.title = "Close tab";
-                // Mirror the closeTab guard so the × doesn't render enabled
-                // while a concurrent close is in flight — clicking would just
-                // produce a misleading "Can't close the last tab" toast.
-                close.disabled = currentTabs.length - closingTabs.size <= 1;
+                close.disabled = closingTabs.has(tab.tabId);
                 close.addEventListener("click", (e) => {
                         e.stopPropagation();
                         void closeTab(tab.tabId, close);
@@ -574,14 +572,6 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
         if (!activeSessionId) return;
         const sessionId = activeSessionId;
         if (closingTabs.has(tabId)) return; // duplicate invocation for same tab
-        // Subtract in-flight closes so two × clicks on different chips can't
-        // both pass the last-tab check — without this, each would see length=2
-        // and the second DELETE would get a 409 from the backend's last-tab
-        // guard and surface a spurious "can't close" toast.
-        if (currentTabs.length - closingTabs.size <= 1) {
-                showToast("Can't close the last tab", true);
-                return;
-        }
         closingTabs.add(tabId);
         // Re-render so sibling chips' × reflects the in-flight close (their
         // disabled state mirrors the same guard).
@@ -593,11 +583,7 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
         } catch (err) {
                 closingTabs.delete(tabId);
                 renderTabBar();
-                if (err instanceof LastTabError) {
-                        showToast("Can't close the last tab", true);
-                } else {
-                        showToast((err as Error).message, true);
-                }
+                showToast((err as Error).message, true);
                 if (triggeredBy?.isConnected) triggeredBy.disabled = false;
                 return;
         }

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -57,8 +57,9 @@ COPY --chown=developer:developer tmux.conf /home/developer/.tmux.conf
 RUN mkdir -p /home/developer/workspace
 
 # ── Entrypoint ───────────────────────────────────────────────────────────────
-# Start a detached tmux session named "main" and then sleep forever so the
-# container stays alive.  The backend attaches via `docker exec`.
+# Keep the container alive. No tmux session is created at boot — tabs are
+# provisioned on demand by the backend via `tmux new-session`, and the
+# container outlives them.
 COPY --chown=developer:developer entrypoint.sh /home/developer/entrypoint.sh
 RUN chmod +x /home/developer/entrypoint.sh
 

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -2,24 +2,18 @@
 # ──────────────────────────────────────────────────────────────────────────────
 # Session container entrypoint.
 #
-# Each tmux session inside the container is ONE browser tab. We boot with a
-# single default tab (`tab-default`); additional tabs are created by the
-# backend via `tmux new-session`, and closed via `tmux kill-session`. The
-# container stays alive as long as any tmux session exists.
+# The container's lifetime is independent of tmux. Tabs (one tmux session
+# each) are created on demand by the backend — no tab is created here, so
+# there is no boot-time race where a client lists tabs before entrypoint has
+# finished provisioning one. The user creates their first tab from the UI.
 # ──────────────────────────────────────────────────────────────────────────────
 set -e
 
-# Navigate to workspace
 cd /home/developer/workspace
 
-# Create the detached default tab. Named deterministically so the backend
-# can address it without an extra round-trip on first attach.
-tmux new-session -d -s tab-default -c /home/developer/workspace -x 120 -y 36
-tmux set-option -t tab-default @tab-label "main"
+echo "[entrypoint] container ready — create a tab from the UI to begin"
 
-echo "[entrypoint] tmux session 'tab-default' started — waiting for connections…"
-
-# Keep the container alive. Tmux server exits when its last session closes,
-# which bubbles out here and terminates the container — matching "always at
-# least one tab per session" enforced by the backend kill-last guard.
-exec tmux wait-for exit-signal
+# Keep PID 1 alive independent of tmux. tmux-server now starts lazily on the
+# first `tmux new-session` from the backend, and dying on its own (last tab
+# closed, crash) no longer bubbles up and kills the container.
+exec tail -f /dev/null


### PR DESCRIPTION
## Summary

Fresh sessions raced `entrypoint.sh` against the first WebSocket attach: the container was "running" as soon as PID 1 started, but tmux's default session hadn't been created yet, so `listTabs` returned `[]` and the WS fell back to a hardcoded `"tab-default"` target that tmux would eventually create — or not — surfacing as an **\"Invalid tab\"** error on every new session.

Decouple the container lifecycle from tmux so the race can't happen:

- `session-image/entrypoint.sh`: don't spawn any tmux session at boot; keep PID 1 alive with \`tail -f /dev/null\`. The tmux server now starts lazily on the first \`tmux new-session\` from the backend, and dying on its own no longer kills the container.
- `dockerManager.ts`: remove the `DEFAULT_TAB_ID` constant and `getDefaultTabId()` fallback; `attach()` requires an explicit \`tabId\`.
- `wsHandler.ts`: `?tab=<id>` is a required query param — no silent fallback to a tab that may not exist.
- `routes.ts`: drop the 409 \"cannot close the last tab\" guard. Zero tabs is a valid state; the user creates a new one from the **+** button.
- `frontend/src/main.ts`: `openSession` no longer auto-creates a tab when `listTabs` is empty. `renderTabBar` keeps the bar visible (just the **+**) so the user can open their first tab. Mirror-guard on the × button and the unreachable `LastTabError` branch are gone.
- `frontend/src/api.ts`: drop `LastTabError` (no more 409).
- `dockerManager.test.ts`: pass explicit tabIds; drop the dead \"attach without tabId\" test.

## Rollout

Rebuild the session image so new containers use the no-tab entrypoint:

\`\`\`bash
docker compose build session-image
# or
docker build -t shared-terminal-session ./session-image
\`\`\`

Existing containers keep working — their tmux sessions are still addressable via the tab bar.

## Test plan

- [ ] Rebuild session image + restart backend
- [ ] Create a brand-new session → terminal area shows an empty tab bar with only the **+** button; no error toast
- [ ] Click **+** → first tab opens and attaches; shell is live
- [ ] Open a second tab → works; switching between them preserves state
- [ ] Close all tabs down to zero → UI falls back to the empty tab bar; no 409 error
- [ ] Click **+** again → new tab opens; session is still usable
- [ ] Reload the page on an existing session → tabs list renders, first tab re-attaches
- [ ] \`npm run build\` in \`backend/\` and \`frontend/\`
- [ ] \`npx vitest run\` in \`backend/\` (30 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)