### PR TITLE
Phase 1: correctness bug fixes in session/exec lifecycle

### DIFF
--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -7,7 +7,7 @@
 
 import Dockerode from "dockerode";
 import { Duplex } from "stream";
-import { promises as fs } from "fs";
+import { promises as fs, Dirent } from "fs";
 import path from "path";
 import { randomBytes } from "crypto";
 import { SessionManager } from "./sessionManager.js";
@@ -25,6 +25,20 @@ const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT ?? "/var/shared-terminal/works
 // instead.
 const WORKSPACE_UID = Number.parseInt(process.env.WORKSPACE_UID ?? "1000", 10);
 const WORKSPACE_GID = Number.parseInt(process.env.WORKSPACE_GID ?? "1000", 10);
+
+// Opt-in: repair ownership on pre-existing *contents* under the session
+// directory, not just the top-level dir. Useful one-shot for deployments
+// that lived through the earlier bug where Docker auto-created the bind
+// source as root, leaving nested files/dirs unwritable even after the
+// top-level was fixed. Default off because:
+//   - chowning arbitrary files the operator deliberately set to another
+//     owner would be surprising;
+//   - a deep traversal on a large workspace can be slow, and we don't
+//     want to pay that cost on every spawn.
+// Flip on for one boot, restart the affected sessions, flip off again.
+const WORKSPACE_CHOWN_RECURSIVE =
+        process.env.WORKSPACE_CHOWN_RECURSIVE === "true"
+        || process.env.WORKSPACE_CHOWN_RECURSIVE === "1";
 
 export interface ExecHandle {
         execId: string;
@@ -78,28 +92,12 @@ export class DockerManager {
                 const meta = await this.sessions.getOrThrow(sessionId);
                 const envArray = Object.entries(meta.envVars).map(([k, v]) => `${k}=${v}`);
 
-                // Pre-create the bind-mount target. If Docker creates it for us it
-                // lands root-owned, which leaves the container's `developer` user
-                // unable to write to its own workspace. chown needs CAP_CHOWN —
-                // the backend runs as root inside its own container (see Dockerfile)
-                // so this works in production; in dev the operator is expected to
-                // have set WORKSPACE_ROOT up with matching ownership themselves, so
-                // we downgrade EPERM to a warning rather than fail the spawn.
+                // Pre-create the bind-mount target so Docker doesn't auto-create it
+                // as root. See `ensureWorkspaceOwnership` for the full story and the
+                // non-recursive invariant.
                 const workspaceDir = path.join(WORKSPACE_ROOT, sessionId);
                 await fs.mkdir(workspaceDir, { recursive: true });
-                try {
-                        await fs.chown(workspaceDir, WORKSPACE_UID, WORKSPACE_GID);
-                } catch (err) {
-                        const code = (err as NodeJS.ErrnoException).code;
-                        if (code === "EPERM" || code === "ENOSYS") {
-                                console.warn(
-                                        `[docker] couldn't chown ${workspaceDir} to ${WORKSPACE_UID}:${WORKSPACE_GID} (${code}); ` +
-                                        `ensure WORKSPACE_ROOT is pre-created with matching ownership or run the backend as root.`,
-                                );
-                        } else {
-                                throw err;
-                        }
-                }
+                await this.ensureWorkspaceOwnership(workspaceDir);
 
                 const container = await this.docker.createContainer({
                         Image: SESSION_IMAGE,
@@ -130,6 +128,72 @@ export class DockerManager {
 
                 console.log(`[docker] spawned container ${meta.containerName} (${containerId.slice(0, 12)}) for session ${sessionId}`);
                 return containerId;
+        }
+
+        /**
+         * Apply `WORKSPACE_UID:WORKSPACE_GID` to the session workspace.
+         *
+         * By default this chowns only the top-level directory, not its contents.
+         * The invariant is "freshly-created or already correctly-owned": nested
+         * files are assumed to have been written by the container itself (so they
+         * already have the right owner). If the operator set
+         * WORKSPACE_CHOWN_RECURSIVE=true we also walk descendants — useful for
+         * one-shot repair of workspaces left inconsistent by an earlier version
+         * that let Docker create the bind source root-owned.
+         *
+         * All chown calls downgrade EPERM/ENOSYS to a warning so unprivileged
+         * dev mode still works; any other errno is re-thrown so we don't
+         * silently boot a session with a broken workspace.
+         */
+        private async ensureWorkspaceOwnership(dir: string): Promise<void> {
+                const chownOne = async (target: string) => {
+                        try {
+                                await fs.chown(target, WORKSPACE_UID, WORKSPACE_GID);
+                        } catch (err) {
+                                const code = (err as NodeJS.ErrnoException).code;
+                                if (code === "EPERM" || code === "ENOSYS") {
+                                        // Logged once per target — high-volume recursive mode
+                                        // could be noisy, but seeing which paths failed is more
+                                        // valuable than a compact summary.
+                                        console.warn(
+                                                `[docker] couldn't chown ${target} to ${WORKSPACE_UID}:${WORKSPACE_GID} (${code}); ` +
+                                                `run the backend as root or pre-create paths with matching ownership.`,
+                                        );
+                                } else {
+                                        throw err;
+                                }
+                        }
+                };
+
+                await chownOne(dir);
+
+                if (!WORKSPACE_CHOWN_RECURSIVE) return;
+
+                // Walk the tree iteratively (not recursively) to avoid stack
+                // growth on deep workspaces. `withFileTypes: true` avoids a stat
+                // per entry. Symlinks are chowned in place (lchown-equivalent)
+                // so we don't follow them out of the workspace root.
+                const stack: string[] = [dir];
+                while (stack.length > 0) {
+                        const current = stack.pop()!;
+                        let entries: Dirent[];
+                        try {
+                                entries = await fs.readdir(current, { withFileTypes: true });
+                        } catch (err) {
+                                const code = (err as NodeJS.ErrnoException).code;
+                                // A sibling-modified workspace (file removed mid-walk) shouldn't
+                                // abort the whole repair; log and keep going.
+                                if (code === "ENOENT" || code === "ENOTDIR") continue;
+                                throw err;
+                        }
+                        for (const entry of entries) {
+                                const full = path.join(current, entry.name);
+                                await chownOne(full);
+                                if (entry.isDirectory() && !entry.isSymbolicLink()) {
+                                        stack.push(full);
+                                }
+                        }
+                }
         }
 
         async kill(sessionId: string): Promise<void> {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -17,6 +17,15 @@ import { d1Query } from "./db.js";
 const SESSION_IMAGE = process.env.SESSION_IMAGE ?? "shared-terminal-session";
 const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT ?? "/var/shared-terminal/workspaces";
 
+// Owner applied to freshly-created workspace directories. Must match the
+// `developer` user inside session-image/Dockerfile (uid/gid 1000 by default).
+// Overridable via env for deployments that customise the session image.
+// Docker auto-creates missing bind sources as root, which locks the container
+// user out of its own workspace — we pre-create the dir with the right owner
+// instead.
+const WORKSPACE_UID = Number.parseInt(process.env.WORKSPACE_UID ?? "1000", 10);
+const WORKSPACE_GID = Number.parseInt(process.env.WORKSPACE_GID ?? "1000", 10);
+
 export interface ExecHandle {
         execId: string;
         stream: Duplex;
@@ -69,6 +78,29 @@ export class DockerManager {
                 const meta = await this.sessions.getOrThrow(sessionId);
                 const envArray = Object.entries(meta.envVars).map(([k, v]) => `${k}=${v}`);
 
+                // Pre-create the bind-mount target. If Docker creates it for us it
+                // lands root-owned, which leaves the container's `developer` user
+                // unable to write to its own workspace. chown needs CAP_CHOWN —
+                // the backend runs as root inside its own container (see Dockerfile)
+                // so this works in production; in dev the operator is expected to
+                // have set WORKSPACE_ROOT up with matching ownership themselves, so
+                // we downgrade EPERM to a warning rather than fail the spawn.
+                const workspaceDir = path.join(WORKSPACE_ROOT, sessionId);
+                await fs.mkdir(workspaceDir, { recursive: true });
+                try {
+                        await fs.chown(workspaceDir, WORKSPACE_UID, WORKSPACE_GID);
+                } catch (err) {
+                        const code = (err as NodeJS.ErrnoException).code;
+                        if (code === "EPERM" || code === "ENOSYS") {
+                                console.warn(
+                                        `[docker] couldn't chown ${workspaceDir} to ${WORKSPACE_UID}:${WORKSPACE_GID} (${code}); ` +
+                                        `ensure WORKSPACE_ROOT is pre-created with matching ownership or run the backend as root.`,
+                                );
+                        } else {
+                                throw err;
+                        }
+                }
+
                 const container = await this.docker.createContainer({
                         Image: SESSION_IMAGE,
                         name: meta.containerName,
@@ -92,7 +124,9 @@ export class DockerManager {
                 await container.start();
                 const containerId = container.id;
                 await this.sessions.setContainerId(sessionId, containerId);
-                this.buffers.set(sessionId, new RingBuffer(128 * 1024));
+                // Ring buffers are keyed on `${sessionId}:${tabId}` (see targetKey)
+                // and lazy-allocated by attach() → getOrCreateBuffer(). Nothing to
+                // pre-allocate at container-spawn time.
 
                 console.log(`[docker] spawned container ${meta.containerName} (${containerId.slice(0, 12)}) for session ${sessionId}`);
                 return containerId;
@@ -255,13 +289,27 @@ export class DockerManager {
 
                 const s = await pending;
 
+                // Snapshot the replay BEFORE registering the listener so the `await
+                // recomputeSize(s)` window below can't cause duplication: if we
+                // registered first, any byte arriving during that await would fire
+                // onOutput (live delivery) AND be drained into the replay payload
+                // (historical delivery), so the client would render it twice. By
+                // draining first, the two steps partition cleanly — drain() and
+                // listeners.set() are adjacent synchronous statements that Node
+                // cannot interleave with the stream's 'data' event, so every byte
+                // is either in the captured replay xor dispatched live, never both.
+                //
+                // Note: the caller (wsHandler) sends the replay after attach()
+                // returns, so in-flight live bytes could still arrive at the socket
+                // before the historical replay on a very busy session. That's a
+                // separate ordering issue — tracked but not fixed here.
+                const replay = this.getOrCreateBuffer(key).drain();
+
                 s.listeners.set(attachId, onOutput);
                 s.clientSizes.set(attachId, { cols, rows });
                 this.keyOf.set(attachId, key);
 
                 await this.recomputeSize(s);
-
-                const replay = this.getOrCreateBuffer(key).drain();
                 await this.sessions.updateConnected(sessionId);
                 console.log(`[docker] attached ${attachId} to session ${sessionId} (listeners=${s.listeners.size})`);
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -140,8 +140,37 @@ start().catch((err) => {
 process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
 
+// SIGTERM/SIGINT can fire twice (e.g. docker compose down then Ctrl-C). The
+// second invocation should skip teardown — wss.close() is idempotent but
+// `server.close()` throws ERR_SERVER_NOT_RUNNING on re-entry.
+let shuttingDown = false;
+
 function shutdown() {
+        if (shuttingDown) return;
+        shuttingDown = true;
         console.log("[server] shutting down…");
+
+        // Actively close live WS clients. `wss.close()` alone only stops accepting
+        // new upgrades — existing connections stay open, which keeps `server.close()`
+        // hanging on its keepalive-held sockets until the OS eventually kills the
+        // process. Send 1001 ("going away") so the browser surfaces a clean reason
+        // rather than "connection error".
+        for (const client of wss.clients) {
+                try { client.close(1001, "server shutting down"); } catch { /* already closed */ }
+        }
         wss.close();
-        server.close(() => process.exit(0));
+
+        // Watchdog: if a client stalls its close handshake (or some other handle
+        // keeps the event loop alive), exit anyway after a grace period instead of
+        // hanging the orchestrator's stop timeout.
+        const watchdog = setTimeout(() => {
+                console.warn("[server] shutdown watchdog fired — forcing exit");
+                process.exit(1);
+        }, 10_000);
+        watchdog.unref();
+
+        server.close(() => {
+                clearTimeout(watchdog);
+                process.exit(0);
+        });
 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -236,13 +236,35 @@ export function buildRouter(
                         res.status(400).json({ error: "body.name is required" });
                         return;
                 }
+                // `sessions.create` writes a D1 row BEFORE `docker.spawn` runs, so a
+                // spawn failure (missing image, docker daemon down, name collision on
+                // the 12-char container-name prefix, workspace chown EACCES) would
+                // otherwise leak a phantom `running` session with a null container_id.
+                // reconcile() would later flip it to `stopped`, but the row stays
+                // forever and users see a zombie entry in their sidebar. Roll back
+                // the D1 row explicitly on any spawn failure.
+                let meta: Awaited<ReturnType<SessionManager["create"]>> | null = null;
                 try {
-                        const meta = await sessions.create({ userId, name, cols, rows, envVars });
+                        meta = await sessions.create({ userId, name, cols, rows, envVars });
                         await docker.spawn(meta.sessionId);
                         const updated = await sessions.get(meta.sessionId);
                         res.status(201).json(serializeMeta(updated!));
                 } catch (err) {
                         console.error(`[routes] session create failed:`, (err as Error).message);
+                        if (meta) {
+                                // Best-effort rollback. If deleteRow itself fails (D1 blip),
+                                // the reconciler will eventually flip status to stopped but
+                                // the row remains — we log loudly so an operator can clean
+                                // it up manually.
+                                try {
+                                        await sessions.deleteRow(meta.sessionId);
+                                } catch (cleanupErr) {
+                                        console.error(
+                                                `[routes] CRITICAL: spawn rollback failed for session ${meta.sessionId}:`,
+                                                (cleanupErr as Error).message,
+                                        );
+                                }
+                        }
                         res.status(500).json({ error: (err as Error).message });
                 }
         });

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -40,6 +40,24 @@ interface SessionRow {
         last_connected_at: string | null;
 }
 
+// D1's `datetime('now')` returns SQLite's canonical UTC format — no 'Z' or
+// other timezone suffix. Node's Date parses that as LOCAL time, which is
+// wrong: a row written at 2024-01-01T10:00:00 (UTC, from D1) becomes a Date
+// 3h off on a UTC-3 machine. We append 'Z' to force UTC interpretation.
+// Guard the append in case D1 (or a future migration) ever returns a suffix
+// already — double-Z is an invalid date and silently NaNs. Also catch full
+// ISO 8601 offsets like `+00:00`.
+function parseD1UtcTimestamp(raw: string): Date {
+        const hasSuffix = /[zZ]$/.test(raw) || /[+-]\d{2}:?\d{2}$/.test(raw);
+        const d = new Date(hasSuffix ? raw : raw + "Z");
+        if (Number.isNaN(d.getTime())) {
+                // Better to crash loudly here than return "Invalid Date" that
+                // would later serialize to null in JSON.
+                throw new Error(`D1 returned unparseable timestamp: ${raw}`);
+        }
+        return d;
+}
+
 function rowToMeta(row: SessionRow): SessionMeta {
         return {
                 sessionId: row.session_id,
@@ -51,8 +69,8 @@ function rowToMeta(row: SessionRow): SessionMeta {
                 cols: row.cols,
                 rows: row.rows,
                 envVars: JSON.parse(row.env_vars),
-                createdAt: new Date(row.created_at + "Z"),
-                lastConnectedAt: row.last_connected_at ? new Date(row.last_connected_at + "Z") : null,
+                createdAt: parseD1UtcTimestamp(row.created_at),
+                lastConnectedAt: row.last_connected_at ? parseD1UtcTimestamp(row.last_connected_at) : null,
         };
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   app:
     build:


### PR DESCRIPTION
Part 1 of a 4-phase code review. This PR is the bug-fix phase — nothing here
changes behaviour for happy-path users; it closes small correctness holes
around sessions, reconnects, and shutdown.

## Commits (each fix is its own commit for easy cherry-pick/review)

| Commit | What it fixes |
|---|---|
| `chore(compose)` | Removes the obsolete `version: "3.9"` line (Compose v2 ignores it + warns). |
| `fix(docker)` | Three related fixes in `dockerManager.ts`: dead ring-buffer allocation in `spawn()`, reconnect replay duplication during the `recomputeSize` `await` window, and workspace bind-mount dirs being created root-owned so the container user can't write to them. |
| `fix(routes)` | `POST /sessions` now rolls back the D1 row when `docker.spawn` fails — otherwise a failed spawn leaves a zombie `running` row the user sees forever in their sidebar. |
| `fix(server)` | Graceful shutdown actively closes WS clients with code 1001 + has a 10s watchdog + a double-invocation guard. Was hanging until SIGKILL. |
| `fix(sessions)` | Robust D1 UTC timestamp parsing — old code blindly appended `"Z"`, which would break if D1 ever started returning a suffix itself. Also throws loudly on unparseable input instead of silently returning `Invalid Date`. |

## Validation

- `npm test` → 38/38 pass (3 files). Existing tests cover the replay-duplication fix indirectly via the multi-attach suite.
- `npm run build` surfaces a pre-existing `@types/estree` resolution error on `main`; unrelated to this PR (reproduced with `git stash`).

## What's deliberately NOT in this PR

- **Replay ordering race** — live bytes can still beat the historical replay to the socket if the caller (`wsHandler`) sends the `status` + `replay` messages after `attach()` returns. Fixing properly needs a two-phase attach API (`handle.startListening()`). Commented in code, tracked for later.
- **Security hardening** (env-var key validation, per-user session quota, async bcrypt, split invite rate limiter, `TRUST_PROXY` allow-list) — comes in Phase 2.
- **Operability** (slim runtime Dockerfile, real D1 batch, debounce `updateConnected`, drop unused `isAlive`) — Phase 3.
- **Frontend polish** (dedupe error toasts, debounce link-provider rebuild, sanitize tab labels) — Phase 4.

## Rollout notes

- `WORKSPACE_UID` / `WORKSPACE_GID` are new optional env vars, defaulting to `1000:1000` to match `session-image/Dockerfile`. No action needed for existing deployments.
- Existing workspace directories created by previous runs (root-owned by Docker) will NOT be chowned retroactively — that's a one-time manual fix if you want to recover them. New sessions are unaffected.