### PR TITLE
fix(session-image): drop sudo + all caps in session container

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Each session runs in a Docker container based on `session-image/Dockerfile`:
 - **Claude CLI:** `@anthropic-ai/claude-code` (globally installed)
 - **VS Code CLI:** `code` (standalone) — see [Connecting from VS Code](#connecting-from-vs-code) below
 - **Terminal:** tmux with a session named `main`, 50k scrollback, mouse support
-- **User:** `developer` (sudo, no password)
+- **User:** `developer` (UID 1000, unprivileged — no sudo, all Linux capabilities dropped, `no-new-privileges` set)
 - **Workspace:** `/home/developer/workspace` (bind-mounted from `<WORKSPACE_ROOT>/<sessionId>` on the host)
 - **Resources:** 2 GB RAM, 2 CPUs per container (configurable in `dockerManager.ts`)
 

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -679,6 +679,35 @@ describe("DockerManager.reconcile", () => {
 	});
 });
 
+describe("DockerManager.startContainer", () => {
+	// Case 2 (containerId on file, container exists in Docker) is the
+	// interactive `POST /api/sessions/:id/start` path. A pre-#15 container
+	// reached this way must surface the same warn as reconcile so a future
+	// refactor can't silently drop the call.
+	it("warns when starting an existing pre-#15 container (Case 2)", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const sessions = makeFakeSessions();
+		const dm = new DockerManager(sessions);
+		(dm as unknown as { docker: unknown }).docker = {
+			getContainer: vi.fn(() => ({
+				inspect: vi.fn(async () => ({
+					State: { Running: false },
+					HostConfig: { CapDrop: [], SecurityOpt: [] },
+				})),
+				start: vi.fn(async () => { /* started */ }),
+			})),
+		};
+
+		await dm.startContainer("s1");
+
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/predates issue-#15 hardening/);
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/session s1/);
+		expect(sessions.updateStatus).toHaveBeenCalledWith("s1", "running");
+		warnSpy.mockRestore();
+	});
+});
+
 // ── sanitiseUploadName ──────────────────────────────────────────────────────
 // Security-sensitive: the result is concatenated into a host filesystem path
 // AND pasted directly into the user's terminal, so it has to (a) prevent any

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -600,6 +600,83 @@ describe("DockerManager.reconcile", () => {
 		expect(sessions.setContainerId).not.toHaveBeenCalled();
 		expect(sessions.updateStatus).toHaveBeenCalledWith("s1", "stopped");
 	});
+
+	// Issue-#15 hardening migration. The warn fires for any pre-hardened
+	// container reconcile sees, regardless of running state — operators who
+	// stopped sessions before redeploying still need the heads-up at boot.
+	function makeDockerWithInspectResult(info: {
+		State: { Running: boolean };
+		HostConfig: { CapDrop?: string[]; SecurityOpt?: string[] };
+	}): { dm: DockerManager; sessions: SessionManager } {
+		const sessions = makeFakeSessions();
+		const dm = new DockerManager(sessions);
+		(dm as unknown as { docker: unknown }).docker = {
+			getContainer: vi.fn(() => ({
+				inspect: vi.fn(async () => info),
+			})),
+		};
+		return { dm, sessions };
+	}
+
+	it("warns when reconcile inspects a running pre-#15 container (no CapDrop/SecurityOpt)", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { dm, sessions } = makeDockerWithInspectResult({
+			State: { Running: true },
+			HostConfig: { CapDrop: [], SecurityOpt: [] },
+		});
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ session_id: "s1", container_id: "container-old" }],
+			meta: { changes: 0 },
+		});
+
+		await dm.reconcile();
+
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/predates issue-#15 hardening/);
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/session s1/);
+		// Running container — reconcile shouldn't flip status.
+		expect(sessions.updateStatus).not.toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+
+	it("warns even when the pre-#15 container is stopped at reconcile time", async () => {
+		// Operators who stop all sessions before deploying would otherwise
+		// only see the warn on the next /start — and might never recycle if
+		// they forget to start each one. The warn has to fire here too.
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { dm, sessions } = makeDockerWithInspectResult({
+			State: { Running: false },
+			HostConfig: { CapDrop: [], SecurityOpt: [] },
+		});
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ session_id: "s2", container_id: "container-old-stopped" }],
+			meta: { changes: 0 },
+		});
+
+		await dm.reconcile();
+
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/session s2/);
+		expect(sessions.updateStatus).toHaveBeenCalledWith("s2", "stopped");
+		warnSpy.mockRestore();
+	});
+
+	it("does not warn for properly hardened containers", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { dm } = makeDockerWithInspectResult({
+			State: { Running: true },
+			HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
+		});
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ session_id: "s3", container_id: "container-new" }],
+			meta: { changes: 0 },
+		});
+
+		await dm.reconcile();
+
+		expect(warnSpy).not.toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
 });
 
 // ── sanitiseUploadName ──────────────────────────────────────────────────────

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -640,9 +640,13 @@ describe("DockerManager.reconcile", () => {
 	});
 
 	it("warns even when the pre-#15 container is stopped at reconcile time", async () => {
-		// Operators who stop all sessions before deploying would otherwise
-		// only see the warn on the next /start — and might never recycle if
-		// they forget to start each one. The warn has to fire here too.
+		// reconcile() queries WHERE status = 'running', so this exercises the
+		// case where D1 still says 'running' but the Docker process is down
+		// (external `docker stop`, OOM kill, host reboot mid-flight). The
+		// warn must fire regardless of Docker's State.Running so the
+		// migration footgun surfaces even on containers that happen to be
+		// dead at reconcile time — they'll be respawned later, and the
+		// operator needs to know the old image is involved.
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const { dm, sessions } = makeDockerWithInspectResult({
 			State: { Running: false },

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -590,6 +590,25 @@ export class DockerManager {
                 // and spawn a replacement.
                 try {
                         const info = await this.docker.getContainer(meta.containerId).inspect();
+                        // Warn if the existing container predates the issue-#15 hardening.
+                        // Docker pins HostConfig at create time, so `container.start()`
+                        // re-uses the original CapDrop / SecurityOpt regardless of what
+                        // spawn() would set today. An operator who deploys this build
+                        // and only stop+starts (instead of DELETE + POST /start) ends
+                        // up with sessions that look fine but still have full caps and
+                        // a setuid sudo from the old image. Detect that explicitly so
+                        // the migration mistake shows up in `docker logs` instead of
+                        // failing silently.
+                        const capDrop = info.HostConfig?.CapDrop ?? [];
+                        const securityOpt = info.HostConfig?.SecurityOpt ?? [];
+                        if (!capDrop.includes("ALL") || !securityOpt.includes("no-new-privileges:true")) {
+                                console.warn(
+                                        `[docker] session ${sessionId} container ${meta.containerId.slice(0, 12)} ` +
+                                        `predates issue-#15 hardening (CapDrop=${JSON.stringify(capDrop)}, ` +
+                                        `SecurityOpt=${JSON.stringify(securityOpt)}). ` +
+                                        `Recycle via DELETE /api/sessions/${sessionId} then POST /start to apply current HostConfig.`,
+                                );
+                        }
                         if (!info.State.Running) {
                                 await this.docker.getContainer(meta.containerId).start();
                         }

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -173,6 +173,17 @@ export class DockerManager {
                                 Memory: 2 * 1024 * 1024 * 1024,
                                 NanoCpus: 2_000_000_000,
                                 RestartPolicy: { Name: "unless-stopped" },
+                                // Defense-in-depth (issue #15): the image already runs as
+                                // unprivileged UID 1000 with no sudo, but we still strip
+                                // every Linux capability from the bag the kernel hands the
+                                // container. tmux, node, git, claude-code, and `code tunnel`
+                                // all run unprivileged and need none of CAP_NET_RAW /
+                                // CAP_SYS_ADMIN / CAP_CHOWN / etc., so dropping ALL is the
+                                // tightest baseline. Pair with no-new-privileges so even if
+                                // a future image change reintroduces a setuid binary, it
+                                // cannot raise effective UID/caps at exec time.
+                                CapDrop: ["ALL"],
+                                SecurityOpt: ["no-new-privileges:true"],
                         },
                         OpenStdin: true,
                         Tty: true,

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -175,13 +175,19 @@ export class DockerManager {
                                 RestartPolicy: { Name: "unless-stopped" },
                                 // Defense-in-depth (issue #15): the image already runs as
                                 // unprivileged UID 1000 with no sudo, but we still strip
-                                // every Linux capability from the bag the kernel hands the
-                                // container. tmux, node, git, claude-code, and `code tunnel`
-                                // all run unprivileged and need none of CAP_NET_RAW /
-                                // CAP_SYS_ADMIN / CAP_CHOWN / etc., so dropping ALL is the
-                                // tightest baseline. Pair with no-new-privileges so even if
-                                // a future image change reintroduces a setuid binary, it
-                                // cannot raise effective UID/caps at exec time.
+                                // every Linux capability from the bounding set Docker
+                                // hands the container. None of tmux, node, git,
+                                // claude-code, or `code tunnel` need any of the default
+                                // bag (e.g. CAP_NET_RAW for raw sockets / ICMP,
+                                // CAP_NET_BIND_SERVICE for ports < 1024, CAP_AUDIT_WRITE,
+                                // CAP_MKNOD), so dropping ALL is the tightest baseline.
+                                // Note: this is about the *container's* bounding set,
+                                // not the backend host process — host-side chowns in
+                                // ensureWorkspaceOwnership rely on the backend's own
+                                // CAP_CHOWN and are unaffected. Pair with
+                                // no-new-privileges so even if a future image change
+                                // reintroduces a setuid binary it cannot raise
+                                // effective UID/caps at exec time.
                                 CapDrop: ["ALL"],
                                 SecurityOpt: ["no-new-privileges:true"],
                         },

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -590,25 +590,7 @@ export class DockerManager {
                 // and spawn a replacement.
                 try {
                         const info = await this.docker.getContainer(meta.containerId).inspect();
-                        // Warn if the existing container predates the issue-#15 hardening.
-                        // Docker pins HostConfig at create time, so `container.start()`
-                        // re-uses the original CapDrop / SecurityOpt regardless of what
-                        // spawn() would set today. An operator who deploys this build
-                        // and only stop+starts (instead of DELETE + POST /start) ends
-                        // up with sessions that look fine but still have full caps and
-                        // a setuid sudo from the old image. Detect that explicitly so
-                        // the migration mistake shows up in `docker logs` instead of
-                        // failing silently.
-                        const capDrop = info.HostConfig?.CapDrop ?? [];
-                        const securityOpt = info.HostConfig?.SecurityOpt ?? [];
-                        if (!capDrop.includes("ALL") || !securityOpt.includes("no-new-privileges:true")) {
-                                console.warn(
-                                        `[docker] session ${sessionId} container ${meta.containerId.slice(0, 12)} ` +
-                                        `predates issue-#15 hardening (CapDrop=${JSON.stringify(capDrop)}, ` +
-                                        `SecurityOpt=${JSON.stringify(securityOpt)}). ` +
-                                        `Recycle via DELETE /api/sessions/${sessionId} then POST /start to apply current HostConfig.`,
-                                );
-                        }
+                        this.warnIfPreHardened(sessionId, meta.containerId, info.HostConfig);
                         if (!info.State.Running) {
                                 await this.docker.getContainer(meta.containerId).start();
                         }
@@ -620,6 +602,31 @@ export class DockerManager {
                         await this.spawn(sessionId);
                         await this.sessions.updateStatus(sessionId, "running");
                 }
+        }
+
+        // Detects containers that predate the issue-#15 hardening. Docker pins
+        // HostConfig at create time, so `container.start()` re-uses the original
+        // CapDrop / SecurityOpt regardless of what spawn() would set today. An
+        // operator who deploys this build and only stop+starts (instead of
+        // DELETE + POST /start) ends up with sessions that look fine but still
+        // have full Linux caps and a setuid sudo from the old image. This helper
+        // is the choke point for surfacing that mistake — call it from any code
+        // path that inspects an existing container so the migration footgun
+        // shows up in `docker logs` instead of failing silently.
+        private warnIfPreHardened(
+                sessionId: string,
+                containerId: string,
+                hostConfig: { CapDrop?: string[] | null; SecurityOpt?: string[] | null } | undefined,
+        ): void {
+                const capDrop = hostConfig?.CapDrop ?? [];
+                const securityOpt = hostConfig?.SecurityOpt ?? [];
+                if (capDrop.includes("ALL") && securityOpt.includes("no-new-privileges:true")) return;
+                console.warn(
+                        `[docker] session ${sessionId} container ${containerId.slice(0, 12)} ` +
+                        `predates issue-#15 hardening (CapDrop=${JSON.stringify(capDrop)}, ` +
+                        `SecurityOpt=${JSON.stringify(securityOpt)}). ` +
+                        `Recycle via DELETE /api/sessions/${sessionId} then POST /start to apply current HostConfig.`,
+                );
         }
 
         async stopContainer(sessionId: string): Promise<void> {
@@ -1182,7 +1189,15 @@ export class DockerManager {
                         }
                         try {
                                 const info = await this.docker.getContainer(row.container_id).inspect();
-                                if (!info.State.Running) {
+                                if (info.State.Running) {
+                                        // reconcile() runs on every backend boot, which is
+                                        // the most-likely deploy moment. Surface pre-#15
+                                        // containers here too so an operator who only
+                                        // restarts the backend (without recycling sessions)
+                                        // sees the warn at startup, not just on the next
+                                        // /start.
+                                        this.warnIfPreHardened(row.session_id, row.container_id, info.HostConfig);
+                                } else {
                                         await this.sessions.updateStatus(row.session_id, "stopped");
                                 }
                         } catch (err) {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -1189,15 +1189,15 @@ export class DockerManager {
                         }
                         try {
                                 const info = await this.docker.getContainer(row.container_id).inspect();
-                                if (info.State.Running) {
-                                        // reconcile() runs on every backend boot, which is
-                                        // the most-likely deploy moment. Surface pre-#15
-                                        // containers here too so an operator who only
-                                        // restarts the backend (without recycling sessions)
-                                        // sees the warn at startup, not just on the next
-                                        // /start.
-                                        this.warnIfPreHardened(row.session_id, row.container_id, info.HostConfig);
-                                } else {
+                                // reconcile() runs on every backend boot, which is the
+                                // most-likely deploy moment. Surface pre-#15 containers
+                                // here regardless of running state — operators who stop
+                                // all sessions before deploying still need the warning,
+                                // since the next `/start` would be the only other place
+                                // it'd surface and that requires the operator to remember
+                                // to start each one.
+                                this.warnIfPreHardened(row.session_id, row.container_id, info.HostConfig);
+                                if (!info.State.Running) {
                                         await this.sessions.updateStatus(row.session_id, "stopped");
                                 }
                         } catch (err) {

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       nano \
       htop \
       tree \
-      sudo \
       locales \
     && rm -rf /var/lib/apt/lists/*
 
@@ -133,9 +132,18 @@ RUN set -eux; \
 # mount), the build will still proceed via `|| true` but the next step's
 # "UID 1000 is not unique" failure will at least come with the actual
 # root cause printed in the build log.
+# No sudo / no extra groups: the session user runs unprivileged. The image
+# previously shipped `sudo` + `NOPASSWD:ALL` for in-tab `apt-get install …`
+# convenience, but on a host bind mount that's a footgun — `sudo chown
+# -R 0:0 /home/developer/workspace` rewrites host-side file ownership to
+# root through the UID-mapped mount (issue #15). Removing the sudo package
+# entirely also drops /usr/bin/sudo as a setuid binary, which combined
+# with the runtime no-new-privileges flag (see dockerManager.ts) means
+# there is no path to elevation even if a future CVE in a setuid helper
+# surfaces. Users who genuinely need elevated tools should rebuild with
+# a custom image.
 RUN userdel -r ubuntu || true \
-    && useradd -m -s /bin/bash -u 1000 -U -G sudo developer \
-    && echo "developer ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/developer
+    && useradd -m -s /bin/bash -u 1000 -U developer
 
 
 USER developer


### PR DESCRIPTION
## Summary
- Removes the `sudo` package, the `developer` user's `sudo` group membership, and the `/etc/sudoers.d/developer` `NOPASSWD:ALL` entry from `session-image/Dockerfile`. The session user now runs as a fully unprivileged UID 1000.
- Adds `CapDrop: ["ALL"]` + `SecurityOpt: ["no-new-privileges:true"]` to the container `HostConfig` in `backend/src/dockerManager.ts` as defense-in-depth, so even a future setuid regression in the image cannot reintroduce an elevation path.
- Updates the README's container description to reflect the new posture.

Closes #15.

## Why
Issue #15 flagged that `sudo chown -R 0:0 /home/developer/workspace` from inside a session rewrites host-side file ownership to root through the UID-mapped bind mount — a footgun that escalates to host workspace corruption and combines badly with any future cross-session backend bug. UID 1000 was already the invariant; this PR completes the fix by removing the residual privilege.

## Operator action required
**Rebuild the image AND fully recycle every running session container.** A backend restart alone is not enough, and `POST /stop` + `POST /start` is **not enough either** — `stopContainer()` only calls `container.stop()`, leaving the container (and its baked-in `HostConfig`) in place; `startContainer()` Case 2 then calls `container.start()` on that same container, and Docker re-uses the original `HostConfig`, so `CapDrop` / `no-new-privileges` are silently dropped for any pre-existing container. The container has to be *removed* so the next start falls into the spawn path with the new `HostConfig`.

```bash
# 1. Rebuild the image
docker build -t shared-terminal-session ./session-image

# 2. For each running session, soft-delete (stops + removes the container,
#    preserves the workspace) then start (which respawns from the new image
#    with the new HostConfig):
#       DELETE /api/sessions/:id
#       POST   /api/sessions/:id/start
#
#    Equivalent: `docker rm -f <container_id>` then POST /api/sessions/:id/start.
```

After the recycle, verify on a session:

```bash
which sudo                 # nothing
id                         # uid=1000(developer) gid=1000(developer) groups=1000(developer)  (no sudo group)
docker inspect <cid> --format '{{.HostConfig.CapDrop}} {{.HostConfig.SecurityOpt}}'
                           # [ALL] [no-new-privileges:true]
```

## User-visible change
Interactive `sudo apt-get install …` etc. inside a session no longer works. Anyone who needs elevated tools should rebuild from a custom image. None of the platform's own code paths (entrypoint, tmux, node, git, claude-code, `code tunnel`, backend exec'd commands) use sudo or require any Linux capability, so platform behaviour is unchanged.

## Test plan
- [x] `cd backend && npm run build` — clean
- [x] `cd backend && npm test` — 128/128 pass
- [x] `cd frontend && npm run build` — clean
- [ ] Operator-side: rebuild image, recycle a session via DELETE + POST /start, confirm verification commands above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
