### PR TITLE
fix(terminal): retry WebGL addon on webglcontextrestored instead of permanent DOM fallback

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -91,13 +91,15 @@ export function openTerminalSession(opts: {
         // bounces repeatedly (rare GPU driver bug).
         const onContextRestored = () => {
                 if (webgl) return;
+                let addon: WebglAddon | undefined;
                 try {
-                        const addon = new WebglAddon();
-                        addon.onContextLoss(() => { addon.dispose(); webgl = null; });
+                        addon = new WebglAddon();
+                        addon.onContextLoss(() => { addon!.dispose(); webgl = null; });
                         term.loadAddon(addon);
                         webgl = addon;
                         console.log("[terminal] WebGL context restored, re-enabled GPU renderer");
                 } catch (err) {
+                        addon?.dispose();
                         console.warn("[terminal] WebGL restore failed:", err);
                 }
         };

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -87,8 +87,8 @@ export function openTerminalSession(opts: {
         let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
                 pendingRestoreCanvas = null;
-                // webgl is null here: xterm's canvas-level onContextLoss fires before
-                // this bubbled handler, so the addon is already disposed.
+                // webgl is null here: the loss event's canvas-level handlers (which set
+                // webgl = null) ran before the event bubbled up and triggered onContextLost.
                 let restoredAddon: WebglAddon | undefined;
                 try {
                         const addon = new WebglAddon();

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -87,6 +87,8 @@ export function openTerminalSession(opts: {
         let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
                 pendingRestoreCanvas = null;
+                // webgl is null here: xterm's canvas-level onContextLoss fires before
+                // this bubbled handler, so the addon is already disposed.
                 let restoredAddon: WebglAddon | undefined;
                 try {
                         const addon = new WebglAddon();

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -86,9 +86,10 @@ export function openTerminalSession(opts: {
         // canvas obtained from the loss event's target.
         let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
+                // Normally null by the time this fires (xterm's canvas-level loss handler
+                // clears it first), but guard defensively against out-of-order driver events.
+                if (webgl) return;
                 pendingRestoreCanvas = null;
-                // webgl is null here: the loss event's canvas-level handlers (which set
-                // webgl = null) ran before the event bubbled up and triggered onContextLost.
                 let restoredAddon: WebglAddon | undefined;
                 try {
                         const addon = new WebglAddon();
@@ -104,6 +105,7 @@ export function openTerminalSession(opts: {
         };
         const onContextLost = (ev: Event) => {
                 if (!(ev.target instanceof HTMLCanvasElement)) return;
+                pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
                 pendingRestoreCanvas = ev.target;
                 pendingRestoreCanvas.addEventListener("webglcontextrestored", onContextRestored, { once: true });
         };

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -87,7 +87,6 @@ export function openTerminalSession(opts: {
         let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
                 pendingRestoreCanvas = null;
-                if (webgl) return;
                 let restoredAddon: WebglAddon | undefined;
                 try {
                         const addon = new WebglAddon();
@@ -102,7 +101,8 @@ export function openTerminalSession(opts: {
                 }
         };
         const onContextLost = (ev: Event) => {
-                pendingRestoreCanvas = ev.target as HTMLCanvasElement;
+                if (!(ev.target instanceof HTMLCanvasElement)) return;
+                pendingRestoreCanvas = ev.target;
                 pendingRestoreCanvas.addEventListener("webglcontextrestored", onContextRestored, { once: true });
         };
         if (webgl) container.addEventListener("webglcontextlost", onContextLost);

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -82,28 +82,28 @@ export function openTerminalSession(opts: {
                 webgl = null;
         }
 
-        // Sleep/wake and monitor hot-plug cause the browser to park and then
-        // reinstate the WebGL context. Re-attach the addon on restore so the
-        // terminal doesn't stay on the slower DOM renderer until the next reload.
-        // webglcontextrestored bubbles, so listening on container is reliable
-        // regardless of which canvas layer xterm assigns the WebGL context to.
-        // The `if (webgl) return` guard prevents thrashing when the context
-        // bounces repeatedly (rare GPU driver bug).
+        // webglcontextlost bubbles; webglcontextrestored does not. Use the loss
+        // event's target to register the restore listener directly on the canvas
+        // that owns the GL context.
         const onContextRestored = () => {
                 if (webgl) return;
-                let addon: WebglAddon | undefined;
+                let restoredAddon: WebglAddon | undefined;
                 try {
-                        addon = new WebglAddon();
-                        addon.onContextLoss(() => { addon!.dispose(); webgl = null; });
+                        const addon = new WebglAddon();
+                        restoredAddon = addon;
+                        addon.onContextLoss(() => { addon.dispose(); webgl = null; });
                         term.loadAddon(addon);
                         webgl = addon;
                         console.log("[terminal] WebGL context restored, re-enabled GPU renderer");
                 } catch (err) {
-                        addon?.dispose();
+                        restoredAddon?.dispose();
                         console.warn("[terminal] WebGL restore failed:", err);
                 }
         };
-        if (webgl) container.addEventListener("webglcontextrestored", onContextRestored);
+        const onContextLost = (ev: Event) => {
+                (ev.target as HTMLCanvasElement).addEventListener("webglcontextrestored", onContextRestored, { once: true });
+        };
+        if (webgl) container.addEventListener("webglcontextlost", onContextLost);
 
         fitAddon.fit();
 
@@ -415,7 +415,7 @@ export function openTerminalSession(opts: {
                 container.removeEventListener("touchcancel", onTouchCancel);
                 inputDisposable.dispose();
                 linkProviderDisposable.dispose();
-                container.removeEventListener("webglcontextrestored", onContextRestored);
+                container.removeEventListener("webglcontextlost", onContextLost);
                 webgl?.dispose();
                 ws.close(1000, "User navigated away");
                 term.dispose();

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -84,8 +84,11 @@ export function openTerminalSession(opts: {
 
         // webglcontextlost bubbles; webglcontextrestored does not. Use the loss
         // event's target to register the restore listener directly on the canvas
-        // that owns the GL context.
+        // that owns the GL context. Track the canvas so dispose() can remove the
+        // pending listener if the user navigates away before the GPU restores.
+        let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
+                pendingRestoreCanvas = null;
                 if (webgl) return;
                 let restoredAddon: WebglAddon | undefined;
                 try {
@@ -101,7 +104,8 @@ export function openTerminalSession(opts: {
                 }
         };
         const onContextLost = (ev: Event) => {
-                (ev.target as HTMLCanvasElement).addEventListener("webglcontextrestored", onContextRestored, { once: true });
+                pendingRestoreCanvas = ev.target as HTMLCanvasElement;
+                pendingRestoreCanvas.addEventListener("webglcontextrestored", onContextRestored, { once: true });
         };
         if (webgl) container.addEventListener("webglcontextlost", onContextLost);
 
@@ -415,6 +419,7 @@ export function openTerminalSession(opts: {
                 container.removeEventListener("touchcancel", onTouchCancel);
                 inputDisposable.dispose();
                 linkProviderDisposable.dispose();
+                pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
                 container.removeEventListener("webglcontextlost", onContextLost);
                 webgl?.dispose();
                 ws.close(1000, "User navigated away");

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -82,10 +82,8 @@ export function openTerminalSession(opts: {
                 webgl = null;
         }
 
-        // webglcontextlost bubbles; webglcontextrestored does not. Use the loss
-        // event's target to register the restore listener directly on the canvas
-        // that owns the GL context. Track the canvas so dispose() can remove the
-        // pending listener if the user navigates away before the GPU restores.
+        // webglcontextlost bubbles; webglcontextrestored does not — listen on the
+        // canvas obtained from the loss event's target.
         let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
                 pendingRestoreCanvas = null;
@@ -97,7 +95,7 @@ export function openTerminalSession(opts: {
                         addon.onContextLoss(() => { addon.dispose(); webgl = null; });
                         term.loadAddon(addon);
                         webgl = addon;
-                        console.log("[terminal] WebGL context restored, re-enabled GPU renderer");
+                        console.debug("[terminal] WebGL context restored, re-enabled GPU renderer");
                 } catch (err) {
                         restoredAddon?.dispose();
                         console.warn("[terminal] WebGL restore failed:", err);

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -82,6 +82,26 @@ export function openTerminalSession(opts: {
                 webgl = null;
         }
 
+        // Sleep/wake and monitor hot-plug cause the browser to park and then
+        // reinstate the WebGL context. Re-attach the addon on restore so the
+        // terminal doesn't stay on the slower DOM renderer until the next reload.
+        // The `if (webgl) return` guard prevents thrashing when the context
+        // bounces repeatedly (rare GPU driver bug).
+        const webglCanvas = webgl ? container.querySelector("canvas") : null;
+        const onContextRestored = () => {
+                if (webgl) return;
+                try {
+                        const addon = new WebglAddon();
+                        addon.onContextLoss(() => { addon.dispose(); webgl = null; });
+                        term.loadAddon(addon);
+                        webgl = addon;
+                        console.log("[terminal] WebGL context restored, re-enabled GPU renderer");
+                } catch (err) {
+                        console.warn("[terminal] WebGL restore failed:", err);
+                }
+        };
+        webglCanvas?.addEventListener("webglcontextrestored", onContextRestored);
+
         fitAddon.fit();
 
         // Cmd/Ctrl + C copies the current xterm selection to the clipboard.
@@ -392,6 +412,7 @@ export function openTerminalSession(opts: {
                 container.removeEventListener("touchcancel", onTouchCancel);
                 inputDisposable.dispose();
                 linkProviderDisposable.dispose();
+                webglCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
                 webgl?.dispose();
                 ws.close(1000, "User navigated away");
                 term.dispose();

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -86,7 +86,7 @@ export function openTerminalSession(opts: {
         // canvas obtained from the loss event's target.
         let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
-                // Guard against misbehaving drivers; by spec webgl is always null here.
+                // Guard against misbehaving drivers; the prior loss handler nulled webgl first.
                 if (webgl) return;
                 pendingRestoreCanvas = null;
                 let restoredAddon: WebglAddon | undefined;

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -85,9 +85,10 @@ export function openTerminalSession(opts: {
         // Sleep/wake and monitor hot-plug cause the browser to park and then
         // reinstate the WebGL context. Re-attach the addon on restore so the
         // terminal doesn't stay on the slower DOM renderer until the next reload.
+        // webglcontextrestored bubbles, so listening on container is reliable
+        // regardless of which canvas layer xterm assigns the WebGL context to.
         // The `if (webgl) return` guard prevents thrashing when the context
         // bounces repeatedly (rare GPU driver bug).
-        const webglCanvas = webgl ? container.querySelector("canvas") : null;
         const onContextRestored = () => {
                 if (webgl) return;
                 try {
@@ -100,7 +101,7 @@ export function openTerminalSession(opts: {
                         console.warn("[terminal] WebGL restore failed:", err);
                 }
         };
-        webglCanvas?.addEventListener("webglcontextrestored", onContextRestored);
+        if (webgl) container.addEventListener("webglcontextrestored", onContextRestored);
 
         fitAddon.fit();
 
@@ -412,7 +413,7 @@ export function openTerminalSession(opts: {
                 container.removeEventListener("touchcancel", onTouchCancel);
                 inputDisposable.dispose();
                 linkProviderDisposable.dispose();
-                webglCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
+                container.removeEventListener("webglcontextrestored", onContextRestored);
                 webgl?.dispose();
                 ws.close(1000, "User navigated away");
                 term.dispose();

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -86,8 +86,7 @@ export function openTerminalSession(opts: {
         // canvas obtained from the loss event's target.
         let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
-                // Normally null by the time this fires (xterm's canvas-level loss handler
-                // clears it first), but guard defensively against out-of-order driver events.
+                // Guard against misbehaving drivers; by spec webgl is always null here.
                 if (webgl) return;
                 pendingRestoreCanvas = null;
                 let restoredAddon: WebglAddon | undefined;


### PR DESCRIPTION
Fixes #83

## Summary

- Registers a `webglcontextrestored` listener on the xterm canvas after the WebGL addon is loaded
- On context restore, re-creates and re-attaches a fresh `WebglAddon` (with its own `onContextLoss` handler) so the GPU renderer comes back automatically after sleep/wake, monitor hot-plug, or DPR changes
- `if (webgl) return` guard caps to one retry per dispose cycle — prevents thrashing on repeated context bounces (rare GPU driver bug)
- Listener is removed in `dispose()` alongside the rest of the WebGL teardown

## Test plan

- [ ] Trigger manual context loss in DevTools (`WEBGL_lose_context.loseContext()`), then restore — console shows "WebGL context restored, re-enabled GPU renderer"
- [ ] Sleep/wake cycle on a laptop — renderer stays WebGL after resume (no DOM fallback)
- [ ] Trigger repeated context loss/restore — only re-attaches once per loss (no thrashing)
- [ ] `npm run build` in `frontend/` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)