### PR TITLE
session-image: install VS Code CLI for code tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,24 @@ as the container is started again.
    `/home/developer/workspace` is the one bind-mounted from the host, so
    anything you save there is persisted across container restarts.
 
-> The tunnel binary is per-arch — the Dockerfile picks `cli-alpine-x64` or
-> `cli-alpine-arm64` automatically based on Buildx `TARGETARCH`, so it works
+> The tunnel binary is per-arch — the Dockerfile picks `cli-linux-x64` or
+> `cli-linux-arm64` automatically based on Buildx `TARGETARCH`, so it works
 > on both Intel servers and Apple Silicon hosts running the image natively.
+> (We use the glibc `cli-linux-*` builds rather than the musl `cli-alpine-*`
+> ones because the base image is `ubuntu:24.04`.)
+>
+> For reproducible builds, pin the CLI release and verify its SHA-256 at
+> build time:
+>
+> ```bash
+> docker build \
+>   --build-arg VSCODE_CLI_VERSION=1.96.4 \
+>   --build-arg VSCODE_CLI_SHA256=<sha256 of the matching .tar.gz> \
+>   -t shared-terminal-session ./session-image
+> ```
+>
+> Without `VSCODE_CLI_SHA256` the build still succeeds but logs a warning,
+> since the `latest`-tracking default cannot be hash-pinned.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,13 @@ code tunnel
 ```
 
 `code tunnel` keeps running in the foreground, so leave it in its own tmux
-tab — the container survives disconnects, and the tunnel comes back as soon
-as the container is started again.
+tab. The CLI's auth state is stored under `~/.vscode-cli/`, which the
+session entrypoint symlinks into `~/workspace/.vscode-cli/` — that path is
+bind-mounted from the host, so the device-login token survives container
+restarts (soft-delete + restart, host reboot triggering reconcile, etc.).
+After a restart you only need to re-launch `code tunnel`; it picks the
+existing registration up automatically. The state is purged on a hard
+delete, same as the rest of the workspace.
 
 **On your Mac:**
 

--- a/README.md
+++ b/README.md
@@ -202,10 +202,47 @@ Each session runs in a Docker container based on `session-image/Dockerfile`:
 - **OS:** Ubuntu 24.04
 - **Dev tools:** git, curl, build-essential, python3, Node.js 22, vim, nano, htop, jq
 - **Claude CLI:** `@anthropic-ai/claude-code` (globally installed)
+- **VS Code CLI:** `code` (standalone) — see [Connecting from VS Code](#connecting-from-vs-code) below
 - **Terminal:** tmux with a session named `main`, 50k scrollback, mouse support
 - **User:** `developer` (sudo, no password)
 - **Workspace:** `/home/developer/workspace` (bind-mounted from `<WORKSPACE_ROOT>/<sessionId>` on the host)
 - **Resources:** 2 GB RAM, 2 CPUs per container (configurable in `dockerManager.ts`)
+
+## Connecting from VS Code
+
+The session image ships the standalone Microsoft VS Code CLI, so any session
+can be opened in desktop VS Code (or `vscode.dev`) without SSH, port-forwards,
+or extra ingress on the home server. The tunnel goes outbound to Microsoft and
+auth is handled through your GitHub or Microsoft account.
+
+**From inside the browser terminal of a session:**
+
+```bash
+# First time only — register this container as a tunnel host.
+# It prints a short device-code URL; paste it on your Mac and sign in
+# with the same GitHub/Microsoft account you'll connect from.
+code tunnel
+
+# Subsequent runs in the same container can skip the prompt:
+#   code tunnel --accept-server-license-terms --name <session-name>
+```
+
+`code tunnel` keeps running in the foreground, so leave it in its own tmux
+tab — the container survives disconnects, and the tunnel comes back as soon
+as the container is started again.
+
+**On your Mac:**
+
+1. Install the [Remote - Tunnels](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-server)
+   extension in VS Code.
+2. Open the Command Palette → **Remote-Tunnels: Connect to Tunnel…** and pick
+   the session you just registered. The workspace at
+   `/home/developer/workspace` is the one bind-mounted from the host, so
+   anything you save there is persisted across container restarts.
+
+> The tunnel binary is per-arch — the Dockerfile picks `cli-alpine-x64` or
+> `cli-alpine-arm64` automatically based on Buildx `TARGETARCH`, so it works
+> on both Intel servers and Apple Silicon hosts running the image natively.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -246,18 +246,21 @@ as the container is started again.
 > (We use the glibc `cli-linux-*` builds rather than the musl `cli-alpine-*`
 > ones because the base image is `ubuntu:24.04`.)
 >
-> For reproducible builds, pin the CLI release and verify its SHA-256 at
-> build time:
+> The default build is reproducible and verified out of the box — the CLI
+> version is pinned to a specific commit and the per-arch SHA-256 of each
+> tarball is checked with `sha256sum -c` before extraction. There is no
+> "skip the hash check" path; an empty SHA fails the build. To bump the
+> pin (or override for a CVE patch), update the three `ARG VSCODE_CLI_*`
+> defaults in `session-image/Dockerfile` together, or pass them on the
+> command line:
 >
 > ```bash
 > docker build \
->   --build-arg VSCODE_CLI_VERSION=1.96.4 \
->   --build-arg VSCODE_CLI_SHA256=<sha256 of the matching .tar.gz> \
+>   --build-arg VSCODE_CLI_VERSION=commit:<sha> \
+>   --build-arg VSCODE_CLI_SHA256_AMD64=<x64 sha256 of the .tar.gz> \
+>   --build-arg VSCODE_CLI_SHA256_ARM64=<arm64 sha256 of the .tar.gz> \
 >   -t shared-terminal-session ./session-image
 > ```
->
-> Without `VSCODE_CLI_SHA256` the build still succeeds but logs a warning,
-> since the `latest`-tracking default cannot be hash-pinned.
 
 ## Tech Stack
 

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -43,6 +43,28 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # Install globally so every session has it available.
 RUN npm install -g @anthropic-ai/claude-code
 
+# ── VS Code CLI (`code tunnel`) ──────────────────────────────────────────────
+# Standalone CLI from Microsoft. Lets the user run `code tunnel` from inside
+# the session and attach to the container from desktop VS Code (or vscode.dev)
+# on any device — no SSH, no exposed ports, auth goes through GitHub/Microsoft.
+#
+# We pull the static linux build that matches the container arch (TARGETARCH
+# is set automatically by Docker Buildx: amd64 on Intel / x86 hosts, arm64
+# on Apple Silicon). The archive only contains a single `code` binary.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) VSCODE_ARCH=cli-alpine-x64 ;; \
+      arm64) VSCODE_ARCH=cli-alpine-arm64 ;; \
+      *) echo "unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fLsS "https://code.visualstudio.com/sha/download?build=stable&os=${VSCODE_ARCH}" \
+         -o /tmp/vscode-cli.tar.gz; \
+    tar -xzf /tmp/vscode-cli.tar.gz -C /usr/local/bin; \
+    rm /tmp/vscode-cli.tar.gz; \
+    chmod +x /usr/local/bin/code; \
+    /usr/local/bin/code --version
+
 # ── Non-root user ────────────────────────────────────────────────────────────
 RUN useradd -m -s /bin/bash -G sudo developer \
     && echo "developer ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/developer

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -96,7 +96,7 @@ RUN set -eux; \
       *) echo "unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     if [ -z "${VSCODE_SHA256}" ]; then \
-      echo "ERROR: no SHA-256 set for ${TARGETARCH} — refusing to install an unverified VS Code CLI. Override VSCODE_CLI_VERSION + VSCODE_CLI_SHA256_${TARGETARCH} together." >&2; \
+      echo "ERROR: no SHA-256 set for ${VSCODE_ARCH} — refusing to install an unverified VS Code CLI. Override VSCODE_CLI_VERSION together with VSCODE_CLI_SHA256_AMD64 / VSCODE_CLI_SHA256_ARM64." >&2; \
       exit 1; \
     fi; \
     curl -fLsS "https://update.code.visualstudio.com/${VSCODE_CLI_VERSION}/${VSCODE_ARCH}/stable" \

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -50,54 +50,59 @@ RUN npm install -g @anthropic-ai/claude-code
 #
 # We pull the static linux build that matches the container arch (TARGETARCH
 # is set automatically by Docker Buildx: amd64 on Intel / x86 hosts, arm64
-# on Apple Silicon). The archive only contains a single `code` binary.
+# on Apple Silicon). The archive only contains a single `code` binary, and
+# we extract only that member explicitly so a tampered tarball cannot drop
+# extra executables into /usr/local/bin alongside it.
 #
 # Linkage: this base image is glibc (ubuntu:24.04), so we use the
 # `cli-linux-*` artifacts. The `cli-alpine-*` builds are musl-linked and
 # will fail at runtime on glibc with "not found" / "Exec format error".
 #
-# Pinning: VSCODE_CLI_VERSION defaults to `latest`, which resolves to the
-# current stable release at build time. The download URL is otherwise
-# unversioned, so the docker layer cache key would not invalidate when
-# upstream ships a new build — set this arg to pin a known-good version
-# for reproducible images:
+# Integrity: the default build is reproducible and verified — the version
+# below is pinned to a specific commit and the per-arch SHA-256 of each
+# tarball is checked with `sha256sum -c` before extraction. There is no
+# "skip the hash check" escape hatch; the build fails if the relevant
+# SHA-256 is empty, which closes the MITM-on-CDN gap (every other install
+# in this image is GPG- or lockfile-verified).
 #
-#     docker build --build-arg VSCODE_CLI_VERSION=1.96.4 ./session-image
-#     docker build --build-arg VSCODE_CLI_VERSION=commit:fabdb6a ./session-image
+# Bumping the pin: pick a release commit hash (vscode releases page,
+# https://code.visualstudio.com/updates/), then download the matching
+# tarballs once to capture both arches' SHA-256:
 #
-# Integrity: every other install in this image is verified (apt = GPG,
-# npm = package-lock integrity hashes) — this download is not, so a
-# compromised CDN response would install an arbitrary executable into
-# /usr/local/bin/code that every session container then runs as a user
-# with NOPASSWD:ALL sudo. To close that gap, pass an expected SHA-256 of
-# the .tar.gz alongside the pinned version. Only meaningful with a pinned
-# VSCODE_CLI_VERSION (the rolling `latest` artifact is hash-unstable):
+#     COMMIT=<release commit hash>
+#     for ARCH in cli-linux-x64 cli-linux-arm64; do
+#       curl -fL "https://update.code.visualstudio.com/commit:${COMMIT}/${ARCH}/stable" \
+#         | sha256sum
+#     done
+#
+# Update VSCODE_CLI_VERSION + VSCODE_CLI_SHA256_AMD64 + VSCODE_CLI_SHA256_ARM64
+# in lockstep. Operators can also override on the command line (e.g. for a
+# CVE bump) without touching the file:
 #
 #     docker build \
-#       --build-arg VSCODE_CLI_VERSION=1.96.4 \
-#       --build-arg VSCODE_CLI_SHA256=<sha256 of the matching .tar.gz> \
+#       --build-arg VSCODE_CLI_VERSION=commit:<sha> \
+#       --build-arg VSCODE_CLI_SHA256_AMD64=<x64 sha256> \
+#       --build-arg VSCODE_CLI_SHA256_ARM64=<arm64 sha256> \
 #       ./session-image
-#
-# When VSCODE_CLI_SHA256 is empty the build still succeeds but logs a
-# loud warning, so the unverified path is opt-out by silence rather than
-# the default-blessed path.
 ARG TARGETARCH
-ARG VSCODE_CLI_VERSION=latest
-ARG VSCODE_CLI_SHA256=
+# Pinned to VS Code stable commit 10c8e557c8b9f9ed0a87f61f1c9a44bde731c409.
+ARG VSCODE_CLI_VERSION=commit:10c8e557c8b9f9ed0a87f61f1c9a44bde731c409
+ARG VSCODE_CLI_SHA256_AMD64=8429d2c1e2f564739be247ca5abc20cc9e6f987b976aee04d3bb8cf350535fe1
+ARG VSCODE_CLI_SHA256_ARM64=452dbfe3bfb901dcb4583910cd5352a63f938b212985c5f72a895a6984d72acd
 RUN set -eux; \
     case "${TARGETARCH:-amd64}" in \
-      amd64) VSCODE_ARCH=cli-linux-x64 ;; \
-      arm64) VSCODE_ARCH=cli-linux-arm64 ;; \
+      amd64) VSCODE_ARCH=cli-linux-x64;   VSCODE_SHA256="${VSCODE_CLI_SHA256_AMD64}" ;; \
+      arm64) VSCODE_ARCH=cli-linux-arm64; VSCODE_SHA256="${VSCODE_CLI_SHA256_ARM64}" ;; \
       *) echo "unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
+    if [ -z "${VSCODE_SHA256}" ]; then \
+      echo "ERROR: no SHA-256 set for ${TARGETARCH} — refusing to install an unverified VS Code CLI. Override VSCODE_CLI_VERSION + VSCODE_CLI_SHA256_${TARGETARCH} together." >&2; \
+      exit 1; \
+    fi; \
     curl -fLsS "https://update.code.visualstudio.com/${VSCODE_CLI_VERSION}/${VSCODE_ARCH}/stable" \
          -o /tmp/vscode-cli.tar.gz; \
-    if [ -n "${VSCODE_CLI_SHA256}" ]; then \
-      echo "${VSCODE_CLI_SHA256}  /tmp/vscode-cli.tar.gz" | sha256sum -c -; \
-    else \
-      echo "WARNING: VSCODE_CLI_SHA256 not set — installing unverified VS Code CLI tarball from update.code.visualstudio.com. Pin VSCODE_CLI_VERSION + VSCODE_CLI_SHA256 for reproducible, attested builds." >&2; \
-    fi; \
-    tar -xzf /tmp/vscode-cli.tar.gz -C /usr/local/bin; \
+    echo "${VSCODE_SHA256}  /tmp/vscode-cli.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/vscode-cli.tar.gz -C /usr/local/bin code; \
     rm /tmp/vscode-cli.tar.gz; \
     chmod +x /usr/local/bin/code; \
     /usr/local/bin/code --version

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -64,8 +64,26 @@ RUN npm install -g @anthropic-ai/claude-code
 #
 #     docker build --build-arg VSCODE_CLI_VERSION=1.96.4 ./session-image
 #     docker build --build-arg VSCODE_CLI_VERSION=commit:fabdb6a ./session-image
+#
+# Integrity: every other install in this image is verified (apt = GPG,
+# npm = package-lock integrity hashes) — this download is not, so a
+# compromised CDN response would install an arbitrary executable into
+# /usr/local/bin/code that every session container then runs as a user
+# with NOPASSWD:ALL sudo. To close that gap, pass an expected SHA-256 of
+# the .tar.gz alongside the pinned version. Only meaningful with a pinned
+# VSCODE_CLI_VERSION (the rolling `latest` artifact is hash-unstable):
+#
+#     docker build \
+#       --build-arg VSCODE_CLI_VERSION=1.96.4 \
+#       --build-arg VSCODE_CLI_SHA256=<sha256 of the matching .tar.gz> \
+#       ./session-image
+#
+# When VSCODE_CLI_SHA256 is empty the build still succeeds but logs a
+# loud warning, so the unverified path is opt-out by silence rather than
+# the default-blessed path.
 ARG TARGETARCH
 ARG VSCODE_CLI_VERSION=latest
+ARG VSCODE_CLI_SHA256=
 RUN set -eux; \
     case "${TARGETARCH:-amd64}" in \
       amd64) VSCODE_ARCH=cli-linux-x64 ;; \
@@ -74,6 +92,11 @@ RUN set -eux; \
     esac; \
     curl -fLsS "https://update.code.visualstudio.com/${VSCODE_CLI_VERSION}/${VSCODE_ARCH}/stable" \
          -o /tmp/vscode-cli.tar.gz; \
+    if [ -n "${VSCODE_CLI_SHA256}" ]; then \
+      echo "${VSCODE_CLI_SHA256}  /tmp/vscode-cli.tar.gz" | sha256sum -c -; \
+    else \
+      echo "WARNING: VSCODE_CLI_SHA256 not set — installing unverified VS Code CLI tarball from update.code.visualstudio.com. Pin VSCODE_CLI_VERSION + VSCODE_CLI_SHA256 for reproducible, attested builds." >&2; \
+    fi; \
     tar -xzf /tmp/vscode-cli.tar.gz -C /usr/local/bin; \
     rm /tmp/vscode-cli.tar.gz; \
     chmod +x /usr/local/bin/code; \

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -51,14 +51,28 @@ RUN npm install -g @anthropic-ai/claude-code
 # We pull the static linux build that matches the container arch (TARGETARCH
 # is set automatically by Docker Buildx: amd64 on Intel / x86 hosts, arm64
 # on Apple Silicon). The archive only contains a single `code` binary.
+#
+# Linkage: this base image is glibc (ubuntu:24.04), so we use the
+# `cli-linux-*` artifacts. The `cli-alpine-*` builds are musl-linked and
+# will fail at runtime on glibc with "not found" / "Exec format error".
+#
+# Pinning: VSCODE_CLI_VERSION defaults to `latest`, which resolves to the
+# current stable release at build time. The download URL is otherwise
+# unversioned, so the docker layer cache key would not invalidate when
+# upstream ships a new build — set this arg to pin a known-good version
+# for reproducible images:
+#
+#     docker build --build-arg VSCODE_CLI_VERSION=1.96.4 ./session-image
+#     docker build --build-arg VSCODE_CLI_VERSION=commit:fabdb6a ./session-image
 ARG TARGETARCH
+ARG VSCODE_CLI_VERSION=latest
 RUN set -eux; \
     case "${TARGETARCH:-amd64}" in \
-      amd64) VSCODE_ARCH=cli-alpine-x64 ;; \
-      arm64) VSCODE_ARCH=cli-alpine-arm64 ;; \
+      amd64) VSCODE_ARCH=cli-linux-x64 ;; \
+      arm64) VSCODE_ARCH=cli-linux-arm64 ;; \
       *) echo "unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
-    curl -fLsS "https://code.visualstudio.com/sha/download?build=stable&os=${VSCODE_ARCH}" \
+    curl -fLsS "https://update.code.visualstudio.com/${VSCODE_CLI_VERSION}/${VSCODE_ARCH}/stable" \
          -o /tmp/vscode-cli.tar.gz; \
     tar -xzf /tmp/vscode-cli.tar.gz -C /usr/local/bin; \
     rm /tmp/vscode-cli.tar.gz; \

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -11,6 +11,22 @@ set -e
 
 cd /home/developer/workspace
 
+# Persist VS Code CLI tunnel state across container replacement.
+#
+# `code tunnel` writes its device-login token, tunnel name, and registration
+# state into ~/.vscode-cli/. That path lives in the container layer, which
+# is thrown away on stop/start (POST /sessions/:id/start respawns a fresh
+# container, host reboot triggers reconcile()). Without this redirection,
+# every restart would force the user back through the interactive
+# https://github.com/login/device flow.
+#
+# Stash it inside the bind-mounted workspace dir instead, so it shares the
+# same lifetime contract as the user's source tree (kept on soft-delete +
+# restart, purged on hard-delete). Dot-prefixed so it stays out of normal
+# `ls` output and out of git's view.
+mkdir -p /home/developer/workspace/.vscode-cli
+ln -sfn /home/developer/workspace/.vscode-cli /home/developer/.vscode-cli
+
 echo "[entrypoint] container ready — create a tab from the UI to begin"
 
 # Keep PID 1 alive independent of tmux. tmux-server now starts lazily on the


### PR DESCRIPTION
## What

Bakes the standalone Microsoft VS Code CLI into the session image so users can run `code tunnel` from inside any session and attach from desktop VS Code (or `vscode.dev`) on any device.

## Why

Today the session image only ships Node.js, the Claude CLI, and the usual editors — there is no `code` binary, so `code tunnel` has nothing to run. Adding it means each session can be opened in a real VS Code window without SSH, port-forwards, or extra ingress on the home server: the tunnel is outbound to Microsoft and auth goes through GitHub/Microsoft, which slots into the existing Cloudflare-fronted setup cleanly.

## How

- `session-image/Dockerfile`: download the static `code` binary into `/usr/local/bin/code` and verify with `code --version`. Picks `cli-linux-x64` / `cli-linux-arm64` automatically via Buildx `TARGETARCH` (glibc artifacts, matching the Ubuntu base image — the `cli-alpine-*` builds are musl-linked and would crash at runtime on glibc).
- The default build is **reproducible and verified out of the box**: `VSCODE_CLI_VERSION` is pinned to a specific release commit and the tarball is checked against per-arch SHA-256 defaults (`VSCODE_CLI_SHA256_AMD64` / `VSCODE_CLI_SHA256_ARM64`) before extraction. An empty hash fails the build — there is no opt-out path. Only the named `code` member is extracted, so a tampered archive cannot drop additional executables into `/usr/local/bin`.
- `README.md`: new **Connecting from VS Code** section documenting the device-login flow inside the browser terminal, the Mac-side **Remote - Tunnels** extension steps, and the override syntax for bumping the pin.

## Test plan

\`\`\`bash
# Default — picks the pinned commit + verified hashes baked into the Dockerfile
docker compose build session-image

# Bumping the pin
docker build \
  --build-arg VSCODE_CLI_VERSION=commit:<sha> \
  --build-arg VSCODE_CLI_SHA256_AMD64=<x64 sha256> \
  --build-arg VSCODE_CLI_SHA256_ARM64=<arm64 sha256> \
  ./session-image
\`\`\`

Then create a fresh session, run `code tunnel` in a tmux tab, complete the device login, and connect from desktop VS Code via **Remote-Tunnels: Connect to Tunnel…**. The workspace at `/home/developer/workspace` is the bind-mounted persistent dir, so edits survive container restarts.