### PR TITLE
fix(terminal): suppress stale onclose from poisoning session status

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -129,6 +129,7 @@ export function openTerminalSession(opts: {
         const token = getToken() ?? "";
         const wsUrl = buildWsUrl(sessionId, token, tabId);
         const ws = new WebSocket(wsUrl, [`auth.bearer.${token}`]);
+        let disposed = false;
 
         ws.onopen = () => {
                 send({ type: "ping" });
@@ -170,11 +171,7 @@ export function openTerminalSession(opts: {
         };
 
         ws.onclose = (ev) => {
-                // Intentional dispose — don't clobber the session status. The race:
-                // dispose() calls ws.close(1000) asynchronously; if the user returns
-                // to the same session+tab before this fires, both onStatus guards pass
-                // (same ownSessionId, same tabId) and the stale close would write
-                // "disconnected" into sessions[], making the session unclickable.
+                // disposed: stale async close from a prior navigate-away — ignore
                 if (disposed) return;
                 if (ev.code !== 1000) {
                         onError(`Connection closed (${ev.code}): ${ev.reason || "unknown reason"}`);
@@ -320,7 +317,6 @@ export function openTerminalSession(opts: {
 
         // ── Heartbeat ───────────────────────────────────────────────────────────
         let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-        let disposed = false;
         function startHeartbeat() {
                 heartbeatInterval = setInterval(() => {
                         if (ws.readyState === WebSocket.OPEN) send({ type: "ping" });

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -165,10 +165,17 @@ export function openTerminalSession(opts: {
         };
 
         ws.onerror = () => {
+                if (disposed) return;
                 onError("WebSocket connection error");
         };
 
         ws.onclose = (ev) => {
+                // Intentional dispose — don't clobber the session status. The race:
+                // dispose() calls ws.close(1000) asynchronously; if the user returns
+                // to the same session+tab before this fires, both onStatus guards pass
+                // (same ownSessionId, same tabId) and the stale close would write
+                // "disconnected" into sessions[], making the session unclickable.
+                if (disposed) return;
                 if (ev.code !== 1000) {
                         onError(`Connection closed (${ev.code}): ${ev.reason || "unknown reason"}`);
                 }
@@ -313,6 +320,7 @@ export function openTerminalSession(opts: {
 
         // ── Heartbeat ───────────────────────────────────────────────────────────
         let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+        let disposed = false;
         function startHeartbeat() {
                 heartbeatInterval = setInterval(() => {
                         if (ws.readyState === WebSocket.OPEN) send({ type: "ping" });
@@ -333,6 +341,7 @@ export function openTerminalSession(opts: {
 
         // ── Dispose ─────────────────────────────────────────────────────────────
         function dispose() {
+                disposed = true;
                 if (heartbeatInterval !== null) clearInterval(heartbeatInterval);
                 ro.disconnect();
                 document.removeEventListener("visibilitychange", onVisibilityChange);


### PR DESCRIPTION
## Summary

- Fixes the bug where the first (and only) tab of a session appears disconnected and unclickable on the second visit
- Root cause: `dispose()` calls `ws.close(1000)` asynchronously; by the time `onclose` fires, the user may have returned to the same session+tab — both identity guards (`ownSessionId`, `tabId`) pass, so the stale event writes `s.status = "disconnected"` into `sessions[]`
- Fix: set `disposed = true` before `ws.close()` in `dispose()`, bail early in `ws.onclose` and `ws.onerror` when disposed

## Test plan

- [ ] Create a session, add a tab — it works
- [ ] Navigate to a different session (or reload the page)
- [ ] Click back to the original session — tab should open and connect, not show as disconnected
- [ ] Verify that genuine disconnects (kill the container mid-session) still surface the error toast and disconnected status

🤖 Generated with [Claude Code](https://claude.com/claude-code)