### PR TITLE
docs(terminal): label box-drawing range in URL regex comments

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -515,14 +515,18 @@ class MultilineUrlLinkProvider implements ILinkProvider {
                 this.cache = [];
                 const buf = this.term.buffer.active;
 
-                // "Terminators" that can't appear inside a URL. Includes whitespace,
-                // common quote/bracket chars, and the Unicode Box Drawing block
-                // (─-╿ — covers │ ─ ╭ ╮ etc. that ink/React TUIs draw
-                // around their panels). This lets us treat a row's URL "zone" as
-                // the contiguous run of URL-safe chars between the left and right
-                // borders/padding of the row.
-                const NON_URL = /[\s<>"'`{}()[\]─-╿|]/;
-                const URL_RE = /https?:\/\/[^\s<>"'`{}()[\]─-╿|]+/g;
+                // "Terminators" that can't appear inside a URL. Includes
+                // whitespace, common quote/bracket chars, and the Unicode Box
+                // Drawing block — the `─-╿` range covers U+2500–U+257F (│ ─
+                // ╭ ╮ etc. that ink/React TUIs draw around their panels). The
+                // dash inside the brackets is a regex range operator, NOT a
+                // literal hyphen-or-three-chars; flagging this so a future
+                // reviewer doesn't "fix" what looks like a typo. This lets
+                // us treat a row's URL "zone" as the contiguous run of
+                // URL-safe chars between the left and right borders/padding
+                // of the row.
+                const NON_URL = /[\s<>"'`{}()[\]─-╿|]/; //   ─-╿ = box-drawing range
+                const URL_RE = /https?:\/\/[^\s<>"'`{}()[\]─-╿|]+/g; // ─-╿ = box-drawing range
 
                 // Phase 1 — for every row in the buffer, strip leading/trailing
                 // non-URL chars (borders, padding) and record where the interior


### PR DESCRIPTION
Closes #57.

## Why

The `─-╿` literal inside the NON_URL / URL_RE character classes is a regex range expression covering the Unicode Box Drawing block (U+2500–U+257F), but at a glance it looks like three loose characters or a typo. PR #46 review flagged this. The prior block-comment above the regexes named the block but didn't call out the *range-vs-literal-hyphen* ambiguity, and the regex line itself had no inline label.

## Change

- Add an inline trailing comment on each regex (`// ─-╿ = box-drawing range`) so the regex line is self-explanatory without scrolling.
- Tighten the explanatory comment above to flag "this is a regex range, not three literals" so a future "helpful" fix doesn't replace `─-╿` with `─\\-╿` or strip the perceived stray dash.

No runtime change.