### PR TITLE
docs(terminal): explain let/const split in onContextRestored

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -90,6 +90,16 @@ export function openTerminalSession(opts: {
                 // Guard against misbehaving drivers; the prior loss handler nulled webgl first.
                 if (webgl) return;
                 pendingRestoreCanvas = null;
+                // The let/const split is deliberate. `restoredAddon` (let, outer) is
+                // the catch-block's only handle for disposing a partially-initialised
+                // addon if `term.loadAddon(addon)` throws after construction —
+                // otherwise the just-allocated WebGL context would leak. `addon`
+                // (const, inner) is what the onContextLoss closure binds to: a
+                // const here keeps the closure immune to a future refactor that
+                // reassigns `restoredAddon` between construction and the closure
+                // firing, which would otherwise have the closure dispose the wrong
+                // addon. Both bindings point at the same object on the success path;
+                // they only diverge on the partial-failure path. Don't collapse them.
                 let restoredAddon: WebglAddon | undefined;
                 try {
                         const addon = new WebglAddon();


### PR DESCRIPTION
Closes #89.

## Why

The `onContextRestored` body has two bindings that look redundant at a glance:

```ts
let restoredAddon: WebglAddon | undefined;
try {
        const addon = new WebglAddon();
        restoredAddon = addon;
        addon.onContextLoss(() => { addon.dispose(); webgl = null; });
        ...
} catch (err) {
        restoredAddon?.dispose();
        ...
}
```

A drive-by reviewer might collapse `addon` into `restoredAddon` and call it cleanup. Doing so would silently introduce a correctness bug: the `onContextLoss` closure currently captures the `const` `addon`, so it always disposes the addon it was registered against. Bind it to the outer `let` instead and a future refactor that reassigns `restoredAddon` between construction and closure firing has the closure dispose the wrong addon.

The other half of the split — keeping the outer `let` so the catch block can clean up — is the visible reason; the closure-binding half is the silent one. Both need to be on the page so the next reviewer doesn't lose them.

## Change

Inline comment only — no behaviour change. Names both invariants and tells future readers "don't collapse them."