### PR TITLE
refactor(terminal): clarify onContextRestored guard comment

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -87,7 +87,7 @@ export function openTerminalSession(opts: {
         // canvas obtained from the loss event's target.
         let pendingRestoreCanvas: HTMLCanvasElement | null = null;
         const onContextRestored = () => {
-                // Guard against misbehaving drivers; the prior loss handler nulled webgl first.
+                // Don't load a second addon while one is already live (prior loss handler nulls webgl).
                 if (webgl) return;
                 pendingRestoreCanvas = null;
                 let restoredAddon: WebglAddon | undefined;


### PR DESCRIPTION
Closes #87.

## Why

The previous comment read "Guard against misbehaving drivers; the prior loss handler nulled webgl first." That phrasing implied the guard exists for a rare GPU driver bug, but the actual job is simpler and more defensive: don't load a second WebGL addon on top of one that's already live. The fact that `webgl` is nulled by the prior loss handler is what makes the guard a no-op in steady state, not what makes it necessary.

## Change

Single-line comment edit:

```diff
- // Guard against misbehaving drivers; the prior loss handler nulled webgl first.
+ // Don't load a second addon while one is already live (prior loss handler nulls webgl).
```

No runtime behaviour change.