### PR TITLE
frontend: guard onmessage + handle JWT expiry (#93, #95)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -32,7 +32,6 @@ export const SESSION_EXPIRED_EVENT = "st:session-expired";
 
 export async function checkAuthStatus(): Promise<{ needsSetup: boolean }> {
         const res = await apiFetch("/auth/status");
-
         return res.json();
 }
 
@@ -262,31 +261,18 @@ async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
         }
         const res = await fetch(`${API_BASE}${path}`, { ...init, headers });
 
-        // Centralised stale-token handling. Fires for #95: without this, the
-        // 15 s session poll produces an error toast every 15 s forever once
-        // the JWT expires, because nothing in the app clears _token on 401.
+        // Centralised stale-token handling (#95). Without this, the 15 s
+        // session poll toasts an error every 15 s forever once the JWT
+        // expires, because nothing else clears _token on 401.
         //
-        // Three-way guard:
-        //   1. sentAuth   — only touch token state when we actually offered
-        //                   one. /auth/login 401 (wrong password) must NOT
-        //                   log the already-logged-in-in-another-tab user
-        //                   out; it's a distinct failure mode.
-        //   2. 401 status — 403 is "insufficient privilege", not "your token
-        //                   is dead". Don't conflate them.
-        //   3. _token !== null at emit time — a burst of N concurrent authed
-        //                   requests all race to 401 together (e.g. the
-        //                   session poll + a user-triggered listTabs). First
-        //                   one through clears _token; subsequent ones
-        //                   short-circuit here so the event fires once, not
-        //                   N times. Without this guard, the listener in
-        //                   main.ts would toast N times and call showAuth()
-        //                   N times (harmless but wasteful).
-        //
-        // The response itself is still returned unchanged — callers that
-        // want to show a more specific error can still read body/status.
-        // In practice the session-expired event swaps the UI to the auth
-        // view before those paths render, so the caller's error path is a
-        // no-op on screen.
+        // - sentAuth (captured pre-fetch) distinguishes authed 401s from
+        //   unauthed ones like a wrong-password /auth/login on a session
+        //   that already has a token — we mustn't clear auth state on that.
+        // - 401 is specifically "token stale"; 403 is policy and must not
+        //   trigger a logout.
+        // - _token !== null dedups concurrent 401 bursts (session poll +
+        //   a user-triggered call racing): the first setToken(null) through
+        //   silences the rest so the event fires exactly once per burst.
         if (sentAuth && res.status === 401 && _token !== null) {
                 setToken(null);
                 window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
@@ -294,4 +280,3 @@ async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
 
         return res;
 }
-

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -24,6 +24,24 @@ export function setToken(token: string | null): void {
 
 export function isLoggedIn(): boolean { return !!_token; }
 
+/**
+ * Dispatched by `apiFetch` when an authenticated request is rejected with
+ * HTTP 401 — i.e. the JWT we hold is no longer accepted (natural expiry,
+ * server-side secret rotation, or future revocation paths). By the time
+ * this fires, the token has already been cleared via setToken(null).
+ *
+ * main.ts listens for this event and performs the UI-side teardown
+ * (dispose active terminals, clear session list, swap back to the auth
+ * view, show a one-shot "session expired" toast). The event-driven
+ * handoff keeps api.ts free of DOM/terminal concerns; the alternative
+ * of having `apiFetch` import from main.ts would be a circular dep.
+ *
+ * Consumers: window.addEventListener(SESSION_EXPIRED_EVENT, handler).
+ * Fires at most once per burst of concurrent 401s — see apiFetch below.
+ */
+export const SESSION_EXPIRED_EVENT = "st:session-expired";
+
+
 // ── Auth API ────────────────────────────────────────────────────────────────
 
 export async function checkAuthStatus(): Promise<{ needsSetup: boolean }> {
@@ -246,8 +264,47 @@ async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
                 "Content-Type": "application/json",
                 ...(init?.headers as Record<string, string> ?? {}),
         };
+        // Captured before the fetch so a concurrent setToken(null) between
+        // here and the response doesn't change how we classify the 401 below.
+        // `sentAuth` pins "this request carried an Authorization header" —
+        // only authed 401s are treated as "token is stale"; an unauthed 401
+        // (e.g. wrong password on /auth/login) must not clear token state.
+        const sentAuth = !!_token;
         if (_token) {
                 headers["Authorization"] = `Bearer ${_token}`;
         }
-        return fetch(`${API_BASE}${path}`, { ...init, headers });
+        const res = await fetch(`${API_BASE}${path}`, { ...init, headers });
+
+        // Centralised stale-token handling. Fires for #95: without this, the
+        // 15 s session poll produces an error toast every 15 s forever once
+        // the JWT expires, because nothing in the app clears _token on 401.
+        //
+        // Three-way guard:
+        //   1. sentAuth   — only touch token state when we actually offered
+        //                   one. /auth/login 401 (wrong password) must NOT
+        //                   log the already-logged-in-in-another-tab user
+        //                   out; it's a distinct failure mode.
+        //   2. 401 status — 403 is "insufficient privilege", not "your token
+        //                   is dead". Don't conflate them.
+        //   3. _token !== null at emit time — a burst of N concurrent authed
+        //                   requests all race to 401 together (e.g. the
+        //                   session poll + a user-triggered listTabs). First
+        //                   one through clears _token; subsequent ones
+        //                   short-circuit here so the event fires once, not
+        //                   N times. Without this guard, the listener in
+        //                   main.ts would toast N times and call showAuth()
+        //                   N times (harmless but wasteful).
+        //
+        // The response itself is still returned unchanged — callers that
+        // want to show a more specific error can still read body/status.
+        // In practice the session-expired event swaps the UI to the auth
+        // view before those paths render, so the caller's error path is a
+        // no-op on screen.
+        if (sentAuth && res.status === 401 && _token !== null) {
+                setToken(null);
+                window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
+        }
+
+        return res;
 }
+

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -24,28 +24,15 @@ export function setToken(token: string | null): void {
 
 export function isLoggedIn(): boolean { return !!_token; }
 
-/**
- * Dispatched by `apiFetch` when an authenticated request is rejected with
- * HTTP 401 — i.e. the JWT we hold is no longer accepted (natural expiry,
- * server-side secret rotation, or future revocation paths). By the time
- * this fires, the token has already been cleared via setToken(null).
- *
- * main.ts listens for this event and performs the UI-side teardown
- * (dispose active terminals, clear session list, swap back to the auth
- * view, show a one-shot "session expired" toast). The event-driven
- * handoff keeps api.ts free of DOM/terminal concerns; the alternative
- * of having `apiFetch` import from main.ts would be a circular dep.
- *
- * Consumers: window.addEventListener(SESSION_EXPIRED_EVENT, handler).
- * Fires at most once per burst of concurrent 401s — see apiFetch below.
- */
+/** Fired by `apiFetch` once per 401-burst after clearing the stale token —
+ * main.ts listens to perform UI teardown. See apiFetch for the emit guard. */
 export const SESSION_EXPIRED_EVENT = "st:session-expired";
-
 
 // ── Auth API ────────────────────────────────────────────────────────────────
 
 export async function checkAuthStatus(): Promise<{ needsSetup: boolean }> {
         const res = await apiFetch("/auth/status");
+
         return res.json();
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,8 +10,10 @@ import {
         listSessions, createSession, deleteSession, stopSession, startSession,
         listTabs, createTab, deleteTab, TabNotFoundError,
         listInvites, createInvite, revokeInvite, InviteRequiredError,
+        SESSION_EXPIRED_EVENT,
         type SessionInfo, type Tab, type Invite,
 } from "./api.js";
+
 import { openTerminalSession, type TerminalSession, type SessionStatus } from "./terminal.js";
 
 // ── DOM refs ────────────────────────────────────────────────────────────────
@@ -58,9 +60,9 @@ const toast = document.getElementById("toast")!;
 // and as the URL bar shows/hides — we mirror its height into --app-vh so the
 // xterm host container refits to the space actually visible to the user.
 function syncViewportHeight() {
-	const vv = window.visualViewport;
-	const h = vv ? vv.height : window.innerHeight;
-	document.documentElement.style.setProperty("--app-vh", `${h}px`);
+        const vv = window.visualViewport;
+        const h = vv ? vv.height : window.innerHeight;
+        document.documentElement.style.setProperty("--app-vh", `${h}px`);
 }
 syncViewportHeight();
 window.visualViewport?.addEventListener("resize", syncViewportHeight);
@@ -74,9 +76,9 @@ const FONT_SIZE_STEPS = [11, 12, 13, 14, 15, 16, 18];
 const DEFAULT_FONT_SIZE = 14;
 const FONT_SIZE_KEY = "shared-terminal:font-size";
 function readFontSize(): number {
-	const raw = localStorage.getItem(FONT_SIZE_KEY);
-	const n = raw ? Number.parseInt(raw, 10) : DEFAULT_FONT_SIZE;
-	return FONT_SIZE_STEPS.includes(n) ? n : DEFAULT_FONT_SIZE;
+        const raw = localStorage.getItem(FONT_SIZE_KEY);
+        const n = raw ? Number.parseInt(raw, 10) : DEFAULT_FONT_SIZE;
+        return FONT_SIZE_STEPS.includes(n) ? n : DEFAULT_FONT_SIZE;
 }
 let currentFontSize = readFontSize();
 
@@ -239,13 +241,39 @@ authForm.addEventListener("submit", async (e) => {
         }
 });
 
-logoutBtn.addEventListener("click", () => {
+// Shared teardown for both the explicit logout button and the auto-triggered
+// session-expired path below. Idempotent: `logout()` clears the already-null
+// token on a second call, disposeAllCurrentTerminals() handles an empty
+// terminal map, and showAuth() just re-applies display styles. So the burst
+// case (multiple 401s briefly racing before _token is cleared) is safe even
+// though apiFetch's `_token !== null` guard already deduplicates.
+function handleLogout(toastMessage?: string): void {
         logout();
         disposeAllCurrentTerminals();
         activeSessionId = null;
         sessions = [];
         showAuth();
+        if (toastMessage) showToast(toastMessage, true);
+}
+
+logoutBtn.addEventListener("click", () => {
+        handleLogout();
 });
+
+// Listen for the api-layer signal that our JWT is no longer accepted (#95).
+// Without this, a `refreshSessions()` tick 15 s after expiry produces a
+// 401 → red toast, the next tick does the same, and so on forever because
+// nothing was clearing `_token`. api.ts now clears the token at the 401 and
+// dispatches this event; we pair that with a UI transition back to the
+// login view and a single explanatory toast.
+//
+// One-shot per burst: apiFetch's internal `_token !== null` guard ensures
+// the event fires at most once per 401 burst, so we don't need extra
+// debouncing here.
+window.addEventListener(SESSION_EXPIRED_EVENT, () => {
+        handleLogout("Your session has expired — please sign in again");
+});
+
 
 // ── Session management ──────────────────────────────────────────────────────
 
@@ -858,18 +886,18 @@ mainEl.setAttribute("data-sidebar-ready", "");
 // ── Font size cycle button ──────────────────────────────────────────────────
 
 function nextFontSize(current: number): number {
-	const i = FONT_SIZE_STEPS.indexOf(current);
-	if (i === -1) return DEFAULT_FONT_SIZE;
-	return FONT_SIZE_STEPS[(i + 1) % FONT_SIZE_STEPS.length]!;
+        const i = FONT_SIZE_STEPS.indexOf(current);
+        if (i === -1) return DEFAULT_FONT_SIZE;
+        return FONT_SIZE_STEPS[(i + 1) % FONT_SIZE_STEPS.length]!;
 }
 
 fontSizeBtn.addEventListener("click", () => {
-	currentFontSize = nextFontSize(currentFontSize);
-	localStorage.setItem(FONT_SIZE_KEY, String(currentFontSize));
-	fontSizeBtn.textContent = `Aa ${currentFontSize}`;
-	for (const { term } of currentTerminals.values()) {
-		term.setFontSize(currentFontSize);
-	}
+        currentFontSize = nextFontSize(currentFontSize);
+        localStorage.setItem(FONT_SIZE_KEY, String(currentFontSize));
+        fontSizeBtn.textContent = `Aa ${currentFontSize}`;
+        for (const { term } of currentTerminals.values()) {
+                term.setFontSize(currentFontSize);
+        }
 });
 // Reflect the persisted size in the label on load so users see e.g. "Aa 16"
 // rather than a generic "Aa" after they've picked their size once.

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -60,9 +60,9 @@ const toast = document.getElementById("toast")!;
 // and as the URL bar shows/hides — we mirror its height into --app-vh so the
 // xterm host container refits to the space actually visible to the user.
 function syncViewportHeight() {
-        const vv = window.visualViewport;
-        const h = vv ? vv.height : window.innerHeight;
-        document.documentElement.style.setProperty("--app-vh", `${h}px`);
+	const vv = window.visualViewport;
+	const h = vv ? vv.height : window.innerHeight;
+	document.documentElement.style.setProperty("--app-vh", `${h}px`);
 }
 syncViewportHeight();
 window.visualViewport?.addEventListener("resize", syncViewportHeight);
@@ -76,9 +76,9 @@ const FONT_SIZE_STEPS = [11, 12, 13, 14, 15, 16, 18];
 const DEFAULT_FONT_SIZE = 14;
 const FONT_SIZE_KEY = "shared-terminal:font-size";
 function readFontSize(): number {
-        const raw = localStorage.getItem(FONT_SIZE_KEY);
-        const n = raw ? Number.parseInt(raw, 10) : DEFAULT_FONT_SIZE;
-        return FONT_SIZE_STEPS.includes(n) ? n : DEFAULT_FONT_SIZE;
+	const raw = localStorage.getItem(FONT_SIZE_KEY);
+	const n = raw ? Number.parseInt(raw, 10) : DEFAULT_FONT_SIZE;
+	return FONT_SIZE_STEPS.includes(n) ? n : DEFAULT_FONT_SIZE;
 }
 let currentFontSize = readFontSize();
 
@@ -885,18 +885,18 @@ mainEl.setAttribute("data-sidebar-ready", "");
 // ── Font size cycle button ──────────────────────────────────────────────────
 
 function nextFontSize(current: number): number {
-        const i = FONT_SIZE_STEPS.indexOf(current);
-        if (i === -1) return DEFAULT_FONT_SIZE;
-        return FONT_SIZE_STEPS[(i + 1) % FONT_SIZE_STEPS.length]!;
+	const i = FONT_SIZE_STEPS.indexOf(current);
+	if (i === -1) return DEFAULT_FONT_SIZE;
+	return FONT_SIZE_STEPS[(i + 1) % FONT_SIZE_STEPS.length]!;
 }
 
 fontSizeBtn.addEventListener("click", () => {
-        currentFontSize = nextFontSize(currentFontSize);
-        localStorage.setItem(FONT_SIZE_KEY, String(currentFontSize));
-        fontSizeBtn.textContent = `Aa ${currentFontSize}`;
-        for (const { term } of currentTerminals.values()) {
-                term.setFontSize(currentFontSize);
-        }
+	currentFontSize = nextFontSize(currentFontSize);
+	localStorage.setItem(FONT_SIZE_KEY, String(currentFontSize));
+	fontSizeBtn.textContent = `Aa ${currentFontSize}`;
+	for (const { term } of currentTerminals.values()) {
+		term.setFontSize(currentFontSize);
+	}
 });
 // Reflect the persisted size in the label on load so users see e.g. "Aa 16"
 // rather than a generic "Aa" after they've picked their size once.

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -13,7 +13,6 @@ import {
         SESSION_EXPIRED_EVENT,
         type SessionInfo, type Tab, type Invite,
 } from "./api.js";
-
 import { openTerminalSession, type TerminalSession, type SessionStatus } from "./terminal.js";
 
 // ── DOM refs ────────────────────────────────────────────────────────────────

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -274,7 +274,6 @@ window.addEventListener(SESSION_EXPIRED_EVENT, () => {
         handleLogout("Your session has expired — please sign in again");
 });
 
-
 // ── Session management ──────────────────────────────────────────────────────
 
 async function refreshSessions() {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -165,24 +165,9 @@ export function openTerminalSession(opts: {
         };
 
         ws.onmessage = (ev) => {
-                // disposed: the session has been torn down but the WebSocket is
-                // still in CLOSING (ws.close() initiates the handshake; `CLOSED`
-                // only arrives after the server's ACK). Any frame the server
-                // sent before receiving the close frame — or that was already
-                // buffered in the browser's network stack — still fires here,
-                // and term.write() on an xterm that's been dispose()d throws
-                // "Cannot read properties of null" from the zeroed internals.
-                //
-                // Surfaces most often when:
-                //   - a backgrounded tab (Chrome/Safari page-freeze) wakes up
-                //     with queued frames after the parent component already
-                //     tore down the session,
-                //   - the user switches between active sessions on a busy tab
-                //     (e.g. Claude Code streaming output) and the last 1-2
-                //     frames from the old session land after dispose().
-                //
-                // Siblings (onopen/onerror/onclose) all have this guard; this
-                // one was missed when PR #77 added the `disposed` flag. See #93.
+                // disposed: post-close frames buffered by the browser or in flight
+                // from the server still fire here, and term.write() throws on a
+                // disposed xterm. Sibling of the onerror/onclose guards below (#93).
                 if (disposed) return;
                 type Msg =
                         | { type: "output"; data: string }

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -165,6 +165,25 @@ export function openTerminalSession(opts: {
         };
 
         ws.onmessage = (ev) => {
+                // disposed: the session has been torn down but the WebSocket is
+                // still in CLOSING (ws.close() initiates the handshake; `CLOSED`
+                // only arrives after the server's ACK). Any frame the server
+                // sent before receiving the close frame — or that was already
+                // buffered in the browser's network stack — still fires here,
+                // and term.write() on an xterm that's been dispose()d throws
+                // "Cannot read properties of null" from the zeroed internals.
+                //
+                // Surfaces most often when:
+                //   - a backgrounded tab (Chrome/Safari page-freeze) wakes up
+                //     with queued frames after the parent component already
+                //     tore down the session,
+                //   - the user switches between active sessions on a busy tab
+                //     (e.g. Claude Code streaming output) and the last 1-2
+                //     frames from the old session land after dispose().
+                //
+                // Siblings (onopen/onerror/onclose) all have this guard; this
+                // one was missed when PR #77 added the `disposed` flag. See #93.
+                if (disposed) return;
                 type Msg =
                         | { type: "output"; data: string }
                         | { type: "status"; status: SessionStatus }


### PR DESCRIPTION
Fixes two small-surface frontend issues that share the same shape — an edge case the code didn't handle, producing a visibly broken UI with no recovery short of a reload.

## #93 — \`ws.onmessage\` runs after dispose()

\`onopen\`, \`onerror\`, and \`onclose\` all short-circuit with \`if (disposed) return\`. \`onmessage\` didn't. That was fine until it wasn't:

- A backgrounded tab (Chrome/Safari page-freeze) wakes up with queued frames after the parent component has already torn down the session.
- The user switches between active sessions on a busy tab (e.g. Claude Code streaming output) and the last 1–2 frames from the old session land after \`dispose()\`.

\`term.write()\` on a disposed xterm throws \`Cannot read properties of null\` from the zeroed internals. One-line guard, matches the sibling handlers. Explanatory comment inline so the next person who copies this handler template doesn't miss it again.

## #95 — expired JWT traps the UI in a 401 loop

Once the token expires, nothing clears \`_token\`. The 15 s session poll keeps sending the stale header, every request comes back 401, each one lights up the red toast, the user ends up staring at a half-alive UI with no obvious way out. Logout → re-login works but isn't discoverable.

Two-part fix:

**\`api.ts\`** — \`apiFetch\` now detects authenticated 401s centrally, clears the token, and dispatches \`SESSION_EXPIRED_EVENT\` on \`window\`. The guard is three-way to avoid false positives:

1. \`sentAuth\` (captured before the fetch) — only touch token state when we actually offered one. A 401 from \`/auth/login\` with the wrong password must not log out a user who's already signed in in another tab.
2. \`res.status === 401\` — 403 is \"insufficient privilege\", not \"your token is dead\". Keep them distinct.
3. \`_token !== null\` at emit time — a burst of N concurrent authed requests all race to 401 together (session poll + a user-triggered \`listTabs\`, say). First one through clears \`_token\`; subsequent ones short-circuit so the event fires once, not N times.

The response itself is returned unchanged — callers' existing error paths still run, but in practice the event handler swaps the UI before those paths render.

**\`main.ts\`** — listens for the event and runs the same teardown as the logout button plus a one-shot explanatory toast (\`\"Your session has expired — please sign in again\"\`). The logout-button handler and the event handler are both factored through a new \`handleLogout()\` so they can't drift. Event-based handoff (rather than importing \`main.ts\` state into \`api.ts\`) keeps \`api.ts\` free of DOM concerns and avoids a circular dep.

## Verification

- \`tsc --noEmit\`: clean.
- \`vite build\`: 411.79 kB bundled, clean.

## What I skipped and why

The linked issue suggests adding a unit test with a fetch mock. The frontend doesn't currently have a test harness (no vitest config, no \`*.test.ts\` files, no test script in \`package.json\`) — backend-only. Wiring up vitest-for-frontend is a separate change that'd dwarf the fix itself; I'd rather land this and track \"set up frontend test infra\" as its own small task. Happy to do that in a follow-up if you want it as part of this review.

The issue also mentions a belt-and-braces guard in the 15 s \`setInterval\`. That path already funnels through \`apiFetch\` (via \`listSessions\`), so the centralised handling covers it — and the interval's existing \`if (isLoggedIn()) refreshSessions()\` gates it behind the token state that \`apiFetch\` just cleared. No second guard needed today; if a future non-\`apiFetch\` caller appears, that's where the belt-and-braces would belong.

Closes #93, #95.