### PR TITLE
fix(session-image): install npm globals under $HOME so claude is updateable

### DIFF
--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -38,10 +38,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# ── Claude CLI ───────────────────────────────────────────────────────────────
-# Install globally so every session has it available.
-RUN npm install -g @anthropic-ai/claude-code
-
 # ── VS Code CLI (`code tunnel`) ──────────────────────────────────────────────
 # Standalone CLI from Microsoft. Lets the user run `code tunnel` from inside
 # the session and attach to the container from desktop VS Code (or vscode.dev)
@@ -149,6 +145,34 @@ RUN userdel -r ubuntu || true \
 USER developer
 WORKDIR /home/developer
 
+# ── Per-user npm prefix ──────────────────────────────────────────────────────
+# Global npm installs land under $HOME instead of /usr/lib/node_modules so the
+# developer user can update / uninstall / let `claude` self-update without
+# sudo. With sudo gone (#15), a root-owned global prefix turns every npm
+# global into a permanent fixture: `npm install -g @anthropic-ai/claude-code`
+# at build time wrote `/usr/bin/claude` + `/usr/lib/node_modules/...` owned
+# by uid 0, and a non-privileged developer can't even `npm uninstall -g` it.
+#
+# Putting the prefix under $HOME keeps /usr/lib/node_modules root-owned and
+# untouchable (the security posture we want), while making in-container npm
+# tooling actually usable.
+#
+# PATH ordering matters: prepend the user prefix so a newer self-updated
+# `claude` shadows any stale /usr/bin/claude that might land in a future
+# image revision. The mkdir is here (not at install time) so the directory
+# exists when a user runs `npm install -g …` at runtime, not just for the
+# build-time install below.
+ENV NPM_CONFIG_PREFIX=/home/developer/.npm-global
+ENV PATH=/home/developer/.npm-global/bin:$PATH
+RUN mkdir -p /home/developer/.npm-global
+
+# ── Claude CLI ───────────────────────────────────────────────────────────────
+# Installed as `developer` (not root) so the binary is updateable in place.
+# Lives in the container layer, so self-updates do not survive a container
+# recreate (POST /sessions/:id/start respawns from the image) — image rebuild
+# is still the durable update path. That's consistent with every other tool
+# in this image.
+RUN npm install -g @anthropic-ai/claude-code
 
 # ── tmux config (nice defaults) ──────────────────────────────────────────────
 COPY --chown=developer:developer tmux.conf /home/developer/.tmux.conf


### PR DESCRIPTION
## Summary

After #15 dropped sudo from the session container, the build-time `npm install -g @anthropic-ai/claude-code` left `/usr/bin/claude` and `/usr/lib/node_modules/@anthropic-ai/claude-code/` owned by root, with no path for the unprivileged `developer` user to update or uninstall it. Same problem for any other tool a user tries to `npm install -g` at runtime.

- Move the global npm prefix to `/home/developer/.npm-global` and install Claude as `developer`, not root. `/usr/lib/node_modules` stays root-owned and untouchable (the security posture we want); in-container npm tooling becomes usable.
- `PATH` is prepended with the user prefix so a self-updated `claude` shadows any stale `/usr/bin/claude` that might land in a future image revision.

## Migration

Operators must rebuild `shared-terminal-session` and recycle running session containers via `DELETE` + `POST /start` (not `/stop` + `/start`, which preserves the old layer) to pick up the new image. The pre-#15 warn from `dockerManager.ts` already nudges operators down the correct recycle path.

## Test plan

- [ ] `docker build -t shared-terminal-session ./session-image` succeeds.
- [ ] In a recycled (`DELETE` + `POST /start`) session: `which claude` resolves under `/home/developer/.npm-global/bin/`, `claude --version` runs, `npm uninstall -g @anthropic-ai/claude-code` succeeds without sudo, then re-install with `npm install -g @anthropic-ai/claude-code`.
- [ ] Existing pre-rebuild containers still log the pre-#15 hardening warn and continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
