### PR TITLE
fix(session-image): drop pre-existing real ~/.vscode-cli before symlink

### DIFF
--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -182,6 +182,23 @@ fi
 # (EACCES vs. ENOSPC vs. EROFS) is what an operator needs to fix the
 # real problem in `docker logs`. The `if !` test handles the non-zero
 # exit; we don't need to swallow the message too.
+# Drop a pre-existing real ~/.vscode-cli before the symlink swap. Same
+# silent-loss path as the ~/.config/gh block below (and fixed there in
+# #132): if `code tunnel` ever ran on an image without this persistence
+# block, or a prior boot's `ln -sfn` failed and code tunnel then wrote
+# to the resulting real directory, `unlink(2)` refuses to remove a
+# non-empty directory and `ln -sfn` exits non-zero. The user sees auth
+# "work" until the container is recycled, then it vanishes with only a
+# stale WARN in the logs.
+#
+# Pre-removing means a one-time re-auth via the device-code flow on the
+# upgrade path, which is strictly better than the silent-loss path. Best-
+# effort with `|| true`: if the rm fails the WARN below still fires and
+# the operator has a signal.
+if [ -d /home/developer/.vscode-cli ] && [ ! -L /home/developer/.vscode-cli ]; then
+        rm -rf /home/developer/.vscode-cli || true
+fi
+
 if ! mkdir -p /home/developer/workspace/.vscode-cli; then
         echo "[entrypoint] WARN: couldn't create workspace .vscode-cli dir " \
              "(uid=$(id -u), workspace owner=$(stat -c '%u:%g' /home/developer/workspace 2>/dev/null || echo '?')). " \

--- a/session-image/entrypoint.sh
+++ b/session-image/entrypoint.sh
@@ -182,6 +182,7 @@ fi
 # (EACCES vs. ENOSPC vs. EROFS) is what an operator needs to fix the
 # real problem in `docker logs`. The `if !` test handles the non-zero
 # exit; we don't need to swallow the message too.
+
 # Drop a pre-existing real ~/.vscode-cli before the symlink swap. Same
 # silent-loss path as the ~/.config/gh block below (and fixed there in
 # #132): if `code tunnel` ever ran on an image without this persistence


### PR DESCRIPTION
## Summary

Follow-up to #132. The `.vscode-cli` persistence block had the same pre-existing-real-directory gap that `.config/gh` had (and was fixed for `.config/gh` in #132). Same fix here: detect a real `~/.vscode-cli` and `rm -rf` it before `ln -sfn`, so the swap doesn't silently fall through into a container-layer dir that vanishes on the next `POST /start`.

## Failure mode this closes

`ln -sfn TARGET LINKNAME` against a non-empty real directory fails because `unlink(2)` refuses to remove a directory. The WARN-and-carry-on path fires, and `code tunnel` then writes its device-login token into the real dir in the container layer. The user sees auth "work" until the container is recycled (`DELETE` + `POST /start`), at which point the layer and the token vanish silently — operator only has a stale entrypoint WARN to correlate.

Two scenarios where this triggers:
- **Older image upgrade.** A session container built before persistence existed had `code tunnel` run inside it, leaving auth state in the container layer. Recycling onto the persistence-aware image hits this on first boot.
- **Prior-boot mkdir-succeeds-ln-fails.** The `mkdir -p` succeeded (e.g., the workspace mount was writable for `mkdir` but the `ln` somehow failed); `code tunnel` then wrote to the resulting real directory in the container layer.

## Why pre-remove rather than migrate

`code tunnel` auth is a device-code flow, not credentials the user typed. Re-auth on the upgrade path is a one-time prompt, not a password to recover. Migrating the dir into the workspace would be more code for almost no UX benefit, and risks moving stale state from a misbehaving prior boot. Drop the dir, log loudly via the existing WARN if anything else goes wrong, let the user re-auth.

## Test plan

- [ ] Verified three paths with mock dirs in `/tmp` before push:
  - Fresh: `ln` creates the workspace symlink as expected.
  - Pre-existing real `~/.vscode-cli` with stale token: dropped, symlink lands cleanly.
  - Already-symlinked from a prior boot: no-op, symlink + token preserved.
- [ ] In a recycled session: `code tunnel` device-login flow still works; `~/.vscode-cli` resolves to a symlink into `~/workspace/.vscode-cli`; recycle the container; tunnel state is still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
