### PR TITLE
feat(file-attach): upload files into the session workspace (mobile + desktop)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,13 @@ SESSION_IMAGE=shared-terminal-session
 # Where session workspace volumes are stored on the host
 WORKSPACE_ROOT=/var/shared-terminal/workspaces
 
+# Per-session disk quota for files uploaded via POST /api/sessions/:id/files
+# (the mobile + → Attach file flow). Counts only files inside the session's
+# uploads/ directory; files the container writes elsewhere in /home/developer/
+# workspace are not counted. Default 1 GB (1073741824). Tune down on
+# resource-constrained hosts.
+# UPLOAD_QUOTA_BYTES=1073741824
+
 # ── Frontend (Cloudflare Pages) ──────────────────────────────────────────────
 # Set this as an env var in Cloudflare Pages dashboard:
 # VITE_API_URL=https://api.terminal.yourdomain.com

--- a/.env.example
+++ b/.env.example
@@ -59,10 +59,17 @@ SESSION_IMAGE=shared-terminal-session
 WORKSPACE_ROOT=/var/shared-terminal/workspaces
 
 # Per-session disk quota for files uploaded via POST /api/sessions/:id/files
-# (the mobile + → Attach file flow). Counts only files inside the session's
+# (the + → Attach file flow). Counts only files inside the session's
 # uploads/ directory; files the container writes elsewhere in /home/developer/
 # workspace are not counted. Default 1 GB (1073741824). Tune down on
 # resource-constrained hosts.
+#
+# AGGREGATE EXPOSURE: this cap is per session, not per user. Sessions
+# survive soft-delete, so a single user holding 20 sessions (the default
+# per-user cap) can accumulate 20 × UPLOAD_QUOTA_BYTES on disk before
+# anything caps them. On a constrained host, size this so
+# (per-user-session-cap × UPLOAD_QUOTA_BYTES) fits comfortably in the
+# disk slice you're willing to allocate per user.
 # UPLOAD_QUOTA_BYTES=1073741824
 
 # ── Frontend (Cloudflare Pages) ──────────────────────────────────────────────

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,11 +8,13 @@
       "name": "shared-terminal-backend",
       "version": "2.0.0",
       "dependencies": {
+        "@types/multer": "^2.1.0",
         "bcryptjs": "^2.4.3",
         "dockerode": "^4.0.4",
         "express": "^4.19.2",
         "express-rate-limit": "^8.3.2",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^2.1.1",
         "uuid": "^9.0.1",
         "ws": "^8.17.1"
       },
@@ -968,7 +970,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -979,7 +980,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1019,7 +1019,6 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1032,7 +1031,6 @@
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
       "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1045,7 +1043,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -1063,7 +1060,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -1072,6 +1068,15 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.39",
@@ -1086,21 +1091,18 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1110,7 +1112,6 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1122,7 +1123,6 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -1323,6 +1323,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1463,6 +1469,12 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/buildcheck": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
@@ -1470,6 +1482,17 @@
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1584,6 +1607,21 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2438,6 +2476,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nan": {
       "version": "2.26.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
@@ -2971,6 +3028,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3125,6 +3190,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "shared-terminal-backend",
       "version": "2.0.0",
       "dependencies": {
-        "@types/multer": "^2.1.0",
         "bcryptjs": "^2.4.3",
         "dockerode": "^4.0.4",
         "express": "^4.19.2",
@@ -23,6 +22,7 @@
         "@types/dockerode": "^3.3.31",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.7",
+        "@types/multer": "^2.1.0",
         "@types/node": "^20.14.2",
         "@types/uuid": "^9.0.8",
         "@types/ws": "^8.5.10",
@@ -970,6 +970,7 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -980,6 +981,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1019,6 +1021,7 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1031,6 +1034,7 @@
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
       "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1043,6 +1047,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -1060,6 +1065,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -1073,6 +1079,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
       "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
@@ -1091,18 +1098,21 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1112,6 +1122,7 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1123,6 +1134,7 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,11 +13,13 @@
     "docker:build-session": "docker build -t shared-terminal-session ../session-image"
   },
   "dependencies": {
+    "@types/multer": "^2.1.0",
     "bcryptjs": "^2.4.3",
     "dockerode": "^4.0.4",
     "express": "^4.19.2",
     "express-rate-limit": "^8.3.2",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.1.1",
     "uuid": "^9.0.1",
     "ws": "^8.17.1"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,6 @@
     "docker:build-session": "docker build -t shared-terminal-session ../session-image"
   },
   "dependencies": {
-    "@types/multer": "^2.1.0",
     "bcryptjs": "^2.4.3",
     "dockerode": "^4.0.4",
     "express": "^4.19.2",
@@ -28,6 +27,7 @@
     "@types/dockerode": "^3.3.31",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.7",
+    "@types/multer": "^2.1.0",
     "@types/node": "^20.14.2",
     "@types/uuid": "^9.0.8",
     "@types/ws": "^8.5.10",

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -9,7 +9,7 @@ const dbStubs = vi.hoisted(() => ({
 }));
 vi.mock("./db.js", () => dbStubs);
 
-import { DockerManager, type OutputListener } from "./dockerManager.js";
+import { DockerManager, sanitiseUploadName, type OutputListener } from "./dockerManager.js";
 import type { SessionManager } from "./sessionManager.js";
 
 // ── Test harness ────────────────────────────────────────────────────────────
@@ -599,5 +599,75 @@ describe("DockerManager.reconcile", () => {
 		expect(sessions.recordContainerGone).not.toHaveBeenCalled();
 		expect(sessions.setContainerId).not.toHaveBeenCalled();
 		expect(sessions.updateStatus).toHaveBeenCalledWith("s1", "stopped");
+	});
+});
+
+// ── sanitiseUploadName ──────────────────────────────────────────────────────
+// Security-sensitive: the result is concatenated into a host filesystem path
+// AND pasted directly into the user's terminal, so it has to (a) prevent any
+// path-traversal segment from being written outside <uploads>/ and (b) keep
+// the resulting filename safe to surface as a shell argument. Tests cover
+// the categories the bot called out: normal pass-through, path-separator
+// stripping, full-strip fallback, length cap with extension preservation,
+// and Unicode-only names.
+
+describe("sanitiseUploadName", () => {
+	it("preserves a normal filename verbatim", () => {
+		expect(sanitiseUploadName("screenshot.png")).toBe("screenshot.png");
+		expect(sanitiseUploadName("notes-2026_04_26.txt")).toBe("notes-2026_04_26.txt");
+	});
+
+	it("strips path separators and traversal segments", () => {
+		// path.basename takes the last segment; the regex collapses anything
+		// non-safe to underscore. The combined effect must never let a
+		// "../" make it through.
+		expect(sanitiseUploadName("../../etc/passwd")).toBe("passwd");
+		expect(sanitiseUploadName("/absolute/path/file.png")).toBe("file.png");
+		expect(sanitiseUploadName("..\\..\\windows\\sys.ini")).toBe("windows_sys.ini");
+		expect(sanitiseUploadName("./hidden.png")).toBe("hidden.png");
+	});
+
+	it("collapses spaces and shell metachars to underscore", () => {
+		// The result is pasted into the terminal; spaces would unquote the
+		// path, dollar signs would expand, and so on. The regex restricts
+		// to [A-Za-z0-9._-] so all of those become _.
+		expect(sanitiseUploadName("my file (1).png")).toBe("my_file_1_.png");
+		expect(sanitiseUploadName("$(whoami).png")).toBe("whoami_.png");
+		// No path separator here — the basename pass would otherwise eat
+		// the dangerous prefix and leave us asserting against ".txt".
+		expect(sanitiseUploadName("a; rm -rf .txt")).toBe("a_rm_-rf_.txt");
+	});
+
+	it("falls back to 'file' when sanitisation strips everything", () => {
+		// All-dots, leading-strip, and Unicode-only names all collapse to
+		// empty after the basename + restrict + leading-strip pipeline.
+		expect(sanitiseUploadName("")).toBe("file");
+		expect(sanitiseUploadName("...")).toBe("file");
+		expect(sanitiseUploadName("___")).toBe("file");
+		expect(sanitiseUploadName("中文")).toBe("file");
+		expect(sanitiseUploadName("📎")).toBe("file");
+	});
+
+	it("preserves a short extension when truncating long names", () => {
+		// 100-char stem + ".png" → MAX_LEN=80 enforced, ext kept.
+		const stem = "a".repeat(100);
+		const out = sanitiseUploadName(`${stem}.png`);
+		expect(out.length).toBe(80);
+		expect(out.endsWith(".png")).toBe(true);
+	});
+
+	it("caps a pathological extension so it can't blow past MAX_LEN", () => {
+		// Hostile name: ".aaa..." with a 200-char extension. Extension cap
+		// is 16 chars, so the trimmed stem still fits inside MAX_LEN=80.
+		const out = sanitiseUploadName(`name.${"x".repeat(200)}`);
+		expect(out.length).toBeLessThanOrEqual(80);
+		expect(out.startsWith("name.")).toBe(true);
+	});
+
+	it("handles names that are nothing but an extension", () => {
+		// `lastIndexOf(".") >= cleaned.length - 1` means extension-only names
+		// shouldn't try to "preserve the extension" — they fall through to
+		// the simple slice path.
+		expect(sanitiseUploadName(".gitignore")).toBe("gitignore"); // leading dot stripped
 	});
 });

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -647,8 +647,20 @@ describe("sanitiseUploadName", () => {
 		expect(sanitiseUploadName("")).toBe("file");
 		expect(sanitiseUploadName("...")).toBe("file");
 		expect(sanitiseUploadName("___")).toBe("file");
+		expect(sanitiseUploadName("---")).toBe("file");
 		expect(sanitiseUploadName("中文")).toBe("file");
 		expect(sanitiseUploadName("📎")).toBe("file");
+	});
+
+	it("strips leading dashes so the result can't start with a flag-like char", () => {
+		// Defends a hypothetical future caller that passes safeBase as a
+		// bare subprocess argument. Today the path is always absolute so
+		// "-rf.sh" wouldn't collide with anything, but an evolving call
+		// site might lose that invariant.
+		expect(sanitiseUploadName("-rf.sh")).toBe("rf.sh");
+		expect(sanitiseUploadName("--help.txt")).toBe("help.txt");
+		// Mid-string dashes are kept; only leading ones are stripped.
+		expect(sanitiseUploadName("data-2026-04-27.csv")).toBe("data-2026-04-27.csv");
 	});
 
 	it("preserves a short extension when truncating long names", () => {

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -618,9 +618,12 @@ describe("sanitiseUploadName", () => {
 	});
 
 	it("strips path separators and traversal segments", () => {
-		// path.basename takes the last segment; the regex collapses anything
-		// non-safe to underscore. The combined effect must never let a
-		// "../" make it through.
+		// Two layered defences: path.basename strips POSIX `/`-separated
+		// segments (covers cases 1, 2, 4 below); for backslash-only paths
+		// on Linux — where `\` is NOT a path separator — basename leaves
+		// the whole string intact and the `[^A-Za-z0-9._-]+` regex
+		// collapses each `\` run to `_`, then the leading-underscore
+		// strip removes them (case 3). Either way, no "../" escapes.
 		expect(sanitiseUploadName("../../etc/passwd")).toBe("passwd");
 		expect(sanitiseUploadName("/absolute/path/file.png")).toBe("file.png");
 		expect(sanitiseUploadName("..\\..\\windows\\sys.ini")).toBe("windows_sys.ini");

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -6,7 +6,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { constants as nodeFsConstants, type Dirent } from "node:fs";
+import type { Dirent } from "node:fs";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { Duplex } from "node:stream";
@@ -137,6 +137,23 @@ export class DockerManager {
                 await fs.mkdir(workspaceDir, { recursive: true });
                 await this.ensureWorkspaceOwnership(workspaceDir);
 
+                // Pre-create the per-session uploads dir at its OUT-OF-WORKSPACE
+                // location and bind-mount it read-only into the container at
+                // /home/developer/workspace/uploads/. Critical TOCTOU defence:
+                // because the container's view is a mount point, the container
+                // can NOT replace, rename, or rmdir the uploads/ entry from
+                // inside (the kernel rejects any modification to a mount point
+                // from the mount user's namespace). Read-only also stops the
+                // container from writing/modifying uploaded files, so an
+                // attacker can't poison files between writes — combined with
+                // writeUploads' atomic rename from .tmp-uploads/ into
+                // .uploads/<sessionId>/, the symlink-swap attack window the
+                // older in-workspace layout had is closed structurally.
+                const uploadsHostDir = path.join(WORKSPACE_ROOT, ".uploads", sessionId);
+                await fs.mkdir(uploadsHostDir, { recursive: true });
+                // No chown — backend (typically root) owns the dir, container
+                // reads via the read-only mount; no need for it to own anything.
+
                 const container = await this.docker.createContainer({
                         Image: SESSION_IMAGE,
                         name: meta.containerName,
@@ -149,7 +166,10 @@ export class DockerManager {
                                 ...envArray,
                         ],
                         HostConfig: {
-                                Binds: [`${WORKSPACE_ROOT}/${sessionId}:/home/developer/workspace`],
+                                Binds: [
+                                        `${WORKSPACE_ROOT}/${sessionId}:/home/developer/workspace`,
+                                        `${uploadsHostDir}:/home/developer/workspace/uploads:ro`,
+                                ],
                                 Memory: 2 * 1024 * 1024 * 1024,
                                 NanoCpus: 2_000_000_000,
                                 RestartPolicy: { Name: "unless-stopped" },
@@ -290,83 +310,62 @@ export class DockerManager {
                 sessionId: string,
                 files: ReadonlyArray<{ originalname: string; path: string }>,
         ): Promise<string[]> {
-                const uploadsHostDir = path.join(WORKSPACE_ROOT, sessionId, "uploads");
-                // Lexical sanity check (matches the same belt in purgeWorkspace).
-                // assertOwnership already constrains sessionId to a UUID from D1,
-                // but if a future refactor ever lets a path-traversal-shaped
-                // sessionId reach here we must not even mkdir outside WORKSPACE_ROOT.
-                const rootAbs = path.resolve(WORKSPACE_ROOT);
+                // Architectural TOCTOU fix: the uploads directory lives at
+                // <WORKSPACE_ROOT>/.uploads/<sessionId>/ — OUTSIDE the
+                // container's bind-mount tree. spawn() bind-mounts this dir
+                // read-only into the container at /home/developer/workspace/
+                // uploads/, so:
+                //   1. The container CANNOT remove or replace /home/developer/
+                //      workspace/uploads (it's a mount point — kernel rejects
+                //      modification from the mount user's namespace).
+                //   2. The container CANNOT write into uploads/ (read-only mount).
+                //   3. The container's bind mount on /home/developer/workspace/
+                //      doesn't reach .uploads/ on the host, so nothing inside
+                //      the container can plant symlinks at the upload destination.
+                // The earlier in-workspace layout needed a stack of defences
+                // (realpath, O_DIRECTORY|O_NOFOLLOW, pre+post inode sentinels)
+                // because the container could replace uploads/ with a symlink
+                // and race rename(2). With the new layout that whole class of
+                // attacks is structurally impossible, so the per-rename TOCTOU
+                // machinery is gone. The lexical containment check stays as a
+                // belt against any future regression that lets a non-UUID
+                // sessionId reach this method.
+                const uploadsHostDir = path.join(WORKSPACE_ROOT, ".uploads", sessionId);
+                // Containment check: must resolve under <WORKSPACE_ROOT>/.uploads/,
+                // not just under WORKSPACE_ROOT. A traversal-shaped sessionId
+                // like "../escape" would otherwise let path.join collapse to
+                // <WORKSPACE_ROOT>/escape — still under WORKSPACE_ROOT but
+                // outside the per-session uploads namespace.
+                const uploadsBaseAbs = path.resolve(WORKSPACE_ROOT, ".uploads");
                 const uploadsHostDirAbs = path.resolve(uploadsHostDir);
-                if (!uploadsHostDirAbs.startsWith(`${rootAbs}${path.sep}`)) {
+                if (!uploadsHostDirAbs.startsWith(`${uploadsBaseAbs}${path.sep}`)) {
                         await this.cleanupTmp(files);
-                        throw new Error(`unsafe session path resolved outside ${rootAbs}: ${uploadsHostDirAbs}`);
+                        throw new Error(`unsafe session path resolved outside ${uploadsBaseAbs}: ${uploadsHostDirAbs}`);
                 }
-                // mkdir-before-realpath note: the realpath check below catches
-                // a symlink-replaced uploads/ (the only entry the container
-                // can swap, since `<sessionId>/` is the bind-mount target —
-                // not removable from inside the container). For the broader
-                // "container replaces `<sessionId>/` itself" attack to land
-                // here, the attacker would need to pre-create that entry on
-                // the host before mkdir runs — but sessionId is a UUID minted
-                // in D1 and gated by assertOwnership in routes.ts, so a
-                // foreign attacker can't guess the path and the legitimate
-                // owner can't reach the host filesystem outside their bind
-                // mount. mkdir is therefore safe to run before realpath.
+                // spawn() pre-creates this dir, but a writeUploads call for a
+                // session that has been spawned but not running (or for one
+                // started before this code shipped) needs us to create it
+                // here too. recursive: true is a no-op when it already exists.
                 await fs.mkdir(uploadsHostDir, { recursive: true });
-
-                // Lexical resolve() above is purely string manipulation — it
-                // does NOT follow symlinks. A container owns its bind-mounted
-                // workspace and could replace `uploads/` with a symlink to /etc
-                // before we got here; the lexical check would still pass and
-                // a subsequent chown would change ownership of the link target.
-                // fs.realpath canonicalises through the filesystem, so a
-                // mis-pointed symlink shows up as a real-path outside
-                // WORKSPACE_ROOT and we bail before touching anything.
-                const rootReal = await fs.realpath(WORKSPACE_ROOT);
-                const realUploadsDir = await fs.realpath(uploadsHostDir);
-                if (!realUploadsDir.startsWith(`${rootReal}${path.sep}`)) {
-                        await this.cleanupTmp(files);
-                        throw new Error(`uploads dir escaped workspace root: ${realUploadsDir}`);
-                }
-                // Deliberately NOT chowning realUploadsDir to the workspace user.
-                // Even with uploads/ owned by root and the per-file chown below,
-                // the container still owns the parent `<sessionId>/` directory
-                // (set by spawn-time ensureWorkspaceOwnership) — POSIX rename(2)
-                // requires write on the source-parent only, NOT ownership of the
-                // entry being renamed, so the container can do
-                //   `mv uploads uploads.bak; ln -s /etc uploads`
-                // mid-loop and have the next rename(2) re-resolve the path
-                // string into /etc. This is a TOCTOU residue we can't fully
-                // close without openat/renameat (Node lacks bindings) or a
-                // separate non-bind-mounted uploads dir (architectural change).
-                // Mitigation: hold uploadsHostDir open via O_DIRECTORY|
-                // O_NOFOLLOW so a freshly-replaced symlink is detected at fd
-                // open time, and re-lstat the dir entry after each rename to
-                // detect a swap during the loop. Window narrows from "the
-                // entire upload" to "the gap between the lstat and the next
-                // rename", on the order of microseconds.
 
                 // Per-session disk-quota check: count current bytes in
                 // uploads/ + bytes about to be added; reject before moving any
                 // tmp file if the cap would be exceeded. Sum-of-statSize is a
                 // tight enough approximation — uploads/ is always one level
                 // deep (writeUploads only writes flat) so no recursion.
+                // lstat (not stat) so any stale symlink left over from the
+                // previous in-workspace layout — or one a future bug plants
+                // here — counts as zero bytes (st.isFile() is false for
+                // symlinks) rather than inflating the quota with the
+                // target's size.
                 let usedBytes = 0;
                 try {
-                        const existing = await fs.readdir(realUploadsDir);
+                        const existing = await fs.readdir(uploadsHostDir);
                         for (const entry of existing) {
-                                // lstat (not stat) so a container-planted symlink in
-                                // its own uploads/ pointing at e.g. /var/log/syslog
-                                // is excluded from the quota count entirely —
-                                // st.isFile() returns false for symlinks, so they
-                                // contribute zero bytes rather than inflating with
-                                // the target's size and letting the container self-
-                                // DoS its own quota.
-                                const st = await fs.lstat(path.join(realUploadsDir, entry));
+                                const st = await fs.lstat(path.join(uploadsHostDir, entry));
                                 if (st.isFile()) usedBytes += st.size;
                         }
                 } catch (err) {
-                        // ENOENT is fine — fresh session with no uploads yet.
                         if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
                 }
                 let attemptedBytes = 0;
@@ -376,8 +375,8 @@ export class DockerManager {
                 }
                 if (usedBytes + attemptedBytes > UPLOAD_QUOTA_BYTES) {
                         // Log the detail server-side; the thrown error carries
-                        // a generic message so the byte counts don't ride out
-                        // in the 413 body to the client.
+                        // a generic message so byte counts don't ride out in
+                        // the 413 body to the client.
                         console.warn(
                                 `[docker] upload quota rejected for session ${sessionId}: ` +
                                 `${usedBytes} used + ${attemptedBytes} attempted > ${UPLOAD_QUOTA_BYTES} cap`,
@@ -386,123 +385,49 @@ export class DockerManager {
                         throw new UploadQuotaExceededError(usedBytes, attemptedBytes, UPLOAD_QUOTA_BYTES);
                 }
 
-                // Open the dir as a stable fd. O_NOFOLLOW makes this fail if
-                // realUploadsDir is already a symlink (defence-in-depth on
-                // top of the realpath check); the captured inode is the
-                // anchor we compare against after each rename to catch a
-                // swap performed during the loop.
-                // O_DIRECTORY is Linux-only — undefined on macOS. The
-                // bitwise OR would silently drop it on dev macOS hosts and
-                // open the path without the "must-be-a-directory" check.
-                // Production target is Linux per CLAUDE.md, but `?? 0` keeps
-                // the fallback explicit so a dev iterating on macOS doesn't
-                // hit a confusing later-stage stat failure instead.
-                const dirHandle = await fs.open(
-                        realUploadsDir,
-                        (nodeFsConstants.O_DIRECTORY ?? 0) | nodeFsConstants.O_NOFOLLOW,
-                );
-                // Use the bigint stat variant on BOTH sides of the inode
-                // comparison. Default `number` ino loses precision past 2^53,
-                // which btrfs and XFS routinely exceed on large filesystems —
-                // two distinct inodes that differ only in high bits would
-                // collide as `===` after float truncation, silently disabling
-                // the swap-detection sentinel. bigint is both precision-safe
-                // and type-exact (no number/bigint mismatch on the live-side
-                // lstat below).
-                let stableIno: bigint;
-                try {
-                        stableIno = (await dirHandle.stat({ bigint: true })).ino;
-                } catch (err) {
-                        await dirHandle.close();
-                        throw err;
-                }
-
                 const containerPaths: string[] = [];
                 const now = Date.now().toString(36);
-                // Track which multer tmp files we've successfully moved so the
-                // finally block can clean up anything we didn't get to.
+                // Track which multer tmp files we've successfully moved so
+                // the finally block can clean up anything we didn't get to.
                 const remaining = new Set(files.map((f) => f.path));
                 try {
                         for (const file of files) {
                                 const safeBase = sanitiseUploadName(file.originalname);
-                                // Random suffix on top of the timestamp so two uploads
-                                // landing in the same millisecond don't collide.
+                                // Random suffix on top of the timestamp so two
+                                // uploads landing in the same millisecond don't
+                                // collide.
                                 const suffix = randomBytes(3).toString("hex");
                                 const filename = `${now}-${suffix}-${safeBase}`;
-                                const finalPath = path.join(realUploadsDir, filename);
+                                const finalPath = path.join(uploadsHostDir, filename);
                                 const finalPathAbs = path.resolve(finalPath);
-                                if (!finalPathAbs.startsWith(`${realUploadsDir}${path.sep}`)) {
-                                        throw new Error(`unsafe upload path resolved outside ${realUploadsDir}: ${finalPathAbs}`);
+                                // Defence-in-depth per-file containment: the
+                                // sanitiser already strips path separators so
+                                // sanitiseUploadName(x) can never escape the
+                                // dir, but resolve+startsWith is one extra
+                                // line of insurance against a future regression
+                                // in the sanitiser.
+                                if (!finalPathAbs.startsWith(`${uploadsHostDirAbs}${path.sep}`)) {
+                                        throw new Error(`unsafe upload path resolved outside ${uploadsHostDirAbs}: ${finalPathAbs}`);
                                 }
-                                // Apply final mode + ownership BEFORE the rename, on
-                                // the multer tmp file in .tmp-uploads/ (root-owned,
-                                // not bind-mounted into any container). rename(2)
-                                // moves the inode in place — mode and owner are
-                                // preserved at the destination — so any post-rename
-                                // chmod/chown that would re-resolve through the
-                                // attacker-planted symlink is unnecessary. Order
-                                // matters: doing chmod/chown after rename leaves a
-                                // residual TOCTOU window where a swap mid-loop
-                                // would have those calls follow the symlink and
-                                // alter permissions of arbitrary host files.
+                                // chmod + chown the multer tmp file BEFORE the
+                                // rename. rename(2) preserves mode + owner at
+                                // the destination, so the file lands in
+                                // uploads/ with mode 0644 owned by uid 1000
+                                // (the container user). With the read-only
+                                // bind mount the container can read but not
+                                // modify the file — chowning to uid 1000 is
+                                // mostly cosmetic now but keeps the in-
+                                // container `ls -l` output consistent with the
+                                // rest of the workspace.
                                 await fs.chmod(file.path, 0o644);
                                 await this.chownToWorkspaceUser(file.path);
-                                // Pre-rename TOCTOU check. Without this, file 1
-                                // of every batch is unprotected: the dir-fd
-                                // anchor was set before the loop started, and
-                                // the first rename could land in a swapped
-                                // symlink before the post-rename lstat catches
-                                // it. Pairing pre+post checks narrows the
-                                // attack window to the microsecond gap between
-                                // the pre-check and the rename for every file.
-                                const preIno = (await fs.lstat(realUploadsDir, { bigint: true })).ino;
-                                if (preIno !== stableIno) {
-                                        console.error(
-                                                `[docker] TOCTOU (pre-rename): uploads dir for session ${sessionId} ` +
-                                                `was swapped before write (anchor inode ${stableIno}, live ${preIno})`,
-                                        );
-                                        throw new Error("uploads dir was swapped during write — possible TOCTOU attack");
-                                }
-                                // Atomic move within the same filesystem (multer's
-                                // tmp dir lives under WORKSPACE_ROOT — see routes.ts).
+                                // Atomic same-filesystem move from the multer
+                                // tmp dir to the per-session uploads dir.
                                 await fs.rename(file.path, finalPath);
                                 remaining.delete(file.path);
-                                // TOCTOU sentinel: if the entry at realUploadsDir
-                                // now resolves to a different inode than the dir
-                                // we opened above, something swapped it during
-                                // the loop. The rename may have landed in the
-                                // swap target — DO NOT try to unlink finalPath
-                                // here: that path now resolves through the
-                                // attacker-planted symlink, and fs.unlink follows
-                                // links on Linux. A "cleanup" unlink would
-                                // delete whatever host file the symlink targets
-                                // (potentially anywhere the backend's uid can
-                                // reach). The leaked file is the container's
-                                // problem; our obligation is to stop writing,
-                                // which the throw below does.
-                                //
-                                // Known false-negative: a swap-and-swap-back
-                                // entirely within this rename→lstat window
-                                // (microseconds) leaves the live inode matching
-                                // the anchor and the file still landed at the
-                                // attacker's chosen path. Not closeable without
-                                // renameat2 (Node lacks bindings); the
-                                // architectural fix is moving the bind mount
-                                // off the parent of uploads/ so the container
-                                // can't replace the entry at all.
-                                const liveIno = (await fs.lstat(realUploadsDir, { bigint: true })).ino;
-                                if (liveIno !== stableIno) {
-                                        console.error(
-                                                `[docker] TOCTOU: uploads dir for session ${sessionId} was swapped ` +
-                                                `during write (anchor inode ${stableIno}, live ${liveIno}); leaked file ` +
-                                                `at ${finalPath} (NOT unlinking — would follow attacker symlink)`,
-                                        );
-                                        throw new Error("uploads dir was swapped during write — possible TOCTOU attack");
-                                }
                                 containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
                         }
                 } finally {
-                        await dirHandle.close();
                         await this.cleanupTmp([...remaining].map((p) => ({ originalname: "", path: p })));
                 }
                 return containerPaths;
@@ -585,11 +510,17 @@ export class DockerManager {
         async purgeWorkspace(sessionId: string): Promise<void> {
                 const rootAbs = path.resolve(WORKSPACE_ROOT);
                 const sessionAbs = path.resolve(path.join(WORKSPACE_ROOT, sessionId));
+                const uploadsAbs = path.resolve(path.join(WORKSPACE_ROOT, ".uploads", sessionId));
 
-                // Safety: the resolved session dir must be a strict child of rootAbs.
+                // Safety: both resolved dirs must be strict children of rootAbs.
                 if (!sessionAbs.startsWith(rootAbs + path.sep)) {
                         throw new Error(
                                 `[docker] refusing to purge workspace outside root (root=${rootAbs}, target=${sessionAbs})`,
+                        );
+                }
+                if (!uploadsAbs.startsWith(rootAbs + path.sep)) {
+                        throw new Error(
+                                `[docker] refusing to purge uploads outside root (root=${rootAbs}, target=${uploadsAbs})`,
                         );
                 }
 
@@ -598,6 +529,17 @@ export class DockerManager {
                         console.log(`[docker] purged workspace dir ${sessionAbs}`);
                 } catch (err) {
                         console.error(`[docker] failed to purge workspace ${sessionAbs}:`, (err as Error).message);
+                        throw err;
+                }
+                // Per-session uploads dir lives at <WORKSPACE_ROOT>/.uploads/<sessionId>/
+                // (out-of-workspace TOCTOU isolation — see writeUploadsImpl). Hard
+                // delete must clean this too or uploaded files would persist
+                // forever for a row that no longer exists in D1.
+                try {
+                        await fs.rm(uploadsAbs, { recursive: true, force: true });
+                        console.log(`[docker] purged uploads dir ${uploadsAbs}`);
+                } catch (err) {
+                        console.error(`[docker] failed to purge uploads ${uploadsAbs}:`, (err as Error).message);
                         throw err;
                 }
         }

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -447,6 +447,22 @@ export class DockerManager {
                                 // alter permissions of arbitrary host files.
                                 await fs.chmod(file.path, 0o644);
                                 await this.chownToWorkspaceUser(file.path);
+                                // Pre-rename TOCTOU check. Without this, file 1
+                                // of every batch is unprotected: the dir-fd
+                                // anchor was set before the loop started, and
+                                // the first rename could land in a swapped
+                                // symlink before the post-rename lstat catches
+                                // it. Pairing pre+post checks narrows the
+                                // attack window to the microsecond gap between
+                                // the pre-check and the rename for every file.
+                                const preIno = (await fs.lstat(realUploadsDir, { bigint: true })).ino;
+                                if (preIno !== stableIno) {
+                                        console.error(
+                                                `[docker] TOCTOU (pre-rename): uploads dir for session ${sessionId} ` +
+                                                `was swapped before write (anchor inode ${stableIno}, live ${preIno})`,
+                                        );
+                                        throw new Error("uploads dir was swapped during write — possible TOCTOU attack");
+                                }
                                 // Atomic move within the same filesystem (multer's
                                 // tmp dir lives under WORKSPACE_ROOT — see routes.ts).
                                 await fs.rename(file.path, finalPath);
@@ -1219,7 +1235,12 @@ export function sanitiseUploadName(original: string): string {
         // Restrict to a small Latin set so the path is shell-safe (the user
         // pastes it into the terminal as-is) and filesystem-portable.
         // Anything else is collapsed to underscore.
-        const cleaned = base.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._]+/, "");
+        // Strip leading [._-] so the sanitised name can never start with a
+        // dash. Today the result is always pasted as part of an absolute
+        // path (so a leading "-" wouldn't matter as a shell flag), but a
+        // future caller passing safeBase as a bare argument would otherwise
+        // be vulnerable to flag injection (`-rf.sh` parsed as `-r -f .sh`).
+        const cleaned = base.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._-]+/, "");
         if (!cleaned) return "file";
         // Preserve the extension up to a max stem length so names stay
         // readable in `ls` and don't blow past common filesystem limits.

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -226,8 +226,16 @@ export class DockerManager {
                 files: ReadonlyArray<{ originalname: string; buffer: Buffer }>,
         ): Promise<string[]> {
                 if (files.length === 0) return [];
+                const rootAbs = path.resolve(WORKSPACE_ROOT);
                 const uploadsHostDir = path.join(WORKSPACE_ROOT, sessionId, "uploads");
                 const uploadsHostDirAbs = path.resolve(uploadsHostDir);
+                // Defence-in-depth (matches purgeWorkspace at L306): assertOwnership
+                // already constrains sessionId to a UUID from D1, but if a future
+                // refactor ever lets a path-traversal-shaped sessionId reach here we
+                // must not create directories or write files outside WORKSPACE_ROOT.
+                if (!uploadsHostDirAbs.startsWith(`${rootAbs}${path.sep}`)) {
+                        throw new Error(`unsafe session path resolved outside ${rootAbs}: ${uploadsHostDirAbs}`);
+                }
                 await fs.mkdir(uploadsHostDir, { recursive: true });
                 await this.chownToWorkspaceUser(uploadsHostDir);
 
@@ -913,8 +921,8 @@ export class DockerManager {
 // Sanitise an uploaded file's original name into a safe basename that's
 // guaranteed to land inside the uploads directory. Strips any path
 // components, restricts the character set, preserves a short extension,
-// and falls back to "file" if everything got stripped.
-function sanitiseUploadName(original: string): string {
+// and falls back to "file" if everything got stripped. Exported for tests.
+export function sanitiseUploadName(original: string): string {
         const base = path.basename(original ?? "");
         // Restrict to a small Latin set so the path is shell-safe (the user
         // pastes it into the terminal as-is) and filesystem-portable.

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -102,6 +102,11 @@ export class DockerManager {
         private sessions: SessionManager;
         private shared = new Map<string /*targetKey*/, Promise<SharedExec>>();
         private keyOf = new Map<string /*attachId*/, string /*targetKey*/>();
+        // Serialises writeUploads calls per session so the quota check
+        // (read existing + add new) can't race two concurrent requests
+        // and let both pass with the same usedBytes snapshot. Entries
+        // self-clean when the chain head finishes.
+        private uploadLocks = new Map<string /*sessionId*/, Promise<void>>();
 
         constructor(sessions: SessionManager, dockerOpts?: Dockerode.DockerOptions) {
                 this.docker = new Dockerode(dockerOpts ?? { socketPath: "/var/run/docker.sock" });
@@ -254,6 +259,32 @@ export class DockerManager {
                 files: ReadonlyArray<{ originalname: string; path: string }>,
         ): Promise<string[]> {
                 if (files.length === 0) return [];
+                // Per-session serialisation. Synchronously chain a new lock
+                // *before* awaiting the prior one, so a concurrent call sees
+                // the chained lock — not an empty slot — and waits behind us.
+                const prior = this.uploadLocks.get(sessionId);
+                let release: () => void = () => { /* set below */ };
+                const ours = new Promise<void>((r) => { release = r; });
+                const newLock = prior ? prior.then(() => ours, () => ours) : ours;
+                this.uploadLocks.set(sessionId, newLock);
+                if (prior) await prior.catch(() => { /* ignore prior errors */ });
+                try {
+                        return await this.writeUploadsImpl(sessionId, files);
+                } finally {
+                        release();
+                        // Clean up if we're still the head — i.e. no later caller
+                        // chained on. Stops the map from growing without bound
+                        // for sessions that aren't actively uploading.
+                        if (this.uploadLocks.get(sessionId) === newLock) {
+                                this.uploadLocks.delete(sessionId);
+                        }
+                }
+        }
+
+        private async writeUploadsImpl(
+                sessionId: string,
+                files: ReadonlyArray<{ originalname: string; path: string }>,
+        ): Promise<string[]> {
                 const uploadsHostDir = path.join(WORKSPACE_ROOT, sessionId, "uploads");
                 // Lexical sanity check (matches purgeWorkspace at L306).
                 // assertOwnership already constrains sessionId to a UUID from D1,
@@ -339,7 +370,12 @@ export class DockerManager {
                         realUploadsDir,
                         nodeFsConstants.O_DIRECTORY | nodeFsConstants.O_NOFOLLOW,
                 );
-                let stableIno: bigint | number;
+                // Stats inherit Node's default (non-BigInt) ino representation.
+                // Narrow to `number` so the strict-equality check against the
+                // post-rename lstat below stays type-aligned — a future
+                // statBig() call would silently break the comparison if this
+                // were the wider `bigint | number` union.
+                let stableIno: number;
                 try {
                         stableIno = (await dirHandle.stat()).ino;
                 } catch (err) {
@@ -1068,12 +1104,19 @@ export class DockerManager {
                         }
                         return;
                 }
-                if (entries.length === 0) return;
+                // Filter to plain files. `fs.unlink` on a directory returns
+                // EISDIR — not actionable here and would skew the
+                // success/failure log. No code path in this module creates
+                // subdirs under .tmp-uploads today, but a future regression
+                // (or operator dropping something there) would silently
+                // accumulate without this guard.
+                const fileEntries = entries.filter((e) => e.isFile());
+                if (fileEntries.length === 0) return;
                 const results = await Promise.allSettled(
-                        entries.map((e) => fs.unlink(path.join(dir, e.name))),
+                        fileEntries.map((e) => fs.unlink(path.join(dir, e.name))),
                 );
                 const failed = results.filter((r) => r.status === "rejected").length;
-                console.log(`[docker] sweepUploadTmp removed ${entries.length - failed}/${entries.length} stale tmp files`);
+                console.log(`[docker] sweepUploadTmp removed ${fileEntries.length - failed}/${fileEntries.length} stale tmp files`);
         }
 
         async reconcile(): Promise<void> {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -372,12 +372,22 @@ export class DockerManager {
                                 // now resolves to a different inode than the dir
                                 // we opened above, something swapped it during
                                 // the loop. The rename may have landed in the
-                                // swap target; best-effort unlink (which follows
-                                // the symlink, removing the leaked file) and bail
-                                // before any more writes go through.
+                                // swap target — DO NOT try to unlink finalPath
+                                // here: that path now resolves through the
+                                // attacker-planted symlink, and fs.unlink follows
+                                // links on Linux. A "cleanup" unlink would
+                                // delete whatever host file the symlink targets
+                                // (potentially anywhere the backend's uid can
+                                // reach). The leaked file is the container's
+                                // problem; our obligation is to stop writing,
+                                // which the throw below does.
                                 const liveIno = (await fs.lstat(realUploadsDir)).ino;
                                 if (liveIno !== stableIno) {
-                                        await fs.unlink(finalPath).catch(() => { /* best-effort */ });
+                                        console.error(
+                                                `[docker] TOCTOU: uploads dir for session ${sessionId} was swapped ` +
+                                                `during write (anchor inode ${stableIno}, live ${liveIno}); leaked file ` +
+                                                `at ${finalPath} (NOT unlinking — would follow attacker symlink)`,
+                                        );
                                         throw new Error("uploads dir was swapped during write — possible TOCTOU attack");
                                 }
                                 await fs.chmod(finalPath, 0o644);

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -299,6 +299,17 @@ export class DockerManager {
                         await this.cleanupTmp(files);
                         throw new Error(`unsafe session path resolved outside ${rootAbs}: ${uploadsHostDirAbs}`);
                 }
+                // mkdir-before-realpath note: the realpath check below catches
+                // a symlink-replaced uploads/ (the only entry the container
+                // can swap, since `<sessionId>/` is the bind-mount target —
+                // not removable from inside the container). For the broader
+                // "container replaces `<sessionId>/` itself" attack to land
+                // here, the attacker would need to pre-create that entry on
+                // the host before mkdir runs — but sessionId is a UUID minted
+                // in D1 and gated by assertOwnership in routes.ts, so a
+                // foreign attacker can't guess the path and the legitimate
+                // owner can't reach the host filesystem outside their bind
+                // mount. mkdir is therefore safe to run before realpath.
                 await fs.mkdir(uploadsHostDir, { recursive: true });
 
                 // Lexical resolve() above is purely string manipulation — it

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -370,14 +370,17 @@ export class DockerManager {
                         realUploadsDir,
                         nodeFsConstants.O_DIRECTORY | nodeFsConstants.O_NOFOLLOW,
                 );
-                // Stats inherit Node's default (non-BigInt) ino representation.
-                // Narrow to `number` so the strict-equality check against the
-                // post-rename lstat below stays type-aligned — a future
-                // statBig() call would silently break the comparison if this
-                // were the wider `bigint | number` union.
-                let stableIno: number;
+                // Use the bigint stat variant on BOTH sides of the inode
+                // comparison. Default `number` ino loses precision past 2^53,
+                // which btrfs and XFS routinely exceed on large filesystems —
+                // two distinct inodes that differ only in high bits would
+                // collide as `===` after float truncation, silently disabling
+                // the swap-detection sentinel. bigint is both precision-safe
+                // and type-exact (no number/bigint mismatch on the live-side
+                // lstat below).
+                let stableIno: bigint;
                 try {
-                        stableIno = (await dirHandle.stat()).ino;
+                        stableIno = (await dirHandle.stat({ bigint: true })).ino;
                 } catch (err) {
                         await dirHandle.close();
                         throw err;
@@ -430,7 +433,17 @@ export class DockerManager {
                                 // reach). The leaked file is the container's
                                 // problem; our obligation is to stop writing,
                                 // which the throw below does.
-                                const liveIno = (await fs.lstat(realUploadsDir)).ino;
+                                //
+                                // Known false-negative: a swap-and-swap-back
+                                // entirely within this rename→lstat window
+                                // (microseconds) leaves the live inode matching
+                                // the anchor and the file still landed at the
+                                // attacker's chosen path. Not closeable without
+                                // renameat2 (Node lacks bindings); the
+                                // architectural fix is moving the bind mount
+                                // off the parent of uploads/ so the container
+                                // can't replace the entry at all.
+                                const liveIno = (await fs.lstat(realUploadsDir, { bigint: true })).ino;
                                 if (liveIno !== stableIno) {
                                         console.error(
                                                 `[docker] TOCTOU: uploads dir for session ${sessionId} was swapped ` +

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -146,26 +146,7 @@ export class DockerManager {
          * silently boot a session with a broken workspace.
          */
         private async ensureWorkspaceOwnership(dir: string): Promise<void> {
-                const chownOne = async (target: string) => {
-                        try {
-                                await fs.chown(target, WORKSPACE_UID, WORKSPACE_GID);
-                        } catch (err) {
-                                const code = (err as NodeJS.ErrnoException).code;
-                                if (code === "EPERM" || code === "ENOSYS") {
-                                        // Logged once per target — high-volume recursive mode
-                                        // could be noisy, but seeing which paths failed is more
-                                        // valuable than a compact summary.
-                                        console.warn(
-                                                `[docker] couldn't chown ${target} to ${WORKSPACE_UID}:${WORKSPACE_GID} (${code}); ` +
-                                                `run the backend as root or pre-create paths with matching ownership.`,
-                                        );
-                                } else {
-                                        throw err;
-                                }
-                        }
-                };
-
-                await chownOne(dir);
+                await this.chownToWorkspaceUser(dir);
 
                 if (!WORKSPACE_CHOWN_RECURSIVE) return;
 
@@ -196,12 +177,78 @@ export class DockerManager {
                         }
                         for (const entry of entries) {
                                 const full = path.join(current, entry.name);
-                                await chownOne(full);
+                                await this.chownToWorkspaceUser(full);
                                 if (entry.isDirectory() && !entry.isSymbolicLink()) {
                                         stack.push(full);
                                 }
                         }
                 }
+        }
+
+        /**
+         * chown a single path to WORKSPACE_UID:WORKSPACE_GID. Downgrades
+         * EPERM/ENOSYS to a warning (unprivileged dev mode), re-throws
+         * everything else so a real broken-workspace error doesn't get
+         * swallowed. Shared by the spawn-time ownership pass and the
+         * upload writer below.
+         */
+        private async chownToWorkspaceUser(target: string): Promise<void> {
+                try {
+                        await fs.chown(target, WORKSPACE_UID, WORKSPACE_GID);
+                } catch (err) {
+                        const code = (err as NodeJS.ErrnoException).code;
+                        if (code === "EPERM" || code === "ENOSYS") {
+                                console.warn(
+                                        `[docker] couldn't chown ${target} to ${WORKSPACE_UID}:${WORKSPACE_GID} (${code}); ` +
+                                        `run the backend as root or pre-create paths with matching ownership.`,
+                                );
+                        } else {
+                                throw err;
+                        }
+                }
+        }
+
+        /**
+         * Save uploaded files into the session workspace under `uploads/`
+         * and return their in-container paths. Caller must have already
+         * verified ownership of `sessionId`.
+         *
+         * Filenames are sanitised to a safe basename and prefixed with a
+         * monotonic timestamp + short random suffix so concurrent uploads
+         * of the same name don't clobber each other. The host path of
+         * every write is `path.resolve()`d and verified to sit inside the
+         * uploads directory before opening the file — the sanitiser
+         * already strips path separators, but the resolve-and-check is a
+         * defence-in-depth belt against a future regression.
+         */
+        async writeUploads(
+                sessionId: string,
+                files: ReadonlyArray<{ originalname: string; buffer: Buffer }>,
+        ): Promise<string[]> {
+                if (files.length === 0) return [];
+                const uploadsHostDir = path.join(WORKSPACE_ROOT, sessionId, "uploads");
+                const uploadsHostDirAbs = path.resolve(uploadsHostDir);
+                await fs.mkdir(uploadsHostDir, { recursive: true });
+                await this.chownToWorkspaceUser(uploadsHostDir);
+
+                const containerPaths: string[] = [];
+                const now = Date.now().toString(36);
+                for (const file of files) {
+                        const safeBase = sanitiseUploadName(file.originalname);
+                        // Random suffix on top of the timestamp so two uploads
+                        // landing in the same millisecond don't collide.
+                        const suffix = randomBytes(3).toString("hex");
+                        const filename = `${now}-${suffix}-${safeBase}`;
+                        const hostPath = path.join(uploadsHostDir, filename);
+                        const hostPathAbs = path.resolve(hostPath);
+                        if (!hostPathAbs.startsWith(`${uploadsHostDirAbs}${path.sep}`)) {
+                                throw new Error(`unsafe upload path resolved outside ${uploadsHostDirAbs}: ${hostPathAbs}`);
+                        }
+                        await fs.writeFile(hostPath, file.buffer, { mode: 0o644 });
+                        await this.chownToWorkspaceUser(hostPath);
+                        containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
+                }
+                return containerPaths;
         }
 
         async kill(sessionId: string): Promise<void> {
@@ -862,6 +909,27 @@ export class DockerManager {
 }
 
 // ── Module-level helpers ─────────────────────────────────────────────────────
+
+// Sanitise an uploaded file's original name into a safe basename that's
+// guaranteed to land inside the uploads directory. Strips any path
+// components, restricts the character set, preserves a short extension,
+// and falls back to "file" if everything got stripped.
+function sanitiseUploadName(original: string): string {
+        const base = path.basename(original ?? "");
+        // Restrict to a small Latin set so the path is shell-safe (the user
+        // pastes it into the terminal as-is) and filesystem-portable.
+        // Anything else is collapsed to underscore.
+        const cleaned = base.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._]+/, "");
+        if (!cleaned) return "file";
+        // Preserve the extension up to a max stem length so names stay
+        // readable in `ls` and don't blow past common filesystem limits.
+        const MAX_LEN = 80;
+        if (cleaned.length <= MAX_LEN) return cleaned;
+        const dot = cleaned.lastIndexOf(".");
+        if (dot < 0 || dot >= cleaned.length - 1) return cleaned.slice(0, MAX_LEN);
+        const ext = cleaned.slice(dot).slice(0, 16); // also cap extension
+        return cleaned.slice(0, MAX_LEN - ext.length) + ext;
+}
 
 // Parse the Docker multiplexed stream format used when Tty:false.
 // Frame layout: [type(1)][pad(3)][size(4 BE)] followed by `size` payload bytes.

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -387,9 +387,15 @@ export class DockerManager {
                 // top of the realpath check); the captured inode is the
                 // anchor we compare against after each rename to catch a
                 // swap performed during the loop.
+                // O_DIRECTORY is Linux-only — undefined on macOS. The
+                // bitwise OR would silently drop it on dev macOS hosts and
+                // open the path without the "must-be-a-directory" check.
+                // Production target is Linux per CLAUDE.md, but `?? 0` keeps
+                // the fallback explicit so a dev iterating on macOS doesn't
+                // hit a confusing later-stage stat failure instead.
                 const dirHandle = await fs.open(
                         realUploadsDir,
-                        nodeFsConstants.O_DIRECTORY | nodeFsConstants.O_NOFOLLOW,
+                        (nodeFsConstants.O_DIRECTORY ?? 0) | nodeFsConstants.O_NOFOLLOW,
                 );
                 // Use the bigint stat variant on BOTH sides of the inode
                 // comparison. Default `number` ino loses precision past 2^53,

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -400,6 +400,19 @@ export class DockerManager {
                                 if (!finalPathAbs.startsWith(`${realUploadsDir}${path.sep}`)) {
                                         throw new Error(`unsafe upload path resolved outside ${realUploadsDir}: ${finalPathAbs}`);
                                 }
+                                // Apply final mode + ownership BEFORE the rename, on
+                                // the multer tmp file in .tmp-uploads/ (root-owned,
+                                // not bind-mounted into any container). rename(2)
+                                // moves the inode in place — mode and owner are
+                                // preserved at the destination — so any post-rename
+                                // chmod/chown that would re-resolve through the
+                                // attacker-planted symlink is unnecessary. Order
+                                // matters: doing chmod/chown after rename leaves a
+                                // residual TOCTOU window where a swap mid-loop
+                                // would have those calls follow the symlink and
+                                // alter permissions of arbitrary host files.
+                                await fs.chmod(file.path, 0o644);
+                                await this.chownToWorkspaceUser(file.path);
                                 // Atomic move within the same filesystem (multer's
                                 // tmp dir lives under WORKSPACE_ROOT — see routes.ts).
                                 await fs.rename(file.path, finalPath);
@@ -426,8 +439,6 @@ export class DockerManager {
                                         );
                                         throw new Error("uploads dir was swapped during write — possible TOCTOU attack");
                                 }
-                                await fs.chmod(finalPath, 0o644);
-                                await this.chownToWorkspaceUser(finalPath);
                                 containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
                         }
                 } finally {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -6,7 +6,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import type { Dirent } from "node:fs";
+import { constants as nodeFsConstants, type Dirent } from "node:fs";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { Duplex } from "node:stream";
@@ -26,6 +26,34 @@ const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT ?? "/var/shared-terminal/works
 // instead.
 const WORKSPACE_UID = Number.parseInt(process.env.WORKSPACE_UID ?? "1000", 10);
 const WORKSPACE_GID = Number.parseInt(process.env.WORKSPACE_GID ?? "1000", 10);
+
+// Per-session disk cap on user-uploaded files. The IP rate limiter (30/5min)
+// bounds request count, not bytes — without this an authenticated user could
+// write 30 × 8 × 25 MB = 6 GB / 5 min of uploads to disk indefinitely
+// (workspace files survive soft-delete). Default is 1 GB; ample for legit
+// "drop a few screenshots" usage, well below host-disk-fill range.
+const UPLOAD_QUOTA_BYTES = (() => {
+        const raw = process.env.UPLOAD_QUOTA_BYTES;
+        if (!raw) return 1024 * 1024 * 1024;
+        const n = Number.parseInt(raw, 10);
+        return Number.isFinite(n) && n > 0 ? n : 1024 * 1024 * 1024;
+})();
+
+export class UploadQuotaExceededError extends Error {
+        readonly quota: number;
+        readonly used: number;
+        readonly attempted: number;
+        constructor(used: number, attempted: number, quota: number) {
+                super(
+                        `Per-session upload quota exceeded: ${used} bytes used + ${attempted} attempted ` +
+                        `> ${quota} cap. Delete files from uploads/ to free space.`,
+                );
+                this.name = "UploadQuotaExceededError";
+                this.used = used;
+                this.attempted = attempted;
+                this.quota = quota;
+        }
+}
 
 // Opt-in: repair ownership on pre-existing *contents* under the session
 // directory, not just the top-level dir. Useful one-shot for deployments
@@ -254,17 +282,65 @@ export class DockerManager {
                         throw new Error(`uploads dir escaped workspace root: ${realUploadsDir}`);
                 }
                 // Deliberately NOT chowning realUploadsDir to the workspace user.
-                // The container owns the parent `<sessionId>/` directory (set by
-                // spawn-time ensureWorkspaceOwnership), so it can rmdir/rename
-                // any subdir it owns. If we chowned uploads/ to uid 1000, the
-                // container could empty the dir then `ln -s /etc uploads/` —
-                // resolving the path string at rename(2) time would land the
-                // backend write outside WORKSPACE_ROOT despite the realpath
-                // check above (TOCTOU on the path component, not the file).
-                // Keeping uploads/ owned by the backend (typically root,
-                // mode 0755) means the container can still traverse and read
-                // its own files (per-file chown to uid 1000 below) but can't
-                // empty or write inside the dir to stage the swap.
+                // Even with uploads/ owned by root and the per-file chown below,
+                // the container still owns the parent `<sessionId>/` directory
+                // (set by spawn-time ensureWorkspaceOwnership) — POSIX rename(2)
+                // requires write on the source-parent only, NOT ownership of the
+                // entry being renamed, so the container can do
+                //   `mv uploads uploads.bak; ln -s /etc uploads`
+                // mid-loop and have the next rename(2) re-resolve the path
+                // string into /etc. This is a TOCTOU residue we can't fully
+                // close without openat/renameat (Node lacks bindings) or a
+                // separate non-bind-mounted uploads dir (architectural change).
+                // Mitigation: hold uploadsHostDir open via O_DIRECTORY|
+                // O_NOFOLLOW so a freshly-replaced symlink is detected at fd
+                // open time, and re-lstat the dir entry after each rename to
+                // detect a swap during the loop. Window narrows from "the
+                // entire upload" to "the gap between the lstat and the next
+                // rename", on the order of microseconds.
+
+                // Per-session disk-quota check: count current bytes in
+                // uploads/ + bytes about to be added; reject before moving any
+                // tmp file if the cap would be exceeded. Sum-of-statSize is a
+                // tight enough approximation — uploads/ is always one level
+                // deep (writeUploads only writes flat) so no recursion.
+                let usedBytes = 0;
+                try {
+                        const existing = await fs.readdir(realUploadsDir);
+                        for (const entry of existing) {
+                                const stat = await fs.stat(path.join(realUploadsDir, entry));
+                                if (stat.isFile()) usedBytes += stat.size;
+                        }
+                } catch (err) {
+                        // ENOENT is fine — fresh session with no uploads yet.
+                        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+                }
+                let attemptedBytes = 0;
+                for (const file of files) {
+                        const stat = await fs.stat(file.path);
+                        attemptedBytes += stat.size;
+                }
+                if (usedBytes + attemptedBytes > UPLOAD_QUOTA_BYTES) {
+                        await this.cleanupTmp(files);
+                        throw new UploadQuotaExceededError(usedBytes, attemptedBytes, UPLOAD_QUOTA_BYTES);
+                }
+
+                // Open the dir as a stable fd. O_NOFOLLOW makes this fail if
+                // realUploadsDir is already a symlink (defence-in-depth on
+                // top of the realpath check); the captured inode is the
+                // anchor we compare against after each rename to catch a
+                // swap performed during the loop.
+                const dirHandle = await fs.open(
+                        realUploadsDir,
+                        nodeFsConstants.O_DIRECTORY | nodeFsConstants.O_NOFOLLOW,
+                );
+                let stableIno: bigint | number;
+                try {
+                        stableIno = (await dirHandle.stat()).ino;
+                } catch (err) {
+                        await dirHandle.close();
+                        throw err;
+                }
 
                 const containerPaths: string[] = [];
                 const now = Date.now().toString(36);
@@ -285,16 +361,26 @@ export class DockerManager {
                                 }
                                 // Atomic move within the same filesystem (multer's
                                 // tmp dir lives under WORKSPACE_ROOT — see routes.ts).
-                                // EXDEV would fire if someone repointed multer's tmp
-                                // root elsewhere; surfacing the error is fine because
-                                // the tmp file is still cleaned up by the finally below.
                                 await fs.rename(file.path, finalPath);
                                 remaining.delete(file.path);
+                                // TOCTOU sentinel: if the entry at realUploadsDir
+                                // now resolves to a different inode than the dir
+                                // we opened above, something swapped it during
+                                // the loop. The rename may have landed in the
+                                // swap target; best-effort unlink (which follows
+                                // the symlink, removing the leaked file) and bail
+                                // before any more writes go through.
+                                const liveIno = (await fs.lstat(realUploadsDir)).ino;
+                                if (liveIno !== stableIno) {
+                                        await fs.unlink(finalPath).catch(() => { /* best-effort */ });
+                                        throw new Error("uploads dir was swapped during write — possible TOCTOU attack");
+                                }
                                 await fs.chmod(finalPath, 0o644);
                                 await this.chownToWorkspaceUser(finalPath);
                                 containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
                         }
                 } finally {
+                        await dirHandle.close();
                         await this.cleanupTmp([...remaining].map((p) => ({ originalname: "", path: p })));
                 }
                 return containerPaths;

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -253,10 +253,18 @@ export class DockerManager {
                         await this.cleanupTmp(files);
                         throw new Error(`uploads dir escaped workspace root: ${realUploadsDir}`);
                 }
-                // Chown the canonical path, not the lexical one — fs.chown
-                // follows symlinks, but realUploadsDir is already the resolved
-                // target, so we operate on the real directory.
-                await this.chownToWorkspaceUser(realUploadsDir);
+                // Deliberately NOT chowning realUploadsDir to the workspace user.
+                // The container owns the parent `<sessionId>/` directory (set by
+                // spawn-time ensureWorkspaceOwnership), so it can rmdir/rename
+                // any subdir it owns. If we chowned uploads/ to uid 1000, the
+                // container could empty the dir then `ln -s /etc uploads/` —
+                // resolving the path string at rename(2) time would land the
+                // backend write outside WORKSPACE_ROOT despite the realpath
+                // check above (TOCTOU on the path component, not the file).
+                // Keeping uploads/ owned by the backend (typically root,
+                // mode 0755) means the container can still traverse and read
+                // its own files (per-file chown to uid 1000 below) but can't
+                // empty or write inside the dir to stage the swap.
 
                 const containerPaths: string[] = [];
                 const now = Date.now().toString(36);

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -223,40 +223,96 @@ export class DockerManager {
          */
         async writeUploads(
                 sessionId: string,
-                files: ReadonlyArray<{ originalname: string; buffer: Buffer }>,
+                files: ReadonlyArray<{ originalname: string; path: string }>,
         ): Promise<string[]> {
                 if (files.length === 0) return [];
-                const rootAbs = path.resolve(WORKSPACE_ROOT);
                 const uploadsHostDir = path.join(WORKSPACE_ROOT, sessionId, "uploads");
+                // Lexical sanity check (matches purgeWorkspace at L306).
+                // assertOwnership already constrains sessionId to a UUID from D1,
+                // but if a future refactor ever lets a path-traversal-shaped
+                // sessionId reach here we must not even mkdir outside WORKSPACE_ROOT.
+                const rootAbs = path.resolve(WORKSPACE_ROOT);
                 const uploadsHostDirAbs = path.resolve(uploadsHostDir);
-                // Defence-in-depth (matches purgeWorkspace at L306): assertOwnership
-                // already constrains sessionId to a UUID from D1, but if a future
-                // refactor ever lets a path-traversal-shaped sessionId reach here we
-                // must not create directories or write files outside WORKSPACE_ROOT.
                 if (!uploadsHostDirAbs.startsWith(`${rootAbs}${path.sep}`)) {
+                        await this.cleanupTmp(files);
                         throw new Error(`unsafe session path resolved outside ${rootAbs}: ${uploadsHostDirAbs}`);
                 }
                 await fs.mkdir(uploadsHostDir, { recursive: true });
-                await this.chownToWorkspaceUser(uploadsHostDir);
+
+                // Lexical resolve() above is purely string manipulation — it
+                // does NOT follow symlinks. A container owns its bind-mounted
+                // workspace and could replace `uploads/` with a symlink to /etc
+                // before we got here; the lexical check would still pass and
+                // a subsequent chown would change ownership of the link target.
+                // fs.realpath canonicalises through the filesystem, so a
+                // mis-pointed symlink shows up as a real-path outside
+                // WORKSPACE_ROOT and we bail before touching anything.
+                const rootReal = await fs.realpath(WORKSPACE_ROOT);
+                const realUploadsDir = await fs.realpath(uploadsHostDir);
+                if (!realUploadsDir.startsWith(`${rootReal}${path.sep}`)) {
+                        await this.cleanupTmp(files);
+                        throw new Error(`uploads dir escaped workspace root: ${realUploadsDir}`);
+                }
+                // Chown the canonical path, not the lexical one — fs.chown
+                // follows symlinks, but realUploadsDir is already the resolved
+                // target, so we operate on the real directory.
+                await this.chownToWorkspaceUser(realUploadsDir);
 
                 const containerPaths: string[] = [];
                 const now = Date.now().toString(36);
-                for (const file of files) {
-                        const safeBase = sanitiseUploadName(file.originalname);
-                        // Random suffix on top of the timestamp so two uploads
-                        // landing in the same millisecond don't collide.
-                        const suffix = randomBytes(3).toString("hex");
-                        const filename = `${now}-${suffix}-${safeBase}`;
-                        const hostPath = path.join(uploadsHostDir, filename);
-                        const hostPathAbs = path.resolve(hostPath);
-                        if (!hostPathAbs.startsWith(`${uploadsHostDirAbs}${path.sep}`)) {
-                                throw new Error(`unsafe upload path resolved outside ${uploadsHostDirAbs}: ${hostPathAbs}`);
+                // Track which multer tmp files we've successfully moved so the
+                // finally block can clean up anything we didn't get to.
+                const remaining = new Set(files.map((f) => f.path));
+                try {
+                        for (const file of files) {
+                                const safeBase = sanitiseUploadName(file.originalname);
+                                // Random suffix on top of the timestamp so two uploads
+                                // landing in the same millisecond don't collide.
+                                const suffix = randomBytes(3).toString("hex");
+                                const filename = `${now}-${suffix}-${safeBase}`;
+                                const finalPath = path.join(realUploadsDir, filename);
+                                const finalPathAbs = path.resolve(finalPath);
+                                if (!finalPathAbs.startsWith(`${realUploadsDir}${path.sep}`)) {
+                                        throw new Error(`unsafe upload path resolved outside ${realUploadsDir}: ${finalPathAbs}`);
+                                }
+                                // Atomic move within the same filesystem (multer's
+                                // tmp dir lives under WORKSPACE_ROOT — see routes.ts).
+                                // EXDEV would fire if someone repointed multer's tmp
+                                // root elsewhere; surfacing the error is fine because
+                                // the tmp file is still cleaned up by the finally below.
+                                await fs.rename(file.path, finalPath);
+                                remaining.delete(file.path);
+                                await fs.chmod(finalPath, 0o644);
+                                await this.chownToWorkspaceUser(finalPath);
+                                containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
                         }
-                        await fs.writeFile(hostPath, file.buffer, { mode: 0o644 });
-                        await this.chownToWorkspaceUser(hostPath);
-                        containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
+                } finally {
+                        await this.cleanupTmp([...remaining].map((p) => ({ originalname: "", path: p })));
                 }
                 return containerPaths;
+        }
+
+        /**
+         * Absolute host path where multer streams uploaded bodies before
+         * `writeUploads` moves them to their final per-session location.
+         * Lives directly under WORKSPACE_ROOT (NOT inside any session
+         * subdirectory) so it's never bind-mounted into a container, and
+         * `fs.rename` from here to the final path is a same-filesystem
+         * atomic move.
+         */
+        getUploadTmpDir(): string {
+                return path.join(WORKSPACE_ROOT, ".tmp-uploads");
+        }
+
+        // Best-effort cleanup of multer's on-disk temp files. Used on the
+        // bail-out paths in writeUploads (containment-check failure, mid-loop
+        // throw). Each unlink is independently swallowed because the only
+        // failure modes here are "file already gone" or "no permission" —
+        // neither is something the upload caller should hear about.
+        private async cleanupTmp(
+                files: ReadonlyArray<{ path: string }>,
+        ): Promise<void> {
+                await Promise.allSettled(files.map((f) => fs.unlink(f.path)));
         }
 
         async kill(sessionId: string): Promise<void> {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -1038,8 +1038,37 @@ export class DockerManager {
 
         // ── Helpers ─────────────────────────────────────────────────────────────
 
+        /**
+         * Best-effort sweep of the multer tmp directory at startup. If the
+         * backend was OOM-killed or crashed mid-upload, multer's tmp files
+         * (which the upload route would normally rename or unlink) are left
+         * behind forever — harmless to security but accumulates on disk
+         * over crash/restart cycles. Called from reconcile() so the same
+         * startup hook handles both forms of stale state.
+         */
+        async sweepUploadTmp(): Promise<void> {
+                const dir = this.getUploadTmpDir();
+                let entries: Dirent[];
+                try {
+                        entries = await fs.readdir(dir, { withFileTypes: true });
+                } catch (err) {
+                        // ENOENT is expected on a fresh deployment — nothing to sweep.
+                        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+                                console.warn(`[docker] sweepUploadTmp readdir failed for ${dir}: ${(err as Error).message}`);
+                        }
+                        return;
+                }
+                if (entries.length === 0) return;
+                const results = await Promise.allSettled(
+                        entries.map((e) => fs.unlink(path.join(dir, e.name))),
+                );
+                const failed = results.filter((r) => r.status === "rejected").length;
+                console.log(`[docker] sweepUploadTmp removed ${entries.length - failed}/${entries.length} stale tmp files`);
+        }
+
         async reconcile(): Promise<void> {
                 console.log("[docker] reconciling session state with Docker…");
+                await this.sweepUploadTmp();
                 const result = await d1Query<{ session_id: string; container_id: string | null }>(
                         "SELECT session_id, container_id FROM sessions WHERE status = 'running'",
                 );

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -253,9 +253,11 @@ export class DockerManager {
          * monotonic timestamp + short random suffix so concurrent uploads
          * of the same name don't clobber each other. The host path of
          * every write is `path.resolve()`d and verified to sit inside the
-         * uploads directory before opening the file — the sanitiser
-         * already strips path separators, but the resolve-and-check is a
-         * defence-in-depth belt against a future regression.
+         * uploads directory before any rename — the sanitiser already
+         * strips path separators, but the resolve-and-check is a defence-
+         * in-depth belt against a future regression. Concurrent calls for
+         * the same session are serialised via `uploadLocks` so the quota
+         * check (read-then-write) can't race itself.
          */
         async writeUploads(
                 sessionId: string,
@@ -289,7 +291,7 @@ export class DockerManager {
                 files: ReadonlyArray<{ originalname: string; path: string }>,
         ): Promise<string[]> {
                 const uploadsHostDir = path.join(WORKSPACE_ROOT, sessionId, "uploads");
-                // Lexical sanity check (matches purgeWorkspace at L306).
+                // Lexical sanity check (matches the same belt in purgeWorkspace).
                 // assertOwnership already constrains sessionId to a UUID from D1,
                 // but if a future refactor ever lets a path-traversal-shaped
                 // sessionId reach here we must not even mkdir outside WORKSPACE_ROOT.
@@ -355,9 +357,11 @@ export class DockerManager {
                         for (const entry of existing) {
                                 // lstat (not stat) so a container-planted symlink in
                                 // its own uploads/ pointing at e.g. /var/log/syslog
-                                // counts as the link's own bytes (~80) rather than
-                                // the target's size — otherwise the container could
-                                // self-DoS by inflating its perceived quota usage.
+                                // is excluded from the quota count entirely —
+                                // st.isFile() returns false for symlinks, so they
+                                // contribute zero bytes rather than inflating with
+                                // the target's size and letting the container self-
+                                // DoS its own quota.
                                 const st = await fs.lstat(path.join(realUploadsDir, entry));
                                 if (st.isFile()) usedBytes += st.size;
                         }

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -44,10 +44,13 @@ export class UploadQuotaExceededError extends Error {
         readonly used: number;
         readonly attempted: number;
         constructor(used: number, attempted: number, quota: number) {
-                super(
-                        `Per-session upload quota exceeded: ${used} bytes used + ${attempted} attempted ` +
-                        `> ${quota} cap. Delete files from uploads/ to free space.`,
-                );
+                // Generic, byte-count-free message — handleSessionError ships
+                // err.message verbatim as the 413 body, so anything precise
+                // here would leak the same per-session usage that route's
+                // structured-field suppression is meant to hide. Server-side
+                // logging happens in writeUploads at the throw site so the
+                // operator still has the detail for capacity planning.
+                super("Per-session upload quota exceeded. Delete files from uploads/ to free space.");
                 this.name = "UploadQuotaExceededError";
                 this.used = used;
                 this.attempted = attempted;
@@ -357,6 +360,13 @@ export class DockerManager {
                         attemptedBytes += stat.size;
                 }
                 if (usedBytes + attemptedBytes > UPLOAD_QUOTA_BYTES) {
+                        // Log the detail server-side; the thrown error carries
+                        // a generic message so the byte counts don't ride out
+                        // in the 413 body to the client.
+                        console.warn(
+                                `[docker] upload quota rejected for session ${sessionId}: ` +
+                                `${usedBytes} used + ${attemptedBytes} attempted > ${UPLOAD_QUOTA_BYTES} cap`,
+                        );
                         await this.cleanupTmp(files);
                         throw new UploadQuotaExceededError(usedBytes, attemptedBytes, UPLOAD_QUOTA_BYTES);
                 }

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -308,8 +308,13 @@ export class DockerManager {
                 try {
                         const existing = await fs.readdir(realUploadsDir);
                         for (const entry of existing) {
-                                const stat = await fs.stat(path.join(realUploadsDir, entry));
-                                if (stat.isFile()) usedBytes += stat.size;
+                                // lstat (not stat) so a container-planted symlink in
+                                // its own uploads/ pointing at e.g. /var/log/syslog
+                                // counts as the link's own bytes (~80) rather than
+                                // the target's size — otherwise the container could
+                                // self-DoS by inflating its perceived quota usage.
+                                const st = await fs.lstat(path.join(realUploadsDir, entry));
+                                if (st.isFile()) usedBytes += st.size;
                         }
                 } catch (err) {
                         // ENOENT is fine — fresh session with no uploads yet.

--- a/backend/src/dockerManager.uploads.test.ts
+++ b/backend/src/dockerManager.uploads.test.ts
@@ -1,0 +1,193 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// WORKSPACE_ROOT and UPLOAD_QUOTA_BYTES are read into module-level consts
+// when dockerManager.ts loads, so they have to be set BEFORE any import of
+// that module. vi.hoisted runs before all imports — including the ones
+// later in this file — making it the right place to mutate process.env.
+//
+// The quota is set tight (10 KB) so we can deterministically trigger
+// UploadQuotaExceededError with a single ~15 KB tmp file.
+const WORKSPACE_ROOT = vi.hoisted(() => {
+        const dir = `/tmp/st-uploads-test-${process.pid}-${Date.now()}`;
+        process.env.WORKSPACE_ROOT = dir;
+        process.env.UPLOAD_QUOTA_BYTES = "10000";
+        return dir;
+});
+
+// dockerode tries to lazy-connect on first call, not at construction —
+// passing a bogus socket keeps the constructor happy and these tests
+// never exercise any docker.* path.
+const dbStubs = vi.hoisted(() => ({
+        d1Query: vi.fn(async () => ({ results: [], meta: { changes: 0 } })),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import { DockerManager, UploadQuotaExceededError } from "./dockerManager.js";
+import type { SessionManager } from "./sessionManager.js";
+
+function makeDocker(): DockerManager {
+        const fakeSessions = {} as unknown as SessionManager;
+        return new DockerManager(fakeSessions, { socketPath: "/dev/null" });
+}
+
+// Drop a file in the multer tmp dir as if multer's diskStorage had just
+// streamed an upload there. Returns the shape writeUploads consumes.
+async function makeTmpFile(
+        dm: DockerManager,
+        originalname: string,
+        content: string | Buffer,
+): Promise<{ originalname: string; path: string }> {
+        const tmpDir = dm.getUploadTmpDir();
+        await fs.mkdir(tmpDir, { recursive: true });
+        const tmpPath = path.join(tmpDir, `tmp-${Math.random().toString(36).slice(2)}`);
+        await fs.writeFile(tmpPath, content);
+        return { originalname, path: tmpPath };
+}
+
+async function rmRf(p: string): Promise<void> {
+        await fs.rm(p, { recursive: true, force: true });
+}
+
+beforeAll(async () => {
+        await fs.mkdir(WORKSPACE_ROOT, { recursive: true });
+});
+
+afterAll(async () => {
+        await rmRf(WORKSPACE_ROOT);
+});
+
+describe("writeUploads", () => {
+        let dm: DockerManager;
+
+        beforeEach(async () => {
+                // Wipe per-test state — the prior test's session dirs and any
+                // stragglers in the tmp dir would otherwise pollute the next
+                // test's expectations.
+                const entries = await fs.readdir(WORKSPACE_ROOT).catch(() => [] as string[]);
+                for (const e of entries) await rmRf(path.join(WORKSPACE_ROOT, e));
+                dm = makeDocker();
+        });
+
+        it("writes each file under <session>/uploads and returns the container path", async () => {
+                // Two small files, well under the 10 KB quota.
+                const a = await makeTmpFile(dm, "alpha.png", "alpha-bytes");
+                const b = await makeTmpFile(dm, "beta.txt", "beta-bytes");
+
+                const result = await dm.writeUploads("session-happy", [a, b]);
+
+                expect(result).toHaveLength(2);
+                for (const p of result) {
+                        expect(p.startsWith("/home/developer/workspace/uploads/")).toBe(true);
+                }
+                // The container paths' filenames map directly onto the
+                // host-side basenames — useful guarantee for tests that want
+                // to spot-check on-disk state.
+                const uploadsDir = path.join(WORKSPACE_ROOT, "session-happy", "uploads");
+                const onDisk = await fs.readdir(uploadsDir);
+                expect(onDisk).toHaveLength(2);
+                for (const p of result) {
+                        expect(onDisk).toContain(path.basename(p));
+                }
+
+                // Tmp dir should be empty — every file got renamed (moved),
+                // not copied; orphans here would leak under the rate limiter.
+                const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
+                expect(tmpEntries).toHaveLength(0);
+        });
+
+        it("preserves file content across the rename(2) move", async () => {
+                const payload = Buffer.from("the quick brown fox jumps over the lazy dog");
+                const f = await makeTmpFile(dm, "phrase.txt", payload);
+
+                const [containerPath] = await dm.writeUploads("session-content", [f]);
+                expect(containerPath).toBeDefined();
+                const hostPath = path.join(
+                        WORKSPACE_ROOT,
+                        "session-content",
+                        "uploads",
+                        path.basename(containerPath as string),
+                );
+                const written = await fs.readFile(hostPath);
+                expect(written.equals(payload)).toBe(true);
+        });
+
+        it("throws UploadQuotaExceededError and cleans tmp files when batch exceeds quota", async () => {
+                // 15 KB > 10 KB cap, in a single file.
+                const big = await makeTmpFile(dm, "log.txt", "x".repeat(15000));
+
+                await expect(dm.writeUploads("session-quota", [big])).rejects.toBeInstanceOf(
+                        UploadQuotaExceededError,
+                );
+
+                // Tmp file unlinked on the bail-out path.
+                const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
+                expect(tmpEntries).toHaveLength(0);
+
+                // Nothing landed in the session's uploads dir.
+                const uploadsDir = path.join(WORKSPACE_ROOT, "session-quota", "uploads");
+                const onDisk = await fs.readdir(uploadsDir).catch(() => [] as string[]);
+                expect(onDisk).toHaveLength(0);
+        });
+
+        it("counts pre-existing uploads against the quota across requests", async () => {
+                // First request: 6 KB succeeds.
+                const first = await makeTmpFile(dm, "a.txt", "x".repeat(6000));
+                await dm.writeUploads("session-cumulative", [first]);
+
+                // Second request: 5 KB would push total to 11 KB > 10 KB cap.
+                const second = await makeTmpFile(dm, "b.txt", "x".repeat(5000));
+                await expect(dm.writeUploads("session-cumulative", [second])).rejects.toBeInstanceOf(
+                        UploadQuotaExceededError,
+                );
+
+                // First file is still in place; only the second was rejected.
+                const onDisk = await fs.readdir(
+                        path.join(WORKSPACE_ROOT, "session-cumulative", "uploads"),
+                );
+                expect(onDisk).toHaveLength(1);
+        });
+
+        it("rejects when the resolved session path escapes WORKSPACE_ROOT", async () => {
+                // sessionId starts with .. so path.join collapses it one level
+                // above WORKSPACE_ROOT — the lexical containment check should
+                // catch it before any fs op runs.
+                const f = await makeTmpFile(dm, "evil.txt", "payload");
+                await expect(dm.writeUploads("../escape", [f])).rejects.toThrow(/unsafe session path/);
+                // Tmp file cleaned up on the bail-out.
+                const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
+                expect(tmpEntries).toHaveLength(0);
+        });
+
+        it("returns an empty array (and writes nothing) for an empty file list", async () => {
+                const result = await dm.writeUploads("session-empty", []);
+                expect(result).toEqual([]);
+                // Should not even mkdir the uploads dir for an empty batch.
+                const sessionDir = path.join(WORKSPACE_ROOT, "session-empty");
+                const exists = await fs.stat(sessionDir).then(() => true, () => false);
+                expect(exists).toBe(false);
+        });
+});
+
+describe("sweepUploadTmp", () => {
+        let dm: DockerManager;
+        beforeEach(() => { dm = makeDocker(); });
+
+        it("removes every file in the tmp dir", async () => {
+                const tmpDir = dm.getUploadTmpDir();
+                await fs.mkdir(tmpDir, { recursive: true });
+                await fs.writeFile(path.join(tmpDir, "stale1"), "x");
+                await fs.writeFile(path.join(tmpDir, "stale2"), "y");
+
+                await dm.sweepUploadTmp();
+
+                const remaining = await fs.readdir(tmpDir);
+                expect(remaining).toEqual([]);
+        });
+
+        it("no-ops when the tmp dir doesn't exist (fresh deployment)", async () => {
+                await rmRf(dm.getUploadTmpDir());
+                await expect(dm.sweepUploadTmp()).resolves.toBeUndefined();
+        });
+});

--- a/backend/src/dockerManager.uploads.test.ts
+++ b/backend/src/dockerManager.uploads.test.ts
@@ -70,7 +70,16 @@ describe("writeUploads", () => {
                 dm = makeDocker();
         });
 
-        it("writes each file under <session>/uploads and returns the container path", async () => {
+        // Helper: per-session uploads dir on host, where writeUploads
+        // actually moves files to. Lives at <WORKSPACE_ROOT>/.uploads/
+        // <sessionId>/ — out-of-workspace by design (TOCTOU isolation,
+        // see writeUploadsImpl). spawn() bind-mounts this dir read-only
+        // into the container at /home/developer/workspace/uploads/, but
+        // these tests never construct containers — they only exercise
+        // host-side state.
+        const uploadsHostDir = (sid: string) => path.join(WORKSPACE_ROOT, ".uploads", sid);
+
+        it("writes each file under .uploads/<session>/ and returns the in-container path", async () => {
                 // Two small files, well under the 10 KB quota.
                 const a = await makeTmpFile(dm, "alpha.png", "alpha-bytes");
                 const b = await makeTmpFile(dm, "beta.txt", "beta-bytes");
@@ -84,8 +93,7 @@ describe("writeUploads", () => {
                 // The container paths' filenames map directly onto the
                 // host-side basenames — useful guarantee for tests that want
                 // to spot-check on-disk state.
-                const uploadsDir = path.join(WORKSPACE_ROOT, "session-happy", "uploads");
-                const onDisk = await fs.readdir(uploadsDir);
+                const onDisk = await fs.readdir(uploadsHostDir("session-happy"));
                 expect(onDisk).toHaveLength(2);
                 for (const p of result) {
                         expect(onDisk).toContain(path.basename(p));
@@ -104,9 +112,7 @@ describe("writeUploads", () => {
                 const [containerPath] = await dm.writeUploads("session-content", [f]);
                 expect(containerPath).toBeDefined();
                 const hostPath = path.join(
-                        WORKSPACE_ROOT,
-                        "session-content",
-                        "uploads",
+                        uploadsHostDir("session-content"),
                         path.basename(containerPath as string),
                 );
                 const written = await fs.readFile(hostPath);
@@ -126,8 +132,7 @@ describe("writeUploads", () => {
                 expect(tmpEntries).toHaveLength(0);
 
                 // Nothing landed in the session's uploads dir.
-                const uploadsDir = path.join(WORKSPACE_ROOT, "session-quota", "uploads");
-                const onDisk = await fs.readdir(uploadsDir).catch(() => [] as string[]);
+                const onDisk = await fs.readdir(uploadsHostDir("session-quota")).catch(() => [] as string[]);
                 expect(onDisk).toHaveLength(0);
         });
 
@@ -143,9 +148,7 @@ describe("writeUploads", () => {
                 );
 
                 // First file is still in place; only the second was rejected.
-                const onDisk = await fs.readdir(
-                        path.join(WORKSPACE_ROOT, "session-cumulative", "uploads"),
-                );
+                const onDisk = await fs.readdir(uploadsHostDir("session-cumulative"));
                 expect(onDisk).toHaveLength(1);
         });
 
@@ -172,19 +175,20 @@ describe("writeUploads", () => {
                 );
 
                 // Exactly one file on disk under uploads/.
-                const onDisk = await fs.readdir(
-                        path.join(WORKSPACE_ROOT, "session-concurrent", "uploads"),
-                );
+                const onDisk = await fs.readdir(uploadsHostDir("session-concurrent"));
                 expect(onDisk).toHaveLength(1);
                 // Both tmp files cleaned up — winner via rename, loser via cleanupTmp.
                 const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
                 expect(tmpEntries).toHaveLength(0);
         });
 
-        it("rejects when the resolved session path escapes WORKSPACE_ROOT", async () => {
-                // sessionId starts with .. so path.join collapses it one level
-                // above WORKSPACE_ROOT — the lexical containment check should
-                // catch it before any fs op runs.
+        it("rejects when the resolved session path escapes the .uploads/ namespace", async () => {
+                // sessionId "../escape" makes path.join collapse one level —
+                // path.join(WORKSPACE_ROOT, ".uploads", "../escape") is
+                // <WORKSPACE_ROOT>/escape, still under WORKSPACE_ROOT but
+                // outside .uploads/. The containment check below is scoped to
+                // .uploads/ specifically (NOT just WORKSPACE_ROOT) so the
+                // traversal is caught before any fs op runs.
                 const f = await makeTmpFile(dm, "evil.txt", "payload");
                 await expect(dm.writeUploads("../escape", [f])).rejects.toThrow(/unsafe session path/);
                 // Tmp file cleaned up on the bail-out.
@@ -196,7 +200,7 @@ describe("writeUploads", () => {
                 const result = await dm.writeUploads("session-empty", []);
                 expect(result).toEqual([]);
                 // Should not even mkdir the uploads dir for an empty batch.
-                const sessionDir = path.join(WORKSPACE_ROOT, "session-empty");
+                const sessionDir = uploadsHostDir("session-empty");
                 const exists = await fs.stat(sessionDir).then(() => true, () => false);
                 expect(exists).toBe(false);
         });

--- a/backend/src/dockerManager.uploads.test.ts
+++ b/backend/src/dockerManager.uploads.test.ts
@@ -149,6 +149,38 @@ describe("writeUploads", () => {
                 expect(onDisk).toHaveLength(1);
         });
 
+        it("serialises concurrent writeUploads for the same session so two batches can't both pass the quota check", async () => {
+                // Each batch is 6 KB on its own; either alone fits under the
+                // 10 KB cap. Together they would push to 12 KB and break the
+                // cap — but only if the two reads of usedBytes both saw
+                // zero. The per-session lock guarantees the second batch
+                // reads the first's bytes, so exactly one wins.
+                const a = await makeTmpFile(dm, "a.txt", "x".repeat(6000));
+                const b = await makeTmpFile(dm, "b.txt", "x".repeat(6000));
+
+                const results = await Promise.allSettled([
+                        dm.writeUploads("session-concurrent", [a]),
+                        dm.writeUploads("session-concurrent", [b]),
+                ]);
+
+                const fulfilled = results.filter((r) => r.status === "fulfilled");
+                const rejected = results.filter((r) => r.status === "rejected");
+                expect(fulfilled).toHaveLength(1);
+                expect(rejected).toHaveLength(1);
+                expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+                        UploadQuotaExceededError,
+                );
+
+                // Exactly one file on disk under uploads/.
+                const onDisk = await fs.readdir(
+                        path.join(WORKSPACE_ROOT, "session-concurrent", "uploads"),
+                );
+                expect(onDisk).toHaveLength(1);
+                // Both tmp files cleaned up — winner via rename, loser via cleanupTmp.
+                const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
+                expect(tmpEntries).toHaveLength(0);
+        });
+
         it("rejects when the resolved session path escapes WORKSPACE_ROOT", async () => {
                 // sessionId starts with .. so path.join collapses it one level
                 // above WORKSPACE_ROOT — the lexical containment check should

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -364,12 +364,15 @@ describe("auth route rate limiting", () => {
 		register: { ipMax: number; ipWindowMs: number };
 		invitesCreate?: { ipMax: number; ipWindowMs: number };
 		invitesRevoke?: { ipMax: number; ipWindowMs: number };
+		fileUpload?: { ipMax: number; ipWindowMs: number };
 	}): Promise<void> {
-		// Invite limiters were split into create/revoke later; both default to
-		// permissive settings for tests that only exercise login/register.
+		// Invite + upload limiters were added later; default each to a
+		// permissive setting so tests that only exercise login/register
+		// don't trip them.
 		const fullCfg = {
 			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
 			invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+			fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
 			...cfg,
 		};
 		const router = buildRouter(fakeSessions, fakeDocker, fullCfg);

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -30,8 +30,13 @@ import { buildRouter } from "./routes.js";
 // Typed placeholders for the route tests — no session/docker routes are
 // hit in these scenarios, so an empty-object cast is fine AND preserves
 // type-checking if a future route starts calling into sessions/docker.
+// getUploadTmpDir IS called eagerly during buildRouter() when configuring
+// multer's diskStorage destination, so fakeDocker has to provide a stub
+// even though no upload route runs in these tests.
 const fakeSessions = {} as unknown as SessionManager;
-const fakeDocker = {} as unknown as DockerManager;
+const fakeDocker = {
+	getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
+} as unknown as DockerManager;
 
 // ── UsernameRateLimiter unit tests ─────────────────────────────────────────
 

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -39,6 +39,16 @@ export interface RateLimitConfig {
 		ipMax: number;
 		ipWindowMs: number;
 	};
+	// Caps how often a single IP can POST file uploads. Each request can
+	// carry up to 8 × 25 MB = 200 MB; without a limiter a valid JWT could
+	// loop the route and fill the host disk (workspace files survive
+	// soft-delete). Sized for the legitimate "drop a few screenshots in a
+	// row" pattern — well above human cadence, well below sustained
+	// abuse rates.
+	fileUpload: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
 }
 
 // Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
@@ -63,6 +73,10 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 		ipMax: 60,
 		ipWindowMs: 60 * 60 * 1000,
 	},
+	fileUpload: {
+		ipMax: 30,
+		ipWindowMs: 5 * 60 * 1000,
+	},
 };
 
 // ── IP-based limiters (express-rate-limit) ─────────────────────────────────
@@ -72,6 +86,7 @@ export interface AuthRateLimiters {
 	registerIp: RateLimitRequestHandler;
 	invitesCreateIp: RateLimitRequestHandler;
 	invitesRevokeIp: RateLimitRequestHandler;
+	fileUploadIp: RateLimitRequestHandler;
 }
 
 export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
@@ -111,7 +126,14 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many invite-revoke requests from this IP, try again later", scope: "ip" },
 	});
-	return { loginIp, registerIp, invitesCreateIp, invitesRevokeIp };
+	const fileUploadIp = rateLimit({
+		windowMs: cfg.fileUpload.ipWindowMs,
+		limit: cfg.fileUpload.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: { error: "Too many file uploads from this IP, try again later", scope: "ip" },
+	});
+	return { loginIp, registerIp, invitesCreateIp, invitesRevokeIp, fileUploadIp };
 }
 
 // ── Per-username limiter ────────────────────────────────────────────────────

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -636,6 +636,14 @@ export function buildRouter(
 
         router.post(
                 "/sessions/:id/files",
+                // Explicit requireAuth so the route doesn't silently inherit
+                // its auth gate from `router.use("/sessions", requireAuth)`
+                // earlier in this file. If a future refactor lifts this
+                // route out of the /sessions prefix, the explicit guard
+                // makes the failure mode a 401 (loud) instead of an
+                // anon-userId reaching assertOwnership and surfacing as a
+                // confusing 404.
+                requireAuth,
                 fileUploadIp,
                 requireSessionOwnership,
                 handleUploadMiddleware,

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -633,13 +633,12 @@ export function buildRouter(
                                 );
                                 res.status(201).json({ paths });
                         } catch (err) {
-                                // writeUploads owns its own tmp cleanup, but a throw
-                                // before it gets called (e.g. the empty-files 400 above
-                                // would only happen if multer ran with no files in the
-                                // form, in which case there's nothing on disk anyway)
-                                // can leave stragglers. Best-effort unlink — failures
-                                // here are not interesting to the caller.
-                                await Promise.allSettled(files.map((f) => fs.unlink(f.path)));
+                                // No tmp cleanup needed here — writeUploads owns
+                                // its own finally block that unlinks every tmp file
+                                // it didn't move. The empty-files 400 above returns
+                                // before the writeUploads call (and only triggers
+                                // when multer parsed zero files, in which case
+                                // there's nothing on disk to clean either way).
                                 handleSessionError(err, res);
                         }
                 },

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -22,6 +22,7 @@ import {
         UsernameTakenError,
 } from "./auth.js";
 import type { DockerManager } from "./dockerManager.js";
+import { UploadQuotaExceededError } from "./dockerManager.js";
 import { EnvVarValidationError, validateEnvVars } from "./envVarValidation.js";
 import type { RateLimitConfig } from "./rateLimit.js";
 import {
@@ -548,6 +549,15 @@ export function buildRouter(
                 limits: {
                         fileSize: 25 * 1024 * 1024,
                         files: 8,
+                        // Endpoint accepts only file parts (named "files"), no
+                        // text fields. Cap fields/parts so a JWT holder can't
+                        // make busboy parse thousands of throwaway parts before
+                        // the file count hits its limit. parts = files (8) + 1
+                        // headroom; fields = 0 means any non-file part trips
+                        // LIMIT_PART_COUNT immediately.
+                        fields: 0,
+                        parts: 9,
+                        fieldNameSize: 64,
                 },
         });
 
@@ -693,6 +703,10 @@ function handleSessionError(err: unknown, res: Response): void {
                 res.status(404).json({ error: err.message });
         } else if (err instanceof ForbiddenError) {
                 res.status(403).json({ error: err.message });
+        } else if (err instanceof UploadQuotaExceededError) {
+                // 413 Payload Too Large is the HTTP-spec answer for "request
+                // would push you past a server-enforced size cap".
+                res.status(413).json({ error: err.message, used: err.used, attempted: err.attempted, quota: err.quota });
         } else {
                 console.error("[routes] unexpected error:", (err as Error).message);
                 res.status(500).json({ error: "Internal server error" });

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -2,8 +2,9 @@
  * routes.ts — REST API routes.
  */
 
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { Router } from "express";
+import multer from "multer";
 import type { AuthedRequest } from "./auth.js";
 import {
         createInvite,
@@ -501,6 +502,58 @@ export function buildRouter(
 
                         await docker.deleteTab(id, tabId);
                         res.status(204).send();
+                } catch (err) {
+                        handleSessionError(err, res);
+                }
+        });
+
+        // ── File uploads ────────────────────────────────────────────────────────
+        // Drop user-uploaded files into the session's bind-mounted workspace
+        // (under uploads/) so the container — and Claude CLI in it — can read
+        // them. Memory storage is fine at the configured size cap; multer
+        // streams the multipart upload, only buffering a single file at a
+        // time. Caps:
+        //   - 25 MB per file: covers the images / PDFs Claude actually
+        //     accepts without forcing chunked upload UI.
+        //   - 8 files per request: enough for a typical "drop a few
+        //     screenshots" gesture, low enough to bound peak memory.
+        const upload = multer({
+                storage: multer.memoryStorage(),
+                limits: {
+                        fileSize: 25 * 1024 * 1024,
+                        files: 8,
+                },
+        });
+
+        // Wrap multer so its async-throw errors land in our handleSessionError-style
+        // responder instead of Express's default HTML 500 page.
+        const handleUploadMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+                upload.array("files", 8)(req, res, (err: unknown) => {
+                        if (!err) { next(); return; }
+                        if (err instanceof multer.MulterError) {
+                                const status = err.code === "LIMIT_FILE_SIZE" ? 413 : 400;
+                                res.status(status).json({ error: `Upload rejected: ${err.message}` });
+                                return;
+                        }
+                        console.error("[routes] upload middleware error:", (err as Error).message);
+                        res.status(500).json({ error: "Upload failed" });
+                });
+        };
+
+        router.post("/sessions/:id/files", handleUploadMiddleware, async (req: Request, res: Response) => {
+                const { userId } = req as AuthedRequest;
+                try {
+                        await sessions.assertOwnership(req.params.id, userId);
+                        const files = (req.files as Express.Multer.File[] | undefined) ?? [];
+                        if (files.length === 0) {
+                                res.status(400).json({ error: "no files provided (use 'files' field, multipart/form-data)" });
+                                return;
+                        }
+                        const paths = await docker.writeUploads(
+                                req.params.id,
+                                files.map((f) => ({ originalname: f.originalname, buffer: f.buffer })),
+                        );
+                        res.status(201).json({ paths });
                 } catch (err) {
                         handleSessionError(err, res);
                 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -724,11 +724,13 @@ function handleSessionError(err: unknown, res: Response): void {
                 res.status(403).json({ error: err.message });
         } else if (err instanceof UploadQuotaExceededError) {
                 // 413 Payload Too Large is the HTTP-spec answer for "request
-                // would push you past a server-enforced size cap". The
-                // err.message string already carries used/attempted/quota
-                // for display; drop the structured byte-count fields so
-                // we don't surface another user's disk usage if sessions
-                // ever become shared.
+                // would push you past a server-enforced size cap".
+                // err.message is intentionally generic — no byte counts —
+                // and the structured used/attempted/quota fields are logged
+                // server-side by writeUploads at the throw site, never
+                // surfaced in the response. Two-layer suppression so a
+                // future tweak to either side doesn't silently leak per-
+                // session usage to the client.
                 res.status(413).json({ error: err.message });
         } else {
                 console.error("[routes] unexpected error:", (err as Error).message);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -595,6 +595,14 @@ export function buildRouter(
                                         res.status(413).json({ error: `Upload rejected: ${err.message}` });
                                         return;
                                 }
+                                if (err.code === "LIMIT_FILE_COUNT" || err.code === "LIMIT_PART_COUNT") {
+                                        // Both are payload-too-large in spirit: the request
+                                        // exceeds a server cap (8 files / 9 parts). 413 is
+                                        // the spec answer and lets clients distinguish
+                                        // "retry-may-help" 4xxs from this hard cap.
+                                        res.status(413).json({ error: `Upload rejected: ${err.message}` });
+                                        return;
+                                }
                                 if (err.code === "LIMIT_UNEXPECTED_FILE") {
                                         // Default message ("Unexpected field") doesn't tell the
                                         // caller what field name we DO expect — name it explicitly.

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -44,7 +44,7 @@ export function buildRouter(
 
         // ── Auth routes (public) ────────────────────────────────────────────────
 
-        const { loginIp, registerIp, invitesCreateIp, invitesRevokeIp } = createAuthRateLimiters(rateLimitConfig);
+        const { loginIp, registerIp, invitesCreateIp, invitesRevokeIp, fileUploadIp } = createAuthRateLimiters(rateLimitConfig);
         const usernameLimiter = new UsernameRateLimiter(
                 rateLimitConfig.login.usernameMax,
                 rateLimitConfig.login.usernameWindowMs,
@@ -540,7 +540,7 @@ export function buildRouter(
                 });
         };
 
-        router.post("/sessions/:id/files", handleUploadMiddleware, async (req: Request, res: Response) => {
+        router.post("/sessions/:id/files", fileUploadIp, handleUploadMiddleware, async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
                 try {
                         await sessions.assertOwnership(req.params.id, userId);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -2,6 +2,8 @@
  * routes.ts — REST API routes.
  */
 
+import { randomBytes } from "node:crypto";
+import { promises as fs } from "node:fs";
 import type { NextFunction, Request, Response } from "express";
 import { Router } from "express";
 import multer from "multer";
@@ -510,15 +512,39 @@ export function buildRouter(
         // ── File uploads ────────────────────────────────────────────────────────
         // Drop user-uploaded files into the session's bind-mounted workspace
         // (under uploads/) so the container — and Claude CLI in it — can read
-        // them. Memory storage is fine at the configured size cap; multer
-        // streams the multipart upload, only buffering a single file at a
-        // time. Caps:
+        // them.
+        //
+        // Disk storage (NOT memoryStorage) is the load-bearing choice here.
+        // 8 × 25 MB = 200 MB of body per request, and the per-IP rate
+        // limiter (30/5min) doesn't bound concurrency — 30 concurrent
+        // requests with memoryStorage would peak at ~6 GB of heap and
+        // OOM-kill the backend. Disk storage streams bytes through Node
+        // into the OS page cache, then `writeUploads` atomically renames
+        // the temp file into the final per-session location.
+        //
+        // Caps:
         //   - 25 MB per file: covers the images / PDFs Claude actually
         //     accepts without forcing chunked upload UI.
         //   - 8 files per request: enough for a typical "drop a few
-        //     screenshots" gesture, low enough to bound peak memory.
+        //     screenshots" gesture, low enough to bound peak disk usage
+        //     per request.
+        const uploadTmpDir = docker.getUploadTmpDir();
         const upload = multer({
-                storage: multer.memoryStorage(),
+                storage: multer.diskStorage({
+                        destination: (_req, _file, cb) => {
+                                // Idempotent — the dir often already exists; recursive: true
+                                // makes mkdir a no-op in that case.
+                                fs.mkdir(uploadTmpDir, { recursive: true })
+                                        .then(() => cb(null, uploadTmpDir))
+                                        .catch((err: Error) => cb(err, ""));
+                        },
+                        filename: (_req, _file, cb) => {
+                                // multer-internal name only; writeUploads renames to the
+                                // user-facing `<ts>-<rand>-<safeBase>` form when it moves
+                                // the file into the per-session uploads/ dir.
+                                cb(null, `${Date.now().toString(36)}-${randomBytes(8).toString("hex")}`);
+                        },
+                }),
                 limits: {
                         fileSize: 25 * 1024 * 1024,
                         files: 8,
@@ -572,18 +598,26 @@ export function buildRouter(
                 requireSessionOwnership,
                 handleUploadMiddleware,
                 async (req: Request, res: Response) => {
+                        const files = (req.files as Express.Multer.File[] | undefined) ?? [];
                         try {
-                                const files = (req.files as Express.Multer.File[] | undefined) ?? [];
                                 if (files.length === 0) {
                                         res.status(400).json({ error: "no files provided (use 'files' field, multipart/form-data)" });
                                         return;
                                 }
                                 const paths = await docker.writeUploads(
                                         req.params.id,
-                                        files.map((f) => ({ originalname: f.originalname, buffer: f.buffer })),
+                                        // diskStorage — pass the on-disk tmp path, not a buffer.
+                                        files.map((f) => ({ originalname: f.originalname, path: f.path })),
                                 );
                                 res.status(201).json({ paths });
                         } catch (err) {
+                                // writeUploads owns its own tmp cleanup, but a throw
+                                // before it gets called (e.g. the empty-files 400 above
+                                // would only happen if multer ran with no files in the
+                                // form, in which case there's nothing on disk anyway)
+                                // can leave stragglers. Best-effort unlink — failures
+                                // here are not interesting to the caller.
+                                await Promise.allSettled(files.map((f) => fs.unlink(f.path)));
                                 handleSessionError(err, res);
                         }
                 },

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -531,8 +531,17 @@ export function buildRouter(
                 upload.array("files", 8)(req, res, (err: unknown) => {
                         if (!err) { next(); return; }
                         if (err instanceof multer.MulterError) {
-                                const status = err.code === "LIMIT_FILE_SIZE" ? 413 : 400;
-                                res.status(status).json({ error: `Upload rejected: ${err.message}` });
+                                if (err.code === "LIMIT_FILE_SIZE") {
+                                        res.status(413).json({ error: `Upload rejected: ${err.message}` });
+                                        return;
+                                }
+                                if (err.code === "LIMIT_UNEXPECTED_FILE") {
+                                        // Default message ("Unexpected field") doesn't tell the
+                                        // caller what field name we DO expect — name it explicitly.
+                                        res.status(400).json({ error: "Upload rejected: field must be named 'files' (multipart/form-data)" });
+                                        return;
+                                }
+                                res.status(400).json({ error: `Upload rejected: ${err.message}` });
                                 return;
                         }
                         console.error("[routes] upload middleware error:", (err as Error).message);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -549,24 +549,45 @@ export function buildRouter(
                 });
         };
 
-        router.post("/sessions/:id/files", fileUploadIp, handleUploadMiddleware, async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
+        // Verify ownership BEFORE multer reads any bytes from the wire. With
+        // up to 200 MB (8 × 25 MB) per request, running the ownership check
+        // in the route handler — i.e. after multer has already buffered
+        // everything into the Node heap — let an authenticated user with a
+        // valid JWT but a foreign session ID cause N × 200 MB allocations
+        // bounded only by the per-IP rate limiter. Doing it here means
+        // unauthorised requests close the socket on the 403 with no body
+        // ever buffered.
+        const requireSessionOwnership = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
                 try {
-                        await sessions.assertOwnership(req.params.id, userId);
-                        const files = (req.files as Express.Multer.File[] | undefined) ?? [];
-                        if (files.length === 0) {
-                                res.status(400).json({ error: "no files provided (use 'files' field, multipart/form-data)" });
-                                return;
-                        }
-                        const paths = await docker.writeUploads(
-                                req.params.id,
-                                files.map((f) => ({ originalname: f.originalname, buffer: f.buffer })),
-                        );
-                        res.status(201).json({ paths });
+                        await sessions.assertOwnership(req.params.id, (req as AuthedRequest).userId);
+                        next();
                 } catch (err) {
                         handleSessionError(err, res);
                 }
-        });
+        };
+
+        router.post(
+                "/sessions/:id/files",
+                fileUploadIp,
+                requireSessionOwnership,
+                handleUploadMiddleware,
+                async (req: Request, res: Response) => {
+                        try {
+                                const files = (req.files as Express.Multer.File[] | undefined) ?? [];
+                                if (files.length === 0) {
+                                        res.status(400).json({ error: "no files provided (use 'files' field, multipart/form-data)" });
+                                        return;
+                                }
+                                const paths = await docker.writeUploads(
+                                        req.params.id,
+                                        files.map((f) => ({ originalname: f.originalname, buffer: f.buffer })),
+                                );
+                                res.status(201).json({ paths });
+                        } catch (err) {
+                                handleSessionError(err, res);
+                        }
+                },
+        );
 
         return router;
 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -556,6 +556,18 @@ export function buildRouter(
         const handleUploadMiddleware = (req: Request, res: Response, next: NextFunction): void => {
                 upload.array("files", 8)(req, res, (err: unknown) => {
                         if (!err) { next(); return; }
+                        // When multer aborts mid-batch (e.g. file 8 trips
+                        // LIMIT_FILE_SIZE after files 1–7 already streamed to
+                        // .tmp-uploads/), it auto-removes only the partial
+                        // file for the entry that errored. The earlier
+                        // successfully-streamed files sit in req.files and
+                        // would otherwise leak — at 30 reqs / 5min × 7 ×
+                        // ~25 MB = ~5 GB/window of orphaned tmp files. Clear
+                        // them on every error branch before returning.
+                        const partial = (req.files as Express.Multer.File[] | undefined) ?? [];
+                        if (partial.length > 0) {
+                                void Promise.allSettled(partial.map((f) => fs.unlink(f.path)));
+                        }
                         if (err instanceof multer.MulterError) {
                                 if (err.code === "LIMIT_FILE_SIZE") {
                                         res.status(413).json({ error: `Upload rejected: ${err.message}` });

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -576,7 +576,19 @@ export function buildRouter(
                         // them on every error branch before returning.
                         const partial = (req.files as Express.Multer.File[] | undefined) ?? [];
                         if (partial.length > 0) {
-                                void Promise.allSettled(partial.map((f) => fs.unlink(f.path)));
+                                void Promise.allSettled(partial.map((f) => fs.unlink(f.path))).then((results) => {
+                                        // Log unlink failures (e.g. EPERM from a misconfigured
+                                        // tmp dir owner) so a real filesystem problem doesn't
+                                        // sit invisible until the next startup sweep. ENOENT
+                                        // is the expected outcome on a never-streamed entry
+                                        // and gets logged too — noise here is a clearer
+                                        // signal than silence.
+                                        for (const r of results) {
+                                                if (r.status === "rejected") {
+                                                        console.warn("[routes] tmp unlink failed:", (r.reason as Error).message);
+                                                }
+                                        }
+                                });
                         }
                         if (err instanceof multer.MulterError) {
                                 if (err.code === "LIMIT_FILE_SIZE") {
@@ -704,8 +716,12 @@ function handleSessionError(err: unknown, res: Response): void {
                 res.status(403).json({ error: err.message });
         } else if (err instanceof UploadQuotaExceededError) {
                 // 413 Payload Too Large is the HTTP-spec answer for "request
-                // would push you past a server-enforced size cap".
-                res.status(413).json({ error: err.message, used: err.used, attempted: err.attempted, quota: err.quota });
+                // would push you past a server-enforced size cap". The
+                // err.message string already carries used/attempted/quota
+                // for display; drop the structured byte-count fields so
+                // we don't surface another user's disk usage if sessions
+                // ever become shared.
+                res.status(413).json({ error: err.message });
         } else {
                 console.error("[routes] unexpected error:", (err as Error).message);
                 res.status(500).json({ error: "Internal server error" });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -101,13 +101,15 @@
           <button id="logout-btn">Logout</button>
         </div>
         <button
-          id="paste-btn"
+          id="actions-btn"
           type="button"
-          title="Paste text into the terminal"
-          aria-label="Paste text into the terminal"
+          title="Insert into terminal"
+          aria-label="Insert into terminal"
+          aria-haspopup="menu"
+          aria-expanded="false"
           hidden
         >
-          Paste
+          +
         </button>
       </header>
       <main>
@@ -236,6 +238,39 @@
         </div>
       </div>
     </div>
+
+    <!-- Actions menu — surfaces Paste / Attach below the + button -->
+    <div id="actions-menu" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card actions-menu-card"
+        role="menu"
+        aria-labelledby="actions-menu-title"
+      >
+        <div class="modal-header">
+          <h2 id="actions-menu-title">Insert</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <button class="actions-menu-item" id="actions-paste-btn" type="button" role="menuitem">
+          <span class="actions-menu-item-title">Paste text</span>
+          <span class="actions-menu-item-hint">Send clipboard or typed text into the terminal</span>
+        </button>
+        <button class="actions-menu-item" id="actions-attach-btn" type="button" role="menuitem">
+          <span class="actions-menu-item-title">Attach file</span>
+          <span class="actions-menu-item-hint">Upload an image, PDF, or any file Claude CLI can read</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Hidden file picker target wired to the Attach action above -->
+    <input id="file-input" type="file" multiple hidden />
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -243,11 +243,39 @@ export async function revokeInvite(code: string): Promise<void> {
         }
 }
 
+// ── File uploads ────────────────────────────────────────────────────────────
+
+/**
+ * Upload one or more files to a session's workspace. The backend writes
+ * them under `<workspace>/uploads/` and returns the in-container paths
+ * the user can pass to Claude CLI.
+ */
+export async function uploadSessionFiles(
+        sessionId: string,
+        files: File[],
+): Promise<{ paths: string[] }> {
+        const fd = new FormData();
+        for (const f of files) fd.append("files", f, f.name);
+        const res = await apiFetch(`/sessions/${sessionId}/files`, {
+                method: "POST",
+                body: fd,
+        });
+        if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error ?? `Upload failed (${res.status})`);
+        }
+        return res.json() as Promise<{ paths: string[] }>;
+}
+
 // ── Fetch wrapper ───────────────────────────────────────────────────────────
 
 async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+        // FormData carries its own multipart boundary — letting us set
+        // Content-Type would clobber that and the server would fail to
+        // parse the upload. Skip the JSON default in that case.
+        const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData;
         const headers: Record<string, string> = {
-                "Content-Type": "application/json",
+                ...(isFormData ? {} : { "Content-Type": "application/json" }),
                 ...(init?.headers as Record<string, string> ?? {}),
         };
         // Captured before the fetch so a concurrent setToken(null) between

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -682,30 +682,78 @@ main:not([data-sidebar-ready]) #sidebar {
   border-color: #58a6ff;
   color: #58a6ff;
 }
-/* Paste button lives in the header; mobile-only because desktop xterm
-   handles Cmd/Ctrl+V natively. The default `display: none` keeps it out
-   of the desktop layout entirely, the @media (max-width: 768px) block
-   below flips it to inline-flex when not [hidden] (the hidden attribute
-   is toggled by main.ts in lockstep with the chrome-toggle pill — both
+/* Actions button (+ menu) lives in the header. Mobile-only because
+   desktop xterm handles Cmd/Ctrl+V natively, and drag-drop covers
+   file uploads on desktop. The default `display: none` keeps it out
+   of the desktop layout; the @media (max-width: 768px) block below
+   flips it to inline-flex when not [hidden] (the hidden attribute is
+   toggled by main.ts in lockstep with the chrome-toggle pill — both
    are gated on whether there's an active session). */
-#paste-btn {
+#actions-btn {
   display: none;
   background: transparent;
   border: 1px solid #30363d;
   border-radius: 6px;
   color: #c9d1d9;
-  font-size: 0.78rem;
-  padding: 0.3rem 0.7rem;
+  font-size: 1.05rem;
+  padding: 0.18rem 0.62rem;
   cursor: pointer;
   line-height: 1;
-  font-weight: 500;
+  font-weight: 600;
+  /* The "+" glyph is heavier than the prior "Paste" label and tends
+     to ride high inside a tightly-padded button; nudge baseline down
+     a hair so it sits centred next to the chrome-toggle pill. */
+  padding-bottom: 0.24rem;
 }
-#paste-btn:hover {
+#actions-btn:hover {
   border-color: #58a6ff;
   color: #58a6ff;
 }
-#paste-btn:active {
-  background: rgba(88, 166, 255, 0.1);
+#actions-btn:active,
+#actions-btn[aria-expanded="true"] {
+  background: rgba(88, 166, 255, 0.12);
+  border-color: #58a6ff;
+  color: #58a6ff;
+}
+
+/* ── Actions menu (mobile + sheet) ─────────────────────────── */
+.actions-menu-card {
+  width: 360px;
+  max-width: 92vw;
+  padding: 1rem 1rem 0.75rem;
+  gap: 0.5rem;
+}
+.actions-menu-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  padding: 0.7rem 0.85rem;
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  color: #e6edf3;
+  cursor: pointer;
+  text-align: left;
+  margin-bottom: 0.4rem;
+}
+.actions-menu-item:hover {
+  border-color: #58a6ff;
+  background: #0e1622;
+}
+.actions-menu-item:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.actions-menu-item-title {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #e6edf3;
+}
+.actions-menu-item-hint {
+  font-size: 0.72rem;
+  color: #8b949e;
+  line-height: 1.35;
 }
 #terminal-tabs {
   display: none;
@@ -967,14 +1015,15 @@ main:not([data-sidebar-ready]) #sidebar {
     opacity: 1;
   }
 
-  /* Paste lives at the right edge of the mobile header. chrome-toggle
-     has `flex: 1` when active, but it can be hidden (no session
-     selected) — `margin-left: auto` pins paste-btn to the right edge
-     in both cases. Safe inside this @media block because #paste-btn
-     is `display: none` at the desktop default; if the button is ever
-     exposed at the desktop breakpoint, this rule needs to lose the
-     auto-margin or it'll fight `.header-right`'s own auto-margin. */
-  #paste-btn:not([hidden]) {
+  /* Actions (+) button lives at the right edge of the mobile header.
+     chrome-toggle has `flex: 1` when active, but it can be hidden (no
+     session selected) — `margin-left: auto` pins actions-btn to the
+     right edge in both cases. Safe inside this @media block because
+     #actions-btn is `display: none` at the desktop default; if the
+     button is ever exposed at the desktop breakpoint, this rule needs
+     to lose the auto-margin or it'll fight `.header-right`'s own
+     auto-margin. */
+  #actions-btn:not([hidden]) {
     display: inline-flex;
     margin-left: auto;
   }

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -682,15 +682,14 @@ main:not([data-sidebar-ready]) #sidebar {
   border-color: #58a6ff;
   color: #58a6ff;
 }
-/* Actions button (+ menu) lives in the header. Mobile-only because
-   desktop xterm handles Cmd/Ctrl+V natively, and drag-drop covers
-   file uploads on desktop. The default `display: none` keeps it out
-   of the desktop layout; the @media (max-width: 768px) block below
-   flips it to inline-flex when not [hidden] (the hidden attribute is
-   toggled by main.ts in lockstep with the chrome-toggle pill — both
-   are gated on whether there's an active session). */
+/* Actions button (+ menu) lives in the header on every viewport. The
+   menu hosts both the paste flow (mobile-essential, desktop-handy as a
+   text-paste fallback) and the file-attach flow (useful everywhere).
+   `display: inline-flex` is the visible default; the [hidden] attribute
+   from main.ts gates it on whether there's an active session, in
+   lockstep with the chrome-toggle pill. */
 #actions-btn {
-  display: none;
+  display: inline-flex;
   background: transparent;
   border: 1px solid #30363d;
   border-radius: 6px;
@@ -704,6 +703,12 @@ main:not([data-sidebar-ready]) #sidebar {
      to ride high inside a tightly-padded button; nudge baseline down
      a hair so it sits centred next to the chrome-toggle pill. */
   padding-bottom: 0.24rem;
+}
+#actions-btn[hidden] {
+  /* The [hidden] attribute defaults to `display: none` in user-agent
+     stylesheets, but our `display: inline-flex` rule above wins on
+     specificity — so we have to spell it out for the hidden case. */
+  display: none;
 }
 #actions-btn:hover {
   border-color: #58a6ff;
@@ -1018,13 +1023,12 @@ main:not([data-sidebar-ready]) #sidebar {
   /* Actions (+) button lives at the right edge of the mobile header.
      chrome-toggle has `flex: 1` when active, but it can be hidden (no
      session selected) — `margin-left: auto` pins actions-btn to the
-     right edge in both cases. Safe inside this @media block because
-     #actions-btn is `display: none` at the desktop default; if the
-     button is ever exposed at the desktop breakpoint, this rule needs
-     to lose the auto-margin or it'll fight `.header-right`'s own
-     auto-margin. */
+     right edge in both cases. Desktop doesn't need the auto-margin
+     because .header-right (which sits earlier in the DOM and carries
+     `margin-left: auto` itself) already pushes itself + actions-btn
+     to the right; on mobile .header-right is `display: none` and
+     would-be auto-pusher disappears, so we need our own. */
   #actions-btn:not([hidden]) {
-    display: inline-flex;
     margin-left: auto;
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1543,6 +1543,11 @@ fileInput.addEventListener("change", async () => {
                         showToast("No active session", true);
                         return;
                 }
+                // Snapshot the id before any await so a session-switch or
+                // logout that flips activeSessionId mid-upload doesn't end
+                // up POSTing to /sessions/null/files. Same pattern as
+                // addTab — see main.ts:741-style snapshot in this file.
+                const sessionId = activeSessionId;
                 if (picked.length > MAX_ATTACH_FILES) {
                         showToast(`Too many files (${picked.length}; max ${MAX_ATTACH_FILES})`, true);
                         return;
@@ -1556,7 +1561,7 @@ fileInput.addEventListener("change", async () => {
                 showToast(`Uploading ${picked.length} file${picked.length === 1 ? "" : "s"}…`);
                 let result: { paths: string[] };
                 try {
-                        result = await uploadSessionFiles(activeSessionId, picked);
+                        result = await uploadSessionFiles(sessionId, picked);
                 } catch (err) {
                         showToast(`Upload failed: ${(err as Error).message}`, true);
                         return;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1557,7 +1557,7 @@ fileInput.addEventListener("change", async () => {
                 // Snapshot the id before any await so a session-switch or
                 // logout that flips activeSessionId mid-upload doesn't end
                 // up POSTing to /sessions/null/files. Same pattern as
-                // addTab — see main.ts:741-style snapshot in this file.
+                // addTab and openSession.
                 const sessionId = activeSessionId;
                 if (picked.length > MAX_ATTACH_FILES) {
                         showToast(`Too many files (${picked.length}; max ${MAX_ATTACH_FILES})`, true);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1536,7 +1536,13 @@ fileInput.addEventListener("change", async () => {
         // Clear immediately so a re-pick of the same files still triggers change.
         fileInput.value = "";
         if (picked.length === 0) return;
-        if (attachInFlight) return;
+        if (attachInFlight) {
+                // Without the toast the picker silently closes and nothing
+                // happens — the prior "Uploading…" toast may have already
+                // scrolled away, so the user has no feedback.
+                showToast("Upload in progress, try again shortly", true);
+                return;
+        }
         attachInFlight = true;
         try {
                 if (!activeSessionId) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -15,6 +15,7 @@ import {
         listSessions, createSession, deleteSession, stopSession, startSession,
         listTabs, createTab, deleteTab, TabNotFoundError,
         listInvites, createInvite, revokeInvite, InviteRequiredError,
+        uploadSessionFiles,
         SESSION_EXPIRED_EVENT,
         type SessionInfo, type Tab, type Invite,
 } from "./api.js";
@@ -61,7 +62,11 @@ const terminalTabs = document.getElementById("terminal-tabs")!;
 const terminalContainer = document.getElementById("terminal-container")!;
 const emptyState = document.getElementById("empty-state")!;
 const fontSizeBtn = document.getElementById("font-size-btn") as HTMLButtonElement;
-const pasteBtn = document.getElementById("paste-btn") as HTMLButtonElement;
+const actionsBtn = document.getElementById("actions-btn") as HTMLButtonElement;
+const actionsMenu = document.getElementById("actions-menu")!;
+const actionsPasteBtn = document.getElementById("actions-paste-btn") as HTMLButtonElement;
+const actionsAttachBtn = document.getElementById("actions-attach-btn") as HTMLButtonElement;
+const fileInput = document.getElementById("file-input") as HTMLInputElement;
 const pasteModal = document.getElementById("paste-modal")!;
 const pasteTextarea = document.getElementById("paste-textarea") as HTMLTextAreaElement;
 const pasteClipboardBtn = document.getElementById("paste-clipboard-btn") as HTMLButtonElement;
@@ -991,7 +996,7 @@ sidebarBackdrop.addEventListener("click", () => setSidebarOpen(false));
 document.addEventListener("keydown", (e) => {
         if (e.key !== "Escape") return;
         if (!isMobile()) return;
-        if (invitesModal.classList.contains("open") || pasteModal.classList.contains("open")) return;
+        if (invitesModal.classList.contains("open") || pasteModal.classList.contains("open") || actionsMenu.classList.contains("open")) return;
         if (!mainEl.classList.contains("sidebar-open")) return;
         setSidebarOpen(false);
 });
@@ -1051,8 +1056,9 @@ function setChromeOpen(open: boolean) {
 // Keep the header chrome-toggle's label in sync with the active session
 // and tab. On mobile this IS the only on-screen indication of "where you
 // are" — sessions sidebar and tabs row are both hidden by default.
-// The mobile paste button rides the same visibility lifecycle: nothing
-// to paste into when no session is active, so hide both together.
+// The mobile actions (+) button rides the same visibility lifecycle:
+// nothing to paste into or attach to when no session is active, so hide
+// both together.
 function updateChromeToggle() {
         const s = sessions.find((x) => x.sessionId === activeSessionId);
         // Hide the toggle entirely when there's no session — there's nothing
@@ -1060,11 +1066,11 @@ function updateChromeToggle() {
         // already explains what to do next.
         if (!s) {
                 chromeToggleBtn.hidden = true;
-                pasteBtn.hidden = true;
+                actionsBtn.hidden = true;
                 return;
         }
         chromeToggleBtn.hidden = false;
-        pasteBtn.hidden = false;
+        actionsBtn.hidden = false;
         const activeTab = currentTabs.find((t) => t.tabId === currentActiveTabId);
         // Format: "session › tab". Falls back to just the session name when
         // no tab is active yet (fresh session, between switches). Using a
@@ -1275,6 +1281,9 @@ document.addEventListener("keydown", (e) => {
                 closeInvitesModal();
         } else if (pasteModal.classList.contains("open")) {
                 closePasteModal();
+        } else if (actionsMenu.classList.contains("open")) {
+                closeActionsMenu();
+                actionsBtn.focus();
         }
 });
 
@@ -1319,16 +1328,15 @@ function closePasteModal() {
         pasteModal.setAttribute("aria-hidden", "true");
         pasteTextarea.value = "";
         pasteSendBtn.disabled = true;
-        // Release the pasteBtn in-flight guard. The pasteBtn click handler
-        // intentionally leaves it set on the modal-open path so a second
-        // tap can't kick off a parallel readClipboardText() while the modal
-        // is open; closure of the modal is the signal that the cycle is
-        // truly finished.
+        // Release the runPasteFlow in-flight guard. The flow intentionally
+        // leaves it set on the modal-open path so a second tap can't kick
+        // off a parallel readClipboardText() while the modal is open;
+        // closure of the modal is the signal that the cycle is truly
+        // finished.
         pasteInFlight = false;
-        // Restore focus to the opener; on mobile the chrome drawer is open
-        // when the modal is dismissed, so paste-btn is reachable. If the
-        // opener is somehow gone (drawer collapsed externally), the focus
-        // call is a harmless no-op.
+        // Restore focus to the opener — typically actionsBtn, which is
+        // visible whenever a session is active. If it's somehow gone the
+        // focus call is a harmless no-op.
         pasteOpener?.focus();
         pasteOpener = null;
 }
@@ -1363,7 +1371,7 @@ async function readClipboardText(): Promise<string | null> {
 // finally without depending on a synthetic catch-and-rethrow.
 let pasteInFlight = false;
 
-pasteBtn.addEventListener("click", async () => {
+async function runPasteFlow(opener: HTMLButtonElement) {
         if (pasteInFlight) return;
         pasteInFlight = true;
         let releaseGuard = true;
@@ -1395,19 +1403,19 @@ pasteBtn.addEventListener("click", async () => {
                 // closePasteModal so the second-tap protection covers the
                 // entire modal lifetime, not just the synchronous tail of
                 // this handler.
-                openPasteModal(pasteBtn);
+                openPasteModal(opener);
                 releaseGuard = false;
         } finally {
                 if (releaseGuard) pasteInFlight = false;
         }
-});
+}
 
 pasteClipboardBtn.addEventListener("click", async () => {
         // Disable for the duration of the async readText() so a double-tap on
         // a slow iOS consent chip doesn't queue a stale second resolve. Same
-        // intent as the pasteBtn pasteInFlight guard, just expressed via the
-        // button's own disabled state since there's nowhere visual to look
-        // for in-flight feedback otherwise.
+        // intent as the runPasteFlow pasteInFlight guard, just expressed via
+        // the button's own disabled state since there's nowhere visual to
+        // look for in-flight feedback otherwise.
         pasteClipboardBtn.disabled = true;
         try {
                 const clip = await readClipboardText();
@@ -1462,6 +1470,116 @@ pasteSendBtn.addEventListener("click", () => {
 pasteModal.addEventListener("click", (e) => {
         const target = e.target as HTMLElement;
         if (target.hasAttribute("data-close-modal")) closePasteModal();
+});
+
+// ── Actions (+) menu ────────────────────────────────────────────────────────
+// The mobile "+" button hosts both the existing paste flow and the new
+// file-attach flow. Two-step UX (open menu → pick action) is the cost of
+// supporting more than one command from a single header button.
+
+function openActionsMenu() {
+        actionsMenu.classList.add("open");
+        actionsMenu.setAttribute("aria-hidden", "false");
+        actionsBtn.setAttribute("aria-expanded", "true");
+        actionsPasteBtn.focus();
+}
+
+function closeActionsMenu() {
+        actionsMenu.classList.remove("open");
+        actionsMenu.setAttribute("aria-hidden", "true");
+        actionsBtn.setAttribute("aria-expanded", "false");
+}
+
+actionsBtn.addEventListener("click", () => {
+        if (actionsMenu.classList.contains("open")) {
+                closeActionsMenu();
+                actionsBtn.focus();
+        } else {
+                openActionsMenu();
+        }
+});
+
+actionsMenu.addEventListener("click", (e) => {
+        const target = e.target as HTMLElement;
+        if (target.hasAttribute("data-close-modal")) {
+                closeActionsMenu();
+                actionsBtn.focus();
+        }
+});
+
+actionsPasteBtn.addEventListener("click", async () => {
+        closeActionsMenu();
+        // actionsBtn is the visible widget the user tapped first; route focus
+        // back to it when the paste modal eventually closes.
+        await runPasteFlow(actionsBtn);
+});
+
+actionsAttachBtn.addEventListener("click", () => {
+        closeActionsMenu();
+        // Reset the input so picking the same file twice in a row still
+        // fires `change` (browsers no-op when value is unchanged).
+        fileInput.value = "";
+        fileInput.click();
+});
+
+// ── File attachment flow ────────────────────────────────────────────────────
+// Upload via multipart, then type the in-container paths into the active
+// terminal so the user can keep typing their prompt around them.
+
+const MAX_ATTACH_FILES = 8;        // mirrors backend multer cap
+const MAX_ATTACH_BYTES = 25 * 1024 * 1024; // mirrors backend per-file cap
+
+let attachInFlight = false;
+
+fileInput.addEventListener("change", async () => {
+        const picked = Array.from(fileInput.files ?? []);
+        // Clear immediately so a re-pick of the same files still triggers change.
+        fileInput.value = "";
+        if (picked.length === 0) return;
+        if (attachInFlight) return;
+        attachInFlight = true;
+        try {
+                if (!activeSessionId) {
+                        showToast("No active session", true);
+                        return;
+                }
+                if (picked.length > MAX_ATTACH_FILES) {
+                        showToast(`Too many files (${picked.length}; max ${MAX_ATTACH_FILES})`, true);
+                        return;
+                }
+                const oversized = picked.find((f) => f.size > MAX_ATTACH_BYTES);
+                if (oversized) {
+                        const mb = (oversized.size / (1024 * 1024)).toFixed(1);
+                        showToast(`"${oversized.name}" is ${mb} MB — files must be ≤25 MB`, true);
+                        return;
+                }
+                showToast(`Uploading ${picked.length} file${picked.length === 1 ? "" : "s"}…`);
+                let result: { paths: string[] };
+                try {
+                        result = await uploadSessionFiles(activeSessionId, picked);
+                } catch (err) {
+                        showToast(`Upload failed: ${(err as Error).message}`, true);
+                        return;
+                }
+                const term = getActiveTerminal();
+                if (term && result.paths.length > 0) {
+                        // Quote any path containing whitespace — the sanitiser shouldn't
+                        // produce one, but the user pastes this directly into the shell.
+                        // Trailing space lets them keep typing immediately after.
+                        const inserted = result.paths
+                                .map((p) => (/\s/.test(p) ? `"${p}"` : p))
+                                .join(" ") + " ";
+                        term.paste(inserted);
+                        showToast(`Attached ${result.paths.length} file${result.paths.length === 1 ? "" : "s"}`);
+                } else {
+                        // Container isn't running, so there's nothing to type into. The
+                        // files still land in the workspace and survive a /start, so the
+                        // user can reference them later.
+                        showToast(`Uploaded ${result.paths.length}; start the session to use them`);
+                }
+        } finally {
+                attachInFlight = false;
+        }
 });
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1544,6 +1544,11 @@ fileInput.addEventListener("change", async () => {
                 return;
         }
         attachInFlight = true;
+        // Every `return` inside this try { } is covered by the finally below
+        // that resets attachInFlight — including the early validation
+        // returns. Don't move attachInFlight = false above the try or
+        // duplicate it on each early return; the finally is the single
+        // release point.
         try {
                 if (!activeSessionId) {
                         showToast("No active session", true);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1577,6 +1577,18 @@ fileInput.addEventListener("change", async () => {
                         showToast(`Upload failed: ${(err as Error).message}`, true);
                         return;
                 }
+                // Re-check identity post-await: if the user switched away
+                // from this session while the upload was in flight, pasting
+                // its paths into whatever terminal they're now looking at
+                // would silently inject foreign-session paths into their
+                // current command. Mirrors the same guard pattern used in
+                // addTab/openSession/closeTab. The files still landed in
+                // session A's workspace; the user can switch back and
+                // reference them manually.
+                if (activeSessionId !== sessionId) {
+                        showToast(`Uploaded ${result.paths.length} to the previous session`);
+                        return;
+                }
                 const term = getActiveTerminal();
                 if (term && result.paths.length > 0) {
                         // Quote any path containing whitespace — the sanitiser shouldn't


### PR DESCRIPTION
## Summary

Adds a file-attach flow alongside the existing paste flow. Users can now drop images, PDFs, logs — anything Claude CLI accepts — directly into their session's workspace and reference them from a prompt. **Works on both mobile and desktop.**

The standalone **Paste** button becomes a **+** action button hosting both:
- **Paste text** — unchanged from #110/#111/#112.
- **Attach file** — opens the native file picker → uploads → types the in-container paths into the terminal so the user can write `summarise this: /home/developer/workspace/uploads/abc123-screenshot.png`.

The `+` button is shown on every viewport (mobile and desktop) when a session is active. Hidden when no session is selected.

## How the data flows

```
Browser (file picker) → multipart POST /api/sessions/:id/files
                       → Backend writes to <WORKSPACE_ROOT>/.uploads/<sessionId>/<ts>-<rand>-<name>
                       → Container reads via the read-only bind mount at /home/developer/workspace/uploads/<filename>
                       → Backend returns container paths
                       → Frontend term.paste() inserts them into the active xterm
                       → Claude CLI reads the file from disk in its prompt context
```

The terminal is just the messenger that tells Claude CLI where to look — the file lands on the host disk via a separate bind mount the container has read-only access to.

## TOCTOU isolation via separate bind mount

The uploads dir lives at **`<WORKSPACE_ROOT>/.uploads/<sessionId>/`** — outside the container's main bind-mount tree. `spawn()` then bind-mounts it **read-only** into the container at `/home/developer/workspace/uploads/`. This makes the historical symlink-swap attack class structurally impossible:
- Container CANNOT remove or replace the `uploads/` entry — it's a mount point.
- Container CANNOT write into `uploads/` — read-only mount.
- Backend's write target on the host (`<WORKSPACE_ROOT>/.uploads/<sessionId>/`) is unreachable from inside the container.

Earlier rounds of this PR added stacks of TOCTOU defences (realpath check, `O_DIRECTORY|O_NOFOLLOW` fd anchor, pre+post inode sentinels) to mitigate the in-workspace layout. With the new layout that whole class of attacks is gone, so the per-rename machinery has been removed in favour of a clean lexical containment check + atomic rename from the multer tmp dir.

## Backend

- `POST /api/sessions/:id/files`, multipart/form-data, field name `files`.
- **Caps:** 25 MB/file, 8 files/request, `parts: 9`, `fields: 0`. Multer errors translate to 413 (size/count/parts) or 400.
- **Auth chain:** explicit `requireAuth` → per-IP rate limiter (30/5min) → per-session ownership check → multer disk storage → handler. Ownership is checked **before** any bytes are buffered.
- **Per-session disk quota:** 1 GB default, env-overridable via `UPLOAD_QUOTA_BYTES`. `.env.example` documents the per-user aggregate exposure (per-session-cap × MAX_SESSIONS_PER_USER).
- **Per-session serialisation lock:** concurrent uploads to the same session can't race the quota check.
- **Filename sanitisation:** `[A-Za-z0-9._-]` only, leading dots/underscores/dashes stripped, capped at 80 chars with extension preservation. 11 unit tests in `dockerManager.test.ts`.
- **Cleanup:** `purgeWorkspace` removes both `<sessionId>/` and `.uploads/<sessionId>/` on hard delete; `sweepUploadTmp` (called from `reconcile`) cleans stale `.tmp-uploads/` files at startup.

## Frontend

- HTML: `#paste-btn` → `#actions-btn` (`+`). New `#actions-menu` modal with two action items, plus a hidden `<input type="file" multiple>`.
- CSS: `+` button visible on all viewports; mobile keeps `margin-left: auto` for right-alignment when the chrome-pill is hidden, desktop gets right-alignment naturally via `.header-right`.
- main.ts: paste click handler refactored into `runPasteFlow(opener)` so the menu item can call it. `runUploadFlow` validates against the same caps the backend enforces, posts via the new `uploadSessionFiles()` api helper, then types the joined paths via `term.paste()`. Snapshots `activeSessionId` before await and re-checks identity post-await so a session switch mid-upload doesn't paste foreign-session paths.

## Decisions baked in (per pre-implementation alignment)

| Choice | Value |
|---|---|
| Per-file size cap | 25 MB |
| Files per request | 8 |
| Path injected into terminal | Bare absolute path with trailing space |
| Multi-file picker | Yes |
| MIME restriction | None |
| Container stopped | Save + toast; don't reject |

## Migration note

Sessions started before this PR's deploy don't have the new bind mount. Stop and start (or terminate + restore) any active session once after deploy to enable file uploads on it.

## Test plan

- [ ] **Mobile + desktop:** tap **+** → menu opens with Paste text / Attach file.
- [ ] **Attach single file:** picker → select an image → toast "Attached 1 file" → path appears in the terminal with trailing space.
- [ ] **Attach multiple:** select 3 files → toast "Attached 3 files" → space-joined paths land in the terminal.
- [ ] **Container stopped:** upload still 201s; toast "Uploaded N; start the session to use them"; no terminal.paste() call.
- [ ] **>25 MB file:** picker → frontend rejects pre-flight with size toast (no network call).
- [ ] **>8 files:** frontend rejects with count toast.
- [ ] **Send ≤25 MB via DevTools that bypasses the frontend cap:** backend returns 413 (multer LIMIT_FILE_SIZE) with JSON error.
- [ ] **Path traversal in filename** (e.g. `../../../etc/passwd`): sanitiser strips it; file lands as `passwd` (or similar) inside `/uploads/`.
- [ ] **Container symlink attack:** container runs `rm -rf /home/developer/workspace/uploads && ln -s /etc /home/developer/workspace/uploads` — both fail because `/home/developer/workspace/uploads` is a read-only mount point.
- [ ] **Escape key:** closes the actions menu when open; doesn't accidentally close the sidebar drawer when both modal and drawer are open.
- [ ] **No session active:** `+` button is hidden on both mobile and desktop.
- [ ] **Session switch mid-upload:** start a long upload to session A, switch to session B before it completes — toast "Uploaded N to the previous session"; terminal in B receives nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)