### PR TITLE
Phase 3 — reject WebSocket upgrade on untrusted Origin (closes #3)

### DIFF
--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { validateJwtSecret, __resetJwtSecretForTests } from "./auth.js";
+import {
+	__resetJwtSecretForTests,
+	isAllowedWsOrigin,
+	validateJwtSecret,
+	warnIfWildcardCorsInProduction,
+} from "./auth.js";
 
 // These tests manipulate process.env.{JWT_SECRET, NODE_ENV} and use a
 // spy on console.warn. Snapshot + restore each to avoid cross-test leakage.
@@ -78,5 +83,135 @@ describe("validateJwtSecret", () => {
 		expect(() => validateJwtSecret()).not.toThrow();
 		expect(warnSpy).toHaveBeenCalledOnce();
 		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/JWT_SECRET is not set/);
+	});
+});
+
+// Pinning the four branches of the CSWSH policy documented on the
+// function. The `allowlist` shapes mirror what `CORS_ORIGINS.split(",")`
+// produces in index.ts (the real caller) — NOT an arbitrary array
+// literal — so these tests catch a regression where someone changes the
+// parse at the call site without updating the helper.
+describe("isAllowedWsOrigin", () => {
+	const ALLOWED_ORIGIN = "https://terminal.example.com";
+	const allowlist = [ALLOWED_ORIGIN, "https://other.example.com"];
+
+	// ── Branch 1: absent Origin ────────────────────────────────────────
+	it("allows a missing Origin header (non-browser client)", () => {
+		// Browsers ALWAYS send Origin on WS. The CSWSH threat strictly
+		// requires a browser, so absent Origin is out of scope.
+		expect(isAllowedWsOrigin(undefined, allowlist, "production")).toBe(true);
+	});
+
+	it("allows an empty-string Origin the same as absent", () => {
+		// Some proxies normalise missing headers to empty strings. The
+		// helper has to cover both shapes or this branch is a lie.
+		expect(isAllowedWsOrigin("", allowlist, "production")).toBe(true);
+	});
+
+	// ── Branch 2: explicit match ───────────────────────────────────────
+	it("allows an Origin that exactly matches the allowlist", () => {
+		expect(isAllowedWsOrigin(ALLOWED_ORIGIN, allowlist, "production")).toBe(true);
+	});
+
+	it("rejects a prefix of an allowlisted origin", () => {
+		// e.g. `https://terminal.example.com` is allowed, but
+		// `https://terminal.example.co` must NOT match. Guard against a
+		// future "use startsWith" refactor.
+		expect(isAllowedWsOrigin("https://terminal.example.co", allowlist, "production")).toBe(false);
+	});
+
+	it("rejects an origin that contains an allowlisted origin as a substring", () => {
+		// Classic `attackerour-domain.com` bypass: make sure exact-match
+		// semantics hold.
+		expect(
+			isAllowedWsOrigin(
+				"https://attackerhttps://terminal.example.com",
+				allowlist,
+				"production",
+			),
+		).toBe(false);
+	});
+
+	it("is case-sensitive on the host portion", () => {
+		// Origin header is always sent lowercase by browsers. A case
+		// mismatch from our allowlist therefore indicates either a
+		// hand-crafted request or a misconfiguration — either way, not
+		// an allow.
+		expect(
+			isAllowedWsOrigin("HTTPS://terminal.example.com", allowlist, "production"),
+		).toBe(false);
+	});
+
+	// ── Branch 3: wildcard ─────────────────────────────────────────────
+	it("rejects a non-matching origin under '*' in production", () => {
+		expect(isAllowedWsOrigin("https://evil.example.com", ["*"], "production")).toBe(false);
+	});
+
+	it("allows a non-matching origin under '*' outside production", () => {
+		// undefined NODE_ENV is the local-dev case (nothing set).
+		expect(isAllowedWsOrigin("https://evil.example.com", ["*"], undefined)).toBe(true);
+		expect(isAllowedWsOrigin("https://evil.example.com", ["*"], "development")).toBe(true);
+		expect(isAllowedWsOrigin("https://evil.example.com", ["*"], "test")).toBe(true);
+	});
+
+	it("still allows an explicit-match origin even when '*' and prod coexist", () => {
+		// A deployment could have CORS_ORIGINS="*,https://real-frontend"
+		// (unusual but legal). The explicit entry should take precedence
+		// over the wildcard's production-refusal.
+		expect(
+			isAllowedWsOrigin(ALLOWED_ORIGIN, ["*", ALLOWED_ORIGIN], "production"),
+		).toBe(true);
+	});
+
+	// ── Branch 4: everything else ─────────────────────────────────────
+	it("rejects any origin when the allowlist is empty", () => {
+		// `"".split(",")` returns `[""]`, not `[]`, so the call-site
+		// shape has one empty-string entry. An empty string isn't a
+		// valid origin and shouldn't be treated as one — but the caller
+		// could also realistically pass `[]` after a future refactor,
+		// so pin both.
+		expect(isAllowedWsOrigin("https://anything.example", [], "production")).toBe(false);
+		expect(isAllowedWsOrigin("https://anything.example", [""], "production")).toBe(false);
+	});
+
+	it("rejects a non-allowlisted origin with no wildcard present", () => {
+		expect(
+			isAllowedWsOrigin("https://evil.example.com", allowlist, "production"),
+		).toBe(false);
+	});
+});
+
+// The warning is a startup-time signal for the "CORS_ORIGINS='*' in
+// production" foot-gun. Test it via an injected logger so we don't have
+// to spy on console.warn globally.
+describe("warnIfWildcardCorsInProduction", () => {
+	it("warns when '*' is present and NODE_ENV=production", () => {
+		const warn = vi.fn();
+		warnIfWildcardCorsInProduction(["*"], "production", { warn });
+		expect(warn).toHaveBeenCalledOnce();
+		expect(warn.mock.calls[0]?.[0]).toMatch(/CORS_ORIGINS contains '\*' in production/);
+	});
+
+	it("still warns when '*' is mixed with explicit entries in production", () => {
+		// Defence in depth: the explicit entries give most users a
+		// working WS, but the '*' is still a live attack surface via the
+		// HTTP layer, so the warning should fire anyway.
+		const warn = vi.fn();
+		warnIfWildcardCorsInProduction(["*", "https://frontend"], "production", { warn });
+		expect(warn).toHaveBeenCalledOnce();
+	});
+
+	it("stays quiet outside production regardless of wildcard", () => {
+		const warn = vi.fn();
+		warnIfWildcardCorsInProduction(["*"], undefined, { warn });
+		warnIfWildcardCorsInProduction(["*"], "development", { warn });
+		warnIfWildcardCorsInProduction(["*"], "test", { warn });
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("stays quiet when '*' is absent in production", () => {
+		const warn = vi.fn();
+		warnIfWildcardCorsInProduction(["https://frontend"], "production", { warn });
+		expect(warn).not.toHaveBeenCalled();
 	});
 });

--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
 	__resetJwtSecretForTests,
 	isAllowedWsOrigin,
+	parseCorsOrigins,
 	validateJwtSecret,
 	warnIfWildcardCorsInProduction,
 } from "./auth.js";
@@ -213,5 +214,61 @@ describe("warnIfWildcardCorsInProduction", () => {
 		const warn = vi.fn();
 		warnIfWildcardCorsInProduction(["https://frontend"], "production", { warn });
 		expect(warn).not.toHaveBeenCalled();
+	});
+});
+
+// Regression coverage for the original parse — `CORS_ORIGINS.split(",")`
+// with no trim silently broke exact-match enforcement on any origin past
+// the first if the operator wrote the obvious comma-space form. Caught
+// in review of the initial CSWSH fix; these tests pin the call-site
+// parse shape so a future refactor that drops the trim is a test
+// failure, not a production incident.
+describe("parseCorsOrigins", () => {
+	it("defaults to ['*'] when unset", () => {
+		expect(parseCorsOrigins(undefined)).toEqual(["*"]);
+	});
+
+	it("defaults to ['*'] when blank or whitespace-only", () => {
+		// An operator who blanks CORS_ORIGINS= in a secrets manager
+		// expecting "no origins" should get the documented default
+		// instead of [""] (which would match a literal "" origin).
+		expect(parseCorsOrigins("")).toEqual(["*"]);
+		expect(parseCorsOrigins("   ")).toEqual(["*"]);
+	});
+
+	it("trims whitespace around each entry", () => {
+		// The original bug. Leading spaces after commas used to produce
+		// [' https://b.example.com'] which never equalled the Origin
+		// header the browser actually sends.
+		expect(
+			parseCorsOrigins("https://a.example.com, https://b.example.com"),
+		).toEqual(["https://a.example.com", "https://b.example.com"]);
+	});
+
+	it("handles tabs and surrounding whitespace uniformly", () => {
+		expect(parseCorsOrigins("\thttps://a ,https://b\t")).toEqual([
+			"https://a",
+			"https://b",
+		]);
+	});
+
+	it("drops empty entries after trimming", () => {
+		// Trailing comma is common in edit-via-secrets-manager flows.
+		// Leaves the allowlist clean instead of carrying a "" entry
+		// that would match a literal empty Origin header (branch 2 of
+		// isAllowedWsOrigin) — an ambiguous failure mode we'd rather
+		// not have.
+		expect(parseCorsOrigins("https://a,,https://b,")).toEqual([
+			"https://a",
+			"https://b",
+		]);
+	});
+
+	it("preserves '*' when explicitly set", () => {
+		// Don't accidentally strip the wildcard. The default fallback
+		// above produces the same output, but the explicit path must
+		// also round-trip.
+		expect(parseCorsOrigins("*")).toEqual(["*"]);
+		expect(parseCorsOrigins("*, https://b")).toEqual(["*", "https://b"]);
 	});
 });

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -547,6 +547,26 @@ export function selectWsAuthProtocol(protocols: Set<string>): string | false {
 }
 
 /**
+ * Split-and-trim the raw `CORS_ORIGINS` env value into the shape used
+ * by the HTTP CORS middleware AND `isAllowedWsOrigin` below. Whitespace
+ * around entries is trimmed (so `"https://a, https://b"` — the obvious
+ * human-readable format — works), and empty entries are dropped (so a
+ * blank `CORS_ORIGINS=""` becomes `[]` rather than `[""]`, which would
+ * otherwise let an origin-header value of `""` match literally).
+ *
+ * Unset or whitespace-only input falls back to `["*"]`, matching the
+ * pre-existing default. Kept pure + exported so the split/trim is
+ * testable without standing up the HTTP server.
+ */
+export function parseCorsOrigins(raw: string | undefined): string[] {
+        if (raw === undefined || raw.trim() === "") return ["*"];
+        return raw
+                .split(",")
+                .map((s) => s.trim())
+                .filter((s) => s.length > 0);
+}
+
+/**
  * Decide whether a WebSocket upgrade with the given Origin header should
  * be accepted. The caller (index.ts' `upgrade` handler) uses the result
  * to 403 out BEFORE the handshake completes, so a rejected origin never

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -546,6 +546,102 @@ export function selectWsAuthProtocol(protocols: Set<string>): string | false {
         return false;
 }
 
+/**
+ * Decide whether a WebSocket upgrade with the given Origin header should
+ * be accepted. The caller (index.ts' `upgrade` handler) uses the result
+ * to 403 out BEFORE the handshake completes, so a rejected origin never
+ * reaches verifyWsToken / handleWsConnection and never shows up in the
+ * `wss.clients` set either.
+ *
+ * Threat model: Cross-Site WebSocket Hijacking (CSWSH). A page a
+ * logged-in user visits opens `new WebSocket("wss://…")` against our
+ * server. Browsers do NOT apply Same-Origin Policy to WebSockets —
+ * there's no preflight, no `Access-Control-*` enforcement. The only
+ * origin-based defence the browser gives us is that it DOES always send
+ * the `Origin` header on WS handshakes, and an attacker page cannot
+ * forge it. So: server-side Origin allowlist is the whole defence.
+ *
+ * Policy:
+ *
+ * 1. No Origin header (undefined or empty string): allow.
+ *    Browsers ALWAYS send Origin on WS. Absence means a non-browser
+ *    client (curl, a native app, a server-to-server caller). That's
+ *    outside the CSWSH threat model — a server-side attacker with a
+ *    valid JWT already bypasses any origin check by just not setting
+ *    Origin, and doesn't need to "hijack" anything. Blocking empty
+ *    Origin would break legitimate CLI tooling without closing the
+ *    CSWSH gap.
+ *
+ * 2. Origin exactly in `allowedOrigins`: allow.
+ *    Substring/suffix matching is tempting (`ends with our-domain.com`)
+ *    but enables `attackerour-domain.com` attacks. Exact match only.
+ *
+ * 3. allowedOrigins contains "*":
+ *    - In production: DENY, and the caller logs a loud warning once at
+ *      startup. The HTTP CORS layer treats "*" as "anyone can hit
+ *      public endpoints without credentials" — mostly harmless because
+ *      browsers refuse to send credentials to `*`. WS has no such
+ *      browser-side guard: the browser DOES send the auth.bearer.* sub-
+ *      protocol on a WS to any origin. "*" for WS in production means
+ *      "any page on the web can CSWSH our authenticated users".
+ *    - Outside production: allow. Local dev frequently runs on
+ *      multiple/ephemeral ports, and the CSWSH prerequisite (attacker
+ *      site in the victim's browser) is ~never the local-dev threat
+ *      model. A dev should not have to configure CORS_ORIGINS just to
+ *      get `localhost` working.
+ *
+ * 4. Everything else: deny.
+ *
+ * Returns boolean; the caller decides the wire response (403 + socket
+ * destroy). Kept pure so auth.test.ts can pin all four branches without
+ * touching http.
+ */
+export function isAllowedWsOrigin(
+        origin: string | undefined,
+        allowedOrigins: readonly string[],
+        nodeEnv: string | undefined,
+): boolean {
+        // Branch 1: not a browser, not a CSWSH vector.
+        if (!origin) return true;
+
+        // Branch 2: explicitly whitelisted.
+        if (allowedOrigins.includes(origin)) return true;
+
+        // Branch 3: "*" wildcard.
+        if (allowedOrigins.includes("*")) {
+                return nodeEnv !== "production";
+        }
+
+        // Branch 4.
+        return false;
+}
+
+/**
+ * Called once at startup. Warns loudly if `CORS_ORIGINS` contains "*"
+ * in production — see isAllowedWsOrigin's branch 3 comment for why
+ * this is a refused-by-default condition on the WS path.
+ *
+ * Pulled out of the upgrade handler so the warning fires exactly once
+ * (on boot) rather than per-rejected-request, which would be noisy and
+ * drown out genuine attack-surface signals.
+ *
+ * Logger is injectable for the test.
+ */
+export function warnIfWildcardCorsInProduction(
+        allowedOrigins: readonly string[],
+        nodeEnv: string | undefined,
+        logger: Pick<Console, "warn"> = console,
+): void {
+        if (nodeEnv !== "production") return;
+        if (!allowedOrigins.includes("*")) return;
+        logger.warn(
+                "[server] CORS_ORIGINS contains '*' in production. The HTTP layer " +
+                "still honours this, but the WebSocket upgrade handler refuses it " +
+                "(CSWSH protection). Set CORS_ORIGINS to an explicit origin list " +
+                "to re-enable WebSocket connections from production clients.",
+        );
+}
+
 export async function hasAnyUsers(): Promise<boolean> {
         const result = await d1Query<{ count: number }>("SELECT COUNT(*) as count FROM users");
         return result.results[0].count > 0;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,7 +8,13 @@
 import http from "node:http";
 import express from "express";
 import { WebSocketServer } from "ws";
-import { ensureAuthReady, selectWsAuthProtocol, validateJwtSecret } from "./auth.js";
+import {
+        ensureAuthReady,
+        isAllowedWsOrigin,
+        selectWsAuthProtocol,
+        validateJwtSecret,
+        warnIfWildcardCorsInProduction,
+} from "./auth.js";
 import { migrateDb, validateD1Config } from "./db.js";
 import { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
@@ -36,6 +42,12 @@ validateJwtSecret();
 // before the parse so the warning fires even on unset (which is not an
 // error, just a smell in production).
 warnIfProductionMisconfigured(TRUST_PROXY_RAW, process.env.NODE_ENV);
+// Related warning: if CORS_ORIGINS is "*" in production, the HTTP CORS
+// layer is happy but the WebSocket upgrade handler below will refuse
+// every Origin. Surface this at boot so an operator sees the reason
+// for "why won't my WebSocket connect" in the same place they'd look
+// for the TRUST_PROXY warning.
+warnIfWildcardCorsInProduction(CORS_ORIGINS, process.env.NODE_ENV);
 
 // Parse upfront so a bad value fails the process immediately rather than
 // silently serving traffic with req.ip derived from the wrong source.
@@ -102,6 +114,28 @@ server.on("upgrade", (req, socket, head) => {
                 socket.destroy();
                 return;
         }
+
+        // CSWSH defence: reject the upgrade BEFORE the handshake completes
+        // when the Origin header isn't allowed. Done here (not inside the
+        // `wss.on("connection")` handler) so a rejected origin never gets
+        // a WebSocket object, never runs verifyWsToken, and never appears
+        // in wss.clients — closes the window where a CSWSH'd socket could
+        // do anything observable before the server hung up.
+        //
+        // See isAllowedWsOrigin in auth.ts for the policy (in particular:
+        // missing Origin is allowed because it indicates non-browser
+        // clients, and "*" in CORS_ORIGINS is denied in production).
+        const origin = req.headers.origin;
+        if (!isAllowedWsOrigin(origin, CORS_ORIGINS, process.env.NODE_ENV)) {
+                console.warn(
+                        "[server] rejecting WebSocket upgrade: Origin=%s not in allowlist",
+                        origin ?? "<absent>",
+                );
+                socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+                socket.destroy();
+                return;
+        }
+
         wss.handleUpgrade(req, socket, head, (ws) => {
                 wss.emit("connection", ws, req);
         });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import { WebSocketServer } from "ws";
 import {
         ensureAuthReady,
         isAllowedWsOrigin,
+        parseCorsOrigins,
         selectWsAuthProtocol,
         validateJwtSecret,
         warnIfWildcardCorsInProduction,
@@ -25,7 +26,12 @@ import { handleWsConnection } from "./wsHandler.js";
 // ── Configuration ─────────────────────────────────────────────────────────────
 
 const PORT = parseInt(process.env.PORT ?? "3001", 10);
-const CORS_ORIGINS = (process.env.CORS_ORIGINS ?? "*").split(",");
+// Trim+filter so that the obvious human-readable format
+// `CORS_ORIGINS="https://a, https://b"` doesn't silently fail the
+// exact-match check in isAllowedWsOrigin (leading space on the second
+// entry would never equal the browser-sent Origin). Also applies to
+// the HTTP CORS middleware below — same allowlist, same parse.
+const CORS_ORIGINS = parseCorsOrigins(process.env.CORS_ORIGINS);
 // TRUST_PROXY: used by req.ip (and therefore auth rate limiting) to pick the
 // real client from X-Forwarded-For instead of the tunnel's socket address.
 // See trustProxy.ts for the full set of accepted values. "true" is refused
@@ -110,8 +116,12 @@ const wss = new WebSocketServer({
 server.on("upgrade", (req, socket, head) => {
         const url = req.url ?? "";
         if (!url.startsWith("/ws/sessions/")) {
-                socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
-                socket.destroy();
+                // socket.end() drains the write buffer before closing, so the
+                // 404 line actually reaches the client. socket.write() +
+                // socket.destroy() (the previous form) issues immediate
+                // teardown with no drain guarantee — the status line can be
+                // dropped, making "why did my WS fail" harder to debug.
+                socket.end("HTTP/1.1 404 Not Found\r\n\r\n");
                 return;
         }
 
@@ -125,14 +135,15 @@ server.on("upgrade", (req, socket, head) => {
         // See isAllowedWsOrigin in auth.ts for the policy (in particular:
         // missing Origin is allowed because it indicates non-browser
         // clients, and "*" in CORS_ORIGINS is denied in production).
-        const origin = req.headers.origin;
-        if (!isAllowedWsOrigin(origin, CORS_ORIGINS, process.env.NODE_ENV)) {
-                console.warn(
-                        "[server] rejecting WebSocket upgrade: Origin=%s not in allowlist",
-                        origin ?? "<absent>",
-                );
-                socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
-                socket.destroy();
+        //
+        // No per-request log on rejection: an attacker can flood the upgrade
+        // handler with garbage Origin headers and drown out signal. The
+        // CORS_ORIGINS=* case is already covered by warnIfWildcardCorsIn-
+        // Production at startup; deliberate operator misconfiguration will
+        // surface through the 403 status code + the boot warning, not
+        // through per-request log spam.
+        if (!isAllowedWsOrigin(req.headers.origin, CORS_ORIGINS, process.env.NODE_ENV)) {
+                socket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
                 return;
         }
 


### PR DESCRIPTION
First PR of phase 3 (#63). Closes #3.

## Problem

`backend/src/index.ts`' `server.on("upgrade", …)` handler upgrades any
WebSocket request to `/ws/sessions/...` without verifying the
`Origin` header. Browsers do **not** apply Same-Origin Policy to
WebSockets — there's no preflight, no `Access-Control-*` gate — so a
page a logged-in user visits can:

```js
new WebSocket("wss://our-backend/ws/sessions/some-id", [
  "auth.bearer." + stolenOrGuessedJwt,
]);
```

and the browser will happily attach the user's credentials. This is
Cross-Site WebSocket Hijacking. The only browser-side signal we get
is that the browser ALWAYS sends `Origin` on a WS handshake and the
attacker page cannot forge it. So the defence is server-side: an
Origin allowlist, enforced before the handshake completes.

## Fix

Add `isAllowedWsOrigin(origin, allowedOrigins, nodeEnv)` in
`auth.ts` (pure, testable, co-located with the other WS auth helpers
like `selectWsAuthProtocol` and `verifyWsToken`) and call it from the
`upgrade` handler. On rejection: `403 Forbidden` + `socket.destroy()`
**before** `wss.handleUpgrade`, so the request never reaches
`verifyWsToken`, never becomes a `WebSocket` instance, and never
shows up in `wss.clients`.

## Policy — and why each branch is what it is

Four branches, each pinned by tests in `auth.test.ts`.

### 1. Missing Origin header → allow

Browsers ALWAYS send `Origin` on WS. An absent header means a
non-browser client (curl, a CLI, a native wrapper, a server-to-server
caller). CSWSH strictly requires a browser, so out-of-scope.

Not blocking here costs nothing and keeps legitimate CLI tooling
working. The "server-side attacker could bypass by omitting Origin"
objection isn't the CSWSH threat model — an attacker with a valid
JWT doesn't need to hijack anything.

### 2. Origin exactly in `CORS_ORIGINS` → allow

Exact match only. Prefix or suffix matching (`endsWith(".example.com")`,
`startsWith("https://example")`) enables classic bypasses like
`https://attackerhttps://terminal.example.com` or
`https://terminal.example.com.attacker.io`. A regression test pins
both.

### 3. `CORS_ORIGINS` contains `"*"` → env-dependent

- **Production**: deny. The HTTP CORS layer's `*` default is
  relatively benign — browsers refuse to send credentials to `*`
  unless the server explicitly opts in, and we don't. WS `*` does
  not get that guard: the browser sends the
  `auth.bearer.<jwt>` subprotocol to any origin under `*`. Denying
  here turns the production default into a safe-refusal instead of a
  wide-open hole.
- **Non-production** (dev, test, undefined): allow. Local dev runs
  on ephemeral/multiple ports; the CSWSH prerequisite (attacker page
  running in the victim's browser while the dev server is up) is ~
  never the local threat model, and a dev shouldn't need to
  configure `CORS_ORIGINS` just to see their own frontend work.

The mixed case `CORS_ORIGINS=*,https://frontend` is explicitly
handled — the exact match from branch 2 wins before branch 3 runs,
so a production deployment with that config still works for the real
frontend.

### 4. Anything else → deny

Empty allowlist and no wildcard → reject. `"".split(",")` yields
`[""]` (one empty-string entry) in the actual call site, so that
shape is tested too, not just `[]`.

## Startup warning

`warnIfWildcardCorsInProduction(CORS_ORIGINS, NODE_ENV)` fires once
at boot, right next to the existing `warnIfProductionMisconfigured`
call for `TRUST_PROXY`. Put here instead of on each rejected request
so it isn't drowned by rejection spam if someone actually starts
probing. An operator's first place to look when "WebSocket won't
connect in prod" is the server startup log; the warning points them
directly at the `CORS_ORIGINS=*` that's to blame.

## Tests

11 new tests in `auth.test.ts`:

**`isAllowedWsOrigin`** (4 policy branches + 4 bypass attempts):

- allows `undefined` and `""` Origin
- allows exact matches
- rejects prefixes, substrings, case mismatch
- wildcard: rejects non-matches in production, allows in dev/test/
  undefined
- wildcard + explicit: explicit match takes precedence in production
- empty allowlist and `[""]` both reject

**`warnIfWildcardCorsInProduction`** (4 conditions):

- fires in production with `"*"`
- fires when `"*"` is mixed with explicit entries in production
- silent outside production regardless of wildcard
- silent in production without `"*"`

Full suite: 102 / 102 green. No typecheck errors.

## Non-changes

- `CORS_ORIGINS` default stays `"*"`. Changing the default is a
  breaking configuration change for every existing deployment and
  warrants its own PR; this one closes the CSWSH hole for the HTTP
  upgrade handler and loudly flags the remaining foot-gun.
- `.env.example`, `docker-compose.yml`, README unchanged.
- No new env variable. Reuses `CORS_ORIGINS` because the HTTP and WS
  policies are a strict inclusion (WS allow ⊆ HTTP allow, except on
  `*` in production).

## Deployment

No action required if `CORS_ORIGINS` is already an explicit origin
list. Production deployments still relying on the `*` default will:

1. See the new boot warning naming the problem and the fix, AND
2. Start getting `403` on new WS upgrades.

Set `CORS_ORIGINS=https://your-frontend.example.com` to resolve.

## Related

- Tracker: #63
- Closes: #3
