### PR TITLE
fix(invites): rate-limit GET /invites for symmetry with POST/DELETE

### DIFF
--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -13,6 +13,7 @@ const authStubs = vi.hoisted(() => ({
 	registerUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	loginUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	hasAnyUsers: vi.fn(async () => true),
+	listInvites: vi.fn(async (_u?: string) => [] as unknown[]),
 	requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
 	// The route handler checks `err instanceof InvalidCredentialsError` where
 	// `InvalidCredentialsError` is imported from `./auth.js`. Because we
@@ -586,5 +587,27 @@ describe("auth route rate limiting", () => {
 		authStubs.loginUser.mockImplementationOnce(async () => ({ userId: "u1", token: "tok" }));
 		const locked = await postLogin({ username: "alice", password: "good" });
 		expect(locked.status).toBe(429);
+	});
+
+	it("GET /invites returns 429 after invitesList.ipMax requests", async () => {
+		// Issue #47: GET /invites must be rate-limited symmetrically with
+		// POST/DELETE so an unbounded polling client can't hammer D1.
+		// If a future refactor drops `invitesListIp` from the route signature
+		// this test will surface it as a 200 on the third call.
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesList: { ipMax: 2, ipWindowMs: 60_000 },
+		});
+
+		const r1 = await fetch(`${baseUrl}/api/invites`);
+		const r2 = await fetch(`${baseUrl}/api/invites`);
+		const r3 = await fetch(`${baseUrl}/api/invites`);
+
+		expect(r1.status).toBe(200);
+		expect(r2.status).toBe(200);
+		expect(r3.status).toBe(429);
+		expect(await r3.json()).toMatchObject({ scope: "ip" });
+		expect(r3.headers.get("retry-after")).not.toBeNull();
 	});
 });

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -368,6 +368,7 @@ describe("auth route rate limiting", () => {
 		login: { ipMax: number; ipWindowMs: number; usernameMax: number; usernameWindowMs: number };
 		register: { ipMax: number; ipWindowMs: number };
 		invitesCreate?: { ipMax: number; ipWindowMs: number };
+		invitesList?: { ipMax: number; ipWindowMs: number };
 		invitesRevoke?: { ipMax: number; ipWindowMs: number };
 		fileUpload?: { ipMax: number; ipWindowMs: number };
 	}): Promise<void> {
@@ -376,6 +377,7 @@ describe("auth route rate limiting", () => {
 		// don't trip them.
 		const fullCfg = {
 			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
 			invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
 			fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
 			...cfg,

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -24,6 +24,19 @@ export interface RateLimitConfig {
 		ipMax: number;
 		ipWindowMs: number;
 	};
+	// Caps how often a single IP can list invites. Kept separate from
+	// invitesCreate because reads are cheap (one D1 SELECT, capped at
+	// INVITE_LIST_LIMIT = 100 rows the caller already owns) and the UI
+	// may legitimately poll the modal — pinning it to the mint rate
+	// would 429 on every other refresh. Mostly here for symmetry with
+	// the other invite endpoints (issue #47): the asymmetry of "POST
+	// and DELETE rate-limited, GET wide open" reads as accidental.
+	// Also bounds runaway client behaviour and D1 read load if a
+	// logged-in client tab gets stuck in a tight refresh loop.
+	invitesList: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
 	// Caps how often a single IP can revoke invites. Kept separate from
 	// invitesCreate because:
 	//   1. Revoke is a cleanup action the legitimate user may need to do in
@@ -52,8 +65,11 @@ export interface RateLimitConfig {
 }
 
 // Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
-// Invites: create 10/h, revoke 60/h — revoke has to cover incident-response
-// bursts, so it's 6x the mint rate.
+// Invites: create 10/h, list 120/h, revoke 60/h. List is cheapest (a single
+// SELECT, capped at INVITE_LIST_LIMIT = 100 owned rows) so it has the most
+// generous default — 120/h ≈ 2/min sustained, plenty for a UI that
+// polls when the modal is open. Revoke is 6x mint to cover incident-response
+// bursts (panic-rotate after suspecting JWT theft).
 export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 	login: {
 		ipMax: 10,
@@ -67,6 +83,10 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 	},
 	invitesCreate: {
 		ipMax: 10,
+		ipWindowMs: 60 * 60 * 1000,
+	},
+	invitesList: {
+		ipMax: 120,
 		ipWindowMs: 60 * 60 * 1000,
 	},
 	invitesRevoke: {
@@ -85,6 +105,7 @@ export interface AuthRateLimiters {
 	loginIp: RateLimitRequestHandler;
 	registerIp: RateLimitRequestHandler;
 	invitesCreateIp: RateLimitRequestHandler;
+	invitesListIp: RateLimitRequestHandler;
 	invitesRevokeIp: RateLimitRequestHandler;
 	fileUploadIp: RateLimitRequestHandler;
 }
@@ -119,6 +140,15 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many invite-mint requests from this IP, try again later", scope: "ip" },
 	});
+	const invitesListIp = rateLimit({
+		windowMs: cfg.invitesList.ipWindowMs,
+		limit: cfg.invitesList.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		// Distinct 429 message so a 429 on the list endpoint isn't mis-
+		// attributed to the mint or revoke endpoint when troubleshooting.
+		message: { error: "Too many invite-list requests from this IP, try again later", scope: "ip" },
+	});
 	const invitesRevokeIp = rateLimit({
 		windowMs: cfg.invitesRevoke.ipWindowMs,
 		limit: cfg.invitesRevoke.ipMax,
@@ -133,7 +163,7 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many file uploads from this IP, try again later", scope: "ip" },
 	});
-	return { loginIp, registerIp, invitesCreateIp, invitesRevokeIp, fileUploadIp };
+	return { loginIp, registerIp, invitesCreateIp, invitesListIp, invitesRevokeIp, fileUploadIp };
 }
 
 // ── Per-username limiter ────────────────────────────────────────────────────

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -47,7 +47,7 @@ export function buildRouter(
 
         // ── Auth routes (public) ────────────────────────────────────────────────
 
-        const { loginIp, registerIp, invitesCreateIp, invitesRevokeIp, fileUploadIp } = createAuthRateLimiters(rateLimitConfig);
+        const { loginIp, registerIp, invitesCreateIp, invitesListIp, invitesRevokeIp, fileUploadIp } = createAuthRateLimiters(rateLimitConfig);
         const usernameLimiter = new UsernameRateLimiter(
                 rateLimitConfig.login.usernameMax,
                 rateLimitConfig.login.usernameWindowMs,
@@ -199,7 +199,11 @@ export function buildRouter(
         // If you ever want to gate this to specific accounts, add an is_admin
         // column to users and a middleware check here.
 
-        router.get("/invites", async (req: Request, res: Response) => {
+        // GET is rate-limited symmetrically with POST/DELETE (issue #47):
+        // a much higher cap because reads are cheap, but the same per-IP
+        // shape so the asymmetry doesn't read as accidental and a runaway
+        // client polling in a loop can't hammer D1 unbounded.
+        router.get("/invites", invitesListIp, async (req: Request, res: Response) => {
                 const { userId } = req as AuthedRequest;
                 try {
                         const invites = await listInvites(userId);


### PR DESCRIPTION
Closes #47.

## Why

PR #45 review flagged that `GET /invites` is the only invite endpoint without an IP limiter — `POST` and `DELETE` both have one. Low severity on its own (the GET only returns the caller's own rows, capped at `INVITE_LIST_LIMIT = 100`), but the asymmetry across one resource is the kind of thing a future reader misreads as intentional. Closing the gap also bounds D1 read load if a client tab gets stuck in a tight refresh loop.

## Change

Adds `invitesList` to `RateLimitConfig` as its own bucket rather than reusing `invitesCreate`, because the read use case (UI polls the modal while it's open) is qualitatively different from the mint use case (occasional human action) — pinning them to the same 10/h window would 429 every other modal refresh.

```ts
invitesList: {
        ipMax: 120,
        ipWindowMs: 60 * 60 * 1000,
},
```

120/h ≈ 2/min sustained, comfortably above legitimate UI cadence and well below abuse rates. Distinct 429 message so a list-endpoint trip isn't mis-attributed when troubleshooting.

Wired into `routes.ts`:

```ts
router.get("/invites", invitesListIp, async (req, res) => { … });
```

## Tested

```
$ npx tsc --noEmit             # clean
$ npx vitest run src/rateLimit.test.ts
✓ src/rateLimit.test.ts (26 tests) — all passing
```

The existing route-level tests use a permissive spread-merge default for invite buckets:

```ts
const fullCfg = {
        invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
        invitesList:   { ipMax: 1000, ipWindowMs: 60_000 },  // new
        invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
        fileUpload:    { ipMax: 1000, ipWindowMs: 60_000 },
        ...cfg,
};
```

So tests that only exercise login/register continue to pass without per-test changes.