### PR TITLE
fix(frontend): iOS empty-clipboard fallback + pin paste-btn right

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -970,7 +970,10 @@ main:not([data-sidebar-ready]) #sidebar {
   /* Paste lives at the right edge of the mobile header. chrome-toggle
      has `flex: 1` when active, but it can be hidden (no session
      selected) — `margin-left: auto` pins paste-btn to the right edge
-     in both cases. */
+     in both cases. Safe inside this @media block because #paste-btn
+     is `display: none` at the desktop default; if the button is ever
+     exposed at the desktop breakpoint, this rule needs to lose the
+     auto-margin or it'll fight `.header-right`'s own auto-margin. */
   #paste-btn:not([hidden]) {
     display: inline-flex;
     margin-left: auto;

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -967,10 +967,12 @@ main:not([data-sidebar-ready]) #sidebar {
     opacity: 1;
   }
 
-  /* Paste lives at the right edge of the mobile header. The chrome-toggle
-     pill in the middle has `flex: 1`, so it eats the slack and pushes
-     paste-btn naturally to the right — no margin-left:auto needed. */
+  /* Paste lives at the right edge of the mobile header. chrome-toggle
+     has `flex: 1` when active, but it can be hidden (no session
+     selected) — `margin-left: auto` pins paste-btn to the right edge
+     in both cases. */
   #paste-btn:not([hidden]) {
     display: inline-flex;
+    margin-left: auto;
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1415,9 +1415,11 @@ pasteClipboardBtn.addEventListener("click", async () => {
                 // clipboard text". null = API unavailable/denied. "" = iOS
                 // resolved without engaging the consent chip, OR the
                 // clipboard genuinely is empty. Either way the textarea
-                // (long-press fallback) is the right next step.
+                // (long-press fallback) is the right next step. The toast
+                // covers both interpretations because we can't distinguish
+                // them: iOS doesn't tell us which "" we got.
                 if (!clip) {
-                        showToast("Couldn't read clipboard — long-press to paste manually", true);
+                        showToast("Clipboard is empty or couldn't be read — long-press to paste manually", true);
                         return;
                 }
                 if (clip.length > MAX_PASTE_CHARS) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1374,11 +1374,14 @@ pasteBtn.addEventListener("click", async () => {
                         return;
                 }
                 const clip = await readClipboardText();
-                if (clip !== null) {
-                        if (clip.length === 0) {
-                                showToast("Clipboard is empty", true);
-                                return;
-                        }
+                // Empty string is treated the same as null. iOS Safari can
+                // resolve readText() with "" when the user dismisses or
+                // never engages with the system "Paste" consent chip — even
+                // if the clipboard genuinely has content. Treating that as
+                // success would dead-end the user with a misleading
+                // "clipboard empty" toast; falling through to the modal
+                // gives them a long-press path that always works.
+                if (clip) {
                         if (clip.length > MAX_PASTE_CHARS) {
                                 showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
                                 return;
@@ -1387,10 +1390,11 @@ pasteBtn.addEventListener("click", async () => {
                         showToast(`Pasted ${clip.length} character${clip.length === 1 ? "" : "s"}`);
                         return;
                 }
-                // Clipboard API unavailable or denied — surface the manual fallback.
-                // Hand the guard ownership to closePasteModal so the second-tap
-                // protection covers the entire modal lifetime, not just the
-                // synchronous tail of this handler.
+                // Clipboard API unavailable, denied, or returned empty —
+                // surface the manual fallback. Hand the guard ownership to
+                // closePasteModal so the second-tap protection covers the
+                // entire modal lifetime, not just the synchronous tail of
+                // this handler.
                 openPasteModal(pasteBtn);
                 releaseGuard = false;
         } finally {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1411,12 +1411,13 @@ pasteClipboardBtn.addEventListener("click", async () => {
         pasteClipboardBtn.disabled = true;
         try {
                 const clip = await readClipboardText();
-                if (clip === null) {
+                // Collapse null and "" — both mean "we couldn't get usable
+                // clipboard text". null = API unavailable/denied. "" = iOS
+                // resolved without engaging the consent chip, OR the
+                // clipboard genuinely is empty. Either way the textarea
+                // (long-press fallback) is the right next step.
+                if (!clip) {
                         showToast("Couldn't read clipboard — long-press to paste manually", true);
-                        return;
-                }
-                if (clip.length === 0) {
-                        showToast("Clipboard is empty", true);
                         return;
                 }
                 if (clip.length > MAX_PASTE_CHARS) {


### PR DESCRIPTION
## Summary

Recovery of two fixes that were on the PR #111 branch but didn't land in the merged commit (only the header-move commit made it into main). Reapplying against current main.

Both bugs are present in production right now:
1. Tapping **Paste** on iPhone consistently shows the "Clipboard is empty" toast even when content is on the clipboard.
2. The paste button drifts to the left when no session is active.

## Fixes

**iOS empty-clipboard resolve** — `navigator.clipboard.readText()` on iOS Safari can resolve with `""` (not reject) when the system "Paste" consent chip is dismissed or never engaged with, even if the clipboard genuinely has content. The silent path was treating empty as success and dead-ending with a misleading toast. Treat empty the same as null and fall through to the modal so the user always has a working long-press path.

**Right-alignment** — `chrome-toggle`'s `flex: 1` only pushes paste-btn to the right when a session is active. With no session selected the pill is hidden and paste-btn drifted next to the sidebar-toggle on the left. Add `margin-left: auto` to pin it to the right edge in both states.

## Test plan

- [ ] **Mobile, no session:** Paste button is hidden (alongside the chrome pill).
- [ ] **Mobile, session active:** Paste button at the right edge of the header.
- [ ] **iPhone, populated clipboard:** Tap Paste → if iOS shows "Paste" chip and you tap it, content lands in the terminal; if you dismiss the chip or the API resolves empty, the modal opens with a textarea you can long-press into.
- [ ] **No more dead-end "Clipboard is empty" toast** when there's actually content on the clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)