### PR TITLE
fix(session-image): pin developer to UID 1000, harden vscode-cli setup

### DIFF
--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -127,10 +127,16 @@ RUN set -eux; \
 # `ubuntu`, so we don't need a separate `groupdel`. The `|| true` is
 # defensive in case Canonical ever drops the pre-baked user from the
 # base image, which would make `userdel ubuntu` fail with "user does
-# not exist" — non-fatal here, since the slot is already free.
-RUN userdel -r ubuntu 2>/dev/null || true \
+# not exist" — non-fatal here, since the slot is already free. We
+# deliberately do NOT redirect stderr: if userdel ever fails for some
+# other reason (e.g. a future base where /home/ubuntu is a non-removable
+# mount), the build will still proceed via `|| true` but the next step's
+# "UID 1000 is not unique" failure will at least come with the actual
+# root cause printed in the build log.
+RUN userdel -r ubuntu || true \
     && useradd -m -s /bin/bash -u 1000 -U -G sudo developer \
     && echo "developer ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/developer
+
 
 USER developer
 WORKDIR /home/developer

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -119,17 +119,22 @@ RUN set -eux; \
 # `useradd -m developer` would skip 1000 (taken) and fall through to 1001,
 # silently breaking the invariant — that exact mismatch caused container
 # crash-loops where every `docker exec tmux list-sessions` returned 500
-# from /api/sessions/:id/tabs. Drop the `ubuntu` user (and its group)
-# explicitly so the slot is free, then create developer pinned to 1000.
-# `userdel -r` removes the home dir too; the `|| true` is defensive in
-# case Canonical ever drops the default user from the base image.
+# from /api/sessions/:id/tabs. Drop the `ubuntu` user explicitly so the
+# slot is free, then create developer pinned to 1000.
+#
+# `userdel -r` also removes the home dir and (because Ubuntu defaults
+# USERGROUPS_ENAB=yes in /etc/login.defs) the matching primary group
+# `ubuntu`, so we don't need a separate `groupdel`. The `|| true` is
+# defensive in case Canonical ever drops the pre-baked user from the
+# base image, which would make `userdel ubuntu` fail with "user does
+# not exist" — non-fatal here, since the slot is already free.
 RUN userdel -r ubuntu 2>/dev/null || true \
-    && groupdel ubuntu 2>/dev/null || true \
     && useradd -m -s /bin/bash -u 1000 -U -G sudo developer \
     && echo "developer ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/developer
 
 USER developer
 WORKDIR /home/developer
+
 
 # ── tmux config (nice defaults) ──────────────────────────────────────────────
 COPY --chown=developer:developer tmux.conf /home/developer/.tmux.conf

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -108,7 +108,24 @@ RUN set -eux; \
     /usr/local/bin/code --version
 
 # ── Non-root user ────────────────────────────────────────────────────────────
-RUN useradd -m -s /bin/bash -G sudo developer \
+# UID 1000 is non-negotiable: the backend chowns each session's workspace
+# bind-mount to WORKSPACE_UID:WORKSPACE_GID (default 1000:1000, see
+# dockerManager.ts) before starting the container. Anything else and
+# `developer` won't be able to write to /home/developer/workspace, which
+# bricks the entrypoint's `.vscode-cli` setup and any in-tab work.
+#
+# The wrinkle: Ubuntu 23.04+ base images (including 24.04 here) ship with
+# a pre-baked `ubuntu` user already holding UID/GID 1000. Plain
+# `useradd -m developer` would skip 1000 (taken) and fall through to 1001,
+# silently breaking the invariant — that exact mismatch caused container
+# crash-loops where every `docker exec tmux list-sessions` returned 500
+# from /api/sessions/:id/tabs. Drop the `ubuntu` user (and its group)
+# explicitly so the slot is free, then create developer pinned to 1000.
+# `userdel -r` removes the home dir too; the `|| true` is defensive in
+# case Canonical ever drops the default user from the base image.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && groupdel ubuntu 2>/dev/null || true \
+    && useradd -m -s /bin/bash -u 1000 -U -G sudo developer \
     && echo "developer ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/developer
 
 USER developer

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -24,8 +24,25 @@ cd /home/developer/workspace
 # same lifetime contract as the user's source tree (kept on soft-delete +
 # restart, purged on hard-delete). Dot-prefixed so it stays out of normal
 # `ls` output and out of git's view.
-mkdir -p /home/developer/workspace/.vscode-cli
-ln -sfn /home/developer/workspace/.vscode-cli /home/developer/.vscode-cli
+#
+# Both steps are best-effort: if the workspace mount is owned by a UID the
+# `developer` user can't write to (e.g. operator misconfigured WORKSPACE_UID,
+# or future Ubuntu base bumps and the Dockerfile fix slips), `mkdir` would
+# fail with EACCES and `set -e` would kill the entrypoint. That used to
+# crash-loop the whole container, taking every `docker exec` (including
+# `tmux list-sessions` from listTabs) down with it — a 500 from
+# /api/sessions/:id/tabs on every freshly-spawned session. Code tunnel
+# auth persistence is a nice-to-have; keeping the container alive isn't.
+# Trap the failure, log loudly enough that an operator can find it, and
+# carry on.
+if ! mkdir -p /home/developer/workspace/.vscode-cli 2>/dev/null; then
+        echo "[entrypoint] WARN: couldn't create workspace .vscode-cli dir " \
+             "(uid=$(id -u), workspace owner=$(stat -c '%u:%g' /home/developer/workspace 2>/dev/null || echo '?')). " \
+             "code tunnel auth won't persist across restarts." >&2
+elif ! ln -sfn /home/developer/workspace/.vscode-cli /home/developer/.vscode-cli 2>/dev/null; then
+        echo "[entrypoint] WARN: couldn't symlink ~/.vscode-cli into workspace; " \
+             "code tunnel auth won't persist across restarts." >&2
+fi
 
 echo "[entrypoint] container ready — create a tab from the UI to begin"
 

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -35,14 +35,21 @@ cd /home/developer/workspace
 # auth persistence is a nice-to-have; keeping the container alive isn't.
 # Trap the failure, log loudly enough that an operator can find it, and
 # carry on.
-if ! mkdir -p /home/developer/workspace/.vscode-cli 2>/dev/null; then
+#
+# stderr stays visible for the same reason the Dockerfile's `userdel`
+# does — the WARN line gives context, but the kernel's actual errno
+# (EACCES vs. ENOSPC vs. EROFS) is what an operator needs to fix the
+# real problem in `docker logs`. The `if !` test handles the non-zero
+# exit; we don't need to swallow the message too.
+if ! mkdir -p /home/developer/workspace/.vscode-cli; then
         echo "[entrypoint] WARN: couldn't create workspace .vscode-cli dir " \
              "(uid=$(id -u), workspace owner=$(stat -c '%u:%g' /home/developer/workspace 2>/dev/null || echo '?')). " \
              "code tunnel auth won't persist across restarts." >&2
-elif ! ln -sfn /home/developer/workspace/.vscode-cli /home/developer/.vscode-cli 2>/dev/null; then
+elif ! ln -sfn /home/developer/workspace/.vscode-cli /home/developer/.vscode-cli; then
         echo "[entrypoint] WARN: couldn't symlink ~/.vscode-cli into workspace; " \
              "code tunnel auth won't persist across restarts." >&2
 fi
+
 
 echo "[entrypoint] container ready — create a tab from the UI to begin"
 


### PR DESCRIPTION
## What

Two-line root-cause fix for a regression introduced by #107.

## Why

`ubuntu:24.04` ships with a pre-baked `ubuntu` user holding UID/GID 1000. The Dockerfile's `useradd -m developer` (no `-u`) skipped the taken slot and landed `developer` at 1001 — but `backend/src/dockerManager.ts` still chowns each session's workspace bind-mount to `WORKSPACE_UID:WORKSPACE_GID` (default `1000:1000`). End result: the workspace dir is owned by the now-vestigial `ubuntu` user, and `developer` can't write to it.

That mismatch was latent until #107, which added

    mkdir -p /home/developer/workspace/.vscode-cli
    ln -sfn /home/developer/workspace/.vscode-cli /home/developer/.vscode-cli

to `entrypoint.sh` for code-tunnel auth persistence. `mkdir` returns EACCES, `set -e` kills the entrypoint, the container exits, every subsequent `docker exec` (including the `tmux list-sessions` that backs `GET /api/sessions/:id/tabs`) fails — surfacing as a **500 on every freshly-spawned session with no tabs**, which is the symptom in the bug report.

## How

**Dockerfile:** drop the `ubuntu` user/group explicitly, then create `developer` pinned to `-u 1000 -U` so the `WORKSPACE_UID=1000` invariant the backend already assumes actually holds. `userdel -r ubuntu || true` + `groupdel ubuntu || true` so the build still works if Canonical drops the default user later.

**entrypoint.sh:** make the `.vscode-cli` mkdir + symlink best-effort — code-tunnel auth persistence is a nice-to-have, keeping the container alive isn't. On EACCES the entrypoint now logs a diagnostic with the offending uid/owner pair and falls through to `tail -f /dev/null`, so future drift is loud instead of silent and the rest of the session keeps working.

## Verifying

- `docker build -t shared-terminal-session ./session-image`
- `docker run --rm shared-terminal-session id developer` → `uid=1000(developer) gid=1000(developer)`
- Create a session in the UI; `GET /api/sessions/:id/tabs` returns `200 []` instead of `500`.