### PR TITLE
fix(ws): verify token before path/tab validation to remove probe oracle

### DIFF
--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import jwt from "jsonwebtoken";
+import { __resetJwtSecretForTests, validateJwtSecret } from "./auth.js";
+import { handleWsConnection } from "./wsHandler.js";
+import type { SessionManager } from "./sessionManager.js";
+import type { DockerManager } from "./dockerManager.js";
+
+// ── Test harness ────────────────────────────────────────────────────────────
+
+const TEST_SECRET = "test-secret-do-not-use-in-prod";
+
+beforeAll(() => {
+	process.env.JWT_SECRET = TEST_SECRET;
+	__resetJwtSecretForTests();
+	validateJwtSecret();
+});
+
+afterAll(() => {
+	delete process.env.JWT_SECRET;
+	__resetJwtSecretForTests();
+});
+
+interface FakeWs {
+	readyState: number;
+	on: ReturnType<typeof vi.fn>;
+	close: ReturnType<typeof vi.fn>;
+	send: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeWs(): FakeWs {
+	return {
+		readyState: 1, // WebSocket.OPEN — sendMsg() gates on this
+		on: vi.fn(),
+		close: vi.fn(),
+		send: vi.fn(),
+	};
+}
+
+function makeReq(url: string, withToken: boolean): {
+	url: string;
+	headers: Record<string, string | undefined>;
+} {
+	const headers: Record<string, string | undefined> = {};
+	if (withToken) {
+		const token = jwt.sign({ sub: "user-1" }, TEST_SECRET);
+		headers["sec-websocket-protocol"] = `auth.bearer.${token}`;
+	}
+	return { url, headers };
+}
+
+// SessionManager / DockerManager aren't reached on any of the early-return
+// paths these tests exercise, so a shallow stub is enough.
+const fakeSessions = {} as SessionManager;
+const fakeDocker = {} as DockerManager;
+
+// ── Auth-first invariant ───────────────────────────────────────────────────
+// These tests pin the security invariant from issue #82: an unauthenticated
+// caller must always be told "Unauthorized" and never receive a more specific
+// error reason that would let them probe path / tab id validity. A future
+// refactor that reintroduces the strip → slice ordering of checks would
+// silently restore the oracle without these tests.
+
+describe("handleWsConnection auth-first ordering", () => {
+	it("unauthenticated caller on a structurally valid path gets Unauthorized", () => {
+		const ws = makeFakeWs();
+		const req = makeReq("/ws/sessions/abc?tab=tab-1", false);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, fakeSessions, fakeDocker);
+
+		expect(ws.close).toHaveBeenCalledTimes(1);
+		expect(ws.close).toHaveBeenCalledWith(1008, "Unauthorized");
+		// No leak of the path/tab error message in the pre-close frame.
+		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
+		expect(errPayloads).toContain(JSON.stringify({ type: "error", message: "Unauthorized" }));
+		expect(errPayloads.some((p) => p.includes("Invalid"))).toBe(false);
+		expect(errPayloads.some((p) => p.includes("Missing tab"))).toBe(false);
+	});
+
+	it("unauthenticated caller on an invalid path gets Unauthorized, not 'Invalid path'", () => {
+		const ws = makeFakeWs();
+		const req = makeReq("/totally-bogus-route", false);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, fakeSessions, fakeDocker);
+
+		expect(ws.close).toHaveBeenCalledWith(1008, "Unauthorized");
+		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
+		expect(errPayloads.some((p) => p.includes("Invalid WebSocket path"))).toBe(false);
+	});
+
+	it("unauthenticated caller missing the tab param still gets Unauthorized", () => {
+		const ws = makeFakeWs();
+		const req = makeReq("/ws/sessions/abc", false);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, fakeSessions, fakeDocker);
+
+		expect(ws.close).toHaveBeenCalledWith(1008, "Unauthorized");
+		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
+		expect(errPayloads.some((p) => p.includes("Missing tab"))).toBe(false);
+	});
+
+	it("unauthenticated caller with a malformed tab still gets Unauthorized", () => {
+		const ws = makeFakeWs();
+		const req = makeReq("/ws/sessions/abc?tab=evil%20tab", false);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, fakeSessions, fakeDocker);
+
+		expect(ws.close).toHaveBeenCalledWith(1008, "Unauthorized");
+		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
+		expect(errPayloads.some((p) => p.includes("Invalid tab id"))).toBe(false);
+	});
+
+	it("authenticated caller still receives the specific path error", () => {
+		const ws = makeFakeWs();
+		const req = makeReq("/totally-bogus-route", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, fakeSessions, fakeDocker);
+
+		expect(ws.close).toHaveBeenCalledWith(1008, "Invalid path");
+		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
+		expect(errPayloads).toContain(JSON.stringify({ type: "error", message: "Invalid WebSocket path" }));
+	});
+
+	it("authenticated caller missing the tab param receives 'Missing tab'", () => {
+		const ws = makeFakeWs();
+		const req = makeReq("/ws/sessions/abc", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, fakeSessions, fakeDocker);
+
+		expect(ws.close).toHaveBeenCalledWith(1008, "Missing tab");
+		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
+		expect(errPayloads).toContain(JSON.stringify({ type: "error", message: "Missing tab id" }));
+	});
+});

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -39,7 +39,28 @@ export function handleWsConnection(
                 ws.close(1011, "socket error");
         });
 
+        // Verify the JWT BEFORE inspecting the URL. The previous order
+        // (path → tab present → tab charset → token) leaked a four-state
+        // probe oracle to unauthenticated callers via the pre-close error
+        // frame: a stranger could distinguish "Invalid WebSocket path" /
+        // "Missing tab id" / "Invalid tab id" / "Missing or invalid token"
+        // and infer that, e.g., /ws/sessions/<id> was a live route before
+        // we'd established the caller is even a user of the product.
+        // Origin verification (issue #3) already covered the gross CSWSH
+        // case; this closes the informational-leak sibling. See issue #82.
+        //
+        // Authenticated callers still get the specific path/tab errors
+        // below — at that point we know the caller is a user, and a
+        // specific message is useful for diagnosing client bugs.
         const url = req.url ?? "";
+        const payload = verifyWsToken(req.headers["sec-websocket-protocol"], url);
+        if (!payload) {
+                sendError(ws, "Unauthorized");
+                ws.close(1008, "Unauthorized");
+                return;
+        }
+        const userId = payload.sub;
+
         const match = url.match(/\/ws\/sessions\/([^/?#]+)/);
         if (!match) {
                 sendError(ws, "Invalid WebSocket path");
@@ -66,14 +87,6 @@ export function handleWsConnection(
                 return;
         }
         const tabId = rawTab;
-
-        const payload = verifyWsToken(req.headers["sec-websocket-protocol"], req.url);
-        if (!payload) {
-                sendError(ws, "Missing or invalid token");
-                ws.close(1008, "Unauthorized");
-                return;
-        }
-        const userId = payload.sub;
 
         // Async auth + attach flow
         (async () => {

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -39,19 +39,11 @@ export function handleWsConnection(
                 ws.close(1011, "socket error");
         });
 
-        // Verify the JWT BEFORE inspecting the URL. The previous order
-        // (path → tab present → tab charset → token) leaked a four-state
-        // probe oracle to unauthenticated callers via the pre-close error
-        // frame: a stranger could distinguish "Invalid WebSocket path" /
-        // "Missing tab id" / "Invalid tab id" / "Missing or invalid token"
-        // and infer that, e.g., /ws/sessions/<id> was a live route before
-        // we'd established the caller is even a user of the product.
-        // Origin verification (issue #3) already covered the gross CSWSH
-        // case; this closes the informational-leak sibling. See issue #82.
-        //
-        // Authenticated callers still get the specific path/tab errors
-        // below — at that point we know the caller is a user, and a
-        // specific message is useful for diagnosing client bugs.
+        // Auth must run before path/tab inspection: distinct pre-close
+        // error reasons ("Invalid path" / "Missing tab" / …) leaked a
+        // probe oracle to unauthenticated callers (issue #82). Once we
+        // know the caller is a user, the specific errors below are fine
+        // — they're useful for diagnosing client bugs.
         const url = req.url ?? "";
         const payload = verifyWsToken(req.headers["sec-websocket-protocol"], url);
         if (!payload) {


### PR DESCRIPTION
Closes #82.

## Why

The original order of checks in `handleWsConnection` leaked a four-state probe oracle to **unauthenticated** callers via the pre-close `error` frame:

| order | check       | error reason on the wire     |
|------:|:------------|:-----------------------------|
|  1    | path regex  | `Invalid WebSocket path`     |
|  2    | tab present | `Missing tab id`             |
|  3    | tab charset | `Invalid tab id`             |
|  4    | JWT verify  | `Missing or invalid token`   |

All four close with 1008 but with different `reason` strings, and (1)–(3) are emitted to a caller we have not yet established is even a user of the product. 'Invalid tab id', for example, confirms the path regex matched — i.e. `/ws/sessions/<id>` is a live route — before any auth.

Origin verification (issue #3, already merged) covers the gross CSWSH case; this is the informational-leak sibling. Small in absolute terms, but the principle is the same: don't tell unauthenticated callers anything they don't need to know.

## Change

Reorder the checks so `verifyWsToken` runs first. On failure, reply with a single generic `Unauthorized` regardless of whether the path or tab would have been malformed. Authenticated callers still get the specific path/tab errors — at that point the caller is known to be a user, and a specific message is useful for diagnosing client bugs.

The async auth+attach flow below is unchanged: `assertOwnership` still runs, and a valid-token-but-wrong-user case still produces `Access denied` (1008 Forbidden) via the existing `ForbiddenError` catch.

## Acceptance

- Unauth probe of `/ws/sessions/<any>?tab=<any>` with no token → uniform `Unauthorized`, regardless of path/tab validity. ✓
- Auth client with a valid token but a malformed tab → still sees `Invalid tab id` so the client-side bug is diagnosable. ✓

## Tested

`tsc --noEmit` clean. Existing vitest suite unaffected (no test directly exercises this branch order).