### PR TITLE
fix(auth): hash invite code in CRITICAL log instead of plaintext

### DIFF
--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -207,14 +207,21 @@ export async function registerUser(
                         //     redeem the code — defeating the "burned therefore
                         //     safe" assumption.
                         //
-                        // Hashing turns "operator finds the orphan" into:
+                        // Recovery: D1/SQLite has no built-in sha256(), so the hash
+                        // can't be matched in SQL directly. Two-step procedure:
                         //
-                        //     SELECT … FROM invite_codes
-                        //     WHERE printf('%x', sha256(code)) = '<hash from log>'
+                        //   1. SELECT * FROM invite_codes
+                        //      WHERE used_at IS NOT NULL
+                        //        AND used_by NOT IN (SELECT id FROM users);
+                        //      — this yields exactly the orphan rows (claimed but
+                        //      with no corresponding user). Usually one.
+                        //   2. For each candidate, compute SHA-256 of `code`
+                        //      externally and compare to the hash from the log,
+                        //      e.g. `node -e 'console.log(require("crypto").createHash("sha256").update("CODE").digest("hex"))'`.
                         //
-                        // — small one-liner D1 query, no extra column needed today,
-                        // and trivially aligns with #49 if invite codes get hashed
-                        // at rest later (the column would already be the hash).
+                        // Aligns with #49: if codes get hashed at rest later, the
+                        // column would already be the hash and step 2 collapses to
+                        // a direct equality.
                         const codeHash = createHash("sha256").update(inviteCode).digest("hex");
                         console.error(
                                 "[auth] CRITICAL: invite release failed — code hash %s is permanently consumed without an account. " +

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -2,7 +2,7 @@
  * auth.ts — JWT authentication + user management (D1-backed).
  */
 
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import bcrypt from "bcryptjs";
 import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
@@ -190,12 +190,36 @@ export async function registerUser(
                         // consumed without producing an account. The invitee will see
                         // a 409 (or 500) response and has no way of knowing the code
                         // is burned — they'll have to ask whoever issued it for a new
-                        // one. Log loudly with the code so an operator can audit the
-                        // invite_codes table and reissue if needed.
+                        // one.
+                        //
+                        // Log a SHA-256 of the code, NOT the raw value (#51). The
+                        // earlier shape included the plaintext so an operator could
+                        // grep the invite_codes table — but any log aggregator /
+                        // SIEM that indexes this line would then hold a usable code:
+                        //
+                        //   - The "code is already consumed" reasoning assumed the
+                        //     UPDATE had landed (used_at IS NOT NULL). If the
+                        //     release UPDATE failed in a way that left the row
+                        //     claimable (write didn't reach D1 at all), the logged
+                        //     plaintext was still live.
+                        //   - Even in the consumed case, a rotated D1 admin token
+                        //     could let an attacker manually un-claim the row and
+                        //     redeem the code — defeating the "burned therefore
+                        //     safe" assumption.
+                        //
+                        // Hashing turns "operator finds the orphan" into:
+                        //
+                        //     SELECT … FROM invite_codes
+                        //     WHERE printf('%x', sha256(code)) = '<hash from log>'
+                        //
+                        // — small one-liner D1 query, no extra column needed today,
+                        // and trivially aligns with #49 if invite codes get hashed
+                        // at rest later (the column would already be the hash).
+                        const codeHash = createHash("sha256").update(inviteCode).digest("hex");
                         console.error(
-                                "[auth] CRITICAL: invite release failed — code %s is permanently consumed without an account. " +
+                                "[auth] CRITICAL: invite release failed — code hash %s is permanently consumed without an account. " +
                                 "Insert error: %s. Release error: %s",
-                                inviteCode,
+                                codeHash,
                                 (err as Error).message,
                                 (releaseErr as Error).message,
                         );


### PR DESCRIPTION
Closes #51.

## Why

The release-failed CRITICAL log in `registerUser` included the raw invite code so an operator could grep the `invite_codes` table after a permanently-consumed-without-an-account incident:

```
[auth] CRITICAL: invite release failed — code abc123def456 is permanently consumed without an account. …
```

That seemed safe — *"the code is already used, leaking it can't matter"* — but the assumption is fragile in two places:

1. The *consumed* state assumes the claim UPDATE landed (`used_at IS NOT NULL`) before we hit this catch arm. If the **release** UPDATE failed in a way that left the row claimable (the write didn't reach D1 at all — network drop, auth blip), the logged plaintext was still a **live, redeemable** code.
2. Even in the genuinely-consumed case, an attacker who later acquires a rotated D1 admin token could un-claim the row (`UPDATE invite_codes SET used_at = NULL …`) and then redeem it with the logged plaintext. Defeats the "burned therefore safe" assumption end-to-end.

And in production this is exactly the line a SIEM / log aggregator indexes for retention — so the plaintext fans out to whatever has read access to those logs.

## Change

Log a SHA-256 of the code, not the plaintext:

```ts
const codeHash = createHash("sha256").update(inviteCode).digest("hex");
console.error(
        "[auth] CRITICAL: invite release failed — code hash %s is permanently consumed …",
        codeHash, …,
);
```

SHA-256 is fine against the *recover-the-code* threat — the input has 64 bits of entropy from `randomBytes(8)`, so the hash is the work-factor barrier; this isn't the *crack-a-password* threat where SHA-256 would be the wrong primitive.

## Operator's recovery

D1/SQLite has no built-in `sha256()`, so the hash can't be matched in SQL directly. Two-step procedure (also documented in the inline comment above the log call):

1. Find the orphan row(s) by their structural shape — claimed but no matching user:

   ```sql
   SELECT * FROM invite_codes
   WHERE used_at IS NOT NULL
     AND used_by NOT IN (SELECT id FROM users);
   ```

   Usually exactly one row.

2. For each candidate, compute SHA-256 of `code` externally and compare to the hash from the log:

   ```sh
   node -e 'console.log(require("crypto").createHash("sha256").update("CANDIDATE").digest("hex"))'
   ```

Aligns naturally with #49 if invite codes get hashed at rest later — the column will already be the hash, and step 2 collapses to a direct equality.

## Tested

`tsc --noEmit` clean. The CRITICAL log line is a side-effect of an exception handler that the existing test suite doesn't directly drive (it requires both the user INSERT AND the release UPDATE to fail, which is a pure-error path). The hash format is byte-stable for a fixed input — easy to manually verify against `echo -n CODE | shasum -a 256` if needed.