### PR TITLE
feat(frontend): paste text into terminal from mobile

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -138,6 +138,14 @@
             <span id="terminal-session-name"></span>
             <span id="terminal-status-badge"></span>
             <button
+              id="paste-btn"
+              type="button"
+              title="Paste text into the terminal"
+              aria-label="Paste text into the terminal"
+            >
+              Paste
+            </button>
+            <button
               id="font-size-btn"
               type="button"
               title="Cycle terminal font size"
@@ -182,6 +190,49 @@
           + Generate new invite
         </button>
         <div id="invite-list" class="invite-list"></div>
+      </div>
+    </div>
+
+    <!-- Paste-into-terminal modal (mobile) -->
+    <div id="paste-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="paste-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="paste-modal-title">Paste into terminal</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint">
+          Long-press to paste from your clipboard, then tap Send. Multi-line
+          content is bracketed so it won't auto-execute on paste.
+        </p>
+        <textarea
+          id="paste-textarea"
+          rows="6"
+          maxlength="65536"
+          placeholder="Paste here…"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+        ></textarea>
+        <div class="paste-modal-actions">
+          <button id="paste-clipboard-btn" type="button">
+            Paste from clipboard
+          </button>
+          <button id="paste-send-btn" type="button" disabled>Send</button>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -355,6 +355,63 @@ main.chrome-open #chrome-toggle-icon {
   padding: 1rem 0;
 }
 
+/* ── Modal (paste) ─────────────────────────────────────────── */
+#paste-textarea {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #e6edf3;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  padding: 0.55rem 0.65rem;
+  resize: vertical;
+  min-height: 110px;
+  max-height: 50vh;
+  margin-bottom: 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+#paste-textarea:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+.paste-modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+#paste-clipboard-btn {
+  background: transparent;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #8b949e;
+  font-size: 0.82rem;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+}
+#paste-clipboard-btn:hover {
+  border-color: #58a6ff;
+  color: #58a6ff;
+}
+#paste-send-btn {
+  background: #238636;
+  border: 1px solid #238636;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.82rem;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+}
+#paste-send-btn:hover:not(:disabled) {
+  background: #2ea043;
+  border-color: #2ea043;
+}
+#paste-send-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 main {
   flex: 1;
   display: grid;
@@ -625,6 +682,23 @@ main:not([data-sidebar-ready]) #sidebar {
   border-color: #58a6ff;
   color: #58a6ff;
 }
+/* Paste button is mobile-only — desktop xterm handles Cmd/Ctrl+V natively.
+   Shown via the @media (max-width: 768px) block below. */
+#paste-btn {
+  display: none;
+  background: transparent;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #8b949e;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.55rem;
+  cursor: pointer;
+  line-height: 1;
+}
+#paste-btn:hover {
+  border-color: #58a6ff;
+  color: #58a6ff;
+}
 #terminal-tabs {
   display: none;
   align-items: stretch;
@@ -883,5 +957,19 @@ main:not([data-sidebar-ready]) #sidebar {
      work without a hover state on touch. Show them always on mobile. */
   .session-actions {
     opacity: 1;
+  }
+
+  /* Paste button surfaces only on mobile and sits left of the font-size
+     button on the right side of the toolbar. paste-btn carries the
+     `margin-left: auto` that pushes the action cluster to the right; we
+     drop font-size-btn's own auto-margin so the two don't fight over the
+     free space (two auto margins in the same flex line would split the
+     slack and leave paste-btn floating in the middle). */
+  #paste-btn {
+    display: inline-flex;
+    margin-left: auto;
+  }
+  #font-size-btn {
+    margin-left: 0;
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1315,6 +1315,12 @@ function closePasteModal() {
         pasteModal.setAttribute("aria-hidden", "true");
         pasteTextarea.value = "";
         pasteSendBtn.disabled = true;
+        // Release the pasteBtn in-flight guard. The pasteBtn click handler
+        // intentionally leaves it set on the modal-open path so a second
+        // tap can't kick off a parallel readClipboardText() while the modal
+        // is open; closure of the modal is the signal that the cycle is
+        // truly finished.
+        pasteInFlight = false;
         // Restore focus to the opener; on mobile the chrome drawer is open
         // when the modal is dismissed, so paste-btn is reachable. If the
         // opener is somehow gone (drawer collapsed externally), the focus
@@ -1338,17 +1344,25 @@ async function readClipboardText(): Promise<string | null> {
         }
 }
 
-// Guards against the iOS "Paste" consent chip race: the chip can take a
-// second to appear, and a second tap during that window would re-enter
-// this handler. If the chip is then dismissed on both paths, both calls
-// fall through to openPasteModal(), and the second one resets
-// pasteTextarea.value silently — clobbering anything the user just
-// started typing in the modal opened by the first call.
+// Guards against two distinct races:
+//   1. iOS "Paste" consent chip: the chip can take a second to appear,
+//      and a second tap during that window would re-enter the async path
+//      and queue a second clipboard read.
+//   2. Modal-open window: openPasteModal() is synchronous, so a naive
+//      try/finally would clear the guard the moment the modal opens —
+//      letting another tap re-fire and re-initialise the modal,
+//      clobbering text the user has started typing in the textarea.
+//
+// The guard therefore stays held across the modal lifetime; closePasteModal
+// is the single release point. The local `releaseGuard` boolean tracks
+// which exit path we're on so the silent-paste path still releases via
+// finally without depending on a synthetic catch-and-rethrow.
 let pasteInFlight = false;
 
 pasteBtn.addEventListener("click", async () => {
         if (pasteInFlight) return;
         pasteInFlight = true;
+        let releaseGuard = true;
         try {
                 const term = getActiveTerminal();
                 if (!term) {
@@ -1370,9 +1384,13 @@ pasteBtn.addEventListener("click", async () => {
                         return;
                 }
                 // Clipboard API unavailable or denied — surface the manual fallback.
+                // Hand the guard ownership to closePasteModal so the second-tap
+                // protection covers the entire modal lifetime, not just the
+                // synchronous tail of this handler.
                 openPasteModal(pasteBtn);
+                releaseGuard = false;
         } finally {
-                pasteInFlight = false;
+                if (releaseGuard) pasteInFlight = false;
         }
 });
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -985,9 +985,13 @@ sidebarBackdrop.addEventListener("click", () => setSidebarOpen(false));
 // Escape closes the mobile drawer, matching the WAI-ARIA modal-dialog
 // expectation. Desktop ignores this — the sidebar is always part of the
 // layout there and Escape conflicts with terminal/xterm key handling.
+// Skip when a modal is open: WAI-ARIA says Escape dismisses the topmost
+// dialog, not every overlay at once. Without this guard, an Escape press
+// while paste/invites and the sidebar are both open would close both.
 document.addEventListener("keydown", (e) => {
         if (e.key !== "Escape") return;
         if (!isMobile()) return;
+        if (invitesModal.classList.contains("open") || pasteModal.classList.contains("open")) return;
         if (!mainEl.classList.contains("sidebar-open")) return;
         setSidebarOpen(false);
 });
@@ -1325,24 +1329,38 @@ async function readClipboardText(): Promise<string | null> {
         }
 }
 
+// Guards against the iOS "Paste" consent chip race: the chip can take a
+// second to appear, and a second tap during that window would re-enter
+// this handler. If the chip is then dismissed on both paths, both calls
+// fall through to openPasteModal(), and the second one resets
+// pasteTextarea.value silently — clobbering anything the user just
+// started typing in the modal opened by the first call.
+let pasteInFlight = false;
+
 pasteBtn.addEventListener("click", async () => {
-        const term = getActiveTerminal();
-        if (!term) {
-                showToast("No active session", true);
-                return;
-        }
-        const clip = await readClipboardText();
-        if (clip !== null) {
-                if (clip.length === 0) {
-                        showToast("Clipboard is empty", true);
+        if (pasteInFlight) return;
+        pasteInFlight = true;
+        try {
+                const term = getActiveTerminal();
+                if (!term) {
+                        showToast("No active session", true);
                         return;
                 }
-                term.paste(clip);
-                showToast(`Pasted ${clip.length} character${clip.length === 1 ? "" : "s"}`);
-                return;
+                const clip = await readClipboardText();
+                if (clip !== null) {
+                        if (clip.length === 0) {
+                                showToast("Clipboard is empty", true);
+                                return;
+                        }
+                        term.paste(clip);
+                        showToast(`Pasted ${clip.length} character${clip.length === 1 ? "" : "s"}`);
+                        return;
+                }
+                // Clipboard API unavailable or denied — surface the manual fallback.
+                openPasteModal(pasteBtn);
+        } finally {
+                pasteInFlight = false;
         }
-        // Clipboard API unavailable or denied — surface the manual fallback.
-        openPasteModal(pasteBtn);
 });
 
 pasteClipboardBtn.addEventListener("click", async () => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -61,6 +61,11 @@ const terminalTabs = document.getElementById("terminal-tabs")!;
 const terminalContainer = document.getElementById("terminal-container")!;
 const emptyState = document.getElementById("empty-state")!;
 const fontSizeBtn = document.getElementById("font-size-btn") as HTMLButtonElement;
+const pasteBtn = document.getElementById("paste-btn") as HTMLButtonElement;
+const pasteModal = document.getElementById("paste-modal")!;
+const pasteTextarea = document.getElementById("paste-textarea") as HTMLTextAreaElement;
+const pasteClipboardBtn = document.getElementById("paste-clipboard-btn") as HTMLButtonElement;
+const pasteSendBtn = document.getElementById("paste-send-btn") as HTMLButtonElement;
 const toast = document.getElementById("toast")!;
 
 
@@ -1257,9 +1262,125 @@ invitesModal.addEventListener("click", (e) => {
 });
 
 document.addEventListener("keydown", (e) => {
-        if (e.key === "Escape" && invitesModal.classList.contains("open")) {
+        if (e.key !== "Escape") return;
+        if (invitesModal.classList.contains("open")) {
                 closeInvitesModal();
+        } else if (pasteModal.classList.contains("open")) {
+                closePasteModal();
         }
+});
+
+// ── Paste modal ─────────────────────────────────────────────────────────────
+// Mobile soft-keyboards don't surface a usable Cmd-V into xterm's helper
+// textarea — the OS clipboard chooser either does nothing or trickles bytes
+// in as individual keystrokes that bypass bracketed-paste, so a multi-line
+// paste gets line-by-line executed by the shell. This modal gives users a
+// reliable surface: try `navigator.clipboard.readText()` first (silent on
+// Android Chrome and after iOS's first consent), and fall back to a
+// long-press-able textarea when the API is blocked or rejected.
+
+let pasteOpener: HTMLButtonElement | null = null;
+
+function getActiveTerminal(): TerminalSession | null {
+        if (!currentActiveTabId) return null;
+        return currentTerminals.get(currentActiveTabId)?.term ?? null;
+}
+
+function openPasteModal(opener: HTMLButtonElement) {
+        pasteOpener = opener;
+        pasteModal.classList.add("open");
+        pasteModal.setAttribute("aria-hidden", "false");
+        pasteTextarea.value = "";
+        pasteSendBtn.disabled = true;
+        // Focus the textarea so the soft keyboard pops and a long-press
+        // immediately offers Paste — saves the user one tap.
+        pasteTextarea.focus();
+}
+
+function closePasteModal() {
+        pasteModal.classList.remove("open");
+        pasteModal.setAttribute("aria-hidden", "true");
+        pasteTextarea.value = "";
+        pasteSendBtn.disabled = true;
+        // Restore focus to the opener; on mobile the chrome drawer is open
+        // when the modal is dismissed, so paste-btn is reachable. If the
+        // opener is somehow gone (drawer collapsed externally), the focus
+        // call is a harmless no-op.
+        pasteOpener?.focus();
+        pasteOpener = null;
+}
+
+async function readClipboardText(): Promise<string | null> {
+        // navigator.clipboard.readText is the silent path. Returns null when
+        // the API is unavailable, rejected (permission denied / in-app
+        // webview), or throws synchronously on browsers that ship the API
+        // gated on a secure context they don't recognise.
+        if (!navigator.clipboard || typeof navigator.clipboard.readText !== "function") {
+                return null;
+        }
+        try {
+                return await navigator.clipboard.readText();
+        } catch {
+                return null;
+        }
+}
+
+pasteBtn.addEventListener("click", async () => {
+        const term = getActiveTerminal();
+        if (!term) {
+                showToast("No active session", true);
+                return;
+        }
+        const clip = await readClipboardText();
+        if (clip !== null) {
+                if (clip.length === 0) {
+                        showToast("Clipboard is empty", true);
+                        return;
+                }
+                term.paste(clip);
+                showToast(`Pasted ${clip.length} character${clip.length === 1 ? "" : "s"}`);
+                return;
+        }
+        // Clipboard API unavailable or denied — surface the manual fallback.
+        openPasteModal(pasteBtn);
+});
+
+pasteClipboardBtn.addEventListener("click", async () => {
+        const clip = await readClipboardText();
+        if (clip === null) {
+                showToast("Couldn't read clipboard — long-press to paste manually", true);
+                return;
+        }
+        if (clip.length === 0) {
+                showToast("Clipboard is empty", true);
+                return;
+        }
+        pasteTextarea.value = clip;
+        pasteSendBtn.disabled = false;
+        pasteTextarea.focus();
+});
+
+pasteTextarea.addEventListener("input", () => {
+        pasteSendBtn.disabled = pasteTextarea.value.length === 0;
+});
+
+pasteSendBtn.addEventListener("click", () => {
+        const text = pasteTextarea.value;
+        if (!text) return;
+        const term = getActiveTerminal();
+        if (!term) {
+                showToast("No active session", true);
+                closePasteModal();
+                return;
+        }
+        term.paste(text);
+        showToast(`Pasted ${text.length} character${text.length === 1 ? "" : "s"}`);
+        closePasteModal();
+});
+
+pasteModal.addEventListener("click", (e) => {
+        const target = e.target as HTMLElement;
+        if (target.hasAttribute("data-close-modal")) closePasteModal();
 });
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1283,6 +1283,15 @@ document.addEventListener("keydown", (e) => {
 // Android Chrome and after iOS's first consent), and fall back to a
 // long-press-able textarea when the API is blocked or rejected.
 
+// Mirror of the textarea's HTML `maxlength` (frontend/index.html). The
+// silent clipboard path bypasses the textarea entirely, and `pasteTextarea
+// .value = clip` in the clipboard-fill handler isn't constrained by HTML
+// maxlength either (that attribute only gates user typing). A user with a
+// multi-megabyte clipboard pasted straight to the tmux exec stream would
+// freeze the pane long before the WS layer's default 100 MB limit fired —
+// cap explicitly so the toast is the worst they see.
+const MAX_PASTE_CHARS = 65_536;
+
 let pasteOpener: HTMLButtonElement | null = null;
 
 function getActiveTerminal(): TerminalSession | null {
@@ -1352,6 +1361,10 @@ pasteBtn.addEventListener("click", async () => {
                                 showToast("Clipboard is empty", true);
                                 return;
                         }
+                        if (clip.length > MAX_PASTE_CHARS) {
+                                showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
+                                return;
+                        }
                         term.paste(clip);
                         showToast(`Pasted ${clip.length} character${clip.length === 1 ? "" : "s"}`);
                         return;
@@ -1373,6 +1386,10 @@ pasteClipboardBtn.addEventListener("click", async () => {
                 showToast("Clipboard is empty", true);
                 return;
         }
+        if (clip.length > MAX_PASTE_CHARS) {
+                showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
+                return;
+        }
         pasteTextarea.value = clip;
         pasteSendBtn.disabled = false;
         pasteTextarea.focus();
@@ -1385,6 +1402,13 @@ pasteTextarea.addEventListener("input", () => {
 pasteSendBtn.addEventListener("click", () => {
         const text = pasteTextarea.value;
         if (!text) return;
+        // Defence in depth — HTML maxlength gates user typing but not
+        // programmatic value sets, so a clipboard-fill of >65 KB could
+        // sneak past it before this point.
+        if (text.length > MAX_PASTE_CHARS) {
+                showToast(`Too large (${text.length} chars; max ${MAX_PASTE_CHARS})`, true);
+                return;
+        }
         const term = getActiveTerminal();
         if (!term) {
                 showToast("No active session", true);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1377,22 +1377,32 @@ pasteBtn.addEventListener("click", async () => {
 });
 
 pasteClipboardBtn.addEventListener("click", async () => {
-        const clip = await readClipboardText();
-        if (clip === null) {
-                showToast("Couldn't read clipboard — long-press to paste manually", true);
-                return;
+        // Disable for the duration of the async readText() so a double-tap on
+        // a slow iOS consent chip doesn't queue a stale second resolve. Same
+        // intent as the pasteBtn pasteInFlight guard, just expressed via the
+        // button's own disabled state since there's nowhere visual to look
+        // for in-flight feedback otherwise.
+        pasteClipboardBtn.disabled = true;
+        try {
+                const clip = await readClipboardText();
+                if (clip === null) {
+                        showToast("Couldn't read clipboard — long-press to paste manually", true);
+                        return;
+                }
+                if (clip.length === 0) {
+                        showToast("Clipboard is empty", true);
+                        return;
+                }
+                if (clip.length > MAX_PASTE_CHARS) {
+                        showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
+                        return;
+                }
+                pasteTextarea.value = clip;
+                pasteSendBtn.disabled = false;
+                pasteTextarea.focus();
+        } finally {
+                pasteClipboardBtn.disabled = false;
         }
-        if (clip.length === 0) {
-                showToast("Clipboard is empty", true);
-                return;
-        }
-        if (clip.length > MAX_PASTE_CHARS) {
-                showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
-                return;
-        }
-        pasteTextarea.value = clip;
-        pasteSendBtn.disabled = false;
-        pasteTextarea.focus();
 });
 
 pasteTextarea.addEventListener("input", () => {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -407,7 +407,6 @@ export function openTerminalSession(opts: {
         // bash, zsh, and Claude CLI all do — so multi-line content arrives as
         // one paste event instead of being executed line-by-line.
         function paste(text: string) {
-                if (!text) return;
                 term.paste(text);
         }
 

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -13,6 +13,7 @@ export type SessionStatus = "running" | "stopped" | "terminated" | "disconnected
 export interface TerminalSession {
         dispose(): void;
         setFontSize(px: number): void;
+        paste(text: string): void;
 }
 
 export type StatusCallback = (status: SessionStatus) => void;
@@ -400,6 +401,16 @@ export function openTerminalSession(opts: {
                 scheduleFit();
         }
 
+        // term.paste() routes through the same onData handler that pipes browser
+        // → WS, and wraps the bytes in DECSET 2004 bracketed-paste sequences
+        // (\e[200~ … \e[201~) when the receiving app has bracketed paste on —
+        // bash, zsh, and Claude CLI all do — so multi-line content arrives as
+        // one paste event instead of being executed line-by-line.
+        function paste(text: string) {
+                if (!text) return;
+                term.paste(text);
+        }
+
         // ── Dispose ─────────────────────────────────────────────────────────────
         function dispose() {
                 disposed = true;
@@ -431,7 +442,7 @@ export function openTerminalSession(opts: {
                 term.dispose();
         }
 
-        return { dispose, setFontSize };
+        return { dispose, setFontSize, paste };
 }
 
 // ── Multiline URL link provider ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Mobile users have no reliable way to paste text into the terminal today: the OS clipboard chooser either does nothing when xterm has focus, or trickles bytes in as individual keystrokes that bypass DECSET 2004 bracketed-paste, so multi-line content gets line-by-line executed by the shell.

This PR adds a **Paste** button to the terminal toolbar (mobile-only — desktop already has working Cmd/Ctrl+V) and a small modal fallback for browsers where the Clipboard API is blocked.

## How it works

When the user taps **Paste** in the toolbar (visible only when the chrome drawer is open on mobile):

1. **Silent path first** — call `navigator.clipboard.readText()`.
   - **Android Chrome / Edge:** prompts once, then silent on subsequent taps.
   - **iOS Safari (16+):** shows the system "Paste" consent chip; on tap, the bytes flow through.
   - On success, the text is written via `term.paste()` and a toast confirms `Pasted N characters`.
2. **Fallback to modal** — if the Clipboard API is unavailable (Firefox quirks, in-app webviews, permission denied), open a textarea modal.
   - User long-presses the textarea, taps OS Paste, taps **Send**.
   - There's also a **Paste from clipboard** button inside the modal that retries `readText()` (useful when the user grants permission only after seeing the prompt).
3. **Bracketed-paste wrapping is automatic** — `term.paste()` wraps the bytes in `\e[200~ … \e[201~` when the receiving app has bracketed paste on (bash, zsh, Claude CLI all do), so multi-line pastes arrive as one paste event instead of being executed line-by-line.

The modal mirrors the existing `#invites-modal` pattern — backdrop, `role="dialog"`, `aria-modal`, `data-close-modal` on backdrop + ×, Escape key handling, focus restoration to the opener button.

## Files

- `frontend/src/terminal.ts` — expose `paste(text)` on `TerminalSession`; thin wrapper around xterm's built-in `term.paste()`.
- `frontend/index.html` — `#paste-btn` in `#terminal-toolbar`, `#paste-modal` markup.
- `frontend/src/main.css` — paste button styling, mobile-only `display`, modal/textarea/action styles.
- `frontend/src/main.ts` — `getActiveTerminal()`, paste-button click handler with the clipboard-then-modal flow, modal open/close + Escape extension, `data-close-modal` wiring.

Backend untouched — the bytes flow through the existing WS input path.

## Test plan

- [ ] **Desktop:** Paste button is hidden; Cmd/Ctrl+V into xterm still works.
- [ ] **Mobile, Android Chrome:** open chrome drawer → tap Paste → grant clipboard permission once → subsequent taps paste silently.
- [ ] **Mobile, iOS Safari:** tap Paste → "Paste" consent chip appears → tap chip → bytes flow into terminal.
- [ ] **Mobile, in-app webview / Clipboard denied:** tap Paste → modal opens → long-press textarea → Paste → Send.
- [ ] **Multi-line paste into Claude CLI:** lines arrive as one paste event (no auto-submit per line).
- [ ] **Empty clipboard:** toast says "Clipboard is empty"; modal does not auto-open.
- [ ] **No active session:** Paste button is hidden because the toolbar itself is hidden in empty-state.
- [ ] **Disconnected session:** paste silently no-ops (WS guard at `terminal.ts:393`); user already sees the disconnected badge.
- [ ] **Escape key:** closes the paste modal when open; doesn't fight with the invites modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)