### PR TITLE
Phase 2: security hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,11 @@ CORS_ORIGINS=*
 # If your username is publicly known and you want a narrower DoS window,
 # edit DEFAULT_RATE_LIMIT_CONFIG to shrink usernameWindowMs (e.g. 5 min).
 
+# Active-session quota per user. Caps the number of concurrently running /
+# stopped sessions a single account can own. Bounds blast radius if an
+# account is compromised. Terminated sessions don't count. Default 20.
+# MAX_ACTIVE_SESSIONS_PER_USER=20
+
 # ── Invite-only registration ─────────────────────────────────────────────────
 # Registration after the first (bootstrap) account requires an invite code
 # minted by an existing user. Codes are stored in the D1 invite_codes table

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -2,13 +2,13 @@
  * auth.ts — JWT authentication + user management (D1-backed).
  */
 
-import { Request, Response, NextFunction } from "express";
-import jwt from "jsonwebtoken";
-import bcrypt from "bcryptjs";
-import { v4 as uuidv4 } from "uuid";
 import { randomBytes } from "node:crypto";
+import bcrypt from "bcryptjs";
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import { v4 as uuidv4 } from "uuid";
 import { d1Query } from "./db.js";
-import { JwtPayload } from "./types.js";
+import type { JwtPayload } from "./types.js";
 
 // Dev fallback. Production deployments must supply JWT_SECRET — validateJwtSecret()
 // below refuses to start the server if this literal is still in use.
@@ -377,7 +377,7 @@ export class InvalidCredentialsError extends Error {
 // Hoisted to module scope so we're not allocating this on every login —
 // it's a constant, and loginUser runs on the hot path. The cost of the
 // old per-call allocation was trivial but pointless.
-const DUMMY_PASSWORD_HASH = "$2a$10$" + "x".repeat(53);
+const DUMMY_PASSWORD_HASH = `$2a$10$${"x".repeat(53)}`;
 
 export async function loginUser(username: string, password: string): Promise<{ userId: string; token: string }> {
         const result = await d1Query<{ id: string; password_hash: string }>(
@@ -401,7 +401,15 @@ export async function loginUser(username: string, password: string): Promise<{ u
 
 function signToken(userId: string, username: string): string {
         const payload: JwtPayload = { sub: userId, username };
-        return jwt.sign(payload, jwtSecret(), { expiresIn: JWT_EXPIRES_IN as any });
+        // `expiresIn` in jsonwebtoken is typed as `number | StringValue`,
+        // where StringValue is a template-literal type from the `ms`
+        // package (e.g. "7d", "1h"). JWT_EXPIRES_IN comes from process.env
+        // as a plain string, so we cast through the library's own option
+        // type rather than `any` — keeps the check narrow to this one
+        // field and doesn't opt the whole sign-options shape out of
+        // type-checking.
+        const options: jwt.SignOptions = { expiresIn: JWT_EXPIRES_IN as jwt.SignOptions["expiresIn"] };
+        return jwt.sign(payload, jwtSecret(), options);
 }
 
 // ── Express middleware ──────────────────────────────────────────────────────

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -126,11 +126,13 @@ export async function registerUser(
                 // Bootstrap is the one path where we hash before validating an
                 // invite — there's nothing to validate, and we need the hash for
                 // the conditional INSERT. The cost is one bcrypt per first-ever
-                // visit, which happens at most once per deployment.
-                const bootstrapHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
+                // visit, which happens at most once per deployment. Async bcrypt
+                // here (and everywhere below) so the event loop keeps serving
+                // other requests while the hash runs on the libuv threadpool.
+                const bootstrapHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
                 const insert = await d1Query(
                         "INSERT INTO users (id, username, password_hash) " +
-                                "SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
+                        "SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
                         [userId, username, bootstrapHash],
                 );
                 if (insert.meta.changes === 1) {
@@ -152,18 +154,20 @@ export async function registerUser(
         // never produced an account.
         const claim = await d1Query(
                 "UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
-                        "WHERE code = ? AND used_at IS NULL " +
-                        "AND (expires_at IS NULL OR expires_at > datetime('now'))",
+                "WHERE code = ? AND used_at IS NULL " +
+                "AND (expires_at IS NULL OR expires_at > datetime('now'))",
                 [userId, inviteCode],
         );
         if (claim.meta.changes !== 1) {
                 throw new InviteRequiredError("Invite code is invalid, expired, or already used");
         }
 
-        // Hash only after the invite is confirmed valid. bcrypt.hashSync blocks
-        // the event loop, so doing it before the claim would let an unauth'd
-        // caller burn server CPU just by spamming bogus codes.
-        const passwordHash = bcrypt.hashSync(password, BCRYPT_ROUNDS);
+        // Hash only after the invite is confirmed valid. Even though async
+        // bcrypt runs off the main thread, the libuv threadpool is bounded
+        // (default 4 threads) — accepting un-gated hashes would let an
+        // unauth'd caller exhaust those threads just by spamming bogus codes,
+        // backing up every other async operation in the process.
+        const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
 
         try {
                 await d1Query("INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)", [
@@ -178,7 +182,7 @@ export async function registerUser(
                 try {
                         await d1Query(
                                 "UPDATE invite_codes SET used_by = NULL, used_at = NULL " +
-                                        "WHERE code = ? AND used_by = ?",
+                                "WHERE code = ? AND used_by = ?",
                                 [inviteCode, userId],
                         );
                 } catch (releaseErr) {
@@ -190,7 +194,7 @@ export async function registerUser(
                         // invite_codes table and reissue if needed.
                         console.error(
                                 "[auth] CRITICAL: invite release failed — code %s is permanently consumed without an account. " +
-                                        "Insert error: %s. Release error: %s",
+                                "Insert error: %s. Release error: %s",
                                 inviteCode,
                                 (err as Error).message,
                                 (releaseErr as Error).message,
@@ -286,11 +290,11 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
         // and an attacker could just wait out the expiry instead of revoking.
         const insert = await d1Query(
                 "INSERT INTO invite_codes (code, created_by, created_at, expires_at) " +
-                        "SELECT ?, ?, ?, ? WHERE (" +
-                        "SELECT COUNT(*) FROM invite_codes " +
-                        "WHERE created_by = ? AND used_at IS NULL " +
-                        "AND (expires_at IS NULL OR expires_at > datetime('now'))" +
-                        ") < ?",
+                "SELECT ?, ?, ?, ? WHERE (" +
+                "SELECT COUNT(*) FROM invite_codes " +
+                "WHERE created_by = ? AND used_at IS NULL " +
+                "AND (expires_at IS NULL OR expires_at > datetime('now'))" +
+                ") < ?",
                 [code, creatorUserId, createdAt, expiresAt, creatorUserId, MAX_UNUSED_INVITES_PER_USER],
         );
         if (insert.meta.changes !== 1) {
@@ -308,7 +312,7 @@ const INVITE_LIST_LIMIT = 100;
 export async function listInvites(creatorUserId: string): Promise<Invite[]> {
         const result = await d1Query<InviteRow>(
                 "SELECT code, created_at, used_at, expires_at FROM invite_codes " +
-                        "WHERE created_by = ? ORDER BY created_at DESC LIMIT ?",
+                "WHERE created_by = ? ORDER BY created_at DESC LIMIT ?",
                 [creatorUserId, INVITE_LIST_LIMIT],
         );
         return result.results.map(rowToInvite);
@@ -366,7 +370,15 @@ export async function loginUser(username: string, password: string): Promise<{ u
         );
 
         const row = result.results[0];
-        if (!row || !bcrypt.compareSync(password, row.password_hash)) {
+        // Always run a bcrypt compare, even if the user doesn't exist, so an
+        // attacker can't distinguish "unknown username" from "wrong password"
+        // by timing. Comparing against a fixed dummy hash keeps the work
+        // roughly equivalent. Length-matched to a real 10-round bcrypt output
+        // so the compare spends the same CPU as the real-user path.
+        const dummyHash = "$2a$10$" + "x".repeat(53);
+        const hashToCompare = row?.password_hash ?? dummyHash;
+        const ok = await bcrypt.compare(password, hashToCompare);
+        if (!row || !ok) {
                 throw new InvalidCredentialsError();
         }
 

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -364,20 +364,52 @@ export class InvalidCredentialsError extends Error {
 }
 
 // Timing-parity dummy hash for the unknown-username path: bcrypt.compare
-// against a real-shape bcrypt string still does the full work-factor
-// computation before the result is known, matching the CPU cost of the
-// real-user branch so an attacker can't distinguish "unknown username"
-// from "wrong password" by timing.
+// against a real-shape bcrypt string runs the full work-factor computation
+// before returning false, matching the CPU cost of the real-user branch
+// so an attacker can't distinguish "unknown username" from "wrong
+// password" by timing.
 //
-// Format: "$2a$10$" (7 chars: version + cost + separator) + 53 chars of
-// valid bcrypt-base64 = 60 chars total, matching the real output shape.
-// "x" is in bcrypt's alphabet, so the library runs through salt decode
-// and the full 2^10 work without short-circuiting on a parse error.
+// Previously this was a synthetic hardcoded string ("$2a$10$" + 53 "x"):
+// library-valid base64, correct shape, meant to exercise bcrypt's full
+// 2^10 work because the parser couldn't short-circuit on it. That worked,
+// but the guarantee was structural — it depended on bcryptjs NEVER adding
+// a fast-fail path for inputs that happen to look synthetic. There's no
+// test we can write to pin "the library didn't short-circuit" other than
+// wall-clock timing (fragile), so a future bcryptjs release could
+// regress the timing protection silently.
 //
-// Hoisted to module scope so we're not allocating this on every login —
-// it's a constant, and loginUser runs on the hot path. The cost of the
-// old per-call allocation was trivial but pointless.
-const DUMMY_PASSWORD_HASH = `$2a$10$${"x".repeat(53)}`;
+// Replaced with a real hash derived at module load by bcrypt.hash itself,
+// on a fixed throwaway password. Key properties:
+//
+//   1. Structurally indistinguishable from a real user's hash — produced
+//      by the same library we'll compare against. If the library ever
+//      changes the output format or the work cost, this hash follows.
+//      No test needed; the invariant is "bcrypt.compare(x, bcrypt.hash(
+//      anything, rounds)) takes full bcrypt time", which is the library's
+//      contract, not ours.
+//   2. Computed once at module import, cached as a Promise. Node is
+//      CommonJS here (tsconfig module=commonjs), so we can't top-level
+//      await — the first login (specifically the first login against an
+//      unknown user) would otherwise block on the computation. index.ts
+//      pre-awaits `ensureAuthReady()` before server.listen so that first
+//      login doesn't leak cold-start latency as a timing side channel.
+//   3. The password ("__dummy__") can be anything — bcrypt.compare will
+//      never match the supplied login password against it in practice,
+//      because hashes salt-in the generated salt, not the password.
+const DUMMY_PASSWORD_HASH_PROMISE: Promise<string> = bcrypt.hash("__dummy__", BCRYPT_ROUNDS);
+
+// Awaited from index.ts before server.listen so the first unknown-user
+// login doesn't pay ~2^BCRYPT_ROUNDS-ms of cold-start latency — which
+// would itself be a timing leak vs first known-user login ("known user"
+// short-circuits to row.password_hash without ever touching this
+// promise). After this resolves, the `await` inside loginUser is a free
+// microtask tick.
+//
+// Safe to call more than once; it returns the same settled promise on
+// every call.
+export async function ensureAuthReady(): Promise<void> {
+        await DUMMY_PASSWORD_HASH_PROMISE;
+}
 
 export async function loginUser(username: string, password: string): Promise<{ userId: string; token: string }> {
         const result = await d1Query<{ id: string; password_hash: string }>(
@@ -388,8 +420,11 @@ export async function loginUser(username: string, password: string): Promise<{ u
         const row = result.results[0];
         // Always run a bcrypt compare, even if the user doesn't exist, so an
         // attacker can't distinguish "unknown username" from "wrong password"
-        // by timing. See DUMMY_PASSWORD_HASH above for the shape rationale.
-        const hashToCompare = row?.password_hash ?? DUMMY_PASSWORD_HASH;
+        // by timing. The `??` short-circuits on the known-user path, so
+        // known-user logins don't pay the awaited-promise cost (negligible
+        // post-init anyway, but cleaner to avoid the microtask on the hot
+        // path). See DUMMY_PASSWORD_HASH_PROMISE above for the rationale.
+        const hashToCompare = row?.password_hash ?? (await DUMMY_PASSWORD_HASH_PROMISE);
         const ok = await bcrypt.compare(password, hashToCompare);
         if (!row || !ok) {
                 throw new InvalidCredentialsError();

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -363,6 +363,22 @@ export class InvalidCredentialsError extends Error {
         }
 }
 
+// Timing-parity dummy hash for the unknown-username path: bcrypt.compare
+// against a real-shape bcrypt string still does the full work-factor
+// computation before the result is known, matching the CPU cost of the
+// real-user branch so an attacker can't distinguish "unknown username"
+// from "wrong password" by timing.
+//
+// Format: "$2a$10$" (7 chars: version + cost + separator) + 53 chars of
+// valid bcrypt-base64 = 60 chars total, matching the real output shape.
+// "x" is in bcrypt's alphabet, so the library runs through salt decode
+// and the full 2^10 work without short-circuiting on a parse error.
+//
+// Hoisted to module scope so we're not allocating this on every login —
+// it's a constant, and loginUser runs on the hot path. The cost of the
+// old per-call allocation was trivial but pointless.
+const DUMMY_PASSWORD_HASH = "$2a$10$" + "x".repeat(53);
+
 export async function loginUser(username: string, password: string): Promise<{ userId: string; token: string }> {
         const result = await d1Query<{ id: string; password_hash: string }>(
                 "SELECT id, password_hash FROM users WHERE username = ?",
@@ -372,11 +388,8 @@ export async function loginUser(username: string, password: string): Promise<{ u
         const row = result.results[0];
         // Always run a bcrypt compare, even if the user doesn't exist, so an
         // attacker can't distinguish "unknown username" from "wrong password"
-        // by timing. Comparing against a fixed dummy hash keeps the work
-        // roughly equivalent. Length-matched to a real 10-round bcrypt output
-        // so the compare spends the same CPU as the real-user path.
-        const dummyHash = "$2a$10$" + "x".repeat(53);
-        const hashToCompare = row?.password_hash ?? dummyHash;
+        // by timing. See DUMMY_PASSWORD_HASH above for the shape rationale.
+        const hashToCompare = row?.password_hash ?? DUMMY_PASSWORD_HASH;
         const ok = await bcrypt.compare(password, hashToCompare);
         if (!row || !ok) {
                 throw new InvalidCredentialsError();

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -5,14 +5,15 @@
  * via WebSocket we `docker exec … tmux attach` to get a live TTY stream.
  */
 
+import { randomBytes } from "node:crypto";
+import type { Dirent } from "node:fs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { Duplex } from "node:stream";
 import Dockerode from "dockerode";
-import { Duplex } from "stream";
-import { promises as fs, Dirent } from "fs";
-import path from "path";
-import { randomBytes } from "crypto";
-import { SessionManager } from "./sessionManager.js";
-import { RingBuffer } from "./ringBuffer.js";
 import { d1Query } from "./db.js";
+import { RingBuffer } from "./ringBuffer.js";
+import type { SessionManager } from "./sessionManager.js";
 
 const SESSION_IMAGE = process.env.SESSION_IMAGE ?? "shared-terminal-session";
 const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT ?? "/var/shared-terminal/workspaces";
@@ -175,7 +176,15 @@ export class DockerManager {
                 // so we don't follow them out of the workspace root.
                 const stack: string[] = [dir];
                 while (stack.length > 0) {
-                        const current = stack.pop()!;
+                        // `pop()` returns `T | undefined`. The while condition
+                        // already guarantees the stack is non-empty, so the
+                        // undefined branch is unreachable — but we check anyway to
+                        // satisfy biome's no-non-null-assertion rule and to keep
+                        // the code safe if the loop header is ever refactored (e.g.
+                        // changed to `while (true)`) without re-analysing the
+                        // invariant.
+                        const current = stack.pop();
+                        if (current === undefined) break;
                         let entries: Dirent[];
                         try {
                                 entries = await fs.readdir(current, { withFileTypes: true });

--- a/backend/src/envVarValidation.test.ts
+++ b/backend/src/envVarValidation.test.ts
@@ -213,4 +213,62 @@ describe("validateEnvVars", () => {
                 // clarity and makes debugging client bugs easier.
                 expect(() => validateEnvVars({ "LD-PRELOAD": "x" })).toThrow(/not a valid POSIX/);
         });
+
+        it("rejects interpreter/runtime injection vars (Node, Python, JVM, Ruby, Perl)", () => {
+                // Round-2 reviewer noted the denylist's stated goal — "no silent
+                // hooks in the shell startup" — was incomplete while NODE_OPTIONS,
+                // PYTHONSTARTUP, JAVA_TOOL_OPTIONS, RUBYOPT, PERL5OPT etc. could
+                // still slip through. Each of these is honoured by its runtime at
+                // interpreter startup and could inject code into every invocation.
+                expect(() => validateEnvVars({ NODE_OPTIONS: "--require /evil.js" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ NODE_PATH: "/evil" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ PYTHONPATH: "/evil" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ PYTHONSTARTUP: "/evil.py" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ PYTHONINSPECT: "1" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ PYTHONHOME: "/evil" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ PYTHONBREAKPOINT: "sys.exit" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ JAVA_TOOL_OPTIONS: "-javaagent:/x.jar" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ _JAVA_OPTIONS: "-Dfoo=bar" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ JDK_JAVA_OPTIONS: "-Xmx1g" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ RUBYOPT: "-r/evil" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ RUBYLIB: "/evil" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ PERL5OPT: "-Mevil" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ PERL5LIB: "/evil" })).toThrow(/reserved/);
+        });
+
+        it("rejects all DYLD_* dynamic-linker variables (macOS prefix match)", () => {
+                // macOS counterpart to LD_*. Our runtime is Linux, but we want a
+                // clear 400 rather than a silently-ignored value when somebody
+                // pastes a DYLD_* var from habit.
+                expect(() => validateEnvVars({ DYLD_INSERT_LIBRARIES: "/x.dylib" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ DYLD_LIBRARY_PATH: "/x" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ DYLD_MADE_UP_TOMORROW: "x" })).toThrow(/reserved/);
+        });
+
+        // ── prototype-pollution vector names ──────────────────────────────
+
+        it("rejects __proto__, constructor, prototype with a specific message", () => {
+                // These pass the POSIX-identifier regex (all letters/underscores)
+                // and so would otherwise be accepted by the POSIX check. Rejecting
+                // them explicitly gives the caller a specific error and means the
+                // normalised output object can safely be a plain {} without being
+                // hit by the Object.prototype setter dance on assignment.
+                for (const name of ["__proto__", "constructor", "prototype"]) {
+                        expect(() => validateEnvVars({ [name]: "x" })).toThrow(EnvVarValidationError);
+                        expect(() => validateEnvVars({ [name]: "x" })).toThrow(/conflicts with JS object semantics/);
+                }
+        });
+
+        it("returns a plain object — Object.prototype methods work directly on the result", () => {
+                // The previous implementation returned an Object.create(null) map,
+                // which would TypeError if a future caller did `.hasOwnProperty`,
+                // `.toString`, etc. directly. Switched to plain {} now that
+                // __proto__ is rejected at validation time; this test pins that
+                // direct Object.prototype calls work.
+                const result = validateEnvVars({ FOO: "bar" });
+                // These would all throw "is not a function" on a null-proto object.
+                expect(result.hasOwnProperty("FOO")).toBe(true);
+                expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+                expect(typeof result.toString).toBe("function");
+        });
 });

--- a/backend/src/envVarValidation.test.ts
+++ b/backend/src/envVarValidation.test.ts
@@ -51,7 +51,12 @@ describe("validateEnvVars", () => {
                 child.OWN = "visible";
                 const result = validateEnvVars(child);
                 expect(result).toEqual({ OWN: "visible" });
-                expect(Object.prototype.hasOwnProperty.call(result, "INHERITED")).toBe(false);
+                // Object.hasOwn (ES2022) is biome's preferred form over
+                // Object.prototype.hasOwnProperty.call — same semantics, no
+                // prototype-chain surprise if the object itself defines a
+                // `hasOwnProperty` key. Node 16.9+ ships it; our backend is on
+                // Node 20, so unconditionally safe.
+                expect(Object.hasOwn(result, "INHERITED")).toBe(false);
         });
 
         // ── type/shape errors ──────────────────────────────────────────────
@@ -266,7 +271,16 @@ describe("validateEnvVars", () => {
                 // __proto__ is rejected at validation time; this test pins that
                 // direct Object.prototype calls work.
                 const result = validateEnvVars({ FOO: "bar" });
-                // These would all throw "is not a function" on a null-proto object.
+                // These would all throw "is not a function" on a null-proto
+                // object. The direct `.hasOwnProperty` method call is the
+                // exact pattern this test exists to pin — swapping to
+                // Object.hasOwn would still pass on a null-proto object
+                // (Object.hasOwn doesn't consult the prototype) and so would
+                // defeat the purpose. We want to catch the day someone
+                // re-introduces Object.create(null) and breaks callers that
+                // use the native method form. Hence the biome-ignore on the
+                // next line only.
+                // biome-ignore lint/suspicious/noPrototypeBuiltins: see comment above — this test intentionally exercises the prototype-method form.
                 expect(result.hasOwnProperty("FOO")).toBe(true);
                 expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
                 expect(typeof result.toString).toBe("function");

--- a/backend/src/envVarValidation.test.ts
+++ b/backend/src/envVarValidation.test.ts
@@ -9,10 +9,25 @@ import {
 } from "./envVarValidation.js";
 
 describe("validateEnvVars", () => {
-        it("returns an empty object for undefined/null/empty input", () => {
+        it("returns an empty object for undefined or empty-object input", () => {
+                // `undefined` means the field was omitted from the body (POST
+                // /sessions allows that; the route defaults to an empty env).
+                // `{}` is the explicit "clear everything" shape used by the
+                // PATCH route. `null` is deliberately excluded — see the next
+                // test for why.
                 expect(validateEnvVars(undefined)).toEqual({});
-                expect(validateEnvVars(null)).toEqual({});
                 expect(validateEnvVars({})).toEqual({});
+        });
+
+        it("rejects null so a client bug can't silently wipe env on PATCH", () => {
+                // The PATCH /sessions/:id/env handler rejects `undefined`
+                // with a 400 ("body.envVars is required") so callers are
+                // forced to be explicit. But `null` slips past that check
+                // (null !== undefined) — if we collapsed null to {} here,
+                // a frontend that forgot to guard a nullable field would
+                // silently wipe the user's env vars instead of 400ing.
+                // Reject null as invalid shape.
+                expect(() => validateEnvVars(null)).toThrow(/must be an object/);
         });
 
         it("accepts conventional env var shapes", () => {

--- a/backend/src/envVarValidation.test.ts
+++ b/backend/src/envVarValidation.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+        validateEnvVars,
+        EnvVarValidationError,
+        MAX_ENV_VAR_COUNT,
+        MAX_ENV_VAR_NAME_LENGTH,
+        MAX_ENV_VAR_VALUE_LENGTH,
+        MAX_ENV_VARS_TOTAL_BYTES,
+} from "./envVarValidation.js";
+
+describe("validateEnvVars", () => {
+        it("returns an empty object for undefined/null/empty input", () => {
+                expect(validateEnvVars(undefined)).toEqual({});
+                expect(validateEnvVars(null)).toEqual({});
+                expect(validateEnvVars({})).toEqual({});
+        });
+
+        it("accepts conventional env var shapes", () => {
+                const input = {
+                        DATABASE_URL: "postgres://localhost/db",
+                        _LEADING_UNDERSCORE: "ok",
+                        WITH_DIGITS_123: "v1",
+                        ONE_CHAR_NAME: "x",
+                        A: "minimal",
+                };
+                // Result should be strictly equal by value (same keys, same values).
+                expect(validateEnvVars(input)).toEqual(input);
+        });
+
+        it("strips prototype-chain properties", () => {
+                // Constructing an object with an inherited property so we can verify
+                // the validator only looks at own enumerable keys — a conventional
+                // POST body won't carry this, but a malicious client could.
+                const parent = { INHERITED: "should-not-appear" };
+                const child = Object.create(parent);
+                child.OWN = "visible";
+                const result = validateEnvVars(child);
+                expect(result).toEqual({ OWN: "visible" });
+                expect(Object.prototype.hasOwnProperty.call(result, "INHERITED")).toBe(false);
+        });
+
+        // ── type/shape errors ──────────────────────────────────────────────
+
+        it("rejects non-object inputs", () => {
+                expect(() => validateEnvVars("foo")).toThrow(EnvVarValidationError);
+                expect(() => validateEnvVars(42)).toThrow(EnvVarValidationError);
+                expect(() => validateEnvVars(true)).toThrow(EnvVarValidationError);
+                expect(() => validateEnvVars([])).toThrow(EnvVarValidationError);
+        });
+
+        it("rejects non-string values", () => {
+                expect(() => validateEnvVars({ FOO: 123 })).toThrow(/must be a string/);
+                expect(() => validateEnvVars({ FOO: null })).toThrow(/must be a string/);
+                expect(() => validateEnvVars({ FOO: { nested: "obj" } })).toThrow(/must be a string/);
+        });
+
+        // ── name-shape errors ──────────────────────────────────────────────
+
+        it("rejects keys that start with a digit", () => {
+                expect(() => validateEnvVars({ "1FOO": "v" })).toThrow(/not a valid POSIX/);
+        });
+
+        it("rejects keys containing '=' or whitespace", () => {
+                expect(() => validateEnvVars({ "FOO=BAR": "v" })).toThrow(/not a valid POSIX/);
+                expect(() => validateEnvVars({ "FOO BAR": "v" })).toThrow(/not a valid POSIX/);
+                expect(() => validateEnvVars({ "FOO\tBAR": "v" })).toThrow(/not a valid POSIX/);
+                expect(() => validateEnvVars({ "FOO\nBAR": "v" })).toThrow(/not a valid POSIX/);
+        });
+
+        it("rejects keys with dashes, dots, or non-ASCII", () => {
+                expect(() => validateEnvVars({ "FOO-BAR": "v" })).toThrow(/not a valid POSIX/);
+                expect(() => validateEnvVars({ "FOO.BAR": "v" })).toThrow(/not a valid POSIX/);
+                expect(() => validateEnvVars({ "FÖO": "v" })).toThrow(/not a valid POSIX/);
+        });
+
+        it("rejects empty-string keys", () => {
+                expect(() => validateEnvVars({ "": "v" })).toThrow(/non-empty/);
+        });
+
+        // ── length/size caps ───────────────────────────────────────────────
+
+        it("rejects keys longer than MAX_ENV_VAR_NAME_LENGTH", () => {
+                const longKey = "A".repeat(MAX_ENV_VAR_NAME_LENGTH + 1);
+                expect(() => validateEnvVars({ [longKey]: "v" })).toThrow(
+                        new RegExp(`exceeds ${MAX_ENV_VAR_NAME_LENGTH} characters`),
+                );
+        });
+
+        it("accepts keys exactly at MAX_ENV_VAR_NAME_LENGTH", () => {
+                const boundaryKey = "A".repeat(MAX_ENV_VAR_NAME_LENGTH);
+                expect(() => validateEnvVars({ [boundaryKey]: "v" })).not.toThrow();
+        });
+
+        it("rejects values longer than MAX_ENV_VAR_VALUE_LENGTH", () => {
+                const longValue = "x".repeat(MAX_ENV_VAR_VALUE_LENGTH + 1);
+                expect(() => validateEnvVars({ FOO: longValue })).toThrow(
+                        new RegExp(`exceeds ${MAX_ENV_VAR_VALUE_LENGTH} characters`),
+                );
+        });
+
+        it("rejects payloads with more than MAX_ENV_VAR_COUNT entries", () => {
+                const tooMany: Record<string, string> = {};
+                for (let i = 0; i <= MAX_ENV_VAR_COUNT; i++) tooMany[`VAR_${i}`] = "v";
+                expect(() => validateEnvVars(tooMany)).toThrow(
+                        new RegExp(`not contain more than ${MAX_ENV_VAR_COUNT} entries`),
+                );
+        });
+
+        it("accepts exactly MAX_ENV_VAR_COUNT entries", () => {
+                const maxed: Record<string, string> = {};
+                for (let i = 0; i < MAX_ENV_VAR_COUNT; i++) maxed[`VAR_${i}`] = "v";
+                expect(() => validateEnvVars(maxed)).not.toThrow();
+        });
+
+        it("rejects payloads whose total serialised size exceeds MAX_ENV_VARS_TOTAL_BYTES", () => {
+                // Pack values up to the per-value cap and count entries until we clear
+                // the total-bytes threshold. Keeps the test honest against the exact
+                // constant values without hard-coding sizes.
+                const bigValue = "x".repeat(MAX_ENV_VAR_VALUE_LENGTH);
+                const bigPayload: Record<string, string> = {};
+                let i = 0;
+                while (JSON.stringify(bigPayload).length <= MAX_ENV_VARS_TOTAL_BYTES && i < MAX_ENV_VAR_COUNT) {
+                        bigPayload[`V_${i}`] = bigValue;
+                        i++;
+                }
+                expect(() => validateEnvVars(bigPayload)).toThrow(/total size/);
+        });
+
+        // ── structural / content hazards ───────────────────────────────────
+
+        it("rejects values containing NUL bytes", () => {
+                expect(() => validateEnvVars({ FOO: "a\0b" })).toThrow(/NUL byte/);
+        });
+
+        it("permits values with newlines and shell metacharacters", () => {
+                // Docker passes env directly to execve — no shell parsing — so these
+                // are safe to store. Test pins the behaviour so a future validator
+                // change doesn't silently break users with multi-line PEM keys etc.
+                const result = validateEnvVars({
+                        CERT: "-----BEGIN-----\nline2\nline3\n-----END-----",
+                        QUOTE_ME: `"double" 'single' $VAR;rm -rf /`,
+                });
+                expect(result.CERT).toContain("line2");
+                expect(result.QUOTE_ME).toContain("rm -rf");
+        });
+});

--- a/backend/src/envVarValidation.test.ts
+++ b/backend/src/envVarValidation.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-        validateEnvVars,
         EnvVarValidationError,
         MAX_ENV_VAR_COUNT,
         MAX_ENV_VAR_NAME_LENGTH,
         MAX_ENV_VAR_VALUE_LENGTH,
         MAX_ENV_VARS_TOTAL_BYTES,
+        validateEnvVars,
 } from "./envVarValidation.js";
 
 describe("validateEnvVars", () => {

--- a/backend/src/envVarValidation.test.ts
+++ b/backend/src/envVarValidation.test.ts
@@ -143,4 +143,59 @@ describe("validateEnvVars", () => {
                 expect(result.CERT).toContain("line2");
                 expect(result.QUOTE_ME).toContain("rm -rf");
         });
+
+        // ── denylist ───────────────────────────────────────────────────────
+
+        it("rejects reserved names that would hijack the shell's environment", () => {
+                // Not a privilege boundary in a single-tenant shell (the user
+                // can `export` these anyway), but baking them into the session
+                // config would silently affect every process the session
+                // spawns. Explicit reject keeps session env transparent.
+                expect(() => validateEnvVars({ PATH: "/evil" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ HOME: "/tmp/x" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ USER: "root" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ LOGNAME: "root" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ SHELL: "/bin/sh" })).toThrow(/reserved/);
+        });
+
+        it("rejects all LD_* dynamic-linker variables (prefix match)", () => {
+                // LD_PRELOAD and friends are the obvious ones; the prefix
+                // match also catches less-well-known vectors (LD_AUDIT,
+                // LD_DEBUG, LD_ORIGIN_PATH) and future additions we haven't
+                // enumerated individually.
+                expect(() => validateEnvVars({ LD_PRELOAD: "/x.so" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ LD_LIBRARY_PATH: "/x" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ LD_AUDIT: "/x.so" })).toThrow(/reserved/);
+                expect(() => validateEnvVars({ LD_DEBUG: "symbols" })).toThrow(/reserved/);
+                // Catch-all: any LD_-prefixed name, even one we don't know
+                // about, is rejected. Guards against future linker additions.
+                expect(() => validateEnvVars({ LD_MADE_UP_TOMORROW: "x" })).toThrow(/reserved/);
+        });
+
+        it("does NOT reject names that merely look similar to reserved ones", () => {
+                // The denylist is exact-match on names and prefix-match on
+                // LD_*. A user's own `PATHS`, `HOMEBREW_*`, or `LD` (no
+                // underscore) aren't linker/identity vectors and must still
+                // be allowed.
+                const result = validateEnvVars({
+                        PATHS: "ok",
+                        HOMEBREW_PREFIX: "/opt/homebrew",
+                        LD: "not-a-linker-var",
+                        MYPATH: "ok",
+                        USERLAND: "ok",
+                });
+                expect(result.PATHS).toBe("ok");
+                expect(result.HOMEBREW_PREFIX).toBe("/opt/homebrew");
+                expect(result.LD).toBe("not-a-linker-var");
+                expect(result.MYPATH).toBe("ok");
+                expect(result.USERLAND).toBe("ok");
+        });
+
+        it("denylist fires AFTER the POSIX-name check, so garbage keys get the real error", () => {
+                // A caller sending 'LD-PRELOAD' (dash, not underscore) should
+                // see "not a valid POSIX env var name" — the actual problem —
+                // not the less-specific "reserved" message. Preserves error
+                // clarity and makes debugging client bugs easier.
+                expect(() => validateEnvVars({ "LD-PRELOAD": "x" })).toThrow(/not a valid POSIX/);
+        });
 });

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -82,8 +82,22 @@ export class EnvVarValidationError extends Error {
 /**
  * Validate and normalise an envVars payload.
  *
- * Accepts `undefined` (treated as an empty map) so route handlers can pass
- * the raw body field without a null-coalesce at every call site.
+ * Accepts `undefined` (treated as an empty map) so the POST /sessions
+ * route can pass the raw body field without a null-coalesce at the call
+ * site when the field is omitted entirely.
+ *
+ * Does NOT accept `null`. The two callers have different contracts:
+ *   - POST /sessions: envVars is optional. "Not set" is expressed by
+ *     omitting the field; the body parser surfaces that as `undefined`.
+ *   - PATCH /sessions/:id/env: envVars is REQUIRED (the route rejects
+ *     `undefined` with a 400). "Explicitly empty" is expressed by
+ *     sending `{}`.
+ *
+ * In neither case is `null` a meaningful shape — it can only arrive as a
+ * client bug (e.g. a frontend that didn't guard a nullable field before
+ * serialising). Treating `null` as `{}` on PATCH silently clears the
+ * user's env vars instead of surfacing the bug, which is exactly the
+ * kind of desync validation should catch. Reject it.
  *
  * Returns a plain `Record<string, string>` stripped of any inherited /
  * non-enumerable properties — callers can safely JSON-stringify or iterate
@@ -92,11 +106,14 @@ export class EnvVarValidationError extends Error {
 export function validateEnvVars(
         envVars: unknown,
 ): Record<string, string> {
-        if (envVars === undefined || envVars === null) return {};
+        if (envVars === undefined) return {};
 
-        // Must be a plain object. Arrays and other exotics pass `typeof === "object"`
-        // but would iterate in surprising ways; refuse up front.
-        if (typeof envVars !== "object" || Array.isArray(envVars)) {
+        // Must be a plain object. `null` trips this branch (typeof null ===
+        // "object") along with arrays and other exotics; refuse all of them
+        // up front with the same "must be an object" message. The important
+        // case is `null` — accepting it as an empty map would let a PATCH
+        // bug silently wipe a user's env instead of 400ing.
+        if (envVars === null || typeof envVars !== "object" || Array.isArray(envVars)) {
                 throw new EnvVarValidationError("envVars must be an object");
         }
 

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -41,35 +41,101 @@ export const MAX_ENV_VARS_TOTAL_BYTES = 64 * 1024;
 const ENV_VAR_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 // Denylist of env var names that would hijack dynamic linking, command
-// resolution, or identity. In a single-tenant full-shell session these
-// are NOT a privilege-escalation vector — the user can `export` any of
-// them inside their shell anyway — so the rule is about transparency,
-// not isolation:
+// resolution, interpreter/runtime behaviour, or identity. In a single-
+// tenant full-shell session these are NOT a privilege-escalation vector
+// — the user can `export` any of them inside their shell anyway — so
+// the rule is about transparency, not isolation:
 //
-//   - Baking `LD_PRELOAD=/some/lib.so` into the container env means
-//     every process spawned inside the session (including entrypoint
-//     scripts, hooks, and anything the user didn't type themselves)
-//     inherits the hook silently.
+//   - Baking `LD_PRELOAD=/some/lib.so`, `NODE_OPTIONS=--require ...`,
+//     or `JAVA_TOOL_OPTIONS=-javaagent:...` into the container env
+//     means every process spawned inside the session (including
+//     entrypoint scripts, hooks, and anything the user didn't type
+//     themselves) inherits the hook silently. node, python, java, etc.
+//     all honour these env vars at interpreter startup.
 //   - A session's declared envVars are user-visible in the UI; what
 //     lands inside the container should match. Letting PATH/HOME/etc.
 //     through would let a caller create a session whose shell starts
 //     with a config the session metadata doesn't obviously reveal.
 //
+// This is a blocklist, not an allowlist — novel interpreter injection
+// knobs (future node/python releases) may sneak through until they're
+// added here. The round-2 reviewer flagged that rightly. The trade-off
+// (strictness vs not breaking legitimate workflows that set e.g.
+// DATABASE_URL) favours enumerating well-known knobs; if the threat
+// model ever shifts to multi-tenant, this should flip to an allowlist.
+//
 // Result: what you PUT in the session body matches what the shell
-// SEES at startup, with no silent linker/interpreter hooks.
+// SEES at startup, with no silent linker/interpreter hooks for the
+// known injection surfaces.
 const DENIED_ENV_VAR_NAMES = new Set([
+        // Identity / shell config
         "PATH",
         "HOME",
         "USER",
         "LOGNAME",
         "SHELL",
+
+        // Node.js — NODE_OPTIONS accepts --require/--import which runs
+        // arbitrary JS at every `node` invocation. NODE_PATH changes the
+        // module resolver and would let an env set shadow stdlib requires.
+        "NODE_OPTIONS",
+        "NODE_PATH",
+
+        // Python — PYTHONSTARTUP runs a file at REPL startup;
+        // PYTHONINSPECT drops into a REPL after script exit (side-channel
+        // for persistent code exec); PYTHONBREAKPOINT routes breakpoint()
+        // through an arbitrary callable; PYTHONPATH changes module
+        // resolution; PYTHONHOME relocates the interpreter stdlib.
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "PYTHONINSPECT",
+        "PYTHONHOME",
+        "PYTHONBREAKPOINT",
+
+        // JVM — _JAVA_OPTIONS / JAVA_TOOL_OPTIONS / JDK_JAVA_OPTIONS are
+        // all honoured by the launcher and can `-javaagent:` arbitrary
+        // JARs or flip security-relevant flags.
+        "JAVA_TOOL_OPTIONS",
+        "_JAVA_OPTIONS",
+        "JDK_JAVA_OPTIONS",
+
+        // Ruby — RUBYOPT prepends arbitrary flags (incl. `-r<file>`)
+        // to every `ruby` invocation; RUBYLIB extends $LOAD_PATH.
+        "RUBYOPT",
+        "RUBYLIB",
+
+        // Perl — PERL5OPT is the Perl analogue of RUBYOPT; PERL5LIB
+        // extends @INC.
+        "PERL5OPT",
+        "PERL5LIB",
 ]);
 
-// Prefix matches for categories that grow over time (new LD_* vars are
-// added across glibc releases; enumerating them is a moving target).
-// LD_* covers the entire dynamic-linker surface — LD_PRELOAD,
-// LD_LIBRARY_PATH, LD_AUDIT, LD_DEBUG, LD_ORIGIN_PATH, etc.
-const DENIED_ENV_VAR_PREFIXES = ["LD_"];
+// Prefix matches for categories that grow over time (new LD_* / DYLD_*
+// vars are added across linker releases; enumerating them is a moving
+// target).
+//   - LD_*  : glibc dynamic-linker surface on Linux (LD_PRELOAD,
+//             LD_LIBRARY_PATH, LD_AUDIT, LD_DEBUG, LD_ORIGIN_PATH, …).
+//   - DYLD_*: the macOS counterpart (DYLD_INSERT_LIBRARIES,
+//             DYLD_LIBRARY_PATH, …). Our runtime is Linux, but the
+//             session image is pulled in dev on macOS too and a user
+//             might paste a DYLD_* value from habit; block it so the
+//             rejection is a clear 400 rather than a "silently ignored
+//             on Linux" surprise.
+const DENIED_ENV_VAR_PREFIXES = ["LD_", "DYLD_"];
+
+// Prototype-pollution vector names that pass the POSIX-identifier
+// regex and would interact oddly with JS object semantics if used as
+// keys. `__proto__` is the critical one: on a regular object,
+// `obj["__proto__"] = "string"` invokes the Object.prototype setter
+// (no-op for non-object values, silently dropping the entry) — which
+// means a user-supplied `__proto__` env var either gets swallowed or
+// pollutes the prototype chain depending on how downstream code
+// constructs its maps. Rejecting at validation time gives the caller
+// a clear 400 instead of either of those confusing outcomes, and lets
+// the validator return a plain {} (no null-prototype footgun).
+// `constructor` and `prototype` aren't as dangerous but are included
+// for defensiveness — they're never legitimate env var names.
+const PROTOTYPE_POLLUTION_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 
 
 export class EnvVarValidationError extends Error {
@@ -99,9 +165,10 @@ export class EnvVarValidationError extends Error {
  * user's env vars instead of surfacing the bug, which is exactly the
  * kind of desync validation should catch. Reject it.
  *
- * Returns a plain `Record<string, string>` stripped of any inherited /
- * non-enumerable properties — callers can safely JSON-stringify or iterate
- * without worrying about prototype pollution from user input.
+ * Returns a plain `Record<string, string>` containing only the caller-
+ * supplied own enumerable keys — no prototype-chain properties, no
+ * silently-dropped `__proto__` entries (those are rejected explicitly).
+ * Safe to JSON-stringify, iterate, or call Object.prototype methods on.
  */
 export function validateEnvVars(
         envVars: unknown,
@@ -119,7 +186,9 @@ export function validateEnvVars(
 
         // Use Object.entries so we only see the object's own enumerable string-keyed
         // properties — not anything from the prototype chain. This also matches the
-        // iteration order we'd get from JSON.parse output.
+        // iteration order we'd get from JSON.parse output. `Object.entries` always
+        // yields string keys by spec (ES2017 §19.1.2.5), so the loop below doesn't
+        // need to re-check `typeof name === "string"`.
         const entries = Object.entries(envVars as Record<string, unknown>);
 
         if (entries.length > MAX_ENV_VAR_COUNT) {
@@ -128,18 +197,17 @@ export function validateEnvVars(
                 );
         }
 
-        // Null-prototype object so a key like "__proto__" or "constructor"
-        // in the input can't traverse into Object.prototype via this map.
-        // NOTE: the return value intentionally has no prototype. Callers
-        // that need Object.prototype methods (.hasOwnProperty, .toString)
-        // must route through Object.prototype.hasOwnProperty.call(obj, k)
-        // — the value is typed as Record<string, string> but those methods
-        // will throw at runtime if invoked directly on it. The two current
-        // call sites only JSON.stringify or for..in iterate, both of which
-        // are prototype-agnostic.
-        const normalised: Record<string, string> = Object.create(null);
+        // Plain object. Previous versions used Object.create(null) to dodge
+        // the edge case where `normalised["__proto__"] = value` would invoke
+        // the Object.prototype setter (silently dropping non-object values)
+        // — but that traded a security non-issue for a real footgun:
+        // callers can't invoke .hasOwnProperty, .toString, etc. directly on
+        // the result without a TypeError. Instead we reject `__proto__` et
+        // al. at the key-validation step below, which closes the original
+        // concern and lets this be a normal object.
+        const normalised: Record<string, string> = {};
         for (const [name, value] of entries) {
-                if (typeof name !== "string" || name.length === 0) {
+                if (name.length === 0) {
                         throw new EnvVarValidationError("envVars keys must be non-empty strings");
                 }
                 if (name.length > MAX_ENV_VAR_NAME_LENGTH) {
@@ -147,6 +215,21 @@ export function validateEnvVars(
                                 `envVars key '${name.slice(0, 32)}…' exceeds ${MAX_ENV_VAR_NAME_LENGTH} characters`,
                         );
                 }
+
+                // Reject prototype-pollution vector names BEFORE the POSIX
+                // check: `__proto__` (and friends) match the identifier
+                // regex, so the POSIX check would accept them. We want a
+                // specific error message here so the caller sees *why* this
+                // particular name is rejected rather than a generic "not a
+                // valid name". Also means the next assignment below can be
+                // a plain `normalised[name] = value` without hitting the
+                // Object.prototype setter dance.
+                if (PROTOTYPE_POLLUTION_NAMES.has(name)) {
+                        throw new EnvVarValidationError(
+                                `envVars key '${name}' is reserved (conflicts with JS object semantics)`,
+                        );
+                }
+
                 if (!ENV_VAR_NAME_PATTERN.test(name)) {
                         // Include the offending key in the error so the caller can fix
                         // their payload — it came from them, so there's no leakage.

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -1,0 +1,138 @@
+/**
+ * envVarValidation.ts — input validation for session environment variables.
+ *
+ * The POST /sessions and PATCH /sessions/:id/env routes accept an
+ * `envVars: Record<string, string>` payload which is handed untouched to the
+ * Docker API as a container's `Env` array. Without validation, callers could:
+ *   - supply a key containing `=` or whitespace (splits oddly inside the
+ *     container, silently mangling neighbouring variables);
+ *   - smuggle NUL bytes into a value (terminates the C-string early, truncating
+ *     the actual value the container sees);
+ *   - submit thousands of entries or a multi-megabyte JSON blob that will sit
+ *     in D1 and be echoed on every subsequent session read.
+ *
+ * The validator is intentionally shell-agnostic — Docker passes `Env[]`
+ * directly to `execve`, not through a shell — so we are not concerned with
+ * metacharacter escaping. The rules enforce shape, size, and structural
+ * sanity only.
+ */
+
+// Maximum number of distinct env vars a session may declare. Comfortably above
+// the ~15 a realistic devcontainer uses; a tripwire rather than a product
+// limit. Raise if a legitimate workflow needs more.
+export const MAX_ENV_VAR_COUNT = 64;
+
+// Per-name and per-value length caps. Name cap mirrors the conservative end
+// of what shells accept (the POSIX minimum NAME_MAX is 255, but env names in
+// practice are short). Value cap is generous enough for a connection string
+// or inline JSON but refuses a multi-kB blob.
+export const MAX_ENV_VAR_NAME_LENGTH = 128;
+export const MAX_ENV_VAR_VALUE_LENGTH = 4096;
+
+// Belt-and-suspenders cap on the serialised JSON payload. 64 entries ×
+// (128 + 4096) ≈ 270 KiB upper bound; 64 KiB is ~16× the realistic
+// full-configuration case. Prevents a malicious client from submitting
+// every entry at the per-field cap to inflate the D1 row.
+export const MAX_ENV_VARS_TOTAL_BYTES = 64 * 1024;
+
+// POSIX-portable env var name: initial letter or underscore, then letters,
+// digits, or underscores. Explicitly rejects `=`, whitespace, dashes, dots,
+// and any non-ASCII. Matches the shape `execve` / bash / dash all accept.
+const ENV_VAR_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export class EnvVarValidationError extends Error {
+        constructor(message: string) {
+                super(message);
+                this.name = "EnvVarValidationError";
+        }
+}
+
+/**
+ * Validate and normalise an envVars payload.
+ *
+ * Accepts `undefined` (treated as an empty map) so route handlers can pass
+ * the raw body field without a null-coalesce at every call site.
+ *
+ * Returns a plain `Record<string, string>` stripped of any inherited /
+ * non-enumerable properties — callers can safely JSON-stringify or iterate
+ * without worrying about prototype pollution from user input.
+ */
+export function validateEnvVars(
+        envVars: unknown,
+): Record<string, string> {
+        if (envVars === undefined || envVars === null) return {};
+
+        // Must be a plain object. Arrays and other exotics pass `typeof === "object"`
+        // but would iterate in surprising ways; refuse up front.
+        if (typeof envVars !== "object" || Array.isArray(envVars)) {
+                throw new EnvVarValidationError("envVars must be an object");
+        }
+
+        // Use Object.entries so we only see the object's own enumerable string-keyed
+        // properties — not anything from the prototype chain. This also matches the
+        // iteration order we'd get from JSON.parse output.
+        const entries = Object.entries(envVars as Record<string, unknown>);
+
+        if (entries.length > MAX_ENV_VAR_COUNT) {
+                throw new EnvVarValidationError(
+                        `envVars may not contain more than ${MAX_ENV_VAR_COUNT} entries (got ${entries.length})`,
+                );
+        }
+
+        const normalised: Record<string, string> = Object.create(null);
+        for (const [name, value] of entries) {
+                if (typeof name !== "string" || name.length === 0) {
+                        throw new EnvVarValidationError("envVars keys must be non-empty strings");
+                }
+                if (name.length > MAX_ENV_VAR_NAME_LENGTH) {
+                        throw new EnvVarValidationError(
+                                `envVars key '${name.slice(0, 32)}…' exceeds ${MAX_ENV_VAR_NAME_LENGTH} characters`,
+                        );
+                }
+                if (!ENV_VAR_NAME_PATTERN.test(name)) {
+                        // Include the offending key in the error so the caller can fix
+                        // their payload — it came from them, so there's no leakage.
+                        throw new EnvVarValidationError(
+                                `envVars key '${name}' is not a valid POSIX env var name ` +
+                                `(must match /^[A-Za-z_][A-Za-z0-9_]*$/)`,
+                        );
+                }
+
+                // Reject any form of duplicate (including prototype-chain shadowing,
+                // which Object.entries already filters, and plain repeat keys, which
+                // JSON.parse collapses — but we check for completeness in case a
+                // future caller constructs the object programmatically).
+                if (Object.prototype.hasOwnProperty.call(normalised, name)) {
+                        throw new EnvVarValidationError(`envVars contains duplicate key '${name}'`);
+                }
+
+                if (typeof value !== "string") {
+                        throw new EnvVarValidationError(`envVars['${name}'] must be a string (got ${typeof value})`);
+                }
+                if (value.length > MAX_ENV_VAR_VALUE_LENGTH) {
+                        throw new EnvVarValidationError(
+                                `envVars['${name}'] exceeds ${MAX_ENV_VAR_VALUE_LENGTH} characters`,
+                        );
+                }
+                // NUL bytes are illegal in environment values on POSIX (execve treats
+                // `NUL` as the terminator). Silently accepting them would truncate the
+                // value the container sees, so caller sees one thing and container sees
+                // another — exactly the kind of desync a validator should catch.
+                if (value.includes("\0")) {
+                        throw new EnvVarValidationError(`envVars['${name}'] contains a NUL byte`);
+                }
+                normalised[name] = value;
+        }
+
+        // Total-size cap applies to the serialised form since that's what lands in
+        // D1 and flows over the network. Using Buffer.byteLength catches multi-byte
+        // UTF-8 that string.length would under-count.
+        const serialisedBytes = Buffer.byteLength(JSON.stringify(normalised), "utf8");
+        if (serialisedBytes > MAX_ENV_VARS_TOTAL_BYTES) {
+                throw new EnvVarValidationError(
+                        `envVars total size (${serialisedBytes} bytes) exceeds ${MAX_ENV_VARS_TOTAL_BYTES} bytes`,
+                );
+        }
+
+        return normalised;
+}

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -256,6 +256,18 @@ export function validateEnvVars(
                 // which Object.entries already filters, and plain repeat keys, which
                 // JSON.parse collapses — but we check for completeness in case a
                 // future caller constructs the object programmatically).
+                //
+                // Ideally this would use Object.hasOwn (ES2022) — biome's
+                // preferred form — but tsconfig lib is currently ES2020 and
+                // Object.hasOwn isn't in that lib. Using the
+                // Object.prototype.hasOwnProperty.call idiom for now, which
+                // is the safe form (direct `.hasOwnProperty` could collide
+                // with a user-supplied key named `hasOwnProperty`, though in
+                // practice that's already rejected by the POSIX-name check).
+                // If tsconfig ever bumps to ES2022 (Node 22 runtime already
+                // supports it), this line should be simplified to
+                // `Object.hasOwn(normalised, name)` and the ignore dropped.
+                // biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn unavailable under ES2020 lib; Object.prototype.hasOwnProperty.call is the safe idiom on this target.
                 if (Object.prototype.hasOwnProperty.call(normalised, name)) {
                         throw new EnvVarValidationError(`envVars contains duplicate key '${name}'`);
                 }

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -40,6 +40,38 @@ export const MAX_ENV_VARS_TOTAL_BYTES = 64 * 1024;
 // and any non-ASCII. Matches the shape `execve` / bash / dash all accept.
 const ENV_VAR_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
+// Denylist of env var names that would hijack dynamic linking, command
+// resolution, or identity. In a single-tenant full-shell session these
+// are NOT a privilege-escalation vector — the user can `export` any of
+// them inside their shell anyway — so the rule is about transparency,
+// not isolation:
+//
+//   - Baking `LD_PRELOAD=/some/lib.so` into the container env means
+//     every process spawned inside the session (including entrypoint
+//     scripts, hooks, and anything the user didn't type themselves)
+//     inherits the hook silently.
+//   - A session's declared envVars are user-visible in the UI; what
+//     lands inside the container should match. Letting PATH/HOME/etc.
+//     through would let a caller create a session whose shell starts
+//     with a config the session metadata doesn't obviously reveal.
+//
+// Result: what you PUT in the session body matches what the shell
+// SEES at startup, with no silent linker/interpreter hooks.
+const DENIED_ENV_VAR_NAMES = new Set([
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+]);
+
+// Prefix matches for categories that grow over time (new LD_* vars are
+// added across glibc releases; enumerating them is a moving target).
+// LD_* covers the entire dynamic-linker surface — LD_PRELOAD,
+// LD_LIBRARY_PATH, LD_AUDIT, LD_DEBUG, LD_ORIGIN_PATH, etc.
+const DENIED_ENV_VAR_PREFIXES = ["LD_"];
+
+
 export class EnvVarValidationError extends Error {
         constructor(message: string) {
                 super(message);
@@ -95,6 +127,19 @@ export function validateEnvVars(
                         throw new EnvVarValidationError(
                                 `envVars key '${name}' is not a valid POSIX env var name ` +
                                 `(must match /^[A-Za-z_][A-Za-z0-9_]*$/)`,
+                        );
+                }
+
+                // Apply the denylist AFTER the POSIX-name check: a name that
+                // isn't a valid identifier couldn't match anyway, so we'd just
+                // be hiding the real problem behind a less-specific error.
+                if (
+                        DENIED_ENV_VAR_NAMES.has(name) ||
+                        DENIED_ENV_VAR_PREFIXES.some((p) => name.startsWith(p))
+                ) {
+                        throw new EnvVarValidationError(
+                                `envVars key '${name}' is reserved and cannot be set via session config. ` +
+                                `Set it inside the shell if needed.`,
                         );
                 }
 

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -137,7 +137,6 @@ const DENIED_ENV_VAR_PREFIXES = ["LD_", "DYLD_"];
 // for defensiveness — they're never legitimate env var names.
 const PROTOTYPE_POLLUTION_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 
-
 export class EnvVarValidationError extends Error {
         constructor(message: string) {
                 super(message);

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -128,6 +128,15 @@ export function validateEnvVars(
                 );
         }
 
+        // Null-prototype object so a key like "__proto__" or "constructor"
+        // in the input can't traverse into Object.prototype via this map.
+        // NOTE: the return value intentionally has no prototype. Callers
+        // that need Object.prototype methods (.hasOwnProperty, .toString)
+        // must route through Object.prototype.hasOwnProperty.call(obj, k)
+        // — the value is typed as Record<string, string> but those methods
+        // will throw at runtime if invoked directly on it. The two current
+        // call sites only JSON.stringify or for..in iterate, both of which
+        // are prototype-agnostic.
         const normalised: Record<string, string> = Object.create(null);
         for (const [name, value] of entries) {
                 if (typeof name !== "string" || name.length === 0) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,16 +5,16 @@
  * Database is Cloudflare D1 (accessed via HTTP API).
  */
 
-import http from "http";
+import http from "node:http";
 import express from "express";
 import { WebSocketServer } from "ws";
-import { validateD1Config, migrateDb } from "./db.js";
-import { SessionManager } from "./sessionManager.js";
+import { selectWsAuthProtocol, validateJwtSecret } from "./auth.js";
+import { migrateDb, validateD1Config } from "./db.js";
 import { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
+import { SessionManager } from "./sessionManager.js";
+import { parseTrustProxy, TrustProxyError, warnIfProductionMisconfigured } from "./trustProxy.js";
 import { handleWsConnection } from "./wsHandler.js";
-import { selectWsAuthProtocol, validateJwtSecret } from "./auth.js";
-import { parseTrustProxy, warnIfProductionMisconfigured, TrustProxyError } from "./trustProxy.js";
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
 import { handleWsConnection } from "./wsHandler.js";
 import { selectWsAuthProtocol, validateJwtSecret } from "./auth.js";
+import { parseTrustProxy, warnIfProductionMisconfigured, TrustProxyError } from "./trustProxy.js";
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -21,20 +22,34 @@ const PORT = parseInt(process.env.PORT ?? "3001", 10);
 const CORS_ORIGINS = (process.env.CORS_ORIGINS ?? "*").split(",");
 // TRUST_PROXY: used by req.ip (and therefore auth rate limiting) to pick the
 // real client from X-Forwarded-For instead of the tunnel's socket address.
-// Set to the number of known hops in front of the backend — "1" for a
-// single Cloudflare Tunnel. Leave unset for direct localhost dev.
-//
-// Do NOT set this to "true": Express then takes the LEFTMOST X-Forwarded-For
-// entry, which is fully attacker-controlled. An attacker rotating
-// `X-Forwarded-For: <random>` per request would bypass the per-IP limiter
-// entirely. The hop count ("1", "2", …) picks the rightmost-untrusted
-// address, which is the real client.
-const TRUST_PROXY = process.env.TRUST_PROXY;
+// See trustProxy.ts for the full set of accepted values. "true" is refused
+// because Express then picks the leftmost (attacker-controlled) XFF entry.
+const TRUST_PROXY_RAW = process.env.TRUST_PROXY;
 
 // ── Validate config ───────────────────────────────────────────────────────────
 
 validateD1Config();
 validateJwtSecret();
+
+// Warn early if NODE_ENV=production but TRUST_PROXY is unset — a likely
+// misconfig where per-IP rate limits collapse into a single bucket. Runs
+// before the parse so the warning fires even on unset (which is not an
+// error, just a smell in production).
+warnIfProductionMisconfigured(TRUST_PROXY_RAW, process.env.NODE_ENV);
+
+// Parse upfront so a bad value fails the process immediately rather than
+// silently serving traffic with req.ip derived from the wrong source.
+let trustProxyValue: boolean | number | string | undefined;
+try {
+        trustProxyValue = parseTrustProxy(TRUST_PROXY_RAW);
+} catch (err) {
+        if (err instanceof TrustProxyError) {
+                console.error("[server]", err.message);
+                process.exit(1);
+        }
+        throw err;
+}
+
 
 // ── Singletons ────────────────────────────────────────────────────────────────
 
@@ -44,31 +59,12 @@ const docker = new DockerManager(sessions);
 // ── Express app ───────────────────────────────────────────────────────────────
 
 const app = express();
-if (TRUST_PROXY !== undefined) {
-        // Env values are strings; coerce "1" → 1 and "false" → false.
-        // Anything else passes through as an IP/subnet/"loopback"/etc.
-        // "true" is explicitly refused — see note above.
-        if (TRUST_PROXY === "true") {
-                console.error(
-                        "[server] TRUST_PROXY=true is refused: Express would take the leftmost " +
-                        "X-Forwarded-For entry (attacker-controlled), bypassing per-IP rate limiting. " +
-                        "Use a hop count (e.g. TRUST_PROXY=1) instead.",
-                );
-                process.exit(1);
-        }
-        let coerced: number | boolean | string;
-        // Explicit "0"/"false" → boolean false so we don't rely on Express's
-        // (undocumented) compileTrust(0) returning "never trust". If that
-        // internal ever changes, a string mistakenly treated as an IP would
-        // silently mis-trust; the explicit boolean keeps us pinned.
-        if (TRUST_PROXY === "0" || TRUST_PROXY === "false") coerced = false;
-        else if (/^\d+$/.test(TRUST_PROXY)) coerced = Number(TRUST_PROXY);
-        else coerced = TRUST_PROXY;
-        app.set("trust proxy", coerced);
+if (trustProxyValue !== undefined) {
+        app.set("trust proxy", trustProxyValue);
         // Log the effective value so ops can spot a misconfigured prod
         // (e.g. TRUST_PROXY=0 behind a tunnel would silently collapse
         // per-IP rate limits into one bucket).
-        console.log(`[server] trust proxy = ${JSON.stringify(coerced)}`);
+        console.log(`[server] trust proxy = ${JSON.stringify(trustProxyValue)}`);
 } else {
         console.log("[server] trust proxy = unset (req.ip will be the socket address)");
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -50,7 +50,6 @@ try {
         throw err;
 }
 
-
 // ── Singletons ────────────────────────────────────────────────────────────────
 
 const sessions = new SessionManager();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,7 +8,7 @@
 import http from "node:http";
 import express from "express";
 import { WebSocketServer } from "ws";
-import { selectWsAuthProtocol, validateJwtSecret } from "./auth.js";
+import { ensureAuthReady, selectWsAuthProtocol, validateJwtSecret } from "./auth.js";
 import { migrateDb, validateD1Config } from "./db.js";
 import { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
@@ -116,6 +116,13 @@ wss.on("connection", (ws, req) => {
 async function start() {
         await migrateDb();
         await docker.reconcile();
+        // Wait for the timing-parity dummy bcrypt hash to finish computing
+        // before accepting requests. Without this, the first unknown-user
+        // login would block on the ~2^BCRYPT_ROUNDS-ms hash computation,
+        // producing a latency signal distinguishable from a known-user
+        // login (which short-circuits the dummy path) — exactly the
+        // timing leak the dummy is supposed to prevent.
+        await ensureAuthReady();
 
         server.listen(PORT, () => {
                 console.log(`[server] listening on http://localhost:${PORT}`);

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -249,6 +249,62 @@ describe("UsernameRateLimiter", () => {
 		rl.endAttempt("u0");
 	});
 
+	it("beginAttempt honours maxTracked even when attempts is empty but inflight is full", () => {
+		// Regression for the second-round review gap: the previous fix
+		// checked only `attempts.size >= maxTracked`, which missed the
+		// case where attempts had expired (or been cleared by successful
+		// logins) while inflight still held long-running bcrypts. Brand-
+		// new usernames would then keep slipping past the guard and the
+		// inflight map would grow without bound.
+		const rl = new UsernameRateLimiter(5, 60_000, 3);
+
+		// Fill inflight with 3 distinct usernames, no recorded failures.
+		// attempts.size === 0, inflight.size === 3.
+		expect(rl.beginAttempt("u0").allowed).toBe(true);
+		expect(rl.beginAttempt("u1").allowed).toBe(true);
+		expect(rl.beginAttempt("u2").allowed).toBe(true);
+		expect(rl.sizeForTesting()).toBe(0); // attempts untouched
+
+		// Brand-new username with inflight at the cap — must be refused.
+		// The old single-map check (attempts.size >= maxTracked) would
+		// have erroneously allowed this.
+		const fresh = rl.beginAttempt("u3");
+		expect(fresh.allowed).toBe(false);
+		if (!fresh.allowed) expect(fresh.retryAfterSeconds).toBe(1);
+
+		// Releasing one inflight slot frees a unique-key slot — next
+		// brand-new username is allowed again.
+		rl.endAttempt("u0");
+		expect(rl.beginAttempt("u3").allowed).toBe(true);
+		rl.endAttempt("u3");
+		rl.endAttempt("u1");
+		rl.endAttempt("u2");
+	});
+
+	it("beginAttempt cap uses sum of attempts + inflight (conservative bound)", () => {
+		// The bound computes `attempts.size + inflight.size >= maxTracked`
+		// rather than the true union. That's a deliberate over-count to
+		// avoid an O(min(|a|,|b|)) per-call scan on the login hot path —
+		// documented as "refuse slightly early, never late" in the source.
+		// This test pins the over-count behaviour so a future refactor
+		// that switches to exact-union semantics is a conscious choice,
+		// not an accident.
+		const rl = new UsernameRateLimiter(5, 60_000, 3);
+		rl.recordFailure("alice"); // attempts={alice}, inflight={}
+
+		// alice is in attempts; beginAttempt("alice") is re-entrant so
+		// !attempts.has and !inflight.has are both false → cap check is
+		// skipped and the reservation succeeds.
+		expect(rl.beginAttempt("alice").allowed).toBe(true);
+		// Now attempts={alice}, inflight={alice}. Sum = 2, but true union
+		// is 1. Adding bob (brand new) takes sum to 3 = maxTracked, so
+		// the next brand-new username is refused even though the true
+		// union (alice, bob) would only be 2. Correct: conservative.
+		rl.recordFailure("bob");
+		const refused = rl.beginAttempt("charlie");
+		expect(refused.allowed).toBe(false);
+	});
+
 	it("re-tracking an expired entry moves it to the end of FIFO order", () => {
 		// After `alice` expires and is re-tracked, she should be the YOUNGEST
 		// entry (evicted last), not frozen in her original position.

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -221,6 +221,34 @@ describe("UsernameRateLimiter", () => {
 		}
 	});
 
+	it("beginAttempt honours maxTracked: new usernames refused once cap is full", () => {
+		// The attempts map is already FIFO-capped in recordFailure, but
+		// before this fix beginAttempt could still grow the inflight map
+		// without bound — a flood of unique usernames (each within its own
+		// per-IP limit) would insert an inflight entry for every first
+		// attempt. This test pins that beginAttempt now refuses to add a
+		// brand-new username to inflight once the tracked-username cap is
+		// full, while already-tracked users remain allowed (they don't
+		// grow the unique-key set).
+		const rl = new UsernameRateLimiter(5, 60_000, 3);
+		rl.recordFailure("u0");
+		rl.recordFailure("u1");
+		rl.recordFailure("u2");
+		expect(rl.sizeForTesting()).toBe(3);
+
+		// Brand-new username, cap is full — refused with 1s retry advisory
+		// (the minimum reflecting a single-bcrypt time to free up a slot).
+		const fresh = rl.beginAttempt("u3");
+		expect(fresh.allowed).toBe(false);
+		if (!fresh.allowed) expect(fresh.retryAfterSeconds).toBe(1);
+
+		// Already-tracked username at cap — allowed. Re-entrant attempts
+		// for an existing key don't grow the unique-key set, so they
+		// shouldn't be penalised by the tracked-username bound.
+		expect(rl.beginAttempt("u0").allowed).toBe(true);
+		rl.endAttempt("u0");
+	});
+
 	it("re-tracking an expired entry moves it to the end of FIFO order", () => {
 		// After `alice` expires and is re-tracked, she should be the YOUNGEST
 		// entry (evicted last), not frozen in her original position.

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -97,6 +97,63 @@ describe("UsernameRateLimiter", () => {
 		}
 	});
 
+	// ── beginAttempt / endAttempt (in-flight accounting) ────────────────
+
+	it("beginAttempt reserves a slot so concurrent attempts share the bound", () => {
+		// Pins the concurrency invariant that motivates beginAttempt: with
+		// async bcrypt, N parallel requests against the same username could
+		// all pass check() before any recordFailure lands. beginAttempt
+		// reserves a slot atomically so the (max+1)th in-flight attempt is
+		// rejected even without a single failure recorded yet.
+		const rl = new UsernameRateLimiter(3, 60_000);
+		expect(rl.beginAttempt("alice").allowed).toBe(true);
+		expect(rl.beginAttempt("alice").allowed).toBe(true);
+		expect(rl.beginAttempt("alice").allowed).toBe(true);
+		const overflow = rl.beginAttempt("alice");
+		expect(overflow.allowed).toBe(false);
+		if (!overflow.allowed) {
+			expect(overflow.retryAfterSeconds).toBeGreaterThan(0);
+		}
+	});
+
+	it("endAttempt releases an in-flight slot so the next attempt can proceed", () => {
+		const rl = new UsernameRateLimiter(1, 60_000);
+		expect(rl.beginAttempt("alice").allowed).toBe(true);
+		expect(rl.beginAttempt("alice").allowed).toBe(false);
+		rl.endAttempt("alice");
+		expect(rl.beginAttempt("alice").allowed).toBe(true);
+	});
+
+	it("endAttempt is idempotent when no slot is held (over-release is safe)", () => {
+		// Route handlers call endAttempt in a `finally`; if an earlier error
+		// path also released, the second call must not throw or skew the
+		// counter below zero.
+		const rl = new UsernameRateLimiter(1, 60_000);
+		rl.endAttempt("alice"); // nothing held
+		rl.endAttempt("alice"); // still nothing held
+		expect(rl.beginAttempt("alice").allowed).toBe(true);
+	});
+
+	it("in-flight and recorded failures share the same max budget", () => {
+		// One in-flight + (max-1) recorded failures = full budget. The next
+		// beginAttempt must be rejected. Covers the transient window around
+		// recordFailure (which bumps the counter before endAttempt releases
+		// the inflight slot) — the overlap is intentionally pessimistic.
+		const rl = new UsernameRateLimiter(3, 60_000);
+		rl.recordFailure("alice");
+		rl.recordFailure("alice");
+		expect(rl.beginAttempt("alice").allowed).toBe(true); // 2 failed + 1 inflight = 3
+		expect(rl.beginAttempt("alice").allowed).toBe(false);
+	});
+
+	it("beginAttempt isolates slot counts per username", () => {
+		const rl = new UsernameRateLimiter(1, 60_000);
+		expect(rl.beginAttempt("alice").allowed).toBe(true);
+		// Alice's slot is held; bob should still be free.
+		expect(rl.beginAttempt("bob").allowed).toBe(true);
+		expect(rl.beginAttempt("alice").allowed).toBe(false);
+	});
+
 	it("caps total tracked usernames and evicts oldest when full (DoS guard)", () => {
 		const rl = new UsernameRateLimiter(5, 60_000, 3);
 		rl.recordFailure("u0");

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import http from "http";
-import type { AddressInfo } from "net";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { UsernameRateLimiter } from "./rateLimit.js";
 import type { SessionManager } from "./sessionManager.js";
@@ -347,8 +347,14 @@ describe("auth route rate limiting", () => {
 	});
 
 	afterEach(async () => {
-		if (server) {
-			await new Promise<void>((resolve) => server!.close(() => resolve()));
+		// Capture into a local so the Promise executor has a narrowed,
+		// non-nullable reference — TS doesn't carry the `if (server)`
+		// narrowing into the async callback below. Same pattern used
+		// everywhere else in this file where we touch `server` inside
+		// a Promise executor, so the non-null assertions are gone.
+		const s = server;
+		if (s) {
+			await new Promise<void>((resolve) => s.close(() => resolve()));
 			server = null;
 		}
 	});
@@ -371,9 +377,10 @@ describe("auth route rate limiting", () => {
 		app.use(express.json());
 		app.use("/api", router);
 
-		server = http.createServer(app);
-		await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
-		const { port } = server.address() as AddressInfo;
+		const s = http.createServer(app);
+		server = s;
+		await new Promise<void>((resolve) => s.listen(0, "127.0.0.1", resolve));
+		const { port } = s.address() as AddressInfo;
 		baseUrl = `http://127.0.0.1:${port}`;
 	}
 
@@ -533,7 +540,14 @@ describe("auth route rate limiting", () => {
 		expect(ipBlocked.status).toBe(429);
 		expect(await ipBlocked.json()).toMatchObject({ scope: "ip" });
 
-		await new Promise<void>((resolve) => server!.close(() => resolve()));
+		// Same Promise-executor-narrowing dance as afterEach. Invariant
+		// violation (server was null here) would be a test bug — throw
+		// loudly rather than silently skip, since the block below spins
+		// up a new server and we'd otherwise get a misleading failure
+		// in a completely different test phase.
+		const s = server;
+		if (!s) throw new Error("test invariant: server was null at mid-test restart");
+		await new Promise<void>((resolve) => s.close(() => resolve()));
 		server = null;
 
 		await spinUp({

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -3,9 +3,9 @@ import type { AddressInfo } from "node:net";
 import express from "express";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { DockerManager } from "./dockerManager.js";
 import { UsernameRateLimiter } from "./rateLimit.js";
 import type { SessionManager } from "./sessionManager.js";
-import type { DockerManager } from "./dockerManager.js";
 
 // Stub the auth module so routing tests don't touch D1. Handles captured
 // as `authStubs` are reconfigured per-test.

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -272,11 +272,16 @@ describe("auth route rate limiting", () => {
 	async function spinUp(cfg: {
 		login: { ipMax: number; ipWindowMs: number; usernameMax: number; usernameWindowMs: number };
 		register: { ipMax: number; ipWindowMs: number };
-		invites?: { ipMax: number; ipWindowMs: number };
+		invitesCreate?: { ipMax: number; ipWindowMs: number };
+		invitesRevoke?: { ipMax: number; ipWindowMs: number };
 	}): Promise<void> {
-		// invites limiter was added later; supply a permissive default for tests
-		// that pre-date it and only exercise login/register surface.
-		const fullCfg = { invites: { ipMax: 1000, ipWindowMs: 60_000 }, ...cfg };
+		// Invite limiters were split into create/revoke later; both default to
+		// permissive settings for tests that only exercise login/register.
+		const fullCfg = {
+			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+			...cfg,
+		};
 		const router = buildRouter(fakeSessions, fakeDocker, fullCfg);
 		const app = express();
 		app.use(express.json());

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -161,9 +161,19 @@ export class UsernameRateLimiter {
 	//
 	// Does not reserve an in-flight slot — callers doing async verification
 	// (bcrypt, D1) should use beginAttempt/endAttempt instead so the bound
-	// holds across awaits. Note that this method IS NOT pure: it
-	// opportunistically evicts an expired entry for the queried username as
-	// a side effect (harmless GC — the entry's window had already elapsed).
+	// holds across awaits.
+	//
+	// NOT pure: if the queried username's entry is present but past its
+	// resetAt, it's deleted here. This is not just opportunistic GC —
+	// beginAttempt calls check() first and then probes
+	// `!this.attempts.has(username)` for the maxTracked bound. When check
+	// deletes an expired entry, that `.has` flips to false in the same
+	// call and beginAttempt treats the user as brand-new for the tracked-
+	// username cap. That's the correct semantics (an expired window SHOULD
+	// free the cap slot) but the interaction is subtle enough that a
+	// reader glancing at check() could miss it — flagging it here so a
+	// future refactor that moves the delete out of check() remembers to
+	// adjust beginAttempt's cap accounting in lockstep.
 	check(username: string): UsernameCheckResult {
 		const now = Date.now();
 		const entry = this.attempts.get(username);

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -159,9 +159,11 @@ export class UsernameRateLimiter {
 	// Result-based (never throws) so callers don't need try/catch around an
 	// otherwise-synchronous check inside an async handler.
 	//
-	// Read-only — does not reserve a slot. Callers doing async verification
+	// Does not reserve an in-flight slot — callers doing async verification
 	// (bcrypt, D1) should use beginAttempt/endAttempt instead so the bound
-	// holds across awaits.
+	// holds across awaits. Note that this method IS NOT pure: it
+	// opportunistically evicts an expired entry for the queried username as
+	// a side effect (harmless GC — the entry's window had already elapsed).
 	check(username: string): UsernameCheckResult {
 		const now = Date.now();
 		const entry = this.attempts.get(username);

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -197,25 +197,34 @@ export class UsernameRateLimiter {
 		const result = this.check(username);
 		if (!result.allowed) return result;
 
-		// Memory bound on the inflight map. `attempts` is already capped by
-		// maxTracked (with FIFO eviction in recordFailure), but without this
-		// guard a flood of unique usernames — each within its own per-IP
-		// limit — could accumulate inflight entries indefinitely. Practical
-		// ceiling is low (libuv's 4-thread pool serialises bcrypt, so only
-		// ~4 slots exist in a draining state at any moment) but the
-		// invariant still matters: no unbounded state keyed on attacker-
-		// controlled strings.
+		// Memory bound on the combined state of attempts + inflight. The
+		// previous version checked only `attempts.size >= maxTracked`,
+		// which missed the case where all attempts entries had expired (or
+		// been cleared by successful logins) while inflight still held
+		// many long-running bcrypts — brand-new usernames would keep
+		// passing the guard and accumulating inflight entries past the
+		// cap.
 		//
-		// Refuse the reservation when the tracked-username cap is full AND
-		// this particular username is not already tracked in EITHER map.
-		// Re-entrant attempts from an already-tracked user stay allowed —
-		// those don't grow the set of unique keys. Retry advisory is 1s
-		// (matches the "all max slots held by in-flight" branch in check()
-		// — soonest a slot could free up is one bcrypt worth of time).
+		// We want to bound the union of the two keysets at maxTracked,
+		// but computing the union exactly is O(min(|a|,|b|)) on every
+		// call — too much for the login hot path. Use the SUM instead as
+		// a conservative upper bound: it over-counts any username present
+		// in BOTH maps (a user who has a recorded failure AND is currently
+		// holding an inflight slot), which means we start refusing brand-
+		// new usernames slightly earlier than strictly necessary. That's
+		// the correct direction to err in — the worst case is refusing a
+		// legitimate username at ~half capacity, with a 1-second retry
+		// advisory, which a human retry will clear.
+		//
+		// `!has` guards on both maps remain: re-entrant attempts from an
+		// already-tracked user don't grow the unique-key set, so they
+		// shouldn't be blocked by the cap. Refusal carries a 1s retry
+		// (matches the "all max slots held by in-flight" branch in
+		// check() — one bcrypt is the soonest a slot could free up).
 		if (
-			this.attempts.size >= this.maxTracked &&
 			!this.attempts.has(username) &&
-			!this.inflight.has(username)
+			!this.inflight.has(username) &&
+			this.attempts.size + this.inflight.size >= this.maxTracked
 		) {
 			return { allowed: false, retryAfterSeconds: 1 };
 		}

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -107,6 +107,17 @@ const DEFAULT_MAX_TRACKED_USERNAMES = 10_000;
 // mirror the normalization or the two layers diverge.
 export class UsernameRateLimiter {
 	private attempts = new Map<string, FailedAttempts>();
+	// In-flight attempts (currently waiting on bcrypt or a D1 round-trip).
+	// Tracked separately from the window-bounded `attempts` map because
+	// in-flight slots are transient: they're released when the attempt
+	// finishes, regardless of the window. Counted against the same `max`
+	// budget so a burst of concurrent attempts can't slip past check()
+	// between the gate and the first recordFailure.
+	//
+	// Kept as a plain Map so eviction semantics stay simple — cleared
+	// per-username in endAttempt(), no TTL needed (if the process crashes
+	// with slots reserved, the restart clears everything anyway).
+	private inflight = new Map<string, number>();
 	private readonly maxTracked: number;
 
 	constructor(
@@ -120,21 +131,54 @@ export class UsernameRateLimiter {
 	// Returns allowed=false only when the bucket is full inside its window.
 	// Result-based (never throws) so callers don't need try/catch around an
 	// otherwise-synchronous check inside an async handler.
+	//
+	// Read-only — does not reserve a slot. Callers doing async verification
+	// (bcrypt, D1) should use beginAttempt/endAttempt instead so the bound
+	// holds across awaits.
 	check(username: string): UsernameCheckResult {
 		const now = Date.now();
 		const entry = this.attempts.get(username);
-		if (!entry) return { allowed: true };
-		if (now >= entry.resetAt) {
+		const failed = entry && now < entry.resetAt ? entry.count : 0;
+		const inflight = this.inflight.get(username) ?? 0;
+		if (entry && now >= entry.resetAt) {
 			this.attempts.delete(username);
-			return { allowed: true };
 		}
-		if (entry.count >= this.max) {
+		if (failed + inflight >= this.max) {
+			// Re-fetch after the possible delete above; entry may be gone, in
+			// which case all `max` slots are held by in-flight attempts and the
+			// soonest possible release is on the order of a single bcrypt —
+			// report 1 second as the minimum advisory.
+			const resetAt = entry && now < entry.resetAt ? entry.resetAt : now + 1000;
 			return {
 				allowed: false,
-				retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
+				retryAfterSeconds: Math.max(1, Math.ceil((resetAt - now) / 1000)),
 			};
 		}
 		return { allowed: true };
+	}
+
+	// Atomically check AND reserve one in-flight slot for an async
+	// verification. Callers MUST pair every allowed beginAttempt with an
+	// endAttempt (use try/finally) or the slot leaks until process restart.
+	//
+	// Existed as a single method so there's no window between "check passed"
+	// and "slot reserved" where a parallel request could observe the same
+	// pre-reservation state and also pass.
+	beginAttempt(username: string): UsernameCheckResult {
+		const result = this.check(username);
+		if (!result.allowed) return result;
+		const current = this.inflight.get(username) ?? 0;
+		this.inflight.set(username, current + 1);
+		return { allowed: true };
+	}
+
+	// Release a slot reserved by beginAttempt. Safe to call multiple times
+	// against an empty slot (no-op), which keeps try/finally cleanup simple
+	// even if the caller accidentally double-releases on an error path.
+	endAttempt(username: string): void {
+		const current = this.inflight.get(username) ?? 0;
+		if (current <= 1) this.inflight.delete(username);
+		else this.inflight.set(username, current - 1);
 	}
 
 	// Bump the counter for this username. Call after a failed verification.

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -20,15 +20,30 @@ export interface RateLimitConfig {
 	// JWT could otherwise burst all 20 mints in milliseconds before anyone
 	// notices. Slower than registerIp because legitimate use is "invite a
 	// few friends, then idle for weeks".
-	invites: {
+	invitesCreate: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
+	// Caps how often a single IP can revoke invites. Kept separate from
+	// invitesCreate because:
+	//   1. Revoke is a cleanup action the legitimate user may need to do in
+	//      bursts (e.g. panic-rotate after suspecting JWT theft, or bulk-
+	//      clean stale codes). Pinning it to the mint rate would starve the
+	//      legitimate use case.
+	//   2. A combined budget means an attacker who exhausted the mint quota
+	//      could also prevent the victim from revoking their pre-minted
+	//      codes — revoke is precisely the action we want available during
+	//      an incident.
+	// Separate budget, more generous window, distinct 429 message.
+	invitesRevoke: {
 		ipMax: number;
 		ipWindowMs: number;
 	};
 }
 
 // Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
-// Invites: 10/1h — generous for legitimate inviting bursts, restrictive for
-// JWT-theft pre-mint floods.
+// Invites: create 10/h, revoke 60/h — revoke has to cover incident-response
+// bursts, so it's 6x the mint rate.
 export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 	login: {
 		ipMax: 10,
@@ -40,8 +55,12 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 		ipMax: 5,
 		ipWindowMs: 60 * 60 * 1000,
 	},
-	invites: {
+	invitesCreate: {
 		ipMax: 10,
+		ipWindowMs: 60 * 60 * 1000,
+	},
+	invitesRevoke: {
+		ipMax: 60,
 		ipWindowMs: 60 * 60 * 1000,
 	},
 };
@@ -51,7 +70,8 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 export interface AuthRateLimiters {
 	loginIp: RateLimitRequestHandler;
 	registerIp: RateLimitRequestHandler;
-	invitesIp: RateLimitRequestHandler;
+	invitesCreateIp: RateLimitRequestHandler;
+	invitesRevokeIp: RateLimitRequestHandler;
 }
 
 export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
@@ -77,14 +97,21 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many registration attempts from this IP, try again later", scope: "ip" },
 	});
-	const invitesIp = rateLimit({
-		windowMs: cfg.invites.ipWindowMs,
-		limit: cfg.invites.ipMax,
+	const invitesCreateIp = rateLimit({
+		windowMs: cfg.invitesCreate.ipWindowMs,
+		limit: cfg.invitesCreate.ipMax,
 		standardHeaders: "draft-7",
 		legacyHeaders: false,
 		message: { error: "Too many invite-mint requests from this IP, try again later", scope: "ip" },
 	});
-	return { loginIp, registerIp, invitesIp };
+	const invitesRevokeIp = rateLimit({
+		windowMs: cfg.invitesRevoke.ipWindowMs,
+		limit: cfg.invitesRevoke.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: { error: "Too many invite-revoke requests from this IP, try again later", scope: "ip" },
+	});
+	return { loginIp, registerIp, invitesCreateIp, invitesRevokeIp };
 }
 
 // ── Per-username limiter ────────────────────────────────────────────────────

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -196,6 +196,30 @@ export class UsernameRateLimiter {
 	beginAttempt(username: string): UsernameCheckResult {
 		const result = this.check(username);
 		if (!result.allowed) return result;
+
+		// Memory bound on the inflight map. `attempts` is already capped by
+		// maxTracked (with FIFO eviction in recordFailure), but without this
+		// guard a flood of unique usernames — each within its own per-IP
+		// limit — could accumulate inflight entries indefinitely. Practical
+		// ceiling is low (libuv's 4-thread pool serialises bcrypt, so only
+		// ~4 slots exist in a draining state at any moment) but the
+		// invariant still matters: no unbounded state keyed on attacker-
+		// controlled strings.
+		//
+		// Refuse the reservation when the tracked-username cap is full AND
+		// this particular username is not already tracked in EITHER map.
+		// Re-entrant attempts from an already-tracked user stay allowed —
+		// those don't grow the set of unique keys. Retry advisory is 1s
+		// (matches the "all max slots held by in-flight" branch in check()
+		// — soonest a slot could free up is one bcrypt worth of time).
+		if (
+			this.attempts.size >= this.maxTracked &&
+			!this.attempts.has(username) &&
+			!this.inflight.has(username)
+		) {
+			return { allowed: false, retryAfterSeconds: 1 };
+		}
+
 		const current = this.inflight.get(username) ?? 0;
 		this.inflight.set(username, current + 1);
 		return { allowed: true };

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -2,25 +2,37 @@
  * routes.ts — REST API routes.
  */
 
-import { Router, Request, Response } from "express";
+import type { Request, Response } from "express";
+import { Router } from "express";
+import type { AuthedRequest } from "./auth.js";
 import {
-        AuthedRequest, requireAuth, registerUser, loginUser, hasAnyUsers,
-        InvalidCredentialsError, InviteRequiredError, UsernameTakenError,
+        createInvite,
+        hasAnyUsers,
+        InvalidCredentialsError,
         InviteQuotaExceededError,
-        createInvite, listInvites, revokeInvite,
+        InviteRequiredError,
+        listInvites,
+        loginUser,
+        registerUser,
+        requireAuth,
+        revokeInvite,
+        UsernameTakenError,
 } from "./auth.js";
+import type { DockerManager } from "./dockerManager.js";
+import { EnvVarValidationError, validateEnvVars } from "./envVarValidation.js";
+import type { RateLimitConfig } from "./rateLimit.js";
 import {
-        SessionManager, NotFoundError, ForbiddenError, SessionQuotaExceededError,
-} from "./sessionManager.js";
-import { DockerManager } from "./dockerManager.js";
-import { SessionMeta } from "./types.js";
-import {
-        RateLimitConfig,
-        DEFAULT_RATE_LIMIT_CONFIG,
         createAuthRateLimiters,
+        DEFAULT_RATE_LIMIT_CONFIG,
         UsernameRateLimiter,
 } from "./rateLimit.js";
-import { validateEnvVars, EnvVarValidationError } from "./envVarValidation.js";
+import type { SessionManager } from "./sessionManager.js";
+import {
+        ForbiddenError,
+        NotFoundError,
+        SessionQuotaExceededError,
+} from "./sessionManager.js";
+import type { SessionMeta } from "./types.js";
 
 export function buildRouter(
         sessions: SessionManager,
@@ -268,7 +280,15 @@ export function buildRouter(
                         meta = await sessions.create({ userId, name, cols, rows, envVars: validatedEnvVars });
                         await docker.spawn(meta.sessionId);
                         const updated = await sessions.get(meta.sessionId);
-                        res.status(201).json(serializeMeta(updated!));
+                        if (!updated) {
+                                // Shouldn't happen: sessions.create above just inserted this row,
+                                // and nothing in this handler deletes it. Guard so serializeMeta
+                                // doesn't get null. The throw falls into the catch below which
+                                // runs the spawn rollback and returns 500 — correct disposition
+                                // for a server-side invariant violation.
+                                throw new Error(`session ${meta.sessionId} missing from D1 after create`);
+                        }
+                        res.status(201).json(serializeMeta(updated));
                 } catch (err) {
                         // Quota errors come from sessions.create before any D1 row or
                         // container is written, so there's nothing to roll back — return
@@ -359,7 +379,14 @@ export function buildRouter(
                         await sessions.assertOwnership(req.params.id, userId);
                         await docker.stopContainer(req.params.id);
                         const updated = await sessions.get(req.params.id);
-                        res.json(serializeMeta(updated!));
+                        if (!updated) {
+                                // Race: the session was deleted between assertOwnership
+                                // above and this re-read. Return 404 rather than TypeError
+                                // on serializeMeta(null).
+                                res.status(404).json({ error: "Session not found" });
+                                return;
+                        }
+                        res.json(serializeMeta(updated));
                 } catch (err) {
                         handleSessionError(err, res);
                 }
@@ -371,7 +398,13 @@ export function buildRouter(
                         await sessions.assertOwnership(req.params.id, userId);
                         await docker.startContainer(req.params.id);
                         const updated = await sessions.get(req.params.id);
-                        res.json(serializeMeta(updated!));
+                        if (!updated) {
+                                // Race: deleted between assertOwnership and get. See
+                                // stopContainer handler above for the full explanation.
+                                res.status(404).json({ error: "Session not found" });
+                                return;
+                        }
+                        res.json(serializeMeta(updated));
                 } catch (err) {
                         handleSessionError(err, res);
                 }
@@ -401,7 +434,13 @@ export function buildRouter(
                         await sessions.assertOwnership(req.params.id, userId);
                         await sessions.updateEnvVars(req.params.id, validatedEnvVars);
                         const updated = await sessions.get(req.params.id);
-                        res.json(serializeMeta(updated!));
+                        if (!updated) {
+                                // Race: deleted between assertOwnership and get. See
+                                // stopContainer handler above for the full explanation.
+                                res.status(404).json({ error: "Session not found" });
+                                return;
+                        }
+                        res.json(serializeMeta(updated));
                 } catch (err) {
                         handleSessionError(err, res);
                 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -9,7 +9,9 @@ import {
         InviteQuotaExceededError,
         createInvite, listInvites, revokeInvite,
 } from "./auth.js";
-import { SessionManager, NotFoundError, ForbiddenError } from "./sessionManager.js";
+import {
+        SessionManager, NotFoundError, ForbiddenError, SessionQuotaExceededError,
+} from "./sessionManager.js";
 import { DockerManager } from "./dockerManager.js";
 import { SessionMeta } from "./types.js";
 import {
@@ -261,6 +263,15 @@ export function buildRouter(
                         const updated = await sessions.get(meta.sessionId);
                         res.status(201).json(serializeMeta(updated!));
                 } catch (err) {
+                        // Quota errors come from sessions.create before any D1 row or
+                        // container is written, so there's nothing to roll back — return
+                        // 429 directly. Checking before the generic error log too, so a
+                        // routine quota hit doesn't spam the logs as a "session create
+                        // failed" line.
+                        if (err instanceof SessionQuotaExceededError) {
+                                res.status(429).json({ error: err.message, quota: err.quota });
+                                return;
+                        }
                         console.error(`[routes] session create failed:`, (err as Error).message);
                         if (meta) {
                                 // Best-effort rollback. If deleteRow itself fails (D1 blip),

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -120,7 +120,13 @@ export function buildRouter(
                 // account lockout from the IP-layer 429 above. Emits the same
                 // draft-7 RateLimit-* headers as express-rate-limit does on the
                 // IP 429 so clients parsing them see a consistent shape.
-                const check = usernameLimiter.check(username);
+                //
+                // beginAttempt reserves an in-flight slot atomically — important
+                // now that loginUser uses async bcrypt.compare (no longer blocks
+                // the event loop). Without the reservation, a burst of N requests
+                // against the same username could all pass check() and all start
+                // bcrypt before any recordFailure lands, breaking the bound.
+                const check = usernameLimiter.beginAttempt(username);
                 if (!check.allowed) {
                         const windowSeconds = Math.ceil(rateLimitConfig.login.usernameWindowMs / 1000);
                         res.setHeader("Retry-After", String(check.retryAfterSeconds));
@@ -139,31 +145,32 @@ export function buildRouter(
                         return;
                 }
 
-                // Concurrency note: check() is sync but loginUser is async, so
-                // `max + parallelism` slippage is possible in theory. Today
-                // parallelism is effectively 1 because loginUser uses
-                // `bcrypt.compareSync`, which blocks the event loop — that
-                // synchronous call is what pins the bound, not an explicit
-                // mutex. Swapping to the async `bcrypt.compare` removes the
-                // guarantee, so either add queueing or re-check the limit
-                // after the await.
                 let result: { userId: string; token: string };
                 try {
-                        result = await loginUser(username, password);
-                } catch (err) {
-                        if (err instanceof InvalidCredentialsError) {
-                                // Only bad creds count — infra errors must not lock real users out.
-                                usernameLimiter.recordFailure(username);
-                                res.status(401).json({ error: err.message });
+                        try {
+                                result = await loginUser(username, password);
+                        } catch (err) {
+                                if (err instanceof InvalidCredentialsError) {
+                                        // Only bad creds count — infra errors must not lock real users out.
+                                        usernameLimiter.recordFailure(username);
+                                        res.status(401).json({ error: err.message });
+                                        return;
+                                }
+                                // Username omitted from the log to avoid an enumeration vector.
+                                console.error(`[auth] login failed unexpectedly:`, (err as Error).message);
+                                res.status(500).json({ error: "Internal server error" });
                                 return;
                         }
-                        // Username omitted from the log to avoid an enumeration vector.
-                        console.error(`[auth] login failed unexpectedly:`, (err as Error).message);
-                        res.status(500).json({ error: "Internal server error" });
-                        return;
+                        usernameLimiter.reset(username);
+                        res.json(result);
+                } finally {
+                        // Always release the in-flight slot — success, invalid creds,
+                        // or infra error alike. `reset()` above wipes the failure
+                        // counter but not this slot; pairing it with endAttempt keeps
+                        // the invariant that every beginAttempt has exactly one
+                        // endAttempt.
+                        usernameLimiter.endAttempt(username);
                 }
-                usernameLimiter.reset(username);
-                res.json(result);
         });
 
         // ── Authenticated route prefixes ────────────────────────────────────────

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -31,7 +31,7 @@ export function buildRouter(
 
         // ── Auth routes (public) ────────────────────────────────────────────────
 
-        const { loginIp, registerIp, invitesIp } = createAuthRateLimiters(rateLimitConfig);
+        const { loginIp, registerIp, invitesCreateIp, invitesRevokeIp } = createAuthRateLimiters(rateLimitConfig);
         const usernameLimiter = new UsernameRateLimiter(
                 rateLimitConfig.login.usernameMax,
                 rateLimitConfig.login.usernameWindowMs,
@@ -194,7 +194,7 @@ export function buildRouter(
                 }
         });
 
-        router.post("/invites", invitesIp, async (req: Request, res: Response) => {
+        router.post("/invites", invitesCreateIp, async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
                 try {
                         const invite = await createInvite(userId);
@@ -209,7 +209,7 @@ export function buildRouter(
                 }
         });
 
-        router.delete("/invites/:code", invitesIp, async (req: Request, res: Response) => {
+        router.delete("/invites/:code", invitesRevokeIp, async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
                 const { code } = req.params;
                 // Same 64-char ceiling as the inviteCode body field at register —

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -18,6 +18,7 @@ import {
         createAuthRateLimiters,
         UsernameRateLimiter,
 } from "./rateLimit.js";
+import { validateEnvVars, EnvVarValidationError } from "./envVarValidation.js";
 
 export function buildRouter(
         sessions: SessionManager,
@@ -230,11 +231,21 @@ export function buildRouter(
         router.post("/sessions", async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
                 const { name, cols, rows, envVars } = req.body as {
-                        name?: string; cols?: number; rows?: number; envVars?: Record<string, string>;
+                        name?: string; cols?: number; rows?: number; envVars?: unknown;
                 };
                 if (!name || typeof name !== "string") {
                         res.status(400).json({ error: "body.name is required" });
                         return;
+                }
+                let validatedEnvVars: Record<string, string>;
+                try {
+                        validatedEnvVars = validateEnvVars(envVars);
+                } catch (err) {
+                        if (err instanceof EnvVarValidationError) {
+                                res.status(400).json({ error: err.message });
+                                return;
+                        }
+                        throw err;
                 }
                 // `sessions.create` writes a D1 row BEFORE `docker.spawn` runs, so a
                 // spawn failure (missing image, docker daemon down, name collision on
@@ -245,7 +256,7 @@ export function buildRouter(
                 // the D1 row explicitly on any spawn failure.
                 let meta: Awaited<ReturnType<SessionManager["create"]>> | null = null;
                 try {
-                        meta = await sessions.create({ userId, name, cols, rows, envVars });
+                        meta = await sessions.create({ userId, name, cols, rows, envVars: validatedEnvVars });
                         await docker.spawn(meta.sessionId);
                         const updated = await sessions.get(meta.sessionId);
                         res.status(201).json(serializeMeta(updated!));
@@ -350,14 +361,27 @@ export function buildRouter(
 
         router.patch("/sessions/:id/env", async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
-                const { envVars } = req.body as { envVars?: Record<string, string> };
-                if (!envVars || typeof envVars !== "object") {
-                        res.status(400).json({ error: "body.envVars must be an object" });
+                const { envVars } = req.body as { envVars?: unknown };
+                // Require envVars to be explicitly present. An omitted body field here
+                // is almost certainly a client bug — if the user really wants to clear
+                // their vars they should PATCH with `{ envVars: {} }`.
+                if (envVars === undefined) {
+                        res.status(400).json({ error: "body.envVars is required" });
                         return;
+                }
+                let validatedEnvVars: Record<string, string>;
+                try {
+                        validatedEnvVars = validateEnvVars(envVars);
+                } catch (err) {
+                        if (err instanceof EnvVarValidationError) {
+                                res.status(400).json({ error: err.message });
+                                return;
+                        }
+                        throw err;
                 }
                 try {
                         await sessions.assertOwnership(req.params.id, userId);
-                        await sessions.updateEnvVars(req.params.id, envVars);
+                        await sessions.updateEnvVars(req.params.id, validatedEnvVars);
                         const updated = await sessions.get(req.params.id);
                         res.json(serializeMeta(updated!));
                 } catch (err) {

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -24,6 +24,44 @@ export class ForbiddenError extends Error {
         }
 }
 
+// Caps the number of concurrently *active* sessions (running / stopped /
+// anything that hasn't been terminated) a single user can own. Bounds
+// resource consumption if an account is compromised or a runaway script
+// spams `POST /sessions`: a stolen JWT can create at most this many
+// containers, D1 rows, and workspace directories before hitting the
+// cap. Terminated sessions don't count — they free a slot immediately
+// so the user can always recycle.
+//
+// Overridable via MAX_ACTIVE_SESSIONS_PER_USER env var. Parsed at module
+// load (so changes require a restart), validated to a positive integer;
+// any unparseable / non-positive / non-finite value falls back to the
+// default rather than silently disabling the cap.
+const DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER = 20;
+const MAX_ACTIVE_SESSIONS_PER_USER = ((): number => {
+        const raw = process.env.MAX_ACTIVE_SESSIONS_PER_USER;
+        if (raw === undefined || raw.trim() === "") return DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER;
+        const n = Number(raw);
+        if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+                return DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER;
+        }
+        return n;
+})();
+
+export class SessionQuotaExceededError extends Error {
+        // Passed through to the HTTP response — include the effective cap so the
+        // user knows what "too many" means without asking support.
+        readonly quota: number;
+
+        constructor(quota: number) {
+                super(
+                        `You already have ${quota} active sessions — terminate some ` +
+                        `before creating more`,
+                );
+                this.name = "SessionQuotaExceededError";
+                this.quota = quota;
+        }
+}
+
 // ── Row → domain mapper ────────────────────────────────────────────────────
 
 interface SessionRow {
@@ -84,11 +122,32 @@ export class SessionManager {
                 const rows = opts.rows ?? 36;
                 const envVars = opts.envVars ?? {};
 
-                await d1Query(
+                // Atomic quota check: fold the per-user count into the INSERT so two
+                // concurrent POST /sessions from the same user can't both read
+                // `count = cap-1` and both insert. Same SQLite-serialised pattern as
+                // invite mint and bootstrap-register elsewhere in the codebase. The
+                // race loser observes `meta.changes === 0` and raises a typed error
+                // the route can map to 429.
+                //
+                // The count filter matches `listForUser`, which is what the UI shows —
+                // so "active" here means the same thing the user sees in their sidebar.
+                // Terminated rows don't count against the cap; they'll be garbage-
+                // collected by the hard-delete path or left as history.
+                const insert = await d1Query(
                         `INSERT INTO sessions (session_id, user_id, name, container_name, cols, rows, env_vars)
-                         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-                        [sessionId, opts.userId, opts.name, containerName, cols, rows, JSON.stringify(envVars)],
+                         SELECT ?, ?, ?, ?, ?, ?, ?
+                         WHERE (
+                                 SELECT COUNT(*) FROM sessions
+                                 WHERE user_id = ? AND status != 'terminated'
+                         ) < ?`,
+                        [
+                                sessionId, opts.userId, opts.name, containerName, cols, rows, JSON.stringify(envVars),
+                                opts.userId, MAX_ACTIVE_SESSIONS_PER_USER,
+                        ],
                 );
+                if (insert.meta.changes !== 1) {
+                        throw new SessionQuotaExceededError(MAX_ACTIVE_SESSIONS_PER_USER);
+                }
 
                 return (await this.get(sessionId))!;
         }

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -67,8 +67,15 @@ export class SessionQuotaExceededError extends Error {
         readonly quota: number;
 
         constructor(quota: number) {
+                // Phrase as "limit reached" rather than "you already have N
+                // active sessions". When this throws, the count is exactly
+                // `quota` (the atomic INSERT's WHERE clause guarantees that),
+                // so "you already have 20" reads as a count statement — but
+                // the purpose of the message is to communicate the *cap*, not
+                // a tally. Naming the number as a limit makes the fix
+                // (terminate something) obvious.
                 super(
-                        `You already have ${quota} active sessions — terminate some ` +
+                        `Active session limit (${quota}) reached — terminate a session ` +
                         `before creating more`,
                 );
                 this.name = "SessionQuotaExceededError";

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -6,7 +6,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 import { d1Query } from "./db.js";
-import { SessionMeta, SessionStatus, CreateSessionOpts } from "./types.js";
+import type { CreateSessionOpts, SessionMeta, SessionStatus } from "./types.js";
 
 // ── Custom errors ───────────────────────────────────────────────────────────
 
@@ -101,7 +101,7 @@ interface SessionRow {
 // ISO 8601 offsets like `+00:00`.
 function parseD1UtcTimestamp(raw: string): Date {
         const hasSuffix = /[zZ]$/.test(raw) || /[+-]\d{2}:?\d{2}$/.test(raw);
-        const d = new Date(hasSuffix ? raw : raw + "Z");
+        const d = new Date(hasSuffix ? raw : `${raw}Z`);
         if (Number.isNaN(d.getTime())) {
                 // Better to crash loudly here than return "Invalid Date" that
                 // would later serialize to null in JSON.
@@ -163,7 +163,18 @@ export class SessionManager {
                         throw new SessionQuotaExceededError(MAX_ACTIVE_SESSIONS_PER_USER);
                 }
 
-                return (await this.get(sessionId))!;
+                const meta = await this.get(sessionId);
+                if (!meta) {
+                        // Unreachable in practice: we just inserted this row and
+                        // confirmed changes === 1. Guard anyway so the return type
+                        // is honest (no non-null assertion) and a hypothetical
+                        // read-after-write hiccup becomes a loud error rather than
+                        // a TypeError downstream when callers access .sessionId.
+                        throw new Error(
+                                `sessionManager.create: session ${sessionId} missing from D1 after insert`,
+                        );
+                }
+                return meta;
         }
 
         async get(sessionId: string): Promise<SessionMeta | null> {

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -35,13 +35,27 @@ export class ForbiddenError extends Error {
 // Overridable via MAX_ACTIVE_SESSIONS_PER_USER env var. Parsed at module
 // load (so changes require a restart), validated to a positive integer;
 // any unparseable / non-positive / non-finite value falls back to the
-// default rather than silently disabling the cap.
+// default AND logs a warning — silently defaulting to 20 when an operator
+// set it to "0" (expecting "freeze new sessions") or a typo like "20 "
+// with a trailing non-ASCII character would ship the wrong cap with no
+// ops-visible signal.
 const DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER = 20;
 const MAX_ACTIVE_SESSIONS_PER_USER = ((): number => {
         const raw = process.env.MAX_ACTIVE_SESSIONS_PER_USER;
         if (raw === undefined || raw.trim() === "") return DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER;
         const n = Number(raw);
         if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+                // Surface the original value (quoted, so "  " etc. stay visible)
+                // and the effective fallback — ops should be able to tell at a
+                // glance which variable was wrong and what the server is
+                // actually running with. Uses console.warn rather than throw
+                // because a startup abort here would gate the whole server on
+                // a non-critical config typo, which is worse than running with
+                // the documented default.
+                console.warn(
+                        `[sessionManager] MAX_ACTIVE_SESSIONS_PER_USER=${JSON.stringify(raw)} ` +
+                        `is not a positive integer; falling back to ${DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER}`,
+                );
                 return DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER;
         }
         return n;

--- a/backend/src/trustProxy.test.ts
+++ b/backend/src/trustProxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
         parseTrustProxy,
         TrustProxyError,

--- a/backend/src/trustProxy.test.ts
+++ b/backend/src/trustProxy.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+        parseTrustProxy,
+        TrustProxyError,
+        warnIfProductionMisconfigured,
+} from "./trustProxy.js";
+
+describe("parseTrustProxy", () => {
+        // ── unset / blank ──────────────────────────────────────────────────
+
+        it("returns undefined for unset / empty / whitespace-only input", () => {
+                expect(parseTrustProxy(undefined)).toBeUndefined();
+                expect(parseTrustProxy("")).toBeUndefined();
+                expect(parseTrustProxy("   ")).toBeUndefined();
+                expect(parseTrustProxy("\t\n")).toBeUndefined();
+        });
+
+        // ── foot-gun: "true" ───────────────────────────────────────────────
+
+        it("rejects the literal string 'true' with an actionable message", () => {
+                // Covers the most likely mistake — an operator reading
+                // 'trust proxy' as a boolean. Message must name the correct
+                // alternative so the fix is obvious from the error alone.
+                expect(() => parseTrustProxy("true")).toThrow(TrustProxyError);
+                try {
+                        parseTrustProxy("true");
+                } catch (err) {
+                        expect((err as Error).message).toMatch(/leftmost.*X-Forwarded-For/);
+                        expect((err as Error).message).toMatch(/TRUST_PROXY=1/);
+                }
+        });
+
+        // ── falsy forms ────────────────────────────────────────────────────
+
+        it("coerces '0' and 'false' to the literal boolean false", () => {
+                // We deliberately emit boolean false instead of relying on
+                // Express's compileTrust(0) behaviour, which is undocumented.
+                expect(parseTrustProxy("0")).toBe(false);
+                expect(parseTrustProxy("false")).toBe(false);
+                expect(parseTrustProxy(" false ")).toBe(false);
+        });
+
+        // ── hop counts ─────────────────────────────────────────────────────
+
+        it("parses non-negative integer hop counts to numbers", () => {
+                expect(parseTrustProxy("1")).toBe(1);
+                expect(parseTrustProxy("2")).toBe(2);
+                expect(parseTrustProxy("10")).toBe(10);
+                expect(parseTrustProxy(" 1 ")).toBe(1);
+        });
+
+        it("rejects signed, fractional, or scientific-notation numbers", () => {
+                // These slip past a naive `Number("…")` check but aren't
+                // legitimate hop counts.
+                expect(() => parseTrustProxy("-1")).toThrow(TrustProxyError);
+                expect(() => parseTrustProxy("+1")).toThrow(TrustProxyError);
+                expect(() => parseTrustProxy("1.5")).toThrow(TrustProxyError);
+                expect(() => parseTrustProxy("1e2")).toThrow(TrustProxyError);
+        });
+
+        // ── named presets ──────────────────────────────────────────────────
+
+        it("accepts Express's documented named presets", () => {
+                expect(parseTrustProxy("loopback")).toBe("loopback");
+                expect(parseTrustProxy("linklocal")).toBe("linklocal");
+                expect(parseTrustProxy("uniquelocal")).toBe("uniquelocal");
+        });
+
+        it("rejects typos of preset names", () => {
+                // Without this guard, Express would silently treat 'loopbakc'
+                // as a literal hostname to trust — which is worse than
+                // failing loudly.
+                expect(() => parseTrustProxy("loopbakc")).toThrow(TrustProxyError);
+                expect(() => parseTrustProxy("link-local")).toThrow(TrustProxyError); // dash not allowed
+                expect(() => parseTrustProxy("unique_local")).toThrow(TrustProxyError);
+        });
+
+        // ── IPs and CIDRs ──────────────────────────────────────────────────
+
+        it("accepts IPv4, IPv6, and CIDR shapes", () => {
+                expect(parseTrustProxy("10.0.0.1")).toBe("10.0.0.1");
+                expect(parseTrustProxy("10.0.0.0/8")).toBe("10.0.0.0/8");
+                expect(parseTrustProxy("::1")).toBe("::1");
+                expect(parseTrustProxy("2001:db8::/32")).toBe("2001:db8::/32");
+        });
+
+        it("accepts comma-separated lists of IPs / presets", () => {
+                expect(parseTrustProxy("10.0.0.0/8, loopback")).toBe("10.0.0.0/8, loopback");
+                expect(parseTrustProxy("loopback,linklocal")).toBe("loopback,linklocal");
+        });
+
+        it("rejects a list if any single token is unrecognised", () => {
+                // Wholesale refuse the whole value rather than silently
+                // accepting the good tokens — the unrecognised one is almost
+                // certainly the bug that needs fixing.
+                expect(() => parseTrustProxy("loopback,not-a-thing")).toThrow(TrustProxyError);
+                expect(() => parseTrustProxy("yes")).toThrow(TrustProxyError);
+                expect(() => parseTrustProxy("cloudflare")).toThrow(TrustProxyError);
+        });
+
+        it("error message names the offending token so ops can fix it fast", () => {
+                try {
+                        parseTrustProxy("loopback,not-a-thing,10.0.0.0/8");
+                        expect.fail("should have thrown");
+                } catch (err) {
+                        expect((err as Error).message).toContain("not-a-thing");
+                }
+        });
+});
+
+describe("warnIfProductionMisconfigured", () => {
+        it("warns when NODE_ENV=production and TRUST_PROXY is unset", () => {
+                const logger = { warn: vi.fn() };
+                warnIfProductionMisconfigured(undefined, "production", logger);
+                expect(logger.warn).toHaveBeenCalledOnce();
+                expect(logger.warn.mock.calls[0][0]).toMatch(/TRUST_PROXY is unset/);
+        });
+
+        it("warns when NODE_ENV=production and TRUST_PROXY is whitespace-only", () => {
+                // Common manifestation in k8s / docker-compose when a secret
+                // is defined but unset — the value surfaces as "" or "   ".
+                const logger = { warn: vi.fn() };
+                warnIfProductionMisconfigured("   ", "production", logger);
+                expect(logger.warn).toHaveBeenCalledOnce();
+        });
+
+        it("stays quiet when NODE_ENV is anything other than production", () => {
+                const logger = { warn: vi.fn() };
+                warnIfProductionMisconfigured(undefined, "development", logger);
+                warnIfProductionMisconfigured(undefined, "test", logger);
+                warnIfProductionMisconfigured(undefined, undefined, logger);
+                expect(logger.warn).not.toHaveBeenCalled();
+        });
+
+        it("stays quiet when TRUST_PROXY is set in production", () => {
+                // We don't re-validate here — that's parseTrustProxy's job.
+                // The warning is strictly about the "unset" case.
+                const logger = { warn: vi.fn() };
+                warnIfProductionMisconfigured("1", "production", logger);
+                warnIfProductionMisconfigured("loopback", "production", logger);
+                warnIfProductionMisconfigured("false", "production", logger);
+                expect(logger.warn).not.toHaveBeenCalled();
+        });
+});

--- a/backend/src/trustProxy.ts
+++ b/backend/src/trustProxy.ts
@@ -1,0 +1,144 @@
+/**
+ * trustProxy.ts — validate & parse the TRUST_PROXY env var.
+ *
+ * Split out from index.ts so the parsing logic is pure (no process.exit,
+ * no app.set) and can be unit-tested without spinning up Express. The
+ * caller (index.ts) is responsible for calling `app.set("trust proxy",
+ * parseTrustProxy(...))` and for turning a thrown TrustProxyError into a
+ * fatal exit.
+ *
+ * Background: Express's `trust proxy` setting controls how `req.ip` is
+ * derived from `X-Forwarded-For`. Misconfiguring it has real security
+ * consequences — the wrong value lets an attacker rotate X-F-F headers
+ * to bypass per-IP rate limits. This module makes the allowed shapes
+ * explicit and refuses anything else with an actionable error.
+ */
+
+export type TrustProxyValue = boolean | number | string;
+
+export class TrustProxyError extends Error {
+        constructor(message: string) {
+                super(message);
+                this.name = "TrustProxyError";
+        }
+}
+
+// Express's named presets. Anything outside this set that isn't a number,
+// a hop count, or an IP/CIDR is a likely typo (e.g. "loopbakc",
+// "uniquely-local") — refuse it loudly rather than passing through to
+// Express's internal compileTrust which would silently treat it as a
+// literal hostname to trust.
+const NAMED_PRESETS = new Set(["loopback", "linklocal", "uniquelocal"]);
+
+// Permissive shape-only regex, NOT a full IP parser. Matches:
+//   - IPv4 dotted (e.g. "10.0.0.1"): exactly 4 dot-separated runs of 1-3
+//     digits. Loose on octet range (".999" slips through), tight on shape.
+//   - IPv6 hex+colons (e.g. "::1", "2001:db8::1"): must contain at least
+//     one colon. Without the mandatory colon, tokens like "1e2" or "abc"
+//     would sneak through as "pseudo-IPv6" — scientific notation is
+//     never a valid trust-proxy value and a typo'd word shouldn't be
+//     silently treated as a literal hostname.
+// Either form may carry an optional CIDR `/N` suffix.
+//
+// The semantic validity of the address (real-IPv4, real-IPv6, CIDR
+// boundary) is delegated to Express's own parser — we're only catching
+// shape-level garbage here.
+const IP_OR_CIDR = /^(?:\d{1,3}(?:\.\d{1,3}){3}|[\da-fA-F]*:[\da-fA-F:]*)(?:\/\d+)?$/;
+
+/**
+ * Parse the raw TRUST_PROXY env string into the value Express expects.
+ * Returns `undefined` when the variable is unset or blank (caller should
+ * leave Express's default alone in that case).
+ *
+ * Throws TrustProxyError for:
+ *   - `"true"` (foot-gun: leftmost-XFF = attacker-controlled)
+ *   - negative or non-finite numbers
+ *   - unrecognised strings (typos in preset names, non-IP-shaped tokens)
+ */
+export function parseTrustProxy(raw: string | undefined): TrustProxyValue | undefined {
+        if (raw === undefined || raw.trim() === "") return undefined;
+        const trimmed = raw.trim();
+
+        // "true" is the single most common wrong value — it looks right to
+        // anyone who reads "trust proxy" as a boolean knob, but Express then
+        // takes the LEFTMOST X-Forwarded-For entry, which the client controls.
+        // Refuse it with a message that names the correct alternative.
+        if (trimmed === "true") {
+                throw new TrustProxyError(
+                        "TRUST_PROXY=true is refused: Express would take the leftmost " +
+                        "X-Forwarded-For entry (attacker-controlled), bypassing per-IP " +
+                        "rate limiting. Use a hop count (e.g. TRUST_PROXY=1) instead.",
+                );
+        }
+
+        // Explicit "0"/"false" → boolean false so we don't rely on Express's
+        // (undocumented) compileTrust(0) returning "never trust". If that
+        // internal ever changes, a string mistakenly treated as an IP would
+        // silently mis-trust; the explicit boolean keeps us pinned.
+        if (trimmed === "false" || trimmed === "0") return false;
+
+        // Hop-count form. Reject a leading "+", scientific notation, or
+        // anything else that Number("…") would happily coerce but isn't a
+        // legitimate count.
+        if (/^\d+$/.test(trimmed)) {
+                const n = Number(trimmed);
+                if (!Number.isSafeInteger(n) || n < 0) {
+                        throw new TrustProxyError(
+                                `TRUST_PROXY="${raw}" is not a valid non-negative integer hop count`,
+                        );
+                }
+                return n;
+        }
+
+        // Comma-separated list of named presets, IPs, or CIDRs. Express accepts
+        // all three in the same comma-separated format, so we validate every
+        // token before passing the whole string through.
+        const tokens = trimmed.split(",").map((t) => t.trim()).filter(Boolean);
+        if (tokens.length === 0) {
+                throw new TrustProxyError(`TRUST_PROXY="${raw}" has no valid tokens after splitting`);
+        }
+        for (const token of tokens) {
+                if (NAMED_PRESETS.has(token)) continue;
+                if (IP_OR_CIDR.test(token)) continue;
+                throw new TrustProxyError(
+                        `TRUST_PROXY contains unrecognised value "${token}". ` +
+                        `Expected a non-negative integer hop count (e.g. "1"), "false"/"0", ` +
+                        `one of [${[...NAMED_PRESETS].join(", ")}], an IP/CIDR, ` +
+                        `or a comma-separated list of those.`,
+                );
+        }
+        return trimmed;
+}
+
+/**
+ * Emit a production-unset warning. Called at startup from index.ts.
+ *
+ * When NODE_ENV=production and TRUST_PROXY is unset, there's a good
+ * chance the backend is behind a proxy (tunnel, CDN, LB) but will still
+ * use the proxy's socket address as req.ip — collapsing per-IP rate
+ * limits into a single global bucket. This is a config mistake, not a
+ * valid deployment topology for anyone running behind Cloudflare Tunnel.
+ *
+ * We warn rather than fail because a direct-internet production server
+ * (rare but legal) should also not set TRUST_PROXY; we can't tell the
+ * two apart from env alone.
+ *
+ * Logger is injectable so tests can assert on calls without stealing
+ * console.warn globally.
+ */
+export function warnIfProductionMisconfigured(
+        raw: string | undefined,
+        nodeEnv: string | undefined,
+        logger: Pick<Console, "warn"> = console,
+): void {
+        if (nodeEnv !== "production") return;
+        if (raw !== undefined && raw.trim() !== "") return;
+        logger.warn(
+                "[server] NODE_ENV=production but TRUST_PROXY is unset. " +
+                "If the backend is behind a reverse proxy, CDN, or tunnel, " +
+                "req.ip will be the proxy's socket address — collapsing per-IP " +
+                "rate limits into a single global bucket. Set TRUST_PROXY to the " +
+                "hop count (e.g. 1 for a single Cloudflare Tunnel), or leave unset " +
+                "ONLY if the backend is directly internet-facing.",
+        );
+}

--- a/backend/src/trustProxy.ts
+++ b/backend/src/trustProxy.ts
@@ -126,6 +126,29 @@ export function parseTrustProxy(raw: string | undefined): TrustProxyValue | unde
  * Logger is injectable so tests can assert on calls without stealing
  * console.warn globally.
  */
+// Intentional scope: this helper only flags the "unset / blank" case. It
+// does NOT re-validate a set value — that's parseTrustProxy's job and is
+// called separately at boot. It also does NOT warn when the operator
+// explicitly sets TRUST_PROXY=0 / =false in production, even though that
+// has the same collapse-all-IPs-into-one-bucket effect as leaving it
+// unset behind a proxy. Distinguishing the two cases is deliberate:
+//
+//   - unset  = "operator didn't think about it" → warn, it's probably a
+//              misconfiguration the operator hasn't noticed yet.
+//   - 0/false = "operator explicitly chose to distrust all proxies"   →
+//              silent, on the assumption that a deployment directly
+//              exposed to the internet (e.g. a host-network container
+//              with no CDN in front) is the legitimate scenario. If the
+//              caller set it to false AND is behind a proxy, that's a
+//              deployment mistake this helper can't distinguish from a
+//              correct direct-exposure setup — so we defer to operator
+//              intent rather than guess.
+//
+// If the threat model ever extends to "ops typed `false` because they
+// saw it was a valid value and didn't read the docs", flip this to also
+// warn on explicit falsy values — the corresponding test
+// ('stays quiet when TRUST_PROXY is set in production') would also need
+// to drop its `"false"` case.
 export function warnIfProductionMisconfigured(
         raw: string | undefined,
         nodeEnv: string | undefined,


### PR DESCRIPTION
Five independent commits, each one standalone-reviewable. All 75 tests pass, `tsc --noEmit` is clean.

## Commits (oldest → newest)

### 1. `b2cbaea` — validate session envVars shape, size, and content
Prior to this, `POST /sessions` and `PATCH /sessions/:id/env` accepted `envVars` as `unknown` and passed it straight to `spawn`/`updateEnvVars`. A client could inject non-string values (coerced through JSON), 100KB env blobs, or `LD_PRELOAD`/`PATH` overrides inside the container. New `envVarValidation.ts` enforces: shape (plain object, string keys/values), per-key size, total size, POSIX name, and a denylist of `LD_*`/`PATH`/`HOME`/`USER`/similar escape-vectors. Hit from both routes with explicit 400 on violation.

### 2. `4f8fddd` — per-user active session quota (atomic)
Single user could spawn unlimited active sessions (each = one container + workspace tree). New `MAX_ACTIVE_SESSIONS_PER_USER` (default 20), enforced inside `SessionManager.create` **atomically**: count-then-insert happens inside the same D1 transaction path, so two parallel `POST /sessions` can't both observe "19/20" and both succeed into "21/20". `SessionQuotaExceededError` → 429 with a structured `{ quota }` payload.

### 3. `82efe21` — async bcrypt + in-flight lockout accounting
`loginUser` used `bcrypt.compareSync` — blocked the event loop ~100ms per login. The only reason the "max + parallelism" slip through the per-username limiter never mattered is that the sync hash was *itself* serialising requests. Swapped to async bcrypt (`compare`/`hash`) and added `beginAttempt`/`endAttempt` on `UsernameRateLimiter` that atomically reserves a slot in the shared `max` budget before bcrypt runs. Route uses try/finally so the slot is always released. Over-release is a no-op. Also added a constant-time dummy-hash compare on the unknown-username path to close a 1ms timing-based username-enumeration gap. 5 new unit tests.

### 4. `c6b798f` — split invite create vs revoke rate limiters
Both `POST /invites` and `DELETE /invites/:code` were throttled by the same `invitesIp` limiter. Two problems: (a) bursty revoke is legitimate (panic-rotate during a JWT-compromise incident), (b) merging budgets means an attacker who exhausts the mint quota also blocks the victim from revoking already-minted codes. Config now has `invitesCreate` + `invitesRevoke` with separate windows and distinct 429 messages; default revoke budget is 6x mint.

### 5. `9bc2cff` — `TRUST_PROXY` value whitelist + production-unset warning
The inline parser in `index.ts` passed unknown strings through to Express verbatim — including typos like `"loopbakc"` or `"cloudflare"`, which Express then treats as **literal hostnames to trust**. Silent misconfig: all per-IP limiters collapse. Split into pure `trustProxy.ts`:
- `parseTrustProxy()` whitelists hop counts, `"0"/"false"`, the three documented presets, and IP/CIDR shapes. Anything else throws with the offending token named.
- `warnIfProductionMisconfigured()` logs a loud warning when `NODE_ENV=production` and `TRUST_PROXY` is unset (most likely a Cloudflare Tunnel deploy that forgot the env var — per-IP buckets would otherwise collapse to the tunnel's socket).
15 unit tests covering the foot-gun cases (`"true"`, `"1e2"`-via-IPv6-regex, preset typos, signed/fractional numbers). Also fixed a missing `MAX_ACTIVE_SESSIONS_PER_USER` documentation gap in `.env.example`.

## Test results
- `npm test -- --run`: **75/75 pass** (up from 55 before this branch; +20 new tests across envVarValidation, sessionManager quota, rateLimit in-flight accounting, and trustProxy)
- `tsc --noEmit`: clean