### PR TITLE
fix(rendering): UTF-8 ring buffer capacity, truecolor env, focus/extended-keys, WebGL guard

### DIFF
--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -109,6 +109,7 @@ export class DockerManager {
                                 `SESSION_ID=${sessionId}`,
                                 `SESSION_NAME=${meta.name}`,
                                 `TERM=xterm-256color`,
+                                `COLORTERM=truecolor`,
                                 ...envArray,
                         ],
                         HostConfig: {

--- a/backend/src/ringBuffer.ts
+++ b/backend/src/ringBuffer.ts
@@ -17,12 +17,12 @@ export class RingBuffer {
 
         push(data: string): void {
                 this.chunks.push(data);
-                this.totalBytes += data.length;
+                this.totalBytes += Buffer.byteLength(data, "utf8");
 
                 // Evict oldest chunks until we are back within capacity.
                 while (this.totalBytes > this.capacityBytes && this.chunks.length > 0) {
                         const evicted = this.chunks.shift()!;
-                        this.totalBytes -= evicted.length;
+                        this.totalBytes -= Buffer.byteLength(evicted, "utf8");
                 }
         }
 

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -36,10 +36,11 @@ export function openTerminalSession(opts: {
                         cursor: "#58a6ff",
                         selectionBackground: "#264f78",
                 },
-                fontFamily: '"Cascadia Code", "Fira Code", "JetBrains Mono", monospace',
+                fontFamily: '"Cascadia Code", "Fira Code", "JetBrains Mono", "Monaco", "Courier New", monospace',
                 fontSize: fontSize ?? 14,
                 lineHeight: 1.2,
                 cursorBlink: true,
+                cursorInactiveStyle: 'outline',
                 convertEol: true,
                 allowProposedApi: true,
                 // Apps like Claude Code emit OSC 8 hyperlink escapes. xterm renders
@@ -295,7 +296,12 @@ export function openTerminalSession(opts: {
         const onVisibilityChange = () => {
                 if (document.hidden) return;
                 scheduleFit();
-                webgl?.clearTextureAtlas();
+                try {
+                        webgl?.clearTextureAtlas();
+                } catch {
+                        webgl?.dispose();
+                        webgl = null;
+                }
                 term.refresh(0, term.rows - 1);
         };
         const onWindowFocus = () => {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -40,7 +40,7 @@ export function openTerminalSession(opts: {
                 fontSize: fontSize ?? 14,
                 lineHeight: 1.2,
                 cursorBlink: true,
-                cursorInactiveStyle: 'outline',
+                cursorInactiveStyle: "outline",
                 convertEol: true,
                 allowProposedApi: true,
                 // Apps like Claude Code emit OSC 8 hyperlink escapes. xterm renders

--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -14,6 +14,13 @@ setw -g pane-base-index 1
 # Faster escape (for vim users)
 set -sg escape-time 10
 
+# Forward focus-in/out events to the inner terminal (vim :FocusGained/:FocusLost)
+set -g focus-events on
+
+# Extended key sequences — lets tmux pass Ctrl+Arrow, Shift+F1, etc. through
+# to apps that use them (neovim, fzf, …)
+set -g extended-keys on
+
 # Hide the tmux status bar. The frontend renders its own tab strip, so the
 # status bar just steals a terminal row — applications inside tmux believe they
 # have (cols × (rows-1)) cells and everything reflows one row too short. With


### PR DESCRIPTION
## Summary

Six independent rendering-quality fixes found during a full audit of the xterm.js + tmux pipeline.

## Changes

### `RingBuffer` — UTF-8 byte capacity was wrong
`String.length` counts UTF-16 code units, not UTF-8 bytes. A single CJK character is 1 code unit but 3 UTF-8 bytes, so the 128 KB eviction threshold was being compared against the wrong unit — the buffer could silently hold up to 3× more content than intended. Switched to `Buffer.byteLength(data, "utf8")` in both `push` and the eviction loop.

### Container env — `COLORTERM=truecolor` missing
vim, neovim, and most rich TUI libraries (rich, textual, etc.) check `$COLORTERM` before emitting 24-bit RGB escapes. Without it they fell back to the 256-color palette even though `tmux.conf` already had `set -ga terminal-overrides ",xterm-256color:Tc"` wired up. Added `COLORTERM=truecolor` alongside `TERM=xterm-256color` in the container spawn env.

### tmux — `focus-events` and `extended-keys`
- `set -g focus-events on` — tmux now forwards `\x1b[I`/`\x1b[O` focus sequences into the pane. vim/neovim relies on these for `:FocusGained`/`:FocusLost` autocommands (auto-reload changed files, dim inactive windows, etc.).
- `set -g extended-keys on` — enables extended key reporting so modifier combos like `Ctrl+Arrow`, `Shift+F1`, `Ctrl+Shift+…` reach apps that bind them (neovim, fzf, lazygit).

### xterm.js — font fallback, inactive cursor, WebGL guard
- Added `"Monaco"` and `"Courier New"` to the font fallback chain. Macs and Linux systems without Cascadia Code / Fira Code / JetBrains Mono installed were falling through to the browser's generic `monospace`, which on some platforms renders serif.
- `cursorInactiveStyle: 'outline'` — when the terminal loses focus the cursor now shows as a hollow box instead of disappearing, so the user can see where input will land after clicking a UI element.
- `webgl.clearTextureAtlas()` on visibility change is now wrapped in try/catch. If the GPU context was lost while the tab was hidden the call can throw; the catch disposes the addon and lets xterm fall back to its DOM renderer.

## Notes on locale
`LANG=en_US.UTF-8` and `LC_ALL=en_US.UTF-8` are already set via `ENV` in the Dockerfile and inherited by all container processes — no entrypoint change needed.

## What needs a session image rebuild
All `session-image/` and `dockerManager.ts` changes require rebuilding the image and restarting containers:
```bash
docker build -t shared-terminal-session ./session-image
```

## Test plan
- [ ] CJK-heavy output (e.g. `echo 日本語テスト`) — ring buffer evicts at correct 128 KB boundary
- [ ] `echo $COLORTERM` inside a session → `truecolor`; `printf '\x1b[38;2;255;100;0mRGB\x1b[0m\n'` renders orange
- [ ] vim `:echo &termguicolors` → `1` (true-color mode active)
- [ ] Open vim, switch browser tab and back — `:FocusGained` autocommand fires (e.g. checktime works)
- [ ] `Ctrl+Right Arrow` in neovim / fzf moves by word
- [ ] On a device without Cascadia Code installed — terminal still renders with a clean monospace font
- [ ] Click outside the terminal then back — cursor is visible as outline when unfocused
- [ ] Background a tab under GPU memory pressure; return — no rendering freeze (WebGL falls back to DOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)