### PR TITLE
fix(sessions): don't leak synthetic "disconnected" WS state into SessionInfo.status

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -581,14 +581,61 @@ function openTab(tabId: string) {
                                 sessionId: ownSessionId,
                                 tabId,
                                 onStatus: (status: SessionStatus) => {
-                                        // Only the active tab drives the shared session status. A
-                                        // background tab's WS drop (idle TCP teardown) must not mark
-                                        // the whole session "disconnected" while the foreground tab
-                                        // is still live.
                                         if (activeSessionId !== ownSessionId) return;
+
+                                        if (status === "disconnected") {
+                                                // "disconnected" is a frontend-only synthetic state
+                                                // fired by ws.onclose — the backend never sends it.
+                                                // Writing it into s.status casts an out-of-type value
+                                                // into SessionInfo.status (typed only as
+                                                // "running"|"stopped"|"terminated") and used to brick
+                                                // the session on any transient WS drop (Cloudflare
+                                                // Tunnel idle timeout ≈100 s, JWT refresh, network
+                                                // blip):
+                                                //   - the sidebar click handler matches neither
+                                                //     "running" nor "stopped" → clicking the session
+                                                //     became a silent no-op. Users reported this as
+                                                //     "my tab went invalid when I came back to the
+                                                //     session" — it's the session, not the tab.
+                                                //   - openTab's `status !== "running"` guard refused
+                                                //     to attach on a perfectly healthy backend.
+                                                //
+                                                // Leave s.status alone; pull the authoritative status
+                                                // with refreshSessions() so the sidebar reflects
+                                                // whatever the backend actually says. Also tear down
+                                                // the dead terminal for this tab so a later click on
+                                                // its chip recreates a fresh WebSocket instead of
+                                                // re-activating a frozen pane. The tab itself stays
+                                                // in currentTabs (still a valid tmux session on the
+                                                // backend) so it remains reachable from the tab bar.
+                                                const entry = currentTerminals.get(tabId);
+                                                if (entry) {
+                                                        // queueMicrotask so we don't dispose xterm
+                                                        // synchronously inside its own ws.onclose
+                                                        // callback chain.
+                                                        queueMicrotask(() => {
+                                                                const latest = currentTerminals.get(tabId);
+                                                                if (!latest || latest !== entry) return;
+                                                                latest.term.dispose();
+                                                                latest.pane.remove();
+                                                                currentTerminals.delete(tabId);
+                                                                if (currentActiveTabId === tabId) {
+                                                                        currentActiveTabId = null;
+                                                                        terminalContainer.style.display = "none";
+                                                                }
+                                                                renderTabBar();
+                                                        });
+                                                }
+                                                void refreshSessions();
+                                                return;
+                                        }
+
+                                        // Backend-sourced status ("running" on attach). Only the
+                                        // active tab drives the shared session badge — a background
+                                        // tab's signal must not override the foreground view.
                                         if (tabId !== currentActiveTabId) return;
                                         const s = sessions.find((x) => x.sessionId === ownSessionId);
-                                        if (s) s.status = status as SessionInfo["status"];
+                                        if (s) s.status = status;
                                         updateToolbar();
                                         renderSessionList();
                                 },


### PR DESCRIPTION
## What users saw

> "I create a new session, I add the first tab and it works properly, but if I try to go back into the session that tab is now invalid."

Reproduced consistently after _any_ transient WebSocket drop: Cloudflare Tunnel idle timeout (~100 s), JWT refresh, a network blip, the browser backgrounding the tab on mobile long enough for the OS to GC the socket, etc. After the drop:

- clicking the session in the sidebar did **nothing** (silent no-op), or
- clicking a tab chip fired `"Session isn't running — start it first"` on a perfectly healthy backend.

Backend / tmux / D1 were fine the whole time — the tmux session for the tab was still alive, `listTabs` returned it, `tmux new-session -A` would have re-attached cleanly. The bug was entirely in frontend client state.

## Root cause

`frontend/src/terminal.ts` exports `SessionStatus = "running" | "stopped" | "terminated" | "disconnected"`. The `"disconnected"` value is fired **only** from `ws.onclose` — it's a frontend-local connection state, never emitted by the backend.

The `onStatus` callback in `openTab` was doing:

```ts
if (s) s.status = status as SessionInfo["status"];
```

`SessionInfo.status` is typed just `"running" | "stopped" | "terminated"`. The `as` cast punched an out-of-type runtime value (`"disconnected"`) into the `sessions[]` array. That then tripped two UI paths:

1. **Sidebar click handler** — `if (s.status === "running") … else if (s.status === "stopped") …` matched neither branch, so clicking the session became a silent no-op. This is what users reported as "invalid tab" — it was actually the _session_ that refused to open.
2. **`openTab` status guard** — `if (s.status !== "running")` → `"Session isn't running — start it first"` toast, refusing to attach.

The only paths that fixed it were a full page reload or `refreshSessions()` overwriting `sessions[]` from the backend — neither of which the normal session-switch flow triggers.

## Fix

In the `onStatus` handler inside `openTab`:

- On `"disconnected"`, leave `s.status` alone. Trigger `refreshSessions()` so the sidebar reflects whatever the backend actually says, and dispose the dead xterm+WS for that tab (via `queueMicrotask` so we don't tear xterm down inside its own `ws.onclose` callback chain). The tab chip stays in `currentTabs` — it's still a valid tmux session on the backend, just reachable again with a fresh WebSocket. Clicking its chip goes through the `currentTerminals.get(tabId) === undefined` branch in `openTab` and reconnects.
- On backend-sourced statuses (`"running"`, `"stopped"`, `"terminated"`), behaviour is unchanged — and `SessionStatus` now narrows cleanly to `SessionInfo["status"]` after the early return, so the `as` cast is gone.

## Scenarios walked through

- **Normal session switch** (`s1` → `s2`): `disposeAllCurrentTerminals` sets `disposed=true` before `ws.close(1000)`; `ws.onclose` short-circuits on `disposed` → `onStatus` never fires. Unchanged.
- **Foreground tab drops**: user sees `onError` toast, microtask disposes the dead terminal, `currentActiveTabId` clears, pane hides, chip remains. Clicking the chip reconnects cleanly.
- **Background tab drops while user views another tab of same session**: that tab's terminal is disposed, `currentActiveTabId` stays on the foreground tab (unchanged), foreground view uninterrupted. The background tab's chip recreates on click.
- **Logout/login**: `handleLogout` → `disposeAllCurrentTerminals` (same `disposed` guard). `showApp` → fresh `refreshSessions`. Unchanged, now also robust to drops that fired before logout.

## Scope

One file: `frontend/src/main.ts`. No D1 schema changes, no backend changes, no new dependencies. `tsc --noEmit` clean on both `frontend/` and `backend/`.
