### PR TITLE
mobile: hide toolbar+tabs behind a header pill

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -126,7 +126,7 @@
           </form>
           <div id="session-list"></div>
           <div id="sidebar-footer">
-            <span id="sidebar-user-display" aria-hidden="true">●</span>
+            <span id="sidebar-user-display" aria-hidden="true"></span>
             <button id="sidebar-invites-btn" type="button">Invites</button>
             <button id="sidebar-logout-btn" type="button">Logout</button>
           </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -76,7 +76,7 @@
           type="button"
           aria-label="Toggle session controls"
           aria-expanded="false"
-          aria-controls="terminal-toolbar"
+          aria-controls="terminal-toolbar terminal-tabs"
           hidden
         >
           <span id="chrome-toggle-label">Session</span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -70,7 +70,31 @@
             <line x1="3" y1="18" x2="21" y2="18"></line>
           </svg>
         </button>
-        <h1>⬛ Shared Terminal</h1>
+        <h1 id="app-title">⬛ Shared Terminal</h1>
+        <button
+          id="chrome-toggle"
+          type="button"
+          aria-label="Toggle session controls"
+          aria-expanded="false"
+          aria-controls="terminal-toolbar"
+          hidden
+        >
+          <span id="chrome-toggle-label">Session</span>
+          <svg
+            id="chrome-toggle-icon"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="6 9 12 15 18 9"></polyline>
+          </svg>
+        </button>
         <div class="header-right">
           <span id="user-display"></span>
           <button id="invites-btn" title="Manage invite codes">Invites</button>
@@ -101,6 +125,11 @@
             <button type="submit">+ New</button>
           </form>
           <div id="session-list"></div>
+          <div id="sidebar-footer">
+            <span id="sidebar-user-display" aria-hidden="true">●</span>
+            <button id="sidebar-invites-btn" type="button">Invites</button>
+            <button id="sidebar-logout-btn" type="button">Logout</button>
+          </div>
         </aside>
         <section id="terminal-area">
           <div id="empty-state">Select or create a session →</div>

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -136,6 +136,47 @@ header h1 {
 #sidebar-toggle svg {
   display: block;
 }
+/* Chrome-toggle: a mobile-only button that surfaces the current session/tab
+   context AND toggles the toolbar+tabs drawer. Hidden on desktop because the
+   toolbar+tabs are always visible there; the explicit `hidden` attribute on
+   the element gives us the same effect when the app first paints, then JS
+   removes/re-applies it as the session state changes. */
+#chrome-toggle {
+  display: none;
+  align-items: center;
+  gap: 0.4rem;
+  background: transparent;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #c9d1d9;
+  font-size: 0.78rem;
+  padding: 0.3rem 0.55rem;
+  cursor: pointer;
+  /* Squeeze the label so it ellipsises rather than wrapping when the
+     active tab name is long ("npm-run-dev-watch-mode" etc.). */
+  min-width: 0;
+  max-width: 60vw;
+}
+#chrome-toggle:hover {
+  border-color: #58a6ff;
+  color: #58a6ff;
+}
+#chrome-toggle[hidden] {
+  display: none !important;
+}
+#chrome-toggle-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+#chrome-toggle-icon {
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+main.chrome-open #chrome-toggle-icon {
+  transform: rotate(180deg);
+}
 .header-right {
   margin-left: auto;
   display: flex;
@@ -415,6 +456,42 @@ main:not([data-sidebar-ready]) #sidebar {
   flex: 1;
   overflow-y: auto;
   padding: 0.5rem;
+}
+/* Mobile-only menu inside the sidebar drawer. On desktop the same
+   actions live in the header; on mobile we surface them here so the
+   header can stay slim. Hidden by default — the mobile media query
+   below flips this to flex. */
+#sidebar-footer {
+  display: none;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1rem;
+  border-top: 1px solid #30363d;
+  background: #0d1117;
+  flex-shrink: 0;
+}
+#sidebar-user-display {
+  font-size: 0.7rem;
+  color: #3fb950;
+  margin-right: auto;
+}
+#sidebar-invites-btn,
+#sidebar-logout-btn {
+  background: transparent;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #8b949e;
+  font-size: 0.78rem;
+  padding: 0.35rem 0.7rem;
+  cursor: pointer;
+}
+#sidebar-invites-btn:hover {
+  border-color: #58a6ff;
+  color: #58a6ff;
+}
+#sidebar-logout-btn:hover {
+  border-color: #f85149;
+  color: #f85149;
 }
 
 .session-item {
@@ -726,5 +803,78 @@ main:not([data-sidebar-ready]) #sidebar {
     display: block;
     background: rgba(0, 0, 0, 0.5);
     z-index: 15;
+  }
+
+  /* Slim header — every pixel here comes off the terminal viewport.
+     Drop the title text and the desktop user/invites/logout cluster;
+     the sidebar drawer's footer surfaces the same actions at the
+     ergonomic bottom of the screen instead. */
+  header {
+    padding: 0.45rem 0.6rem;
+    gap: 0.5rem;
+  }
+  header h1 {
+    /* Hide rather than remove from layout — keeps the document
+       outline intact for screen readers. */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+  .header-right {
+    display: none;
+  }
+  /* The chrome-toggle replaces the title as the centre-of-screen widget
+     while a session is active — its label shows "session › tab" so the
+     user always knows their context without expanding anything. */
+  #chrome-toggle:not([hidden]) {
+    display: inline-flex;
+    flex: 1;
+  }
+
+  /* Surface the mobile menu inside the sidebar drawer. */
+  #sidebar-footer {
+    display: flex;
+  }
+
+  /* When the chrome drawer is closed (default on mobile), force the
+     toolbar + tabs out of the layout entirely so the terminal owns
+     the full viewport. The desktop inline `display: flex/none` set
+     by main.ts toolbar/tabs visibility logic is preserved when the
+     drawer is open — we just gate it behind .chrome-open. */
+  main:not(.chrome-open) #terminal-toolbar,
+  main:not(.chrome-open) #terminal-tabs {
+    display: none !important;
+  }
+
+  /* Compact toolbar+tabs when they DO show — saves another ~30 % of
+     vertical space on a 430-pt-wide screen. */
+  #terminal-toolbar {
+    padding: 0.4rem 0.6rem;
+    gap: 0.5rem;
+    font-size: 0.72rem;
+  }
+  #terminal-tabs {
+    padding: 4px 6px 0 6px;
+  }
+  .tab-chip {
+    padding: 0.3rem 0.45rem;
+    max-width: 140px;
+  }
+  /* Touch targets — tap-to-close needs to stay reachable without zoom,
+     and the always-visible × is fine on mobile (no hover state to
+     gate it on like desktop has). */
+  .tab-close {
+    opacity: 1;
+    padding: 4px 6px;
+  }
+
+  /* Active session/tab in the sidebar should already be obvious — but
+     surfacing the action buttons (start/stop/✕) only on hover doesn't
+     work without a hover state on touch. Show them always on mobile. */
+  .session-actions {
+    opacity: 1;
   }
 }

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -820,7 +820,14 @@ main:not([data-sidebar-ready]) #sidebar {
     width: 1px;
     height: 1px;
     overflow: hidden;
-    clip: rect(0 0 0 0);
+    /* CSS 2.1 requires the rect() args to be comma-separated; the space-
+       separated form is a quirk most browsers still tolerate but isn't
+       guaranteed long-term. clip itself is deprecated, so pair it with the
+       modern clip-path so future engines that drop clip still hide the
+       node. Both rules together remain the canonical "visually hidden"
+       recipe (matches Bootstrap's .visually-hidden, Tailwind's sr-only). */
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
     white-space: nowrap;
   }
   .header-right {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -478,12 +478,20 @@ async function openSession(sessionId: string) {
                 return;
         }
 
+        // Tapping a session in the sidebar drawer is the user's "go to that
+        // tmux" gesture; collapse the chrome drawer too so the freshly-attached
+        // terminal gets the full viewport. Mirrors the chip-click and addTab
+        // success paths — without this, switching session-to-session on mobile
+        // leaves whichever drawer state was last set by the previous session
+        // covering the top of the viewport.
+        if (isMobile()) setChromeOpen(false);
 
         // openTab can throw synchronously (openTerminalSession init failure) —
         // openSession is called with `void`, so an unhandled throw here would
         // become an unhandled rejection with no toast and the UI left mid-switch.
         try {
                 openTab(currentTabs[0]!.tabId);
+
         } catch (err) {
                 if (activeSessionId === sessionId) {
                         activeSessionId = null;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -34,6 +34,8 @@ const authInviteCode = document.getElementById("auth-invite-code") as HTMLInputE
 const authSubmitBtn = document.getElementById("auth-submit") as HTMLButtonElement;
 
 const userDisplay = document.getElementById("user-display")!;
+const sidebarUserDisplay = document.getElementById("sidebar-user-display")!;
+
 const logoutBtn = document.getElementById("logout-btn")!;
 const invitesBtn = document.getElementById("invites-btn") as HTMLButtonElement;
 const invitesModal = document.getElementById("invites-modal")!;
@@ -163,8 +165,13 @@ function showApp() {
         authView.style.display = "none";
         appView.style.display = "flex";
         userDisplay.textContent = "●";
+        // Keep the sidebar-footer marker in lockstep with the header one so
+        // a future swap of "●" for the actual username only needs editing
+        // a single line.
+        sidebarUserDisplay.textContent = userDisplay.textContent;
         refreshSessions();
 }
+
 
 function updateAuthUI() {
         if (isRegisterMode) {
@@ -839,7 +846,16 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
         }
         currentTabs = currentTabs.filter((t) => t.tabId !== tabId);
 
+        // Closing the last tab on mobile leaves the chrome drawer collapsed
+        // (default state), and the CSS hides #terminal-tabs entirely while
+        // collapsed — so the + button rebuilt by renderTabBar() below isn't
+        // reachable until the user discovers the header pill. Mirror the
+        // openSession empty-tabs branch and auto-expand here too, so the
+        // first new tab is always one tap away.
+        if (isMobile() && currentTabs.length === 0) setChromeOpen(true);
+
         if (currentActiveTabId === tabId) {
+
                 currentActiveTabId = null;
                 // Nearest surviving neighbour: what was at the same index is now
                 // the next sibling; clamp to the new last tab when we closed the

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -47,6 +47,10 @@ const mainEl = document.querySelector("main")!;
 const sidebarEl = document.getElementById("sidebar")!;
 const sidebarToggleBtn = document.getElementById("sidebar-toggle") as HTMLButtonElement;
 const sidebarBackdrop = document.getElementById("sidebar-backdrop")!;
+const sidebarInvitesBtn = document.getElementById("sidebar-invites-btn") as HTMLButtonElement;
+const sidebarLogoutBtn = document.getElementById("sidebar-logout-btn") as HTMLButtonElement;
+const chromeToggleBtn = document.getElementById("chrome-toggle") as HTMLButtonElement;
+const chromeToggleLabel = document.getElementById("chrome-toggle-label")!;
 
 const terminalToolbar = document.getElementById("terminal-toolbar")!;
 const terminalSessionName = document.getElementById("terminal-session-name")!;
@@ -56,6 +60,7 @@ const terminalContainer = document.getElementById("terminal-container")!;
 const emptyState = document.getElementById("empty-state")!;
 const fontSizeBtn = document.getElementById("font-size-btn") as HTMLButtonElement;
 const toast = document.getElementById("toast")!;
+
 
 // ── Viewport height ─────────────────────────────────────────────────────────
 // iOS Safari's soft keyboard overlays the layout viewport without resizing
@@ -113,7 +118,13 @@ function disposeAllCurrentTerminals() {
         terminalTabs.innerHTML = "";
         terminalTabs.style.display = "none";
         terminalContainer.style.display = "none";
+        // Clearing the tabs invalidates the chrome-toggle label — refresh
+        // even though updateToolbar() (which would also do this) typically
+        // runs immediately after. The defensive call costs almost nothing
+        // and stops a stale "Tab N" lingering in the header on logout.
+        updateChromeToggle();
 }
+
 
 // ── Auth flow ───────────────────────────────────────────────────────────────
 
@@ -263,6 +274,15 @@ function handleLogout(toastMessage?: string): void {
 logoutBtn.addEventListener("click", () => {
         handleLogout();
 });
+
+// Mobile sidebar buttons just delegate to the desktop ones — single source
+// of truth for the actual handlers, so future changes to invites/logout
+// behaviour don't need to be mirrored in two places. Click() is enough
+// here: invitesBtn opens a modal (which manages its own focus), and
+// logoutBtn calls handleLogout() which tears the whole UI down anyway.
+sidebarInvitesBtn.addEventListener("click", () => invitesBtn.click());
+sidebarLogoutBtn.addEventListener("click", () => logoutBtn.click());
+
 
 // Listen for the api-layer signal that our JWT is no longer accepted (#95).
 // Without this, a `refreshSessions()` tick 15 s after expiry produces a
@@ -444,8 +464,13 @@ async function openSession(sessionId: string) {
         // their first tab, and keep the terminal pane hidden.
         if (currentTabs.length === 0) {
                 renderTabBar();
+                // On mobile the chrome drawer (where the + button lives) is
+                // collapsed by default — auto-expand it for the empty session
+                // so the user can actually find the + without hunting for it.
+                if (isMobile()) setChromeOpen(true);
                 return;
         }
+
 
         // openTab can throw synchronously (openTerminalSession init failure) —
         // openSession is called with `void`, so an unhandled throw here would
@@ -470,6 +495,7 @@ function updateToolbar() {
                 terminalTabs.style.display = "none";
                 terminalContainer.style.display = "none";
                 emptyState.style.display = "flex";
+                updateChromeToggle();
                 return;
         }
         terminalToolbar.style.display = "flex";
@@ -480,7 +506,11 @@ function updateToolbar() {
         terminalSessionName.textContent = s.name;
         terminalStatusBadge.textContent = s.status;
         terminalStatusBadge.className = s.status;
+        // Refresh the mobile header context pill — its label tracks the
+        // active session/tab, and visibility flips on/off here.
+        updateChromeToggle();
 }
+
 
 // ── Tabs within the active session ──────────────────────────────────────────
 
@@ -536,7 +566,13 @@ function renderTabBar() {
         addBtn.title = "Open a new tab (runs services independently; close to SIGHUP them)";
         addBtn.addEventListener("click", () => void addTab(addBtn));
         terminalTabs.appendChild(addBtn);
+        // The chrome-toggle label tracks whichever tab is active — refresh
+        // every time the bar is rebuilt so renames/closes/switches stay in
+        // sync without having to thread updateChromeToggle() through every
+        // caller of openTab/addTab/closeTab.
+        updateChromeToggle();
 }
+
 
 function openTab(tabId: string) {
         if (!activeSessionId) return;
@@ -723,7 +759,15 @@ async function addTab(triggeredBy?: HTMLButtonElement) {
                 currentTabs.push(tab);
                 try {
                         openTab(tab.tabId);
+                        // The tab-bar click listener auto-closes the chrome drawer
+                        // on chip clicks, but the + button is filtered out of that
+                        // path (it's not a chip yet at click time). Mirror the
+                        // behaviour here so adding a tab on mobile drops the user
+                        // straight into the new tmux pane instead of leaving the
+                        // drawer covering the top of the viewport.
+                        if (isMobile()) setChromeOpen(false);
                 } catch (err) {
+
                         // Roll back the push so the chip doesn't linger pointing at a
                         // tab with no currentTerminals entry, and clean up the backend
                         // tab fire-and-forget since it was never actually shown.
@@ -935,7 +979,13 @@ sessionList.addEventListener("click", (e) => {
 // already slid in (sidebar-open class still set, mobile CSS reads it as
 // "show drawer"), and a mobile user who widens the window would find the
 // sidebar column pinned at 0 with no visible trigger to recover.
-mobileMql.addEventListener("change", () => setSidebarOpen(!isMobile()));
+mobileMql.addEventListener("change", () => {
+        setSidebarOpen(!isMobile());
+        // Re-derive the chrome drawer state too — desktop always wants it open
+        // (since the toolbar/tabs are part of the layout there), and mobile
+        // wants it closed unless the user is mid-onboarding (no tabs yet).
+        setChromeOpen(chromeDefaultOpen());
+});
 
 // Default state: open on desktop, closed on mobile. The HTML+CSS start in
 // the closed state with transitions suppressed via `[data-sidebar-ready]`,
@@ -943,6 +993,76 @@ mobileMql.addEventListener("change", () => setSidebarOpen(!isMobile()));
 // that would otherwise fire on every desktop page load.
 setSidebarOpen(!isMobile());
 mainEl.setAttribute("data-sidebar-ready", "");
+
+// ── Chrome (toolbar + tabs) drawer toggle ───────────────────────────────────
+// Mobile only — desktop always shows the toolbar+tabs as part of the layout.
+// On mobile we hide them by default to give tmux the full viewport, and
+// surface a slim toggle in the header that mirrors the sessions-sidebar
+// pattern: tap to expand, tap a tab to collapse again.
+
+function chromeDefaultOpen(): boolean {
+        // Desktop: always open — the layout includes the toolbar/tabs row.
+        if (!isMobile()) return true;
+        // Mobile + active session with no tabs: expand so the user can see
+        // the "+" button and create their first tab. Without this they'd
+        // land on a blank screen with no obvious way forward.
+        if (activeSessionId !== null && currentTabs.length === 0) return true;
+        return false;
+}
+
+function setChromeOpen(open: boolean) {
+        mainEl.classList.toggle("chrome-open", open);
+        chromeToggleBtn.setAttribute("aria-expanded", String(open));
+}
+
+// Keep the header chrome-toggle's label in sync with the active session
+// and tab. On mobile this IS the only on-screen indication of "where you
+// are" — sessions sidebar and tabs row are both hidden by default.
+function updateChromeToggle() {
+        const s = sessions.find((x) => x.sessionId === activeSessionId);
+        // Hide the toggle entirely when there's no session — there's nothing
+        // for it to toggle, and the empty-state message in the terminal area
+        // already explains what to do next.
+        if (!s) {
+                chromeToggleBtn.hidden = true;
+                return;
+        }
+        chromeToggleBtn.hidden = false;
+        const activeTab = currentTabs.find((t) => t.tabId === currentActiveTabId);
+        // Format: "session › tab". Falls back to just the session name when
+        // no tab is active yet (fresh session, between switches). Using a
+        // thin space + chevron keeps it scannable on a 430-pt-wide screen.
+        chromeToggleLabel.textContent = activeTab
+                ? `${s.name} › ${activeTab.label}`
+                : s.name;
+}
+
+chromeToggleBtn.addEventListener("click", () => {
+        setChromeOpen(!mainEl.classList.contains("chrome-open"));
+});
+
+// On mobile, picking a tab from the chrome drawer is the user's signal
+// that they're done with the controls and want to focus on tmux —
+// auto-collapse so the terminal regains the full viewport. Mirrors the
+// sessions-sidebar drawer behaviour. Closing/adding tabs and the font-size
+// button are NOT collapse triggers: those are tweaks the user often
+// repeats in succession, and forcing a re-expand each time is annoying.
+terminalTabs.addEventListener("click", (e) => {
+        if (!isMobile()) return;
+        const target = e.target as HTMLElement;
+        // Ignore the × close button and the + add button — they're explicit
+        // affordances inside the chrome drawer that the user expects to stay
+        // accessible. Only collapse on a chip click (tab switch).
+        if (target.closest(".tab-close")) return;
+        if (target.closest("#tab-add")) return;
+        if (target.closest(".tab-chip")) setChromeOpen(false);
+});
+
+// Default chrome state — apply once, then defer to the per-action
+// setChromeOpen calls scattered through openSession/openTab/etc.
+setChromeOpen(chromeDefaultOpen());
+updateChromeToggle();
+
 
 // ── Font size cycle button ──────────────────────────────────────────────────
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -275,13 +275,13 @@ logoutBtn.addEventListener("click", () => {
         handleLogout();
 });
 
-// Mobile sidebar buttons just delegate to the desktop ones — single source
-// of truth for the actual handlers, so future changes to invites/logout
-// behaviour don't need to be mirrored in two places. Click() is enough
-// here: invitesBtn opens a modal (which manages its own focus), and
-// logoutBtn calls handleLogout() which tears the whole UI down anyway.
-sidebarInvitesBtn.addEventListener("click", () => invitesBtn.click());
+// Logout from the sidebar footer just delegates — handleLogout() tears
+// the whole UI down so focus return is moot. Invites is wired separately
+// further below: closeInvitesModal needs the actual opener button to
+// restore focus to (the desktop invitesBtn is `display:none` on mobile,
+// so a delegated `invitesBtn.click()` would silently lose focus on close).
 sidebarLogoutBtn.addEventListener("click", () => logoutBtn.click());
+
 
 
 // Listen for the api-layer signal that our JWT is no longer accepted (#95).
@@ -1086,12 +1086,20 @@ fontSizeBtn.textContent = `Aa ${currentFontSize}`;
 
 // ── Invites modal ───────────────────────────────────────────────────────────
 
-function openInvitesModal() {
+// Tracks which button opened the modal so close can return focus to the
+// same element. Without this, mobile users opening via the sidebar footer
+// would have focus restored to the desktop `invitesBtn` (display:none on
+// mobile) and lose their place in the tab order — `.focus()` is a no-op
+// on hidden elements.
+let invitesOpener: HTMLButtonElement | null = null;
+
+function openInvitesModal(opener: HTMLButtonElement) {
+        invitesOpener = opener;
         invitesModal.classList.add("open");
         invitesModal.setAttribute("aria-hidden", "false");
         // Move focus into the dialog so a keyboard user activating the Invites
         // button via Enter doesn't have their first Tab walk through the page
-        // behind the backdrop. Mirrors the invitesBtn.focus() in close.
+        // behind the backdrop. Restored to invitesOpener on close.
         inviteCreateBtn.focus();
         void renderInvites();
 }
@@ -1099,8 +1107,15 @@ function openInvitesModal() {
 function closeInvitesModal() {
         invitesModal.classList.remove("open");
         invitesModal.setAttribute("aria-hidden", "true");
-        invitesBtn.focus();
+        // Fall back to invitesBtn if the opener is missing (legacy path or
+        // a future caller that forgot to set it). On mobile invitesBtn is
+        // hidden, so a missing opener would still drop focus — but that's
+        // a regression to flag in code review, not something to silently
+        // paper over here.
+        (invitesOpener ?? invitesBtn).focus();
+        invitesOpener = null;
 }
+
 
 async function renderInvites() {
         inviteList.textContent = "Loading…";
@@ -1194,7 +1209,9 @@ async function renderInvites() {
         }
 }
 
-invitesBtn.addEventListener("click", openInvitesModal);
+invitesBtn.addEventListener("click", () => openInvitesModal(invitesBtn));
+sidebarInvitesBtn.addEventListener("click", () => openInvitesModal(sidebarInvitesBtn));
+
 
 inviteCreateBtn.addEventListener("click", async () => {
         inviteCreateBtn.disabled = true;


### PR DESCRIPTION
## What

Mobile-friendly layout for iPhone-sized viewports. On screens <= 768 px the header collapses to just `☰` (sessions) and a context pill that reads `session › tab`. Tapping the pill expands a drawer with the toolbar and tab strip. Tapping a tab chip dismisses the drawer, mirroring the sessions sidebar UX. `+` and `×` stay reachable while the drawer is open.

Invites and Logout move into a new sidebar footer so they're still reachable on mobile (the buttons delegate to the existing desktop handlers).

A freshly-created session with zero tabs auto-expands the drawer once so the `+` button is discoverable.

## Why

The user reported that on an iPhone 15 Pro Max in portrait, too much vertical space went to the title, status badge and tab strip, leaving little room for tmux. The drawer pattern frees the full viewport for the terminal while keeping the controls one tap away.

## Files

- `frontend/index.html` - chrome-toggle button + sidebar-footer markup
- `frontend/src/main.css` - chrome-toggle/sidebar-footer styles, expanded mobile media query
- `frontend/src/main.ts` - chrome drawer state, breakpoint sync, mobile menu delegation, auto-open on empty session, auto-close on chip/+ tap

## How to test

1. Open the app on a phone (or desktop devtools at 430 x 932).
2. Log in and pick a running session.
3. Header should show `☰` and a `name › Tab N` pill. Toolbar and tab strip should be hidden.
4. Tap the pill - toolbar/tabs slide in, chevron rotates.
5. Tap an existing tab chip - drawer collapses, terminal owns full viewport.
6. Tap `☰` - sessions drawer opens. Footer shows Invites + Logout. Both should work.
7. Create a fresh session with no tabs - drawer auto-expands so `+` is visible.
8. Resize past 768 px - desktop layout returns cleanly (header text, full toolbar, sidebar pinned).

TypeScript and Vite build are clean.
