### PR TITLE
fix(terminal): clear stale lastTouchY in onTouchMove early-return

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -243,7 +243,22 @@ export function openTerminalSession(opts: {
                 touchIsScroll = false;
         };
         const onTouchMove = (ev: TouchEvent) => {
-                if (lastTouchY === null || ev.touches.length !== 1) return;
+                if (lastTouchY === null || ev.touches.length !== 1) {
+                        // Defence-in-depth: clear lastTouchY whenever we see a non-
+                        // single-touch frame. onTouchStart already clears it when a
+                        // second finger lands (touchstart fires for each new touch
+                        // point), so under normal browser behaviour this is a no-op.
+                        // But touch events are notoriously flaky on the long tail of
+                        // mobile browsers — Safari has shipped bugs where a touch's
+                        // touchstart was suppressed while it still appeared in
+                        // ev.touches on a later move. If anything ever skips that
+                        // path, lastTouchY would carry over from before the multi-
+                        // touch and produce a phantom scroll jump on the first
+                        // single-touch frame after the second finger lifts. Clearing
+                        // here makes that impossible regardless.
+                        if (ev.touches.length !== 1) lastTouchY = null;
+                        return;
+                }
                 const y = ev.touches[0]!.clientY;
                 const cellH = getCellHeight();
                 const deltaPx = lastTouchY - y;


### PR DESCRIPTION
Closes #73.

## Why

`onTouchMove` returned early on a non-single-touch frame without clearing `lastTouchY`:

```ts
const onTouchMove = (ev: TouchEvent) => {
    if (lastTouchY === null || ev.touches.length !== 1) return;
    // …
};
```

In practice this is fine: `onTouchStart` fires for every new touch point and always clears `lastTouchY` when length !== 1. But touch events are notoriously flaky on the long tail of mobile browsers (Safari has shipped bugs where a touch's `touchstart` was suppressed while it still appeared in `ev.touches` on a later move). In that scenario `lastTouchY` carries over from before the multi-touch and produces a phantom scroll jump on the first single-touch frame after the second finger lifts.

## Change

Defence-in-depth: clear `lastTouchY` whenever the early-return branch sees `ev.touches.length !== 1`:

```ts
const onTouchMove = (ev: TouchEvent) => {
    if (lastTouchY === null || ev.touches.length !== 1) {
        if (ev.touches.length !== 1) lastTouchY = null;
        return;
    }
    // …
};
```

Inline comment notes that this is a defence-in-depth move and explains the Safari-class quirk it covers.

## Tested

`tsc --noEmit` clean. Single-touch swipes behave identically; the new branch only fires on multi-touch frames, which the old code returned from anyway.