### PR TITLE
fix(docker): strip leading/trailing dashes from sanitised hostnames

### DIFF
--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -9,7 +9,7 @@ const dbStubs = vi.hoisted(() => ({
 }));
 vi.mock("./db.js", () => dbStubs);
 
-import { DockerManager, sanitiseUploadName, type OutputListener } from "./dockerManager.js";
+import { DockerManager, sanitiseHostname, sanitiseUploadName, type OutputListener } from "./dockerManager.js";
 import type { SessionManager } from "./sessionManager.js";
 
 // ── Test harness ────────────────────────────────────────────────────────────
@@ -873,5 +873,55 @@ describe("sanitiseUploadName", () => {
 		// shouldn't try to "preserve the extension" — they fall through to
 		// the simple slice path.
 		expect(sanitiseUploadName(".gitignore")).toBe("gitignore"); // leading dot stripped
+	});
+});
+
+// ── sanitiseHostname ────────────────────────────────────────────────────────
+// RFC 1123 says a hostname label can't start or end with `-`, max 63 chars.
+// Docker enforces this at createContainer; a violation is a 400 the user
+// can't recover from without renaming the session. The slice-before-strip
+// ordering invariant is what keeps a >63-char name with a dash at index 62
+// from sneaking a trailing dash past the regex.
+describe("sanitiseHostname", () => {
+	const sid = "abcdef1234567890"; // 8-char prefix → "session-abcdef12"
+
+	it("returns a clean name unchanged", () => {
+		expect(sanitiseHostname("my-session", sid)).toBe("my-session");
+		expect(sanitiseHostname("Project42", sid)).toBe("Project42");
+	});
+
+	it("collapses non-alphanumeric chars to dashes", () => {
+		expect(sanitiseHostname("my session!", sid)).toBe("my-session");
+		expect(sanitiseHostname("foo_bar.baz", sid)).toBe("foo-bar-baz");
+	});
+
+	it("strips leading and trailing boundary dashes", () => {
+		expect(sanitiseHostname("-foo", sid)).toBe("foo");
+		expect(sanitiseHostname("foo-", sid)).toBe("foo");
+		expect(sanitiseHostname("-foo-", sid)).toBe("foo");
+		expect(sanitiseHostname("---foo---", sid)).toBe("foo");
+	});
+
+	it("falls back to a session-prefixed label when the result collapses to empty", () => {
+		expect(sanitiseHostname("---", sid)).toBe("session-abcdef12");
+		expect(sanitiseHostname("中文", sid)).toBe("session-abcdef12");
+		expect(sanitiseHostname("", sid)).toBe("session-abcdef12");
+	});
+
+	it("truncates to 63 chars and re-strips trailing dashes left by truncation", () => {
+		// 62 'a's + '-' + 'rest' is 67 chars; charset-replace is a no-op,
+		// slice(0,63) cuts to "aa…aa-" (62 'a' + '-'), strip trims the
+		// trailing dash — Docker would otherwise refuse the hostname.
+		const longWithDashAtBoundary = "a".repeat(62) + "-rest";
+		const out = sanitiseHostname(longWithDashAtBoundary, sid);
+		expect(out).toBe("a".repeat(62));
+		expect(out.length).toBe(62);
+		expect(out.endsWith("-")).toBe(false);
+	});
+
+	it("caps length at 63 chars for any input", () => {
+		const out = sanitiseHostname("x".repeat(200), sid);
+		expect(out.length).toBe(63);
+		expect(out).toBe("x".repeat(63));
 	});
 });

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -166,21 +166,7 @@ export class DockerManager {
                 // No chown — backend (typically root) owns the dir, container
                 // reads via the read-only mount; no need for it to own anything.
 
-                // RFC 1123 forbids hostname labels from starting or ending with
-                // `-`, and Docker rejects createContainer with such hostnames.
-                // The previous one-liner only filtered the *charset* — a session
-                // named "-foo" or "foo-" produced a hostname Docker refused, and
-                // a session named "---" (or any name made entirely of forbidden
-                // chars) produced an empty hostname which Docker also refuses.
-                // Order matters: slice *before* the boundary strip so a name
-                // longer than 63 chars whose 63rd char is `-` doesn't sneak a
-                // trailing dash past the regex. Fall back to the short session
-                // id if every char gets stripped.
-                const hostname =
-                        meta.name
-                                .replace(/[^a-zA-Z0-9-]/g, "-")
-                                .slice(0, 63)
-                                .replace(/^-+|-+$/g, "") || `session-${sessionId.slice(0, 8)}`;
+                const hostname = sanitiseHostname(meta.name, sessionId);
                 const container = await this.docker.createContainer({
                         Image: SESSION_IMAGE,
                         name: meta.containerName,
@@ -1245,6 +1231,21 @@ export class DockerManager {
 }
 
 // ── Module-level helpers ─────────────────────────────────────────────────────
+
+// RFC 1123 forbids hostname labels from starting or ending with `-`, and
+// Docker rejects createContainer for such hostnames. Order matters: slice
+// *before* the boundary strip so a name longer than 63 chars whose 63rd
+// char is `-` doesn't sneak a trailing dash past the regex. Fall back to a
+// short-session-id label if every char gets stripped (e.g. "---", "中文").
+// Exported for tests.
+export function sanitiseHostname(name: string, sessionId: string): string {
+        return (
+                name
+                        .replace(/[^a-zA-Z0-9-]/g, "-")
+                        .slice(0, 63)
+                        .replace(/^-+|-+$/g, "") || `session-${sessionId.slice(0, 8)}`
+        );
+}
 
 // Sanitise an uploaded file's original name into a safe basename that's
 // guaranteed to land inside the uploads directory. Strips any path

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -166,10 +166,23 @@ export class DockerManager {
                 // No chown — backend (typically root) owns the dir, container
                 // reads via the read-only mount; no need for it to own anything.
 
+                // RFC 1123 forbids hostname labels from starting or ending with
+                // `-`, and Docker rejects createContainer with such hostnames.
+                // The previous one-liner only filtered the *charset* — a session
+                // named "-foo" or "foo-" produced a hostname Docker refused, and
+                // a session named "---" (or any name made entirely of forbidden
+                // chars) produced an empty hostname which Docker also refuses.
+                // Build the sanitised hostname in three steps and fall back to
+                // the short session id if every char gets stripped.
+                const hostname =
+                        meta.name
+                                .replace(/[^a-zA-Z0-9-]/g, "-")
+                                .replace(/^-+|-+$/g, "")
+                                .slice(0, 63) || `session-${sessionId.slice(0, 8)}`;
                 const container = await this.docker.createContainer({
                         Image: SESSION_IMAGE,
                         name: meta.containerName,
-                        Hostname: meta.name.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 63),
+                        Hostname: hostname,
                         Env: [
                                 `SESSION_ID=${sessionId}`,
                                 `SESSION_NAME=${meta.name}`,

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -172,13 +172,15 @@ export class DockerManager {
                 // named "-foo" or "foo-" produced a hostname Docker refused, and
                 // a session named "---" (or any name made entirely of forbidden
                 // chars) produced an empty hostname which Docker also refuses.
-                // Build the sanitised hostname in three steps and fall back to
-                // the short session id if every char gets stripped.
+                // Order matters: slice *before* the boundary strip so a name
+                // longer than 63 chars whose 63rd char is `-` doesn't sneak a
+                // trailing dash past the regex. Fall back to the short session
+                // id if every char gets stripped.
                 const hostname =
                         meta.name
                                 .replace(/[^a-zA-Z0-9-]/g, "-")
-                                .replace(/^-+|-+$/g, "")
-                                .slice(0, 63) || `session-${sessionId.slice(0, 8)}`;
+                                .slice(0, 63)
+                                .replace(/^-+|-+$/g, "") || `session-${sessionId.slice(0, 8)}`;
                 const container = await this.docker.createContainer({
                         Image: SESSION_IMAGE,
                         name: meta.containerName,


### PR DESCRIPTION
Closes #6.

## Why

The previous hostname sanitiser was a one-liner that only filtered the **charset** of `meta.name`:

```ts
Hostname: meta.name.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 63),
```

Three ways this fails the RFC 1123 hostname rules Docker enforces:

1. `-foo` or `foo-` keeps its leading/trailing dash after the substitution. Docker rejects such hostnames with a 400 `Invalid hostname` and `createContainer` blows up.
2. `---` (or any name made entirely of forbidden chars) collapses to `""`. Docker rejects empty hostnames too.
3. A name longer than 63 chars whose 63rd char (after charset normalisation) is `-` is also rejected — `slice(0, 63)` can re-introduce a trailing dash that a strip-then-slice ordering would miss.

## Change

Extract the pipeline into an exported `sanitiseHostname(name, sessionId)` helper. Order matters — slice **before** the boundary strip so any trailing dash introduced by truncation is also cleaned up:

```ts
name
        .replace(/[^a-zA-Z0-9-]/g, "-")   // charset
        .slice(0, 63)                      // DNS label limit
        .replace(/^-+|-+$/g, "")          // RFC 1123 boundary (post-slice)
        || `session-${sessionId.slice(0, 8)}`; // empty-fallback
```

The fallback uses the first 8 chars of the session UUID — always `[0-9a-f-]`, so it stays inside the post-regex charset, and is deterministic per session (helpful for log-grepping when a name was pathological).

## Verifies the issue's acceptance criteria

- Session name `-foo-` → hostname `foo` ✓
- Session name `---` → hostname `session-<short id>` ✓
- 62×`a` + `-rest` → hostname `aaaa…aaaa` (62 chars, no trailing `-`) ✓

## Tested

`tsc --noEmit` clean. New `describe("sanitiseHostname")` block in `dockerManager.test.ts` covers leading/trailing/both-side dash, all-stripped fallback, the slice-before-strip ordering case, and the 63-char cap.