### PR TITLE
fix(session-image): persist ~/.npm-global into workspace + ship gh CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Each session runs in a Docker container based on `session-image/Dockerfile`:
 - **Dev tools:** git, curl, build-essential, python3, Node.js 22, vim, nano, htop, jq
 - **Claude CLI:** `@anthropic-ai/claude-code` (globally installed)
 - **VS Code CLI:** `code` (standalone) — see [Connecting from VS Code](#connecting-from-vs-code) below
+- **GitHub CLI:** `gh` (standalone) — auth once with `gh auth login`, then drive PRs / issues / `gh api …` from the session
 - **Terminal:** tmux with a session named `main`, 50k scrollback, mouse support
 - **User:** `developer` (UID 1000, unprivileged — no sudo, all Linux capabilities dropped, `no-new-privileges` set)
 - **Workspace:** `/home/developer/workspace` (bind-mounted from `<WORKSPACE_ROOT>/<sessionId>` on the host)

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -102,6 +102,60 @@ RUN set -eux; \
     chmod +x /usr/local/bin/code; \
     /usr/local/bin/code --version
 
+# ── GitHub CLI (`gh`) ────────────────────────────────────────────────────────
+# Standalone CLI from GitHub. Lets the user run `gh auth login` once per
+# session and then drive PRs / issues / releases / `gh api …` from the
+# terminal without round-tripping through the browser. Closes the gap left
+# by removing sudo (#15) — `apt-get install gh` is no longer reachable
+# in-session, so the binary has to ship in the image.
+#
+# Same supply-chain posture as the VS Code CLI block above: pinned release
+# tag, per-arch SHA-256 verified before extraction, no "skip the hash
+# check" escape hatch. The published tarball contains a binary, man pages,
+# completions, and LICENSE; we extract only the binary by name (not the
+# whole archive) so a tampered tarball can't drop extra executables into
+# /usr/local/bin alongside it.
+#
+# Bumping the pin: pick a release from https://github.com/cli/cli/releases,
+# then capture both arches' SHA-256:
+#
+#     GH_VERSION=v2.92.0
+#     for ARCH in amd64 arm64; do
+#       curl -fL "https://github.com/cli/cli/releases/download/${GH_VERSION}/gh_${GH_VERSION#v}_linux_${ARCH}.tar.gz" \
+#         | sha256sum
+#     done
+#
+# Update GH_CLI_VERSION + GH_CLI_SHA256_AMD64 + GH_CLI_SHA256_ARM64 in
+# lockstep. Operators can also override on the command line for a CVE
+# bump without touching the file:
+#
+#     docker build \
+#       --build-arg GH_CLI_VERSION=v2.92.0 \
+#       --build-arg GH_CLI_SHA256_AMD64=<x64 sha256> \
+#       --build-arg GH_CLI_SHA256_ARM64=<arm64 sha256> \
+#       ./session-image
+ARG GH_CLI_VERSION=v2.92.0
+ARG GH_CLI_SHA256_AMD64=b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4
+ARG GH_CLI_SHA256_ARM64=c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) GH_ARCH=amd64; GH_SHA256="${GH_CLI_SHA256_AMD64}" ;; \
+      arm64) GH_ARCH=arm64; GH_SHA256="${GH_CLI_SHA256_ARM64}" ;; \
+      *) echo "unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    if [ -z "${GH_SHA256}" ]; then \
+      echo "ERROR: no SHA-256 set for gh_linux_${GH_ARCH} — refusing to install an unverified GitHub CLI. Override GH_CLI_VERSION together with GH_CLI_SHA256_AMD64 / GH_CLI_SHA256_ARM64." >&2; \
+      exit 1; \
+    fi; \
+    GH_DIR="gh_${GH_CLI_VERSION#v}_linux_${GH_ARCH}"; \
+    curl -fLsS "https://github.com/cli/cli/releases/download/${GH_CLI_VERSION}/${GH_DIR}.tar.gz" \
+         -o /tmp/gh.tar.gz; \
+    echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tar.gz --strip-components=2 -C /usr/local/bin "${GH_DIR}/bin/gh"; \
+    rm /tmp/gh.tar.gz; \
+    chmod +x /usr/local/bin/gh; \
+    /usr/local/bin/gh --version
+
 # ── Non-root user ────────────────────────────────────────────────────────────
 # UID 1000 is non-negotiable: the backend chowns each session's workspace
 # bind-mount to WORKSPACE_UID:WORKSPACE_GID (default 1000:1000, see

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -144,6 +144,11 @@ RUN set -eux; \
 #       --build-arg GH_CLI_SHA256_AMD64=<x64 sha256> \
 #       --build-arg GH_CLI_SHA256_ARM64=<arm64 sha256> \
 #       ./session-image
+# Re-declare TARGETARCH so this block doesn't rely on the VS Code
+# section's earlier ARG remaining in scope. ARGs survive within a stage,
+# but if the VS Code block is later removed or reordered, an implicit
+# dependency would silently fall back to `:-amd64` on every architecture.
+ARG TARGETARCH
 ARG GH_CLI_VERSION=v2.92.0
 ARG GH_CLI_SHA256_AMD64=b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4
 ARG GH_CLI_SHA256_ARM64=c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -117,9 +117,19 @@ RUN set -eux; \
 # /usr/local/bin alongside it.
 #
 # Bumping the pin: pick a release from https://github.com/cli/cli/releases,
-# then capture both arches' SHA-256:
+# then capture both arches' SHA-256. The release ships a published
+# `checksums.txt` listing every artifact's hash — pull that and read the
+# linux_amd64 / linux_arm64 lines, instead of (only) hashing the tarballs
+# yourself, so a tampered tarball can't paper over its own hash at bump
+# time:
 #
 #     GH_VERSION=v2.92.0
+#     curl -fL "https://github.com/cli/cli/releases/download/${GH_VERSION}/gh_${GH_VERSION#v}_checksums.txt" \
+#       | grep -E 'linux_(amd64|arm64).tar.gz$'
+#
+# For belt-and-braces, also re-hash the tarballs themselves and confirm
+# the values match the checksums file:
+#
 #     for ARCH in amd64 arm64; do
 #       curl -fL "https://github.com/cli/cli/releases/download/${GH_VERSION}/gh_${GH_VERSION#v}_linux_${ARCH}.tar.gz" \
 #         | sha256sum

--- a/session-image/Dockerfile
+++ b/session-image/Dockerfile
@@ -168,10 +168,13 @@ RUN mkdir -p /home/developer/.npm-global
 
 # ── Claude CLI ───────────────────────────────────────────────────────────────
 # Installed as `developer` (not root) so the binary is updateable in place.
-# Lives in the container layer, so self-updates do not survive a container
-# recreate (POST /sessions/:id/start respawns from the image) — image rebuild
-# is still the durable update path. That's consistent with every other tool
-# in this image.
+# Lands in /home/developer/.npm-global, which entrypoint.sh migrates into
+# the workspace bind mount on first boot — so `claude --update` (and any
+# user-installed npm global) survives a container recreate (POST
+# /sessions/:id/start respawns the container, but the workspace dir
+# persists by design). Image rebuilds reseed the workspace copy only on
+# first boot of a fresh workspace; existing workspaces keep their
+# self-updated version, since a user who chose v.X probably wants v.X.
 RUN npm install -g @anthropic-ai/claude-code
 
 # ── tmux config (nice defaults) ──────────────────────────────────────────────

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -167,7 +167,7 @@ fi
 #   from a previous user / context.
 # - Existing session restarted (same workspace) → tokens persist, no
 #   re-auth on every container recycle.
-# Same contract as ~/.vscode-cli above and ~/.npm-global below.
+# Same contract as ~/.npm-global and ~/.vscode-cli above.
 #
 # Only ~/.config/gh is symlinked, not ~/.config wholesale: other tools
 # may also use XDG and we don't want their state hitching a ride into

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -64,7 +64,12 @@ NPM_GLOBAL_OLD="${NPM_GLOBAL_HOME}.old"
 # will retry, and if the cleanup rm fails .old leaks (cosmetic, not
 # functional). The entrypoint must not exit on these.
 if [ -e "$NPM_GLOBAL_OLD" ]; then
-        if [ ! -e "$NPM_GLOBAL_HOME" ]; then
+        # `-e` follows symlinks and reports false on a dangling one (target
+        # gone, e.g. workspace unmounted after a successful ln). Without the
+        # `-L` clause the dangling-symlink + stale-.old case would mis-route
+        # to the restore branch and the .old dir would replace the symlink,
+        # contradicting the comment above ("symlink case → drop .old").
+        if [ ! -e "$NPM_GLOBAL_HOME" ] && [ ! -L "$NPM_GLOBAL_HOME" ]; then
                 mv "$NPM_GLOBAL_OLD" "$NPM_GLOBAL_HOME" || true
         else
                 rm -rf "$NPM_GLOBAL_OLD" || true

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -137,7 +137,6 @@ elif ! ln -sfn /home/developer/workspace/.config/gh /home/developer/.config/gh; 
              "gh auth state won't persist across restarts." >&2
 fi
 
-
 echo "[entrypoint] container ready — create a tab from the UI to begin"
 
 # Keep PID 1 alive independent of tmux. tmux-server now starts lazily on the

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -45,6 +45,32 @@ NPM_GLOBAL_HOME=/home/developer/.npm-global
 NPM_GLOBAL_WS=/home/developer/workspace/.npm-global
 NPM_GLOBAL_OLD="${NPM_GLOBAL_HOME}.old"
 
+# Step 0: recover from a prior-boot crash mid-swap. The container can be
+# SIGKILL'd / OOM'd / lose the host between Step 2's `mv` and `ln`, leaving
+# .old behind on disk. `docker start` re-runs entrypoint with that state on
+# disk (the layer is preserved across stop/start, this only resets on
+# /sessions/:id/start which recreates the container). Three cases:
+#
+#   - ~/.npm-global is missing, .old exists → crash between mv and ln on
+#     a prior boot. Restore from .old so PATH lookups work and Step 2 can
+#     re-attempt the swap.
+#   - ~/.npm-global is a symlink or directory, .old exists → either a
+#     crash between ln and rm (symlink case), or a more exotic interleave
+#     where home was rebuilt (directory case). Either way .old is stale;
+#     drop it so Step 2 isn't gated by the `[ ! -e $NPM_GLOBAL_OLD ]`
+#     guard below.
+#
+# Both branches are best-effort: if the restore mv fails the next boot
+# will retry, and if the cleanup rm fails .old leaks (cosmetic, not
+# functional). The entrypoint must not exit on these.
+if [ -e "$NPM_GLOBAL_OLD" ]; then
+        if [ ! -e "$NPM_GLOBAL_HOME" ]; then
+                mv "$NPM_GLOBAL_OLD" "$NPM_GLOBAL_HOME" || true
+        else
+                rm -rf "$NPM_GLOBAL_OLD" || true
+        fi
+fi
+
 if [ ! -L "$NPM_GLOBAL_HOME" ]; then
         # Step 1: seed the workspace dir on first boot. cp -a (not mv)
         # so the image copy stays in place if Step 2 needs to roll back.
@@ -59,13 +85,20 @@ if [ ! -L "$NPM_GLOBAL_HOME" ]; then
         # Step 2: rename-then-restore swap. Only runs if both the workspace
         # dir is present (either pre-seeded or freshly seeded above) and the
         # image's ~/.npm-global is still a real directory waiting to be
-        # replaced.
+        # replaced. Step 0 ensures .old is absent here under normal
+        # conditions; the guard is belt-and-braces in case the recovery mv
+        # itself failed.
         if [ -d "$NPM_GLOBAL_WS" ] && [ -d "$NPM_GLOBAL_HOME" ] && [ ! -e "$NPM_GLOBAL_OLD" ]; then
                 if ! mv "$NPM_GLOBAL_HOME" "$NPM_GLOBAL_OLD"; then
                         echo "[entrypoint] WARN: couldn't rename ~/.npm-global to swap in symlink; " \
                              "claude self-updates and runtime npm globals won't persist across restarts." >&2
                 elif ln -sfn "$NPM_GLOBAL_WS" "$NPM_GLOBAL_HOME"; then
-                        rm -rf "$NPM_GLOBAL_OLD"
+                        # `|| true`: a failure here just leaks .old in the
+                        # container layer (Step 0 will clean it on the next
+                        # boot). Honour the block's "WARN-and-carry-on"
+                        # contract instead of letting `set -e` crash the
+                        # entrypoint.
+                        rm -rf "$NPM_GLOBAL_OLD" || true
                 else
                         # ln failed after successful rename. Roll back so
                         # ~/.npm-global is the image's regular directory

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -19,50 +19,64 @@ cd /home/developer/workspace
 # would land in the container layer and vanish on the next /start, putting
 # the user back on whatever version the image baked.
 #
-# The wrinkle vs. the .vscode-cli block below: ~/.npm-global already
-# exists as a populated directory after the image build, so a plain
-# `mkdir -p` + `ln -sfn` would put a symlink *inside* the existing dir
-# instead of replacing it. We branch on what's already there:
+# Two-step structure:
 #
-#   - Symlink already in place — left over within this container's
-#     lifetime. Nothing to do; the rest of the entrypoint can run.
-#   - Workspace already seeded — operator/user has prior state. Drop the
-#     image's fresh copy and symlink the home path into the workspace.
-#     User-persisted version wins over a re-baked image so a self-updated
-#     Claude survives an image bump.
-#   - First boot, no workspace seed — move the image's directory into
-#     the bind mount, then symlink. Bind mounts and the container layer
-#     are different filesystems so `mv` falls back to copy+unlink, which
-#     is what we want.
+#   1. Seed the workspace dir from the image's copy if the workspace
+#      doesn't have one yet (first boot of a fresh workspace). `cp -a`
+#      preserves the source — the image's directory stays available so
+#      Step 2 has something to fall back on if the symlink swap fails.
 #
-# Best-effort: any failure WARNs loudly and falls through to use the
-# image's local copy at ~/.npm-global (still on PATH, since
-# /home/developer/.npm-global/bin is prepended in the Dockerfile). Claude
-# still works in that container, it just won't persist self-updates.
+#   2. Replace ~/.npm-global with a symlink to the workspace dir. This
+#      uses a rename-then-restore dance instead of `rm -rf && ln -sfn`:
+#      stash the image dir to .old, then ln, then drop .old on success;
+#      on ln failure, restore .old back to ~/.npm-global. The naive
+#      rm-then-ln approach would leave the container with neither the
+#      directory nor the symlink if ln failed mid-step, taking `claude`
+#      offline entirely (not just non-persistent) — see the bot review
+#      on PR #131 for the original analysis. The dance keeps the image
+#      copy reachable through every transient failure mode.
+#
+# Best-effort throughout: any failure WARNs and either (a) falls through
+# to use the image's local copy at ~/.npm-global (still on PATH, since
+# /home/developer/.npm-global/bin is prepended in the Dockerfile), or
+# (b) restores the image copy from .old. Either way, claude is still
+# usable in that container — only persistence is at risk.
 NPM_GLOBAL_HOME=/home/developer/.npm-global
 NPM_GLOBAL_WS=/home/developer/workspace/.npm-global
+NPM_GLOBAL_OLD="${NPM_GLOBAL_HOME}.old"
 
 if [ ! -L "$NPM_GLOBAL_HOME" ]; then
-        if [ -d "$NPM_GLOBAL_WS" ]; then
-                if ! rm -rf "$NPM_GLOBAL_HOME"; then
-                        echo "[entrypoint] WARN: couldn't drop image .npm-global; " \
-                             "claude self-updates and runtime npm globals won't persist across restarts." >&2
-                fi
-        elif [ -d "$NPM_GLOBAL_HOME" ]; then
-                if ! mv "$NPM_GLOBAL_HOME" "$NPM_GLOBAL_WS"; then
+        # Step 1: seed the workspace dir on first boot. cp -a (not mv)
+        # so the image copy stays in place if Step 2 needs to roll back.
+        if [ ! -d "$NPM_GLOBAL_WS" ] && [ -d "$NPM_GLOBAL_HOME" ]; then
+                if ! cp -a "$NPM_GLOBAL_HOME" "$NPM_GLOBAL_WS"; then
                         echo "[entrypoint] WARN: couldn't seed workspace .npm-global from image " \
                              "(uid=$(id -u), workspace owner=$(stat -c '%u:%g' /home/developer/workspace 2>/dev/null || echo '?')). " \
                              "claude self-updates and runtime npm globals won't persist across restarts." >&2
                 fi
         fi
-        # Skip the symlink if the prior step left ~/.npm-global in place —
-        # `ln -sfn` against an existing real directory creates the link
-        # *inside* it (with the basename of the target), which is exactly
-        # the breakage we're trying to avoid.
-        if [ ! -e "$NPM_GLOBAL_HOME" ] && [ -d "$NPM_GLOBAL_WS" ]; then
-                if ! ln -sfn "$NPM_GLOBAL_WS" "$NPM_GLOBAL_HOME"; then
-                        echo "[entrypoint] WARN: couldn't symlink ~/.npm-global into workspace; " \
+
+        # Step 2: rename-then-restore swap. Only runs if both the workspace
+        # dir is present (either pre-seeded or freshly seeded above) and the
+        # image's ~/.npm-global is still a real directory waiting to be
+        # replaced.
+        if [ -d "$NPM_GLOBAL_WS" ] && [ -d "$NPM_GLOBAL_HOME" ] && [ ! -e "$NPM_GLOBAL_OLD" ]; then
+                if ! mv "$NPM_GLOBAL_HOME" "$NPM_GLOBAL_OLD"; then
+                        echo "[entrypoint] WARN: couldn't rename ~/.npm-global to swap in symlink; " \
                              "claude self-updates and runtime npm globals won't persist across restarts." >&2
+                elif ln -sfn "$NPM_GLOBAL_WS" "$NPM_GLOBAL_HOME"; then
+                        rm -rf "$NPM_GLOBAL_OLD"
+                else
+                        # ln failed after successful rename. Roll back so
+                        # ~/.npm-global is the image's regular directory
+                        # again — claude stays available, persistence is
+                        # the only thing lost. The mv-back is best-effort
+                        # itself; if it fails the container is broken, but
+                        # at that point the operator has bigger problems
+                        # than this entrypoint.
+                        mv "$NPM_GLOBAL_OLD" "$NPM_GLOBAL_HOME" || true
+                        echo "[entrypoint] WARN: couldn't symlink ~/.npm-global into workspace; " \
+                             "image copy restored — claude works but self-updates won't persist across restarts." >&2
                 fi
         fi
 fi

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -106,6 +106,37 @@ elif ! ln -sfn /home/developer/workspace/.vscode-cli /home/developer/.vscode-cli
              "code tunnel auth won't persist across restarts." >&2
 fi
 
+# Persist GitHub CLI auth state across container replacement.
+#
+# `gh auth login` writes its OAuth token + host config to
+# ~/.config/gh/{hosts,state}.yml. That path lives in the container layer,
+# so without this redirection every `POST /start` (which respawns the
+# container, see Architecture in CLAUDE.md) would force the user back
+# through the device-code flow. README's "auth once" line implicitly
+# assumes the redirection is in place.
+#
+# Auth lifetime intentionally tied to the *workspace*, not the *image*:
+# - New session (fresh workspace) → empty .config/gh → no leaked tokens
+#   from a previous user / context.
+# - Existing session restarted (same workspace) → tokens persist, no
+#   re-auth on every container recycle.
+# Same contract as ~/.vscode-cli above and ~/.npm-global below.
+#
+# Only ~/.config/gh is symlinked, not ~/.config wholesale: other tools
+# may also use XDG and we don't want their state hitching a ride into
+# the workspace bind mount unintentionally. ~/.config itself stays a
+# real directory in the container layer so the symlink lands cleanly.
+#
+# Best-effort, same WARN-and-carry-on pattern as the blocks above.
+if ! mkdir -p /home/developer/.config /home/developer/workspace/.config/gh; then
+        echo "[entrypoint] WARN: couldn't create workspace .config/gh dir " \
+             "(uid=$(id -u), workspace owner=$(stat -c '%u:%g' /home/developer/workspace 2>/dev/null || echo '?')). " \
+             "gh auth state won't persist across restarts." >&2
+elif ! ln -sfn /home/developer/workspace/.config/gh /home/developer/.config/gh; then
+        echo "[entrypoint] WARN: couldn't symlink ~/.config/gh into workspace; " \
+             "gh auth state won't persist across restarts." >&2
+fi
+
 
 echo "[entrypoint] container ready — create a tab from the UI to begin"
 

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -11,6 +11,62 @@ set -e
 
 cd /home/developer/workspace
 
+# Persist the user-level npm global prefix across container replacement.
+#
+# Dockerfile sets NPM_CONFIG_PREFIX=/home/developer/.npm-global and bakes
+# the Claude CLI into that directory at build time. Without this block,
+# every `claude` self-update (and any user-installed `npm install -g …`)
+# would land in the container layer and vanish on the next /start, putting
+# the user back on whatever version the image baked.
+#
+# The wrinkle vs. the .vscode-cli block below: ~/.npm-global already
+# exists as a populated directory after the image build, so a plain
+# `mkdir -p` + `ln -sfn` would put a symlink *inside* the existing dir
+# instead of replacing it. We branch on what's already there:
+#
+#   - Symlink already in place — left over within this container's
+#     lifetime. Nothing to do; the rest of the entrypoint can run.
+#   - Workspace already seeded — operator/user has prior state. Drop the
+#     image's fresh copy and symlink the home path into the workspace.
+#     User-persisted version wins over a re-baked image so a self-updated
+#     Claude survives an image bump.
+#   - First boot, no workspace seed — move the image's directory into
+#     the bind mount, then symlink. Bind mounts and the container layer
+#     are different filesystems so `mv` falls back to copy+unlink, which
+#     is what we want.
+#
+# Best-effort: any failure WARNs loudly and falls through to use the
+# image's local copy at ~/.npm-global (still on PATH, since
+# /home/developer/.npm-global/bin is prepended in the Dockerfile). Claude
+# still works in that container, it just won't persist self-updates.
+NPM_GLOBAL_HOME=/home/developer/.npm-global
+NPM_GLOBAL_WS=/home/developer/workspace/.npm-global
+
+if [ ! -L "$NPM_GLOBAL_HOME" ]; then
+        if [ -d "$NPM_GLOBAL_WS" ]; then
+                if ! rm -rf "$NPM_GLOBAL_HOME"; then
+                        echo "[entrypoint] WARN: couldn't drop image .npm-global; " \
+                             "claude self-updates and runtime npm globals won't persist across restarts." >&2
+                fi
+        elif [ -d "$NPM_GLOBAL_HOME" ]; then
+                if ! mv "$NPM_GLOBAL_HOME" "$NPM_GLOBAL_WS"; then
+                        echo "[entrypoint] WARN: couldn't seed workspace .npm-global from image " \
+                             "(uid=$(id -u), workspace owner=$(stat -c '%u:%g' /home/developer/workspace 2>/dev/null || echo '?')). " \
+                             "claude self-updates and runtime npm globals won't persist across restarts." >&2
+                fi
+        fi
+        # Skip the symlink if the prior step left ~/.npm-global in place —
+        # `ln -sfn` against an existing real directory creates the link
+        # *inside* it (with the basename of the target), which is exactly
+        # the breakage we're trying to avoid.
+        if [ ! -e "$NPM_GLOBAL_HOME" ] && [ -d "$NPM_GLOBAL_WS" ]; then
+                if ! ln -sfn "$NPM_GLOBAL_WS" "$NPM_GLOBAL_HOME"; then
+                        echo "[entrypoint] WARN: couldn't symlink ~/.npm-global into workspace; " \
+                             "claude self-updates and runtime npm globals won't persist across restarts." >&2
+                fi
+        fi
+fi
+
 # Persist VS Code CLI tunnel state across container replacement.
 #
 # `code tunnel` writes its device-login token, tunnel name, and registration


### PR DESCRIPTION
## Summary

Stacked on the prior PR (`fix/session-image-npm-user-prefix`). Two changes bundled per maintainer ask:

### 1. Persist `~/.npm-global` into the workspace bind mount

Without this, `claude --update` (and any user-run `npm install -g …`) lands in the container layer and gets blown away on the next `POST /start`, putting the user back on whatever Claude version the image baked. Image rebuild was the only durable update path.

- Add an entrypoint block that migrates `~/.npm-global` into the workspace bind mount on first boot, then symlinks. Bootstrap from the image's dir if the workspace isn't seeded; on subsequent container recreate, drop the image's fresh copy and symlink to the workspace. User-persisted version wins over a re-baked image — a user who self-updated to v.X probably wants v.X.
- The wrinkle vs. the existing `.vscode-cli` pattern is that `~/.npm-global` is already populated at build time, so a plain `mkdir -p` + `ln -sfn` would put the symlink *inside* the existing dir. The block branches on "is it already a symlink / is the workspace seeded / is the image's dir still here" and either `rm`'s or `mv`'s before linking.
- Best-effort throughout: any failure WARNs and falls through to use the image's local copy at `~/.npm-global` (still on `PATH`). Claude keeps working — only persistence is lost.

### 2. Ship the GitHub CLI (`gh`) in the image

Closes a gap from #15: with sudo gone, `apt-get install gh` is no longer reachable in-session, and downloading the binary by hand on every fresh session is friction. `gh` is the canonical way to auth from a terminal-only environment and drive PRs / issues / `gh api …` without round-tripping through the browser.

- Modeled on the VS Code CLI block already in the Dockerfile: pinned release tag (`v2.92.0`), per-arch SHA-256 verified before extraction, no "skip the hash check" escape hatch, extract only the binary by name.
- Operators can override on the command line for CVE bumps:
  ```
  docker build \
    --build-arg GH_CLI_VERSION=v2.92.0 \
    --build-arg GH_CLI_SHA256_AMD64=<x64 sha256> \
    --build-arg GH_CLI_SHA256_ARM64=<arm64 sha256> \
    ./session-image
  ```

## Migration

Operators rebuild `shared-terminal-session` and recycle sessions via `DELETE` + `POST /start` (not `/stop` + `/start`, which preserves the old layer). Same migration story as the parent PR.

## Edge cases worth flagging (npm-global persistence)

- **Operator/user has manually created `~/workspace/.npm-global` before deploy.** Block treats workspace as authoritative and `rm`'s the image's Claude copy, so `claude` would be missing in that container. Recover by deleting the workspace dir and recycling. Unlikely in practice; not worth code complexity to detect.
- **Partial `mv` failure** (e.g., bind mount runs out of space mid-copy). WARN fires; on next boot the workspace dir exists but is partial — symlink gets created, Claude is broken. Operator follows the WARN, manually clears the partial dir, recycles. Same "best-effort, WARN, carry on" tradeoff the entrypoint already makes for `.vscode-cli`.

## Test plan

- [ ] `docker build -t shared-terminal-session ./session-image` succeeds on amd64 and arm64.
- [ ] First boot of a fresh session: `ls -la ~/.npm-global` shows a symlink → `~/workspace/.npm-global`; `which claude` resolves; `claude --version` works.
- [ ] `npm install -g cowsay` succeeds; recycle the container (`DELETE` + `POST /start`); `cowsay` is still available.
- [ ] Pre-existing session with no workspace `.npm-global` recycles cleanly (image's Claude gets moved into workspace, symlink in place).
- [ ] Workspace path unwritable (e.g., chown to root before recycle): WARN fires in `docker logs`, container stays up, Claude still on PATH from image's copy.
- [ ] `gh --version` resolves to v2.92.0 in a fresh session; `gh auth login` flow works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
