### PR TITLE
fix(terminal): fix UTF-8 corruption, status bar row theft, and mouse scroll

### DIFF
--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -10,6 +10,7 @@ import type { Dirent } from "node:fs";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { Duplex } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import Dockerode from "dockerode";
 import { d1Query } from "./db.js";
 import { RingBuffer } from "./ringBuffer.js";
@@ -483,13 +484,19 @@ export class DockerManager {
 
                 // Single fan-out for the entire session. Each byte from tmux fires this
                 // exactly once, regardless of how many clients are attached.
-                stream.on("data", (chunk: Buffer) => {
-                        const data = chunk.toString("utf-8");
+                //
+                // StringDecoder buffers incomplete multi-byte UTF-8 sequences across
+                // chunk boundaries. Without it, chunk.toString("utf-8") on a Buffer
+                // split mid-character produces U+FFFD replacement characters.
+                const decoder = new StringDecoder("utf8");
+                const broadcast = (data: string) => {
+                        if (!data) return;
                         buffer.push(data);
                         for (const l of s.listeners.values()) {
                                 try { l(data); } catch { /* listener error */ }
                         }
-                });
+                };
+                stream.on("data", (chunk: Buffer) => { broadcast(decoder.write(chunk)); });
 
                 // If the stream dies on its own (tmux server exits, container restarted,
                 // docker daemon hiccup), forget the shared entry so the next attach will
@@ -504,7 +511,7 @@ export class DockerManager {
                                 if (currentS.stream === stream) this.shared.delete(key);
                         } catch { /* newer spawn rejected; not our concern */ }
                 };
-                stream.on("end", () => { void forgetIfCurrent(); });
+                stream.on("end", () => { broadcast(decoder.end()); void forgetIfCurrent(); });
                 stream.on("close", () => { void forgetIfCurrent(); });
                 stream.on("error", (err) => {
                         console.error(`[docker] shared exec stream error for ${key}:`, (err as Error).message);

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -512,6 +512,10 @@ export class DockerManager {
                         } catch { /* newer spawn rejected; not our concern */ }
                 };
                 stream.on("end", () => { broadcast(decoder.end()); void forgetIfCurrent(); });
+                // "close" fires on abrupt destroy (container killed). We intentionally
+                // skip decoder.end() here — calling it would emit U+FFFD for any bytes
+                // stranded in the decoder, and a partial sequence at hard close is
+                // unrecoverable anyway.
                 stream.on("close", () => { void forgetIfCurrent(); });
                 stream.on("error", (err) => {
                         console.error(`[docker] shared exec stream error for ${key}:`, (err as Error).message);

--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -1,6 +1,6 @@
 # ── Shared Terminal — tmux defaults for session containers ───────────────────
 
-# Use 256 colours
+# Use 256 colours + true-color (24-bit RGB) passthrough
 set -g default-terminal "xterm-256color"
 set -ga terminal-overrides ",xterm-256color:Tc"
 
@@ -14,7 +14,13 @@ setw -g pane-base-index 1
 # Faster escape (for vim users)
 set -sg escape-time 10
 
-# Enable mouse (for scrolling / clicking in xterm.js)
+# Hide the tmux status bar. The frontend renders its own tab strip, so the
+# status bar just steals a terminal row — applications inside tmux believe they
+# have (cols × (rows-1)) cells and everything reflows one row too short. With
+# status off, the full xterm viewport is available to the running program.
+set -g status off
+
+# Enable mouse so TUI apps (vim, htop, …) can receive click/drag events.
 set -g mouse on
 
 # Disable tmux's right-click popup menus. In a browser-hosted terminal the
@@ -29,15 +35,19 @@ unbind -n MouseDown3StatusLeft
 unbind -n MouseDown3StatusRight
 unbind -n M-MouseDown3Pane
 
-# Status bar styling
-set -g status-style "bg=#1e1e2e,fg=#cdd6f4"
-set -g status-left "#[fg=#89b4fa,bold] #S "
-set -g status-right "#[fg=#6c7086] %H:%M "
-set -g status-left-length 30
-
-# Window styles
-setw -g window-status-current-style "fg=#89b4fa,bold"
-setw -g window-status-style "fg=#6c7086"
+# Rebind wheel scroll so it uses xterm.js's native scrollback in the shell
+# (main buffer) rather than entering tmux copy-mode. When an application
+# requests mouse (e.g. vim with set mouse=a), xterm still forwards scroll
+# events as escape sequences to the app — copy-mode is only suppressed for
+# the plain shell prompt where the user expects browser-style scrollback.
+bind -n WheelUpPane \
+  if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
+    "send-keys -M" \
+    ""
+bind -n WheelDownPane \
+  if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
+    "send-keys -M" \
+    ""
 
 # Pane borders
 set -g pane-border-style "fg=#313244"

--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -36,16 +36,18 @@ unbind -n MouseDown3StatusRight
 unbind -n M-MouseDown3Pane
 
 # Rebind wheel scroll so it uses xterm.js's native scrollback in the shell
-# (main buffer) rather than entering tmux copy-mode. When an application
-# requests mouse (e.g. vim with set mouse=a), xterm still forwards scroll
-# events as escape sequences to the app — copy-mode is only suppressed for
-# the plain shell prompt where the user expects browser-style scrollback.
+# (main buffer) rather than entering tmux copy-mode. Pass the event through
+# when any of these are true:
+#   #{pane_in_mode}    — already in copy-mode, keep scrolling
+#   #{mouse_any_flag}  — app requested xterm mouse (vim, htop, …); let app handle it
+#   #{alternate_on}    — alt-screen app without mouse (less, man, git diff, …);
+#                        drop into copy-mode so scroll still works
 bind -n WheelUpPane \
-  if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
+  if-shell -F "#{||:#{pane_in_mode},#{||:#{mouse_any_flag},#{alternate_on}}}" \
     "send-keys -M" \
     ""
 bind -n WheelDownPane \
-  if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
+  if-shell -F "#{||:#{pane_in_mode},#{||:#{mouse_any_flag},#{alternate_on}}}" \
     "send-keys -M" \
     ""
 


### PR DESCRIPTION
## Summary

- **UTF-8 corruption** — `chunk.toString("utf-8")` was splitting multi-byte characters (emoji, CJK, accented letters) across TCP chunk boundaries, producing `U+FFFD` replacement characters. Fixed by using `StringDecoder` which buffers incomplete sequences between chunks and flushes the remainder on stream end.
- **Status bar steals a terminal row** — with `set -g status on` (default), tmux reserved the bottom row for its status bar, so applications saw `cols × (rows-1)` cells while xterm.js reported the full `cols × rows`. Since the frontend renders its own tab strip, the tmux status bar was redundant. `set -g status off` gives the full viewport to running programs.
- **Mouse wheel entering tmux copy-mode** — `set -g mouse on` caused wheel scroll events forwarded by xterm.js to trigger tmux copy-mode in the shell, instead of xterm.js's native scrollback. New `WheelUpPane`/`WheelDownPane` bindings suppress copy-mode entry in the main buffer while still passing scroll events through to TUI apps that declare mouse support.

## Test plan

- [ ] Rebuild session image: `docker build -t shared-terminal-session ./session-image`
- [ ] Output containing non-ASCII characters (emoji, CJK) renders correctly without replacement characters
- [ ] Terminal uses the full xterm viewport height with no status bar visible at the bottom
- [ ] Mouse wheel scrolls xterm.js scrollback in the shell; vim/htop still receive scroll events normally
- [ ] Existing sessions: restart containers to pick up new tmux.conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)