### PR TITLE
refactor(terminal): register webglcontextlost listener unconditionally

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -109,7 +109,15 @@ export function openTerminalSession(opts: {
                 pendingRestoreCanvas = ev.target;
                 pendingRestoreCanvas.addEventListener("webglcontextrestored", onContextRestored, { once: true });
         };
-        if (webgl) container.addEventListener("webglcontextlost", onContextLost);
+        // Listener is registered unconditionally. The cost is one no-op
+        // attach when WebGL never initialised (no canvas under `container`
+        // ever fires webglcontextlost), but in exchange a future code path
+        // that hot-swaps the renderer — disposing the addon and replacing it
+        // without a full navigate-away — gets the loss/restore plumbing
+        // already wired for free, instead of having to re-register the
+        // listener from inside that swap. The dispose path was already
+        // unconditional, so the symmetry is now properly established.
+        container.addEventListener("webglcontextlost", onContextLost);
 
         fitAddon.fit();
 


### PR DESCRIPTION
Closes #88.

## Why

The `webglcontextlost` listener was only attached when the initial `WebglAddon` load succeeded:

```ts
if (webgl) container.addEventListener("webglcontextlost", onContextLost);
```

That works today only because the dispose path runs unconditionally and the initial load is the only place an addon is created. If anything ever hot-swaps the renderer at runtime (dispose + recreate without a navigate-away — exactly the kind of pattern the existing restore handler is designed for), there'd be no listener wired up and the next context loss would silently fall on the floor.

## Change

Drop the `if (webgl)` guard and register the listener unconditionally. The cost is one no-op event registration when WebGL never initialised (no canvas → no event ever fires); the win is symmetry with the dispose path and a future-proofed restore handler.

```diff
- if (webgl) container.addEventListener("webglcontextlost", onContextLost);
+ container.addEventListener("webglcontextlost", onContextLost);
```

Plus a comment explaining the rationale so the next reviewer doesn't "helpfully" add the guard back.

## Tested

- `npx tsc --noEmit` clean.
- No behaviour change in the WebGL-initialised path (the guard was a no-op there).
- No behaviour change in the WebGL-failed path either, since no canvas exists under the container to ever emit `webglcontextlost`.