### PR TITLE
fix(server): bound CLOSE_WAIT window on rejected WebSocket upgrades

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -113,6 +113,34 @@ const wss = new WebSocketServer({
         handleProtocols: (protocols) => selectWsAuthProtocol(protocols),
 });
 
+// Send a tiny HTTP error response on the raw upgrade socket and tear
+// it down with a bounded grace window.
+//
+// socket.end(msg) flushes the status line, sends FIN, and waits for the
+// peer's FIN before fully releasing the fd. A misbehaving peer that
+// never sends FIN leaves the socket in CLOSE_WAIT until kernel keep-
+// alive kicks in (minutes to hours depending on tuning) — and on the
+// 403 path that's cheap to script, since an attacker piling up garbage-
+// Origin upgrades and dropping post-response could exhaust the process
+// fd table. socket.destroy() alone (the form before #64) was bounded
+// but didn't guarantee the status line flushed first, hiding the 4xx
+// reason from anyone debugging.
+//
+// Belt-and-braces: end() for the flush, then a hard destroy() after
+// 500 ms if the peer hasn't FIN'd. unref()'d so the timer never holds
+// the process open during shutdown. 500 ms is generous for any real
+// client to ack and tight enough that a flood can't accumulate.
+// See issue #67.
+function endUpgradeSocketWithReply(
+        socket: NodeJS.Socket & { end: (data?: string) => void; destroy: () => void },
+        reply: string,
+): void {
+        socket.end(reply);
+        setTimeout(() => {
+                try { socket.destroy(); } catch { /* already destroyed */ }
+        }, 500).unref();
+}
+
 server.on("upgrade", (req, socket, head) => {
         const url = req.url ?? "";
         if (!url.startsWith("/ws/sessions/")) {
@@ -121,7 +149,10 @@ server.on("upgrade", (req, socket, head) => {
                 // socket.destroy() (the previous form) issues immediate
                 // teardown with no drain guarantee — the status line can be
                 // dropped, making "why did my WS fail" harder to debug.
-                socket.end("HTTP/1.1 404 Not Found\r\n\r\n");
+                // The bounded-destroy timer in endUpgradeSocketWithReply
+                // closes the CLOSE_WAIT window a half-close otherwise opens
+                // up against a peer that never FINs (#67).
+                endUpgradeSocketWithReply(socket, "HTTP/1.1 404 Not Found\r\n\r\n");
                 return;
         }
 
@@ -143,7 +174,7 @@ server.on("upgrade", (req, socket, head) => {
         // surface through the 403 status code + the boot warning, not
         // through per-request log spam.
         if (!isAllowedWsOrigin(req.headers.origin, CORS_ORIGINS, process.env.NODE_ENV)) {
-                socket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
+                endUpgradeSocketWithReply(socket, "HTTP/1.1 403 Forbidden\r\n\r\n");
                 return;
         }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,7 +21,7 @@ import { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
 import { SessionManager } from "./sessionManager.js";
 import { parseTrustProxy, TrustProxyError, warnIfProductionMisconfigured } from "./trustProxy.js";
-import { handleWsConnection } from "./wsHandler.js";
+import { endUpgradeSocketWithReply, handleWsConnection } from "./wsHandler.js";
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -112,34 +112,6 @@ const wss = new WebSocketServer({
         noServer: true,
         handleProtocols: (protocols) => selectWsAuthProtocol(protocols),
 });
-
-// Send a tiny HTTP error response on the raw upgrade socket and tear
-// it down with a bounded grace window.
-//
-// socket.end(msg) flushes the status line, sends FIN, and waits for the
-// peer's FIN before fully releasing the fd. A misbehaving peer that
-// never sends FIN leaves the socket in CLOSE_WAIT until kernel keep-
-// alive kicks in (minutes to hours depending on tuning) — and on the
-// 403 path that's cheap to script, since an attacker piling up garbage-
-// Origin upgrades and dropping post-response could exhaust the process
-// fd table. socket.destroy() alone (the form before #64) was bounded
-// but didn't guarantee the status line flushed first, hiding the 4xx
-// reason from anyone debugging.
-//
-// Belt-and-braces: end() for the flush, then a hard destroy() after
-// 500 ms if the peer hasn't FIN'd. unref()'d so the timer never holds
-// the process open during shutdown. 500 ms is generous for any real
-// client to ack and tight enough that a flood can't accumulate.
-// See issue #67.
-function endUpgradeSocketWithReply(
-        socket: NodeJS.Socket & { end: (data?: string) => void; destroy: () => void },
-        reply: string,
-): void {
-        socket.end(reply);
-        setTimeout(() => {
-                try { socket.destroy(); } catch { /* already destroyed */ }
-        }, 500).unref();
-}
 
 server.on("upgrade", (req, socket, head) => {
         const url = req.url ?? "";

--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -1,7 +1,7 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import jwt from "jsonwebtoken";
 import { __resetJwtSecretForTests, validateJwtSecret } from "./auth.js";
-import { handleWsConnection } from "./wsHandler.js";
+import { endUpgradeSocketWithReply, handleWsConnection } from "./wsHandler.js";
 import type { SessionManager } from "./sessionManager.js";
 import type { DockerManager } from "./dockerManager.js";
 
@@ -129,5 +129,58 @@ describe("handleWsConnection auth-first ordering", () => {
 		expect(ws.close).toHaveBeenCalledWith(1008, "Missing tab");
 		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
 		expect(errPayloads).toContain(JSON.stringify({ type: "error", message: "Missing tab id" }));
+	});
+});
+
+// ── endUpgradeSocketWithReply ──────────────────────────────────────────────
+// Pins the half-close → bounded-destroy invariant from issue #67. A peer
+// that never FINs would otherwise hold the upgrade socket in CLOSE_WAIT
+// until kernel keepalive kicks in; the 500 ms timer caps the window so
+// an attacker can't pile up dangling rejected upgrades.
+
+describe("endUpgradeSocketWithReply", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function makeFakeSocket() {
+		return {
+			end: vi.fn(),
+			destroy: vi.fn(),
+		};
+	}
+
+	it("calls end() synchronously with the reply and defers destroy() by 500 ms", () => {
+		const socket = makeFakeSocket();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		endUpgradeSocketWithReply(socket as any, "HTTP/1.1 403 Forbidden\r\n\r\n");
+
+		expect(socket.end).toHaveBeenCalledTimes(1);
+		expect(socket.end).toHaveBeenCalledWith("HTTP/1.1 403 Forbidden\r\n\r\n");
+		expect(socket.destroy).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(499);
+		expect(socket.destroy).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1);
+		expect(socket.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it("swallows a destroy() error from a socket the peer already RST'd", () => {
+		const socket = {
+			end: vi.fn(),
+			destroy: vi.fn(() => {
+				throw new Error("ERR_SOCKET_ALREADY_DESTROYED");
+			}),
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		endUpgradeSocketWithReply(socket as any, "HTTP/1.1 404 Not Found\r\n\r\n");
+
+		// Advancing past 500 ms must not propagate the throw.
+		expect(() => vi.advanceTimersByTime(500)).not.toThrow();
+		expect(socket.destroy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -3,12 +3,40 @@
  */
 
 import { IncomingMessage } from "http";
+import type { Duplex } from "node:stream";
 import { WebSocket } from "ws";
 import { v4 as uuidv4 } from "uuid";
 import { verifyWsToken } from "./auth.js";
 import { SessionManager, NotFoundError, ForbiddenError } from "./sessionManager.js";
 import { DockerManager } from "./dockerManager.js";
 import { WsClientMessage, WsServerMessage } from "./types.js";
+
+// Send a tiny HTTP error response on the raw upgrade socket and tear it
+// down with a bounded grace window.
+//
+// socket.end(msg) flushes the status line, sends FIN, and waits for the
+// peer's FIN before fully releasing the fd. A misbehaving peer that never
+// sends FIN leaves the socket in CLOSE_WAIT until kernel keepalive kicks
+// in (minutes to hours depending on tuning) — and on the 403 path that's
+// cheap to script, since an attacker piling up garbage-Origin upgrades
+// and dropping post-response could exhaust the process fd table.
+// socket.destroy() alone (the pre-#64 form) was bounded but didn't
+// guarantee the status line flushed first, hiding the 4xx reason from
+// anyone debugging. Belt-and-braces: end() for the flush, then a hard
+// destroy() after 500 ms if the peer hasn't FIN'd. unref()'d so the timer
+// never holds the process open during shutdown. See issue #67.
+// `Duplex` matches the upgrade-event signature for http.Server and a
+// hypothetical https.Server (TLSSocket extends Duplex too).
+export function endUpgradeSocketWithReply(socket: Duplex, reply: string): void {
+        // socket.end() on an already-destroyed socket is a no-op in Node 20+,
+        // so the asymmetry with the guarded destroy() below is intentional —
+        // the only failure mode worth swallowing is a peer that RST'd between
+        // the upgrade event and our 500 ms timer firing.
+        socket.end(reply);
+        setTimeout(() => {
+                try { socket.destroy(); } catch { /* already destroyed */ }
+        }, 500).unref();
+}
 
 export function handleWsConnection(
         ws: WebSocket,


### PR DESCRIPTION
Closes #67.

## Why

The 404 and 403 branches of the upgrade handler both ended with:

```ts
socket.end("HTTP/1.1 4xx ...\r\n\r\n");
```

`socket.end()` is a **graceful** TCP half-close: it flushes the status line, sends FIN, and waits for the peer's FIN before fully releasing the fd. A misbehaving peer that never sends FIN leaves the socket in `CLOSE_WAIT` until the kernel's keepalive/timeout kicks in — minutes to hours depending on tuning.

On the 403 path (rejected Origin) that's cheap to script: an attacker piling up garbage-Origin upgrades and dropping the connection post-response could accumulate `CLOSE_WAIT` sockets and eventually exhaust the process fd table. The 404 path is the same shape with a smaller payoff.

The earlier `socket.write() + socket.destroy()` form (before #64) didn't have this problem but didn't guarantee the status line flushed first — that's why #64 moved to `end()`.

## Change

Belt-and-braces: factor the teardown into `endUpgradeSocketWithReply()`:

```ts
function endUpgradeSocketWithReply(socket, reply) {
        socket.end(reply);                                    // flush
        setTimeout(() => {
                try { socket.destroy(); } catch { /* … */ }   // hard close
        }, 500).unref();                                      // don't hold the loop
}
```

Apply on both 404 and 403 branches. 500 ms is generous for any real client to ack and tight enough that a flood can't accumulate. `unref()` so the timer never blocks shutdown.

## Priority

Genuinely low — production is currently fronted by a Cloudflare Tunnel which brokers connection state, so an attacker can't directly drive our socket table the way they could on a raw Internet-exposed port. This is defence-in-depth.

## Tested

`tsc --noEmit` clean.