### PR TITLE
ci: run tsc + vitest on PRs; unstale CLAUDE.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+# github-actions ecosystem: keeps the SHA pins in .github/workflows/*.yml
+# current. Without this, SHA-pinning locks us to a specific action version
+# forever and we miss security fixes in newer releases. Dependabot opens a
+# PR per update with the new SHA and a version comment, so the pin stays
+# explicit but tracked.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # Collapse all action updates into a single PR so we don't end up
+      # with N separate PRs on a quiet week.
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,13 @@ on:
   push:
     branches: [main]
 
-# Cancel in-flight runs when a PR gets pushed to rapidly — mirrors the
-# concurrency policy in claude-review.yml.
+# Cancel in-flight runs when a PR gets pushed to rapidly. On main we let
+# every run finish — cancelling mid-merge would leave main without a
+# recorded green status, which branch protection needs to gate future
+# merges.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Read-only by default. Neither job pushes code or posts comments.
 permissions:
@@ -30,12 +32,12 @@ jobs:
         working-directory: backend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -58,12 +60,12 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+# Runs on every PR and every push to main. The two workspaces build and test
+# independently — if only the frontend changes, the backend job still runs
+# because path filters here would miss shared-root edits (Dockerfile,
+# docker-compose, workflow itself). CI is fast enough (<1 min each) that the
+# extra noise is cheaper than the false-negative risk of path-filtering.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel in-flight runs when a PR gets pushed to rapidly — mirrors the
+# concurrency policy in claude-review.yml.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only by default. Neither job pushes code or posts comments.
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend (tsc + vitest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck + build
+        run: npm run build
+
+      - name: Tests
+        run: npm test
+
+  frontend:
+    name: Frontend (tsc + vite build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      # `npm run build` is `tsc && vite build`. VITE_API_URL is consumed by
+      # vite.config.ts to rewrite the CSP meta tag; falls back to localhost
+      # if unset, but setting it here exercises the replacement path.
+      - name: Typecheck + build
+        env:
+          VITE_API_URL: http://localhost:3001
+        run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ docker build -t shared-terminal-session ./session-image
 docker compose up -d --build
 ```
 
-There is no test suite and no linter configured — verify changes by running `npm run build` in both workspaces and exercising the feature in a browser.
+Backend has a vitest suite — `cd backend && npm test` (also runs in CI). No frontend tests yet, and no linter is wired up. CI (`.github/workflows/ci.yml`) runs `tsc` and (backend) `vitest` on every PR, so typos and broken tests will block merge. Beyond that, verify by running `npm run build` in both workspaces and exercising the feature in a browser.
 
 ## Required environment
 
@@ -49,12 +49,14 @@ Three pieces cooperate:
 
 ### The terminal data path
 
-`wsHandler.ts` → `DockerManager.attach()` runs `docker exec … tmux attach -t main` with `Tty: true`. The hijacked stream is piped both ways:
+`wsHandler.ts` → `DockerManager.attach()` runs `docker exec … tmux new-session -A -s <tabId>` with `Tty: true`. `-A` is the self-heal: attach if the tab's tmux session exists, create it if it doesn't. The hijacked exec stream is piped both ways:
 
-- bytes from tmux → pushed into a per-session `RingBuffer` (128 KB) **and** broadcast to all listeners for that session;
+- bytes from tmux → fanned out via `broadcast(…)` to every live listener for that session;
 - bytes from the browser → `docker.write(attachId, …)` back into the exec stdin.
 
-On reconnect, the ring buffer is drained and sent as a single `output` message so the user sees recent scrollback. Multiple browser tabs can attach to the same session — they all share the same tmux and see the same stream (each with its own `attachId`, listener, and resize).
+Replay on reconnect is a `tmux capture-pane -p -e` snapshot of the current pane (colour + position preserved), not a raw byte stream — there is no `RingBuffer`. To avoid a live/replay ordering race, `attach()` installs an armed `bufferedListener` that collects live bytes into a local tail array during the attach window; `wsHandler` sends the replay, then calls `flushTail()` which drains the tail in order and flips the listener to forward-directly. From the moment the listener is armed onward, the client-visible sequence is deterministic: `[replay][every live delta in arrival order]`.
+
+Multiple browser tabs attaching to the same session share the same tmux exec (each has its own `attachId`, listener, and resize).
 
 ### Persistence model
 


### PR DESCRIPTION
Adds the missing CI gate. Closes #94.

## What

`.github/workflows/ci.yml` with two jobs:

- **backend** — `npm ci` → `npm run build` (tsc) → `npm test` (vitest, 109 tests)
- **frontend** — `npm ci` → `npm run build` (tsc + vite build)

Both on Node 22, with npm caches keyed per workspace. Concurrency group cancels in-flight runs on rapid pushes. Permissions locked to `contents: read` — no writes back, no secrets consumed.

`VITE_API_URL=http://localhost:3001` is set on the frontend job so `vite.config.ts`'s CSP-rewrite plugin runs against a real value instead of its localhost fallback.

## Why

The only existing workflow (`claude-review.yml`) posts an advisory review comment. It does not run tests, typecheck, or build. A PR breaking every test could merge without a red signal — and during PR #84's review rounds I had to run `npm test` manually on every iteration because nothing else was doing it.

## Doc changes

Same commit fixes two stale paragraphs in `CLAUDE.md`:

- **Line 32** ("There is no test suite and no linter configured") was written before the vitest suite existed. Now correctly points at `cd backend && npm test` and the new CI gate.
- **"The terminal data path"** section still described the deleted `RingBuffer` and the pre-#84 replay mechanism. Rewritten to match the `capture-pane` snapshot + armed listener + `flushTail` ordering that actually ships now.

## Verification

Ran locally on `main` parity before committing:

```
backend  — npm ci ✓, tsc ✓, vitest 109/109 ✓
frontend — npm ci ✓, tsc + vite build ✓ (1.13 s)
```

The CI on this PR is its own best test — if the YAML is malformed or the commands don't match reality, the checks at the bottom of this PR will flag it before merge.

## Follow-ups (not in this PR)

- Enable branch protection on `main` requiring both jobs to pass. That's a repo-settings change, not a file change.
- Wire up biome (tracked separately — not #94).
- Add a frontend vitest suite once a first test is written (the job's `tsc && vite build` already typechecks, so this is purely additive).
