### PR TITLE
fix(frontend): move mobile paste button to header for one-tap reach

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -100,6 +100,15 @@
           <button id="invites-btn" title="Manage invite codes">Invites</button>
           <button id="logout-btn">Logout</button>
         </div>
+        <button
+          id="paste-btn"
+          type="button"
+          title="Paste text into the terminal"
+          aria-label="Paste text into the terminal"
+          hidden
+        >
+          Paste
+        </button>
       </header>
       <main>
         <div id="sidebar-backdrop" aria-hidden="true"></div>
@@ -137,14 +146,6 @@
             <span>Session:</span>
             <span id="terminal-session-name"></span>
             <span id="terminal-status-badge"></span>
-            <button
-              id="paste-btn"
-              type="button"
-              title="Paste text into the terminal"
-              aria-label="Paste text into the terminal"
-            >
-              Paste
-            </button>
             <button
               id="font-size-btn"
               type="button"

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -682,22 +682,30 @@ main:not([data-sidebar-ready]) #sidebar {
   border-color: #58a6ff;
   color: #58a6ff;
 }
-/* Paste button is mobile-only — desktop xterm handles Cmd/Ctrl+V natively.
-   Shown via the @media (max-width: 768px) block below. */
+/* Paste button lives in the header; mobile-only because desktop xterm
+   handles Cmd/Ctrl+V natively. The default `display: none` keeps it out
+   of the desktop layout entirely, the @media (max-width: 768px) block
+   below flips it to inline-flex when not [hidden] (the hidden attribute
+   is toggled by main.ts in lockstep with the chrome-toggle pill — both
+   are gated on whether there's an active session). */
 #paste-btn {
   display: none;
   background: transparent;
   border: 1px solid #30363d;
   border-radius: 6px;
-  color: #8b949e;
-  font-size: 0.75rem;
-  padding: 0.2rem 0.55rem;
+  color: #c9d1d9;
+  font-size: 0.78rem;
+  padding: 0.3rem 0.7rem;
   cursor: pointer;
   line-height: 1;
+  font-weight: 500;
 }
 #paste-btn:hover {
   border-color: #58a6ff;
   color: #58a6ff;
+}
+#paste-btn:active {
+  background: rgba(88, 166, 255, 0.1);
 }
 #terminal-tabs {
   display: none;
@@ -959,17 +967,10 @@ main:not([data-sidebar-ready]) #sidebar {
     opacity: 1;
   }
 
-  /* Paste button surfaces only on mobile and sits left of the font-size
-     button on the right side of the toolbar. paste-btn carries the
-     `margin-left: auto` that pushes the action cluster to the right; we
-     drop font-size-btn's own auto-margin so the two don't fight over the
-     free space (two auto margins in the same flex line would split the
-     slack and leave paste-btn floating in the middle). */
-  #paste-btn {
+  /* Paste lives at the right edge of the mobile header. The chrome-toggle
+     pill in the middle has `flex: 1`, so it eats the slack and pushes
+     paste-btn naturally to the right — no margin-left:auto needed. */
+  #paste-btn:not([hidden]) {
     display: inline-flex;
-    margin-left: auto;
-  }
-  #font-size-btn {
-    margin-left: 0;
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1051,6 +1051,8 @@ function setChromeOpen(open: boolean) {
 // Keep the header chrome-toggle's label in sync with the active session
 // and tab. On mobile this IS the only on-screen indication of "where you
 // are" — sessions sidebar and tabs row are both hidden by default.
+// The mobile paste button rides the same visibility lifecycle: nothing
+// to paste into when no session is active, so hide both together.
 function updateChromeToggle() {
         const s = sessions.find((x) => x.sessionId === activeSessionId);
         // Hide the toggle entirely when there's no session — there's nothing
@@ -1058,9 +1060,11 @@ function updateChromeToggle() {
         // already explains what to do next.
         if (!s) {
                 chromeToggleBtn.hidden = true;
+                pasteBtn.hidden = true;
                 return;
         }
         chromeToggleBtn.hidden = false;
+        pasteBtn.hidden = false;
         const activeTab = currentTabs.find((t) => t.tabId === currentActiveTabId);
         // Format: "session › tab". Falls back to just the session name when
         // no tab is active yet (fresh session, between switches). Using a


### PR DESCRIPTION
## Summary

Follow-up to #110. The Paste button shipped in the terminal toolbar — which is collapsed by default on mobile and only appears after tapping the chrome-toggle pill in the header. Reported on iPhone test: the button wasn't visible at all without first discovering the drawer gesture.

This PR moves it into the header next to (logically right of) the chrome-toggle pill so it's there the moment a session is active. Single tap to reach.

## How it works

- `#paste-btn` moves from `#terminal-toolbar` to `<header>` (right of `.header-right`).
- Visibility mirrors `#chrome-toggle`: both gated on `updateChromeToggle()` based on whether there's an active session — nothing to paste into when none is selected.
- Mobile-only via the existing `@media (max-width: 768px)` block. Desktop stays unchanged (Cmd/Ctrl+V works natively in xterm).
- Layout: chrome-toggle pill has `flex: 1` so it eats the slack and pushes paste-btn to the right naturally — no `margin-left: auto` gymnastics required, unlike the toolbar version.

Drop the toolbar-internal positioning override (`margin-left: 0` on `font-size-btn` to suppress its auto-margin fight with paste-btn) since paste-btn no longer lives there.

## Test plan

- [ ] **Mobile portrait:** Paste button visible in header next to the session pill the moment a session is active.
- [ ] **Mobile, no session:** Paste button hidden (alongside the chrome pill).
- [ ] **Mobile, session selected then deleted:** Button hides automatically.
- [ ] **Desktop:** Button completely absent from the header.
- [ ] **Behaviour unchanged:** Tapping Paste still tries `navigator.clipboard.readText()` first, falls back to the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)