### PR TITLE
fix(sessions): updateToolbar() inside the disconnect microtask

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -622,6 +622,17 @@ function openTab(tabId: string) {
                                                                 if (currentActiveTabId === tabId) {
                                                                         currentActiveTabId = null;
                                                                         terminalContainer.style.display = "none";
+                                                                        // refreshSessions() below will eventually round-trip
+                                                                        // and call updateToolbar(), but until that resolves
+                                                                        // the toolbar still shows the session name + status
+                                                                        // badge with no terminal beneath it. Match the rest
+                                                                        // of the codebase (closeTab, openSession's error
+                                                                        // paths) by syncing the toolbar to the new state
+                                                                        // synchronously — if the session was meanwhile
+                                                                        // dropped from sessions[] (rare, but possible if
+                                                                        // refreshSessions raced ahead), the empty-state
+                                                                        // panel takes over instead of an orphan toolbar.
+                                                                        updateToolbar();
                                                                 }
                                                                 renderTabBar();
                                                         });


### PR DESCRIPTION
Follow-up to the review nit on #105.

## What was missed

The `onStatus("disconnected")` microtask in `openTab` nulls `currentActiveTabId` and hides `terminalContainer` when the dropped WS belonged to the active tab — but didn't call `updateToolbar()` afterwards. The session toolbar (name + status badge) sat dangling above an empty pane until the parallel `refreshSessions()` round-trip resolved and triggered a re-render via its own path. Every other call site that nulls `currentActiveTabId` (`disposeAllCurrentTerminals`'s callers, `closeTab`'s no-sibling branch, `deleteSession` on the active session) calls `updateToolbar()` synchronously straight after — this site should too.

## Fix

```diff
 if (currentActiveTabId === tabId) {
     currentActiveTabId = null;
     terminalContainer.style.display = "none";
+    updateToolbar();
 }
 renderTabBar();
```

Inside the `queueMicrotask` block in `frontend/src/main.ts`, scoped to the same `if (currentActiveTabId === tabId)` branch the reviewer flagged.

## Why it matters (and why it's still a NIT)

Visually a no-op in the common case: the session is still in `sessions[]` while the WS drop is being handled, so `updateToolbar()`'s `find(... === activeSessionId)` succeeds and the toolbar stays visible. The win is in the racy edge case where `refreshSessions()` has already evicted the session from `sessions[]` (e.g. another client deleted it during the disconnect window) before the microtask runs — now the empty-state panel takes over synchronously instead of leaving an orphan toolbar above an empty pane until the next 15 s `setInterval` tick.

Also makes the cleanup symmetric with the rest of the codebase, so the next person reading these branches doesn't have to wonder why one of them skips the toolbar sync.

## Scope

Same one file as #105: `frontend/src/main.ts`. `tsc --noEmit` clean on `frontend/`.
