### PR TITLE
chore(docker): drop docker.io install from backend runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,13 @@ COPY backend/ .
 RUN npm run build
 
 FROM node:22-slim AS runtime
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      docker.io \
-    && rm -rf /var/lib/apt/lists/*
-
+# No Docker CLI in the runtime stage on purpose: the backend talks to
+# /var/run/docker.sock through dockerode (HTTP over the unix socket), not
+# through the `docker` CLI. The previous `apt-get install docker.io` line
+# pulled in ~100 MB of containerd/runc/etc. for nothing — every daemon verb
+# the backend needs is a method on dockerode (see backend/src/dockerManager.ts:
+# spawn / inspect / start / stop / kill / remove / exec). The bind-mounted
+# socket is the only ingress to the daemon and stays mounted from compose.
 WORKDIR /app
 COPY backend/package.json backend/package-lock.json ./
 RUN npm ci --omit=dev


### PR DESCRIPTION
Closes #17.

## Why

The backend never shells out to the `docker` CLI — it talks to `/var/run/docker.sock` through dockerode (HTTP over the unix socket). I grepped the backend source for CLI usage:

```
$ grep -rEn 'child_process|exec\\(|spawn\\(|execSync|spawnSync' backend/src/
(no CLI invocations — only DockerManager method calls)
```

Yet the runtime stage was apt-get-installing `docker.io`, which on Debian Bookworm pulls in containerd, runc, iptables, libnetwork-plugin, libapparmor, libdevmapper and a long tail — ~100 MB the image never reaches into.

## Change

- Drop the `apt-get install -y docker.io` block from the runtime stage.
- Leave a comment naming dockerode as the load-bearing client so a future contributor doesn't reflexively put the install back.
- The bind-mounted socket from compose is the only ingress to the daemon and is unaffected.

## Tested

- `docker compose build app` succeeds.
- Image size drops on the runtime stage by ~100 MB (`docker images | grep shared-terminal`).
- Sessions still create / attach / kill cleanly — exercised the WS path against a fresh image.