### PR TITLE
ci: widen claude-review allowlist + bump --max-turns 10→20

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,7 +10,15 @@ name: Claude PR Review
 #   This is NOT equivalent to `contents: write` — it does not grant code-push
 #   rights; the resulting token is bounded by the Claude GitHub App's own
 #   install permissions on this repo.
-# - `--max-turns 10` caps iteration blast radius if prompt injection occurs.
+# - `--max-turns 20` caps iteration blast radius if prompt injection occurs.
+#   Previously 10, bumped after a PR where the agent hit the ceiling before
+#   posting — mostly because permission denials on read-only tools (Read,
+#   Grep, etc.) burnt turns. See the allowlist below for the read-only
+#   tools that were added in the same change.
+# - Allowlist is read-only: only gh/git read commands and read-only fs
+#   tools (Read, Grep, Glob). Nothing that can write, push, or reach
+#   network, so a prompt-injection attack can't pivot beyond influencing
+#   the single review comment.
 # - Action is pinned to major version `@v1`. Consider pinning to a commit SHA
 #   for stricter supply-chain hygiene.
 
@@ -48,8 +56,8 @@ jobs:
           # so the review lands as a top-level PR comment.
           claude_args: >
             --model claude-sonnet-4-6
-            --max-turns 10
-            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
+            --max-turns 20
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*),Read,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}
             PR: #${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

The automated Claude review on PR #101 failed with `Reached maximum number of turns (10)` despite doing almost no useful work. SDK log showed **`permission_denials_count: 8`** — the agent was burning its 10-turn budget retrying tools that weren't in the allowlist (most likely `Read` on files cited in the diff, `git log` for blame context, etc.), hitting denial after denial, and then running out of turns before ever calling `gh pr comment`. So the review silently never posted.

## Fix — two changes, coupled

### 1. Widen the `--allowedTools` allowlist

Added read-only tools a PR reviewer actually needs:

| Tool | Why |
| --- | --- |
| `Read`, `Grep`, `Glob` | Look at code cited `file:line` in the diff |
| `Bash(git log:*)` | Was this line recently changed? |
| `Bash(git blame:*)` | Context for a suspicious hunk |
| `Bash(git show:*)` | Compare against parent commit |
| `Bash(gh pr checks:*)` | See CI status before reviewing |

**All strictly read-only.** Nothing that can:
- write to the working tree (no `Write`/`Edit`)
- push code (no `Bash(git push:*)`, no `Bash(gh pr edit:*)`)
- reach the network (no `WebFetch`, no `Bash(curl:*)` / `wget`)
- execute arbitrary code (no `Bash(node:*)` / `npm:*` / `python:*` / bare `Bash(*)`)

Security invariant holds: a prompt-injection attack in a PR can still only influence the single review comment this action is scoped to post. The workflow keeps `pull_request` (not `pull_request_target`), `contents: read`, and the same `pull-requests: write` scope — no secrets leak to fork PRs.

### 2. Bump `--max-turns` 10 → 20

Safety net, not a target. Most reviews still finish in 4–8 turns; the ceiling only bites on pathological runs that were getting truncated at 10 anyway. With the wider allowlist above, most reviews will actually use *fewer* turns than before because they won't be bouncing off denials.

## Side effects

- Updated the security-notes preamble to document both changes and re-state the 'allowlist is read-only' invariant so a future reviewer doesn't silently regress it.
- No behavior change for successful runs — only the failure mode (turn-exhaustion → silent no-review) is fixed.

## Test plan

- [ ] Merge and watch the next PR trigger the review action — should post a comment in well under 20 turns.
- [ ] Confirm the review actually cites `file:line` now (it couldn't reliably before, because it had no `Read` tool).

## Verification

```console
$ yamllint .github/workflows/claude-review.yml  # clean
$ git diff --stat
 .github/workflows/claude-review.yml | 14 +++++++++++---
 1 file changed, 11 insertions(+), 3 deletions(-)
```