### PR TITLE
fix(server): log rejected WS upgrade Origin in dev/staging only

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -139,13 +139,22 @@ server.on("upgrade", (req, socket, head) => {
         // missing Origin is allowed because it indicates non-browser
         // clients, and "*" in CORS_ORIGINS is denied in production).
         //
-        // No per-request log on rejection: an attacker can flood the upgrade
-        // handler with garbage Origin headers and drown out signal. The
-        // CORS_ORIGINS=* case is already covered by warnIfWildcardCorsIn-
-        // Production at startup; deliberate operator misconfiguration will
-        // surface through the 403 status code + the boot warning, not
-        // through per-request log spam.
+        // No per-request log in PRODUCTION: an attacker can flood the
+        // upgrade handler with garbage Origin headers and drown out signal.
+        // The CORS_ORIGINS=* case is already covered by warnIfWildcard-
+        // CorsInProduction at startup; deliberate operator misconfiguration
+        // surfaces through the 403 status code + the boot warning, not
+        // through per-request log spam. In dev/staging we DO log (gated
+        // below) so an operator deploying a typo'd Origin can grep for it.
         if (!isAllowedWsOrigin(req.headers.origin, CORS_ORIGINS, process.env.NODE_ENV)) {
+                // Dev/staging only: see the block comment above and issue #66.
+                if (process.env.NODE_ENV !== "production") {
+                        console.debug(
+                                "[ws] rejecting upgrade: Origin=%s not in allowlist %j",
+                                req.headers.origin ?? "<absent>",
+                                CORS_ORIGINS,
+                        );
+                }
                 endUpgradeSocketWithReply(socket, "HTTP/1.1 403 Forbidden\r\n\r\n");
                 return;
         }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -149,7 +149,7 @@ server.on("upgrade", (req, socket, head) => {
         if (!isAllowedWsOrigin(req.headers.origin, CORS_ORIGINS, process.env.NODE_ENV)) {
                 // Dev/staging only: see the block comment above and issue #66.
                 if (process.env.NODE_ENV !== "production") {
-                        console.debug(
+                        console.log(
                                 "[ws] rejecting upgrade: Origin=%s not in allowlist %j",
                                 req.headers.origin ?? "<absent>",
                                 CORS_ORIGINS,


### PR DESCRIPTION
Closes #66.

## Why

PR #64 deliberately dropped the per-request `console.warn` on a rejected upgrade Origin to prevent an attacker flooding the upgrade handler with garbage Origin headers and drowning out legitimate signal in production logs. Sound trade-off, but it left an ops gap: an operator deploying a typo'd explicit origin (wrong case, wrong protocol, stale subdomain after a rename) got **zero runtime feedback** beyond a 403 arriving at the client — nothing in the server log to grep for.

`warnIfWildcardCorsInProduction` only fires for the `CORS_ORIGINS=*` case at boot. Any other misconfig surfaced as a silent 403.

## Change

```ts
if (!isAllowedWsOrigin(req.headers.origin, CORS_ORIGINS, process.env.NODE_ENV)) {
        if (process.env.NODE_ENV !== "production") {
                console.debug(
                        "[ws] rejecting upgrade: Origin=%s not in allowlist %j",
                        req.headers.origin ?? "<absent>",
                        CORS_ORIGINS,
                );
        }
        socket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
        return;
}
```

- Gated on `NODE_ENV !== "production"` so the prod log-flood amplification surface stays closed.
- Logs both the offending `Origin` (or `<absent>`) and the current `CORS_ORIGINS` allowlist so a typo diff is obvious at a glance.
- Updates the surrounding "no per-request log" comment to make the prod-only scope explicit, so a future reader doesn't see the new `console.debug` and conclude the comment is stale.

## Tested

`tsc --noEmit` clean. The branch above ("isAllowedWsOrigin" rejection) is already covered by the auth tests; this PR only adds a logging side-effect inside that branch.