### PR TITLE
feat(docker): honour DOCKER_HOST env var; docs(readme): add Security model section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,16 @@ SESSION_IMAGE=shared-terminal-session
 # Where session workspace volumes are stored on the host
 WORKSPACE_ROOT=/var/shared-terminal/workspaces
 
+# Optional: route Docker API calls through a socket proxy (e.g. tecnativa/
+# docker-socket-proxy) instead of the default /var/run/docker.sock. With this
+# set, DockerManager passes no explicit connection options to dockerode and
+# docker-modem reads the URL from the environment; with it unset the backend
+# falls back to the canonical Unix socket. Don't combine the two — bind-
+# mounting /var/run/docker.sock alongside DOCKER_HOST has no effect because
+# the explicit socket path would shadow the env var. See README "Security
+# model → Optional: docker-socket-proxy" for the full overlay snippet.
+# DOCKER_HOST=tcp://docker-socket-proxy:2375
+
 # Per-session disk quota for files uploaded via POST /api/sessions/:id/files
 # (the + → Attach file flow). Counts only files inside the session's
 # uploads/ directory; files the container writes elsewhere in /home/developer/

--- a/.env.example
+++ b/.env.example
@@ -62,10 +62,12 @@ WORKSPACE_ROOT=/var/shared-terminal/workspaces
 # docker-socket-proxy) instead of the default /var/run/docker.sock. With this
 # set, DockerManager passes no explicit connection options to dockerode and
 # docker-modem reads the URL from the environment; with it unset the backend
-# falls back to the canonical Unix socket. Don't combine the two — bind-
-# mounting /var/run/docker.sock alongside DOCKER_HOST has no effect because
-# the explicit socket path would shadow the env var. See README "Security
-# model → Optional: docker-socket-proxy" for the full overlay snippet.
+# falls back to the canonical Unix socket. If both are configured at once,
+# DOCKER_HOST takes precedence — when it's set DockerManager passes no
+# socketPath at all, so a /var/run/docker.sock bind-mount is silently
+# unused. Drop the bind-mount in proxy deployments so an RCE has nothing
+# to fall back to. See README "Security model → Optional: docker-socket-
+# proxy" for the full overlay snippet.
 # DOCKER_HOST=tcp://docker-socket-proxy:2375
 
 # Per-session disk quota for files uploaded via POST /api/sessions/:id/files

--- a/README.md
+++ b/README.md
@@ -218,10 +218,17 @@ daemon for: container create, start, stop, kill, remove, inspect,
 exec create + start + resize.
 
 [`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy)
-is a small HAProxy-based filter that does exactly this. With it,
-even an RCE in the backend can't pull images, mount host paths into
-new containers, or read other containers' configs — only the
-endpoints listed below resolve.
+is a small HAProxy-based filter that does exactly this. With the
+ruleset below, an RCE in the backend can't pull or build images,
+reach the Swarm/network/volume APIs, or touch any daemon surface
+outside `/containers/*` and `/exec/*`. It **can** still create a
+container — including one that bind-mounts the host rootfs
+(`HostConfig.Binds`) — and inspect existing containers (which
+exposes their environment variables). The proxy is blast-radius
+reduction, not a privilege boundary: a determined attacker with
+RCE can still escape via a new privileged container, just not via
+the image/network/volume side of the API. Treat it as one layer of
+defence in depth, paired with the tunnel + Access posture above.
 
 A drop-in `docker-compose.yml` overlay (illustrative — verify the
 endpoint set against the proxy's docs when you adopt it):
@@ -240,7 +247,7 @@ services:
     restart: unless-stopped
     environment:
       # Endpoints required by dockerManager.ts:
-      CONTAINERS: 1 # create, inspect, list
+      CONTAINERS: 1 # create, inspect, start, stop, kill, remove
       EXEC: 1 # exec create + start + resize (WS attach path)
       POST: 1 # POST verbs (create/start/exec/resize/stop/kill)
       DELETE: 1 # DELETE /containers/{id} for container.remove() on

--- a/README.md
+++ b/README.md
@@ -229,7 +229,14 @@ endpoint set against the proxy's docs when you adopt it):
 ```yaml
 services:
   docker-socket-proxy:
-    image: tecnativa/docker-socket-proxy:latest
+    # Pin to an immutable digest in production (`image:
+    # tecnativa/docker-socket-proxy@sha256:…`) so a future
+    # `docker compose pull` can't silently swap the proxy out from
+    # under the operator. A floating `:latest` defeats the
+    # blast-radius story this whole section is selling. The
+    # explicit version tag below is the minimum bar; the digest is
+    # the right answer.
+    image: tecnativa/docker-socket-proxy:v0.4.2
     restart: unless-stopped
     environment:
       # Endpoints required by dockerManager.ts:
@@ -265,6 +272,12 @@ Caveats:
   `.uploads/<id>`) must still exist on the _host_ — the proxy
   forwards container-create requests verbatim, so the daemon
   resolves bind sources from its own filesystem.
+- Pin the proxy image to an immutable digest
+  (`@sha256:…`) in production. A floating `:latest` would let a
+  future `docker compose pull` silently change the proxy under
+  you, defeating the point of installing it. The example above
+  uses an explicit version tag as the minimum bar — promote to a
+  digest when you adopt this in your own deployment.
 - A scoped proxy reduces blast radius. It does **not** make the
   backend safe to expose without authentication; the tunnel + Access
   posture above is still load-bearing.

--- a/README.md
+++ b/README.md
@@ -281,10 +281,12 @@ Caveats:
   connection options to dockerode and lets docker-modem read the
   URL from the environment. With `DOCKER_HOST` unset it falls back
   to `/var/run/docker.sock`, so the default `docker-compose.yml`
-  stack continues to work untouched. Don't try to reach the proxy
-  by also bind-mounting `/var/run/docker.sock` — the explicit
-  socket option would shadow `DOCKER_HOST` and pin the backend to
-  the daemon.
+  stack continues to work untouched. If you also bind-mount
+  `/var/run/docker.sock` while `DOCKER_HOST` is set, the bind-mount
+  is silently ignored — `DOCKER_HOST` wins because no `socketPath`
+  is forwarded to dockerode at all in that branch. Drop the bind-
+  mount in the proxy overlay (the snippet above already does) so
+  there's nothing left for an RCE to fall back to.
 - Bind-mount paths the backend asks for (`<WORKSPACE_ROOT>/<id>`,
   `.uploads/<id>`) must still exist on the _host_ — the proxy
   forwards container-create requests verbatim, so the daemon

--- a/README.md
+++ b/README.md
@@ -240,9 +240,13 @@ services:
     restart: unless-stopped
     environment:
       # Endpoints required by dockerManager.ts:
-      CONTAINERS: 1 # create, inspect, list, start, stop, kill, remove
+      CONTAINERS: 1 # create, inspect, list
       EXEC: 1 # exec create + start + resize (WS attach path)
-      POST: 1 # POST verbs (create/start/exec/resize)
+      POST: 1 # POST verbs (create/start/exec/resize/stop/kill)
+      DELETE: 1 # DELETE /containers/{id} for container.remove() on
+      # session kill — without this the call is silently swallowed
+      # by dockerManager's try/catch and stopped containers pile up
+      # on the host indefinitely.
       # Default-deny everything else: IMAGES, NETWORKS, VOLUMES,
       # SERVICES, SWARM, NODES, INFO, AUTH, BUILD, COMMIT, etc.
     volumes:
@@ -265,9 +269,15 @@ services:
 
 Caveats:
 
-- The backend uses dockerode's default socket path. Setting
-  `DOCKER_HOST=tcp://…` is the supported override; no code change
-  is required.
+- The backend honours `DOCKER_HOST` when it's set: with that env
+  var present, the `DockerManager` constructor passes no explicit
+  connection options to dockerode and lets docker-modem read the
+  URL from the environment. With `DOCKER_HOST` unset it falls back
+  to `/var/run/docker.sock`, so the default `docker-compose.yml`
+  stack continues to work untouched. Don't try to reach the proxy
+  by also bind-mounting `/var/run/docker.sock` — the explicit
+  socket option would shadow `DOCKER_HOST` and pin the backend to
+  the daemon.
 - Bind-mount paths the backend asks for (`<WORKSPACE_ROOT>/<id>`,
   `.uploads/<id>`) must still exist on the _host_ — the proxy
   forwards container-create requests verbatim, so the daemon

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ services:
     restart: unless-stopped
     environment:
       # Endpoints required by dockerManager.ts:
-      CONTAINERS: 1 # create, inspect, start, stop, kill, remove
+      CONTAINERS: 1 # create, inspect, start, stop, remove
       EXEC: 1 # exec create + start + resize (WS attach path)
       POST: 1 # POST verbs (create/start/exec/resize/stop/kill)
       DELETE: 1 # DELETE /containers/{id} for container.remove() on

--- a/README.md
+++ b/README.md
@@ -160,6 +160,115 @@ cloudflared tunnel route dns shared-terminal api.terminal.yourdomain.com
 cloudflared tunnel --url http://localhost:3001 run shared-terminal
 ```
 
+## Security model
+
+Read this before exposing the backend to the public internet.
+
+### Threat model
+
+The backend's job is to spawn, attach to, and kill Docker containers
+on demand. To do that, `docker-compose.yml` bind-mounts the host's
+`/var/run/docker.sock` into the backend container:
+
+```yaml
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock
+```
+
+This is the standard tradeoff for a session-orchestrator design, but
+the consequences need to be explicit:
+
+- **The backend has full Docker daemon access.** The Docker API the
+  socket exposes is unauthenticated to anything that can `connect(2)`
+  to it. There is no per-endpoint ACL on a vanilla socket.
+- **An RCE in the backend is host root.** An attacker who reaches
+  arbitrary code execution inside the backend container can ask the
+  daemon to start a privileged container that bind-mounts the host
+  rootfs and chroots into it. There is no container-level mitigation
+  for this once the socket is reachable.
+- **The session containers themselves run unprivileged** (no
+  `--privileged`, no extra capabilities, no host PID/net namespaces).
+  The socket exposure is a backend-trust property, not a session-
+  trust property.
+
+### Recommended deployment posture
+
+- **Do not expose port 3001 directly to the internet.** Treat the
+  backend as a private service.
+- **Run behind Cloudflare Tunnel** (already documented above) so the
+  origin has no inbound ports open at all. The tunnel terminates at
+  Cloudflare; the home server only makes outbound connections.
+- **Gate the tunnel hostname with Cloudflare Access.** A short Access
+  policy ("emails matching me@example.com") in front of the tunnel
+  hostname turns "anyone on the internet" into "people who can prove
+  they're me" before any HTTP request reaches the backend. The
+  in-app JWT auth is still the primary control; Access is a hard
+  belt around it.
+- **Keep the host patched and the backend image rebuilt.** Both the
+  Node runtime and the dependencies in `backend/package.json` are
+  CVE-bearing surfaces, and an unpatched RCE there inherits the
+  socket-access blast radius above.
+
+### Optional: docker-socket-proxy
+
+For deployments that want to shrink the backend's daemon surface
+below "all of the Docker API", you can interpose a proxy that only
+exposes the endpoints this app actually needs. The backend uses the
+daemon for: container create, start, stop, kill, remove, inspect,
+exec create + start + resize.
+
+[`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy)
+is a small HAProxy-based filter that does exactly this. With it,
+even an RCE in the backend can't pull images, mount host paths into
+new containers, or read other containers' configs — only the
+endpoints listed below resolve.
+
+A drop-in `docker-compose.yml` overlay (illustrative — verify the
+endpoint set against the proxy's docs when you adopt it):
+
+```yaml
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    restart: unless-stopped
+    environment:
+      # Endpoints required by dockerManager.ts:
+      CONTAINERS: 1 # create, inspect, list, start, stop, kill, remove
+      EXEC: 1 # exec create + start + resize (WS attach path)
+      POST: 1 # POST verbs (create/start/exec/resize)
+      # Default-deny everything else: IMAGES, NETWORKS, VOLUMES,
+      # SERVICES, SWARM, NODES, INFO, AUTH, BUILD, COMMIT, etc.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    # Internal only: never publish ports to the host or the public net.
+    expose:
+      - "2375"
+
+  app:
+    # Replace the direct socket mount with a network connection to the proxy.
+    environment:
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
+    depends_on:
+      - docker-socket-proxy
+    # Drop the /var/run/docker.sock bind mount from the default service.
+    volumes:
+      - ${WORKSPACE_ROOT:-/var/shared-terminal/workspaces}:/var/shared-terminal/workspaces
+      # /var/run/docker.sock:/var/run/docker.sock  ← removed
+```
+
+Caveats:
+
+- The backend uses dockerode's default socket path. Setting
+  `DOCKER_HOST=tcp://…` is the supported override; no code change
+  is required.
+- Bind-mount paths the backend asks for (`<WORKSPACE_ROOT>/<id>`,
+  `.uploads/<id>`) must still exist on the _host_ — the proxy
+  forwards container-create requests verbatim, so the daemon
+  resolves bind sources from its own filesystem.
+- A scoped proxy reduces blast radius. It does **not** make the
+  backend safe to expose without authentication; the tunnel + Access
+  posture above is still load-bearing.
+
 ## API Reference
 
 ### Auth (public)

--- a/README.md
+++ b/README.md
@@ -214,8 +214,10 @@ the consequences need to be explicit:
 For deployments that want to shrink the backend's daemon surface
 below "all of the Docker API", you can interpose a proxy that only
 exposes the endpoints this app actually needs. The backend uses the
-daemon for: container create, start, stop, kill, remove, inspect,
-exec create + start + resize.
+daemon for: container create, start, stop, remove, inspect,
+exec create + start + resize. (`DockerManager.kill()` is a method
+name, not a daemon endpoint — it routes through `stop` + `remove`,
+so `POST /containers/{id}/kill` is never issued.)
 
 [`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy)
 is a small HAProxy-based filter that does exactly this. With the
@@ -249,7 +251,7 @@ services:
       # Endpoints required by dockerManager.ts:
       CONTAINERS: 1 # create, inspect, start, stop, remove
       EXEC: 1 # exec create + start + resize (WS attach path)
-      POST: 1 # POST verbs (create/start/exec/resize/stop/kill)
+      POST: 1 # POST verbs (create/start/exec/resize/stop)
       DELETE: 1 # DELETE /containers/{id} for container.remove() on
       # session kill — without this the call is silently swallowed
       # by dockerManager's try/catch and stopped containers pile up

--- a/README.md
+++ b/README.md
@@ -214,10 +214,27 @@ the consequences need to be explicit:
 For deployments that want to shrink the backend's daemon surface
 below "all of the Docker API", you can interpose a proxy that only
 exposes the endpoints this app actually needs. The backend uses the
-daemon for: container create, start, stop, remove, inspect,
-exec create + start + resize. (`DockerManager.kill()` is a method
-name, not a daemon endpoint — it routes through `stop` + `remove`,
-so `POST /containers/{id}/kill` is never issued.)
+daemon for: container create, start, stop, remove, inspect, exec
+create + start + resize. The split between HTTP verbs matters for
+the proxy's allowlist:
+
+- `POST` paths: `containers/create`, `containers/{id}/start`,
+  `containers/{id}/stop`, `exec/create`, `exec/{id}/start`,
+  `exec/{id}/resize`.
+- `GET` paths: `containers/{id}/json` (called by `isAlive()`,
+  `startContainer()`, `reconcile()`) and `exec/{id}/json` (called
+  by `execOneShot()` to read tmux exit codes — every
+  `capture-pane`, `list-sessions`, `kill-session`, `new-session
+-d`, `set-option` runs through this path). Without `GET=1` the
+  backend boots fine and authenticates fine, but `reconcile()`
+  silently 403s at startup, every `POST /api/sessions/:id/start`
+  fails when it inspects the container, and every tab attach
+  fails when the tmux exec exit code can't be read.
+- `DELETE` paths: `containers/{id}` (full removal at session kill).
+
+(`DockerManager.kill()` is a method name, not a daemon endpoint —
+it routes through `stop` + `remove`, so `POST /containers/{id}/kill`
+is never issued.)
 
 [`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy)
 is a small HAProxy-based filter that does exactly this. With the
@@ -232,10 +249,32 @@ RCE can still escape via a new privileged container, just not via
 the image/network/volume side of the API. Treat it as one layer of
 defence in depth, paired with the tunnel + Access posture above.
 
-A drop-in `docker-compose.yml` overlay (illustrative — verify the
-endpoint set against the proxy's docs when you adopt it):
+The snippet below is a **drop-in replacement** for the project's
+`docker-compose.yml`, not a `docker-compose.override.yml` overlay.
+This matters because Compose merges `volumes:` lists from override
+files onto the base service rather than replacing them — the base
+file's `/var/run/docker.sock:/var/run/docker.sock` mount would
+survive the override and an RCE would still find the live socket
+file descriptor inside the container even with `DOCKER_HOST`
+pointed at the proxy. Either replace `docker-compose.yml`
+wholesale (the simpler path), or remove the socket mount from
+the base file before layering an override.
 
 ```yaml
+networks:
+  # Internal-only network for the backend ↔ proxy hop. `internal:
+  # true` blocks egress to the default bridge AND prevents the
+  # session containers (which the backend creates on the default
+  # network) from reaching the proxy: a compromised session
+  # container can't issue Docker API calls through this hop to
+  # inspect other sessions' env vars or spawn its own containers.
+  # `expose:` alone would NOT achieve this — it gates host-level
+  # publishing, not inter-container reachability on a shared
+  # bridge, so the proxy port would otherwise be a flat lateral-
+  # movement target.
+  docker-proxy:
+    internal: true
+
 services:
   docker-socket-proxy:
     # Pin to an immutable digest in production (`image:
@@ -247,10 +286,22 @@ services:
     # the right answer.
     image: tecnativa/docker-socket-proxy:v0.4.2
     restart: unless-stopped
+    networks: [docker-proxy]
     environment:
-      # Endpoints required by dockerManager.ts:
-      CONTAINERS: 1 # create, inspect, start, stop, remove
-      EXEC: 1 # exec create + start + resize (WS attach path)
+      # Endpoints required by dockerManager.ts. The proxy enforces
+      # HTTP-verb ACLs (POST/GET/DELETE) SEPARATELY from the
+      # resource flags (CONTAINERS/EXEC/…), and every verb defaults
+      # to 0. All four of POST/GET/DELETE + the two resource flags
+      # are required; dropping any one silently breaks a different
+      # part of the app:
+      CONTAINERS: 1 # /containers/* — create, inspect, start, stop, remove
+      EXEC: 1 # /exec/* — create + start + resize + inspect (WS attach path)
+      GET: 1 # GET /containers/{id}/json (isAlive/start/reconcile)
+      # and GET /exec/{id}/json (execOneShot exit-code read).
+      # Without this the backend boots and authenticates fine but
+      # is non-functional: reconcile silently 403s, /start fails,
+      # every tab attach fails when execOneShot can't read its
+      # exit code.
       POST: 1 # POST verbs (create/start/exec/resize/stop)
       DELETE: 1 # DELETE /containers/{id} for container.remove() on
       # session kill — without this the call is silently swallowed
@@ -260,20 +311,26 @@ services:
       # SERVICES, SWARM, NODES, INFO, AUTH, BUILD, COMMIT, etc.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # Internal only: never publish ports to the host or the public net.
-    expose:
-      - "2375"
+    # No `expose:` and no `ports:`: the internal network already
+    # makes the proxy reachable to peers on `docker-proxy` and
+    # unreachable to anything else, including session containers
+    # the backend creates on the default Docker network.
 
   app:
-    # Replace the direct socket mount with a network connection to the proxy.
+    # Replace the direct socket mount with a network connection to
+    # the proxy. The backend joins BOTH networks: `docker-proxy`
+    # for the daemon hop, `default` for everything else (Cloudflare
+    # Tunnel egress, the session containers it creates, etc.).
     environment:
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
     depends_on:
       - docker-socket-proxy
-    # Drop the /var/run/docker.sock bind mount from the default service.
+    networks: [docker-proxy, default]
+    # No /var/run/docker.sock bind mount at all: this snippet is a
+    # full replacement for docker-compose.yml's `volumes:`, not
+    # additive on top of it.
     volumes:
       - ${WORKSPACE_ROOT:-/var/shared-terminal/workspaces}:/var/shared-terminal/workspaces
-      # /var/run/docker.sock:/var/run/docker.sock  ← removed
 ```
 
 Caveats:
@@ -286,9 +343,13 @@ Caveats:
   stack continues to work untouched. If you also bind-mount
   `/var/run/docker.sock` while `DOCKER_HOST` is set, the bind-mount
   is silently ignored — `DOCKER_HOST` wins because no `socketPath`
-  is forwarded to dockerode at all in that branch. Drop the bind-
-  mount in the proxy overlay (the snippet above already does) so
-  there's nothing left for an RCE to fall back to.
+  is forwarded to dockerode at all in that branch. The replacement
+  snippet above already drops the bind-mount; if you instead layer
+  a `docker-compose.override.yml`, Compose merges `volumes:` lists
+  and the base mount survives, so the live socket file descriptor
+  is still inside the container even though the backend is using
+  the proxy. Replace `docker-compose.yml` wholesale rather than
+  overriding it so there's nothing left for an RCE to fall back to.
 - Bind-mount paths the backend asks for (`<WORKSPACE_ROOT>/<id>`,
   `.uploads/<id>`) must still exist on the _host_ — the proxy
   forwards container-create requests verbatim, so the daemon

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -732,6 +732,19 @@ describe("DockerManager constructor", () => {
 	// docker-modem behaviour, not DockerManager behaviour, so the FakeDocker
 	// shim used by every other test would defeat the assertion.
 	//
+	// FRAGILITY NOTE: both branches assert on `docker.modem.socketPath`,
+	// which is a docker-modem private field — not part of dockerode's
+	// public surface. A future docker-modem version that renames or
+	// lazily-initialises that field would break these tests with no
+	// behavioural change in DockerManager. If they fail after a `npm
+	// update` of dockerode/docker-modem, look for the field rename in
+	// node_modules/docker-modem/lib/modem.js BEFORE assuming
+	// DockerManager regressed. The tradeoff is intentional: the only
+	// equivalent we could observe through dockerode's public API would
+	// involve actually opening a connection, which would either need a
+	// real Docker daemon or a TCP fixture per test — both heavier and
+	// slower than this targeted private-field read.
+	//
 	// process.env.DOCKER_HOST is process-global state, so save and restore
 	// it around each case. A leak into other suites in the same vitest
 	// run could change the implicit constructor branch the harness exercises

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { PassThrough } from "stream";
 
 // d1Query is the only direct D1 touch-point in DockerManager (reconcile()).
@@ -624,7 +624,7 @@ describe("DockerManager.reconcile", () => {
 	}
 
 	it("warns when reconcile inspects a running pre-#15 container (no CapDrop/SecurityOpt)", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
 		const { dm, sessions } = makeDockerWithInspectResult({
 			State: { Running: true },
 			HostConfig: { CapDrop: [], SecurityOpt: [] },
@@ -652,7 +652,7 @@ describe("DockerManager.reconcile", () => {
 		// migration footgun surfaces even on containers that happen to be
 		// dead at reconcile time — they'll be respawned later, and the
 		// operator needs to know the old image is involved.
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
 		const { dm, sessions } = makeDockerWithInspectResult({
 			State: { Running: false },
 			HostConfig: { CapDrop: [], SecurityOpt: [] },
@@ -671,7 +671,7 @@ describe("DockerManager.reconcile", () => {
 	});
 
 	it("does not warn for properly hardened containers", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
 		const { dm } = makeDockerWithInspectResult({
 			State: { Running: true },
 			HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
@@ -694,7 +694,7 @@ describe("DockerManager.startContainer", () => {
 	// reached this way must surface the same warn as reconcile so a future
 	// refactor can't silently drop the call.
 	it("warns when starting an existing pre-#15 container (Case 2)", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
 		const sessions = makeFakeSessions();
 		const dm = new DockerManager(sessions);
 		(dm as unknown as { docker: unknown }).docker = {
@@ -714,6 +714,67 @@ describe("DockerManager.startContainer", () => {
 		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/session s1/);
 		expect(sessions.updateStatus).toHaveBeenCalledWith("s1", "running");
 		warnSpy.mockRestore();
+	});
+});
+
+describe("DockerManager constructor", () => {
+	// The constructor's default-selection logic — pass `{ socketPath: '/var/
+	// run/docker.sock' }` when DOCKER_HOST is unset, and `undefined` when it
+	// IS set so docker-modem reads the URL from the env — is trivial in
+	// shape but load-bearing for the optional docker-socket-proxy
+	// deployment posture documented in the README. A future refactor that
+	// reinstates the always-socketPath default would silently break proxy
+	// deployments and only surface at deploy time, so pin both branches.
+	//
+	// We have to do real `new DockerManager()` instantiation here (no fake-
+	// Dockerode swap) because the unit under test is what `new Dockerode(
+	// opts)` ends up doing with the options the constructor picks. That's
+	// docker-modem behaviour, not DockerManager behaviour, so the FakeDocker
+	// shim used by every other test would defeat the assertion.
+	//
+	// process.env.DOCKER_HOST is process-global state, so save and restore
+	// it around each case. A leak into other suites in the same vitest
+	// run could change the implicit constructor branch the harness exercises
+	// (see makeDocker comment) and produce confusing failures elsewhere.
+
+	let savedDockerHost: string | undefined;
+	beforeEach(() => {
+		savedDockerHost = process.env.DOCKER_HOST;
+	});
+	afterEach(() => {
+		if (savedDockerHost === undefined) {
+			delete process.env.DOCKER_HOST;
+		} else {
+			process.env.DOCKER_HOST = savedDockerHost;
+		}
+	});
+
+	it("falls back to /var/run/docker.sock when DOCKER_HOST is unset", () => {
+		// Explicit delete rather than 'if undefined skip' — a CI runner that
+		// happens to have DOCKER_HOST inherited from the shell would silently
+		// flip this case into the wrong branch and pass for the wrong reason.
+		delete process.env.DOCKER_HOST;
+		const dm = new DockerManager(makeFakeSessions());
+		// docker-modem exposes the resolved transport on .modem; the field is
+		// untyped on dockerode's side so we cast.
+		const modem = (dm as unknown as { docker: { modem: { socketPath?: string } } }).docker.modem;
+		expect(modem.socketPath).toBe("/var/run/docker.sock");
+	});
+
+	it("forwards no socketPath to dockerode when DOCKER_HOST is set (proxy posture)", () => {
+		// Use a syntactically valid URL so docker-modem's parser is happy.
+		// We never actually open a connection — DockerManager doesn't
+		// exercise the client at construction time, so just instantiating
+		// is enough to inspect what options ended up on the modem.
+		process.env.DOCKER_HOST = "tcp://docker-socket-proxy:2375";
+		const dm = new DockerManager(makeFakeSessions());
+		const modem = (dm as unknown as { docker: { modem: { socketPath?: string } } }).docker.modem;
+		// The proxy overlay in README "Security model" depends on this
+		// branch: with socketPath undefined, docker-modem reads
+		// DOCKER_HOST and routes to the proxy. If a refactor reinstates a
+		// hardcoded socketPath, this assertion fails and CI catches it
+		// before deploy.
+		expect(modem.socketPath).toBeUndefined();
 	});
 });
 

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -137,8 +137,13 @@ function makeDocker(opts?: { sessions?: SessionManager; oneShot?: OneShotHook })
 	const sessions = opts?.sessions ?? makeFakeSessions();
 	const container = makeFakeContainer(opts?.oneShot);
 	const dm = new DockerManager(sessions);
-	// Swap in the fake Dockerode. The constructor already instantiated a real
-	// one against /var/run/docker.sock but we never touch it before this.
+	// Swap in the fake Dockerode BEFORE any method on `dm` is called. The
+	// constructor's default-selection logic now picks between letting
+	// docker-modem read DOCKER_HOST (env var present) and pinning to
+	// /var/run/docker.sock (env var absent), so the "real" client it
+	// instantiated could be aimed at either depending on the runner's
+	// environment. The swap is safe regardless because the field is
+	// replaced before any code path that would actually open a connection.
 	(dm as unknown as { docker: unknown }).docker = makeFakeDocker(container);
 	return { dm, container };
 }

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -112,7 +112,19 @@ export class DockerManager {
         private uploadLocks = new Map<string /*sessionId*/, Promise<void>>();
 
         constructor(sessions: SessionManager, dockerOpts?: Dockerode.DockerOptions) {
-                this.docker = new Dockerode(dockerOpts ?? { socketPath: "/var/run/docker.sock" });
+                // docker-modem reads DOCKER_HOST from the environment ONLY when the
+                // caller passes no connection options at all. The previous default
+                // of `{ socketPath: "/var/run/docker.sock" }` therefore silently
+                // shadowed DOCKER_HOST, which matters for the docker-socket-proxy
+                // deployment shape (overlay sets DOCKER_HOST=tcp://proxy:2375 and
+                // drops the bind mount). Behaviour: explicit `dockerOpts` always
+                // wins (tests rely on this); otherwise honour DOCKER_HOST when
+                // present; finally fall back to the canonical Unix socket so the
+                // default docker-compose.yml stack still works untouched.
+                const defaultOpts: Dockerode.DockerOptions | undefined = process.env.DOCKER_HOST
+                        ? undefined
+                        : { socketPath: "/var/run/docker.sock" };
+                this.docker = new Dockerode(dockerOpts ?? defaultOpts);
                 this.sessions = sessions;
         }
 


### PR DESCRIPTION
Closes #16.

## Why

`docker-compose.yml` bind-mounts `/var/run/docker.sock` into the backend
container so the backend can spawn, attach to, and kill session containers.
This is the standard tradeoff for a session-orchestrator design, but the
consequences (full Docker daemon access; RCE in the backend = host root)
were not written down anywhere. Operators picking the repo up had no signal
that the deployment posture assumes the backend is private and gated.

## What changed

This PR has **two** parts — a real code change and a documentation
addition. Listing them separately because the round-7 review (rightly)
called out that the original PR title and body underclaimed the scope.

### `feat(docker)` — `DockerManager` honours `DOCKER_HOST`

`backend/src/dockerManager.ts` constructor used to hardcode
`{ socketPath: "/var/run/docker.sock" }` as the default options forwarded
to `new Dockerode(...)`. That silently shadowed the standard
`DOCKER_HOST` environment variable: even with `DOCKER_HOST` set, the
backend would still connect over the Unix socket because the explicit
`socketPath` won.

After this PR:

```ts
const defaultOpts = process.env.DOCKER_HOST
    ? undefined
    : { socketPath: "/var/run/docker.sock" };
this.docker = new Dockerode(dockerOpts ?? defaultOpts);
```

When `DOCKER_HOST` is set, `defaultOpts` becomes `undefined`, dockerode
gets no explicit socket path, and `docker-modem` reads the URL from the
environment. When `DOCKER_HOST` is unset, behaviour is unchanged from
`main`. This is the change that makes the optional socket-proxy overlay
documented below actually work — without it, the `DOCKER_HOST` line in
the overlay snippet would have no effect.

**Operational note:** if a deploy pipeline sets `DOCKER_HOST` for an
unrelated reason (inherited from a Buildx/CI base image, etc.), the
socket path will silently stop being used. The `.env.example` entry
flags this.

### `docs(readme)` — Security model section + `.env.example` entry

A new **Security model** section between *Production Deployment* and
*API Reference* covering:

- **Threat model.** Full daemon access; RCE in the backend = host root
  via privileged-container escape; session containers themselves run
  unprivileged.
- **Recommended posture.** Don't expose port 3001 directly. Run behind
  Cloudflare Tunnel (already documented above). Gate the tunnel
  hostname with Cloudflare Access. Keep host and backend image patched.
- **Optional `tecnativa/docker-socket-proxy` overlay.** Drop-in
  `docker-compose.yml` snippet scoped to `CONTAINERS=1 EXEC=1 POST=1
  DELETE=1` — the daemon verbs `dockerManager.ts` actually issues
  (container create / inspect / start / stop / remove + exec create /
  start / resize). The proxy reduces blast radius (no image pull/build,
  no Swarm/network/volume APIs, nothing outside `/containers/*` and
  `/exec/*`); it is **not** a privilege boundary — an RCE can still
  create a privileged container with `HostConfig.Binds` and inspect
  others' env vars. The README is explicit about this so operators
  don't treat the proxy as a substitute for the tunnel + Access posture.
- **`DOCKER_HOST` precedence note.** When both `DOCKER_HOST` and a
  `/var/run/docker.sock` bind-mount are present, `DOCKER_HOST` wins —
  no `socketPath` is forwarded to dockerode, so the bind-mount is
  silently unused. Drop the bind-mount in proxy deployments so an RCE
  has nothing left to fall back to.
- **`backend/src/dockerManager.test.ts`** — updated the test-harness
  comment to describe the new env-aware constructor honestly (the swap
  into the fake Dockerode is still safe because nothing exercises the
  pre-swap connection).
- **`.env.example`** — added a commented-out `DOCKER_HOST` entry to the
  `# Docker` section so operators following the example file discover
  the variable without having to read the README.
