### PR TITLE
fix(mobile): stop swipe from showing keyboard and triggering xterm selection

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -210,6 +210,12 @@ export function openTerminalSession(opts: {
                 const cellH = getCellHeight();
                 const deltaPx = lastTouchY - y;
                 const lines = Math.trunc(deltaPx / cellH);
+
+                // Once the gesture is classified as a scroll, keep suppressing
+                // xterm's drag-selection handler on every subsequent frame —
+                // including sub-cell frames where lines === 0. Without this,
+                // slow swipes leave an unguarded window at the start.
+                if (touchIsScroll) ev.preventDefault();
                 if (lines === 0) return;
 
                 touchIsScroll = true;
@@ -233,7 +239,10 @@ export function openTerminalSession(opts: {
                 // If the finger never moved a full cell it was a tap: focus xterm
                 // so the OS keyboard appears for typing. Scroll gestures skip this
                 // so the keyboard doesn't flash open mid-swipe.
-                if (!touchIsScroll) term.focus();
+                // Guard on lastTouchY !== null: a multi-touch start (pinch) clears
+                // lastTouchY and resets touchIsScroll, so when one finger lifts we
+                // must not treat it as a tap and pop the keyboard.
+                if (!touchIsScroll && lastTouchY !== null) term.focus();
                 lastTouchY = null;
                 touchIsScroll = false;
         };

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -111,10 +111,12 @@ export function openTerminalSession(opts: {
                 new MultilineUrlLinkProvider(term),
         );
 
-        // Mobile: tapping the terminal should move the keyboard caret here so
-        // the user can actually type. xterm only auto-focuses on mouse clicks,
-        // not on touch taps inside its helper textarea layout.
-        const focusOnPointer = () => term.focus();
+        // Mouse clicks should focus xterm immediately. Touch taps are handled
+        // in onTouchEnd below — we wait until touchend to distinguish a tap
+        // from a scroll gesture so a swipe doesn't pop the keyboard mid-drag.
+        const focusOnPointer = (ev: PointerEvent) => {
+                if (ev.pointerType !== "touch") term.focus();
+        };
         container.addEventListener("pointerdown", focusOnPointer);
 
         // ── WebSocket connection ────────────────────────────────────────────────
@@ -194,11 +196,13 @@ export function openTerminalSession(opts: {
         // Direction follows iOS/Android convention — content tracks the
         // finger: drag up → view moves up → scroll toward newer (bottom).
         let lastTouchY: number | null = null;
+        let touchIsScroll = false; // true once the gesture has moved ≥1 cell
         const getCellHeight = () => (term.rows > 0 ? container.clientHeight / term.rows : 20);
 
         const onTouchStart = (ev: TouchEvent) => {
-                if (ev.touches.length !== 1) { lastTouchY = null; return; }
+                if (ev.touches.length !== 1) { lastTouchY = null; touchIsScroll = false; return; }
                 lastTouchY = ev.touches[0]!.clientY;
+                touchIsScroll = false;
         };
         const onTouchMove = (ev: TouchEvent) => {
                 if (lastTouchY === null || ev.touches.length !== 1) return;
@@ -207,6 +211,12 @@ export function openTerminalSession(opts: {
                 const deltaPx = lastTouchY - y;
                 const lines = Math.trunc(deltaPx / cellH);
                 if (lines === 0) return;
+
+                touchIsScroll = true;
+                // Prevent xterm from treating the drag as a text-selection gesture
+                // (touch-action:none is set in CSS, so this won't cause a passive
+                // event listener warning).
+                ev.preventDefault();
 
                 if (term.buffer.active.type === "alternate") {
                         // Cap the burst so a fast flick doesn't fire 100+ arrows
@@ -219,12 +229,21 @@ export function openTerminalSession(opts: {
                 }
                 lastTouchY -= lines * cellH;
         };
-        const onTouchEnd = () => { lastTouchY = null; };
+        const onTouchEnd = () => {
+                // If the finger never moved a full cell it was a tap: focus xterm
+                // so the OS keyboard appears for typing. Scroll gestures skip this
+                // so the keyboard doesn't flash open mid-swipe.
+                if (!touchIsScroll) term.focus();
+                lastTouchY = null;
+                touchIsScroll = false;
+        };
+        const onTouchCancel = () => { lastTouchY = null; touchIsScroll = false; };
 
         container.addEventListener("touchstart", onTouchStart, { passive: true });
-        container.addEventListener("touchmove", onTouchMove, { passive: true });
+        // passive:false required so ev.preventDefault() can stop xterm's drag-selection
+        container.addEventListener("touchmove", onTouchMove, { passive: false });
         container.addEventListener("touchend", onTouchEnd, { passive: true });
-        container.addEventListener("touchcancel", onTouchEnd, { passive: true });
+        container.addEventListener("touchcancel", onTouchCancel, { passive: true });
 
         // ── Resize ──────────────────────────────────────────────────────────────
         // ResizeObserver fires continuously during mobile viewport churn (URL
@@ -307,7 +326,7 @@ export function openTerminalSession(opts: {
                 container.removeEventListener("touchstart", onTouchStart);
                 container.removeEventListener("touchmove", onTouchMove);
                 container.removeEventListener("touchend", onTouchEnd);
-                container.removeEventListener("touchcancel", onTouchEnd);
+                container.removeEventListener("touchcancel", onTouchCancel);
                 inputDisposable.dispose();
                 linkProviderDisposable.dispose();
                 webgl?.dispose();

--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -41,7 +41,8 @@ unbind -n M-MouseDown3Pane
 #   #{pane_in_mode}    — already in copy-mode, keep scrolling
 #   #{mouse_any_flag}  — app requested xterm mouse (vim, htop, …); let app handle it
 #   #{alternate_on}    — alt-screen app without mouse (less, man, git diff, …);
-#                        drop into copy-mode so scroll still works
+#                        forward to the app via send-keys -M; less/man handle
+#                        xterm mouse scroll natively without copy-mode
 bind -n WheelUpPane \
   if-shell -F "#{||:#{pane_in_mode},#{||:#{mouse_any_flag},#{alternate_on}}}" \
     "send-keys -M" \


### PR DESCRIPTION
## Summary

Two bugs with touch scroll on mobile:

- **Keyboard flashes during swipe** — `pointerdown` called `term.focus()` on every touch, including the start of scroll gestures. The OS keyboard would pop open mid-swipe. Fixed by skipping focus on touch `pointerdown` and moving it to `onTouchEnd`, where we only call it when the gesture moved less than one cell (a tap, not a scroll).

- **xterm treats swipe as text selection** — `touchmove` was registered as `passive: true`, so `ev.preventDefault()` could not be called. xterm's internal drag handler was still firing alongside our scroll handler, treating the swipe as a selection gesture and visually highlighting text. Fixed by registering `touchmove` as `passive: false` and calling `ev.preventDefault()` once the gesture qualifies as a scroll. This is safe because `touch-action: none` is already set in CSS on the xterm layers, so there is no passive-listener performance warning.

## Notes on tmux resize

The resize chain (`visualViewport.resize` → `syncViewportHeight` → `--app-vh` → ResizeObserver → `fitAddon.fit()` → WebSocket resize → `exec.resize()`) is working correctly and no changes are needed there.

## Test plan

- [ ] Swipe up/down in main buffer (shell): scrollback scrolls, keyboard does NOT appear
- [ ] Swipe up/down in alt buffer (vim/less): arrow keys navigate, keyboard does NOT appear
- [ ] Tap terminal: OS keyboard appears for typing
- [ ] Mouse click (desktop): still focuses immediately
- [ ] No visible text selection highlight during a scroll gesture

🤖 Generated with [Claude Code](https://claude.com/claude-code)