### PR TITLE
chore(backend): add Biome lint+format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Lint (Biome)
+        run: npm run lint
+
       - name: Typecheck + build
         run: npm run build
 

--- a/backend/biome.json
+++ b/backend/biome.json
@@ -20,9 +20,9 @@
 			"recommended": true,
 			"style": {
 				"noNonNullAssertion": "off",
-				"useImportType": "warn",
-				"useNodejsImportProtocol": "warn",
-				"useTemplate": "warn"
+				"useImportType": "error",
+				"useNodejsImportProtocol": "error",
+				"useTemplate": "error"
 			},
 			"suspicious": {
 				"noExplicitAny": "warn"

--- a/backend/biome.json
+++ b/backend/biome.json
@@ -1,0 +1,57 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": true,
+		"includes": ["src/**/*.ts", "src/**/*.tsx"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"lineWidth": 100
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"noNonNullAssertion": "off",
+				"useImportType": "warn",
+				"useNodejsImportProtocol": "warn",
+				"useTemplate": "warn"
+			},
+			"suspicious": {
+				"noExplicitAny": "warn"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
+	"overrides": [
+		{
+			"includes": ["**/*.test.ts"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noExplicitAny": "off"
+					}
+				}
+			}
+		}
+	]
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "ws": "^8.17.1"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
         "@types/bcryptjs": "^2.4.6",
         "@types/dockerode": "^3.3.31",
         "@types/express": "^4.17.21",
@@ -36,6 +37,169 @@
       "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+      "integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.14",
+        "@biomejs/cli-darwin-x64": "2.4.14",
+        "@biomejs/cli-linux-arm64": "2.4.14",
+        "@biomejs/cli-linux-arm64-musl": "2.4.14",
+        "@biomejs/cli-linux-x64": "2.4.14",
+        "@biomejs/cli-linux-x64-musl": "2.4.14",
+        "@biomejs/cli-win32-arm64": "2.4.14",
+        "@biomejs/cli-win32-x64": "2.4.14"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.14.tgz",
+      "integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.14.tgz",
+      "integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.14.tgz",
+      "integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.14.tgz",
+      "integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.14.tgz",
+      "integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.14.tgz",
+      "integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.14.tgz",
+      "integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.14.tgz",
+      "integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,9 @@
     "dev": "tsx watch src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "lint": "biome check src/",
+    "lint:fix": "biome check src/ --write",
+    "format": "biome format src/ --write",
     "db:migrate": "node -e \"require('./dist/db.js').migrateDb().then(() => console.log('done'))\"",
     "docker:build-session": "docker build -t shared-terminal-session ../session-image"
   },
@@ -23,6 +26,7 @@
     "ws": "^8.17.1"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.14",
     "@types/bcryptjs": "^2.4.6",
     "@types/dockerode": "^3.3.31",
     "@types/express": "^4.17.21",

--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	__resetJwtSecretForTests,
 	isAllowedWsOrigin,
@@ -16,7 +16,9 @@ describe("validateJwtSecret", () => {
 	beforeEach(() => {
 		delete process.env.JWT_SECRET;
 		delete process.env.NODE_ENV;
-		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { /* swallow */ });
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+			/* swallow */
+		});
 		// Reset the module-level captured secret so each test starts from
 		// "validateJwtSecret has not run yet". Without this, the capture
 		// from an earlier successful validate leaks into later tests.
@@ -125,11 +127,7 @@ describe("isAllowedWsOrigin", () => {
 		// Classic `attackerour-domain.com` bypass: make sure exact-match
 		// semantics hold.
 		expect(
-			isAllowedWsOrigin(
-				"https://attackerhttps://terminal.example.com",
-				allowlist,
-				"production",
-			),
+			isAllowedWsOrigin("https://attackerhttps://terminal.example.com", allowlist, "production"),
 		).toBe(false);
 	});
 
@@ -138,9 +136,7 @@ describe("isAllowedWsOrigin", () => {
 		// mismatch from our allowlist therefore indicates either a
 		// hand-crafted request or a misconfiguration — either way, not
 		// an allow.
-		expect(
-			isAllowedWsOrigin("HTTPS://terminal.example.com", allowlist, "production"),
-		).toBe(false);
+		expect(isAllowedWsOrigin("HTTPS://terminal.example.com", allowlist, "production")).toBe(false);
 	});
 
 	// ── Branch 3: wildcard ─────────────────────────────────────────────
@@ -159,9 +155,7 @@ describe("isAllowedWsOrigin", () => {
 		// A deployment could have CORS_ORIGINS="*,https://real-frontend"
 		// (unusual but legal). The explicit entry should take precedence
 		// over the wildcard's production-refusal.
-		expect(
-			isAllowedWsOrigin(ALLOWED_ORIGIN, ["*", ALLOWED_ORIGIN], "production"),
-		).toBe(true);
+		expect(isAllowedWsOrigin(ALLOWED_ORIGIN, ["*", ALLOWED_ORIGIN], "production")).toBe(true);
 	});
 
 	// ── Branch 4: everything else ─────────────────────────────────────
@@ -176,9 +170,7 @@ describe("isAllowedWsOrigin", () => {
 	});
 
 	it("rejects a non-allowlisted origin with no wildcard present", () => {
-		expect(
-			isAllowedWsOrigin("https://evil.example.com", allowlist, "production"),
-		).toBe(false);
+		expect(isAllowedWsOrigin("https://evil.example.com", allowlist, "production")).toBe(false);
 	});
 });
 
@@ -245,16 +237,14 @@ describe("parseCorsOrigins", () => {
 		// The original bug. Leading spaces after commas used to produce
 		// [' https://b.example.com'] which never equalled the Origin
 		// header the browser actually sends.
-		expect(
-			parseCorsOrigins("https://a.example.com, https://b.example.com"),
-		).toEqual(["https://a.example.com", "https://b.example.com"]);
+		expect(parseCorsOrigins("https://a.example.com, https://b.example.com")).toEqual([
+			"https://a.example.com",
+			"https://b.example.com",
+		]);
 	});
 
 	it("handles tabs and surrounding whitespace uniformly", () => {
-		expect(parseCorsOrigins("\thttps://a ,https://b\t")).toEqual([
-			"https://a",
-			"https://b",
-		]);
+		expect(parseCorsOrigins("\thttps://a ,https://b\t")).toEqual(["https://a", "https://b"]);
 	});
 
 	it("drops empty entries after trimming", () => {
@@ -263,10 +253,7 @@ describe("parseCorsOrigins", () => {
 		// that would match a literal empty Origin header (branch 2 of
 		// isAllowedWsOrigin) — an ambiguous failure mode we'd rather
 		// not have.
-		expect(parseCorsOrigins("https://a,,https://b,")).toEqual([
-			"https://a",
-			"https://b",
-		]);
+		expect(parseCorsOrigins("https://a,,https://b,")).toEqual(["https://a", "https://b"]);
 	});
 
 	it("preserves '*' when explicitly set", () => {

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -22,13 +22,13 @@ const BCRYPT_ROUNDS = 10;
 let capturedJwtSecret: string | null = null;
 
 function jwtSecret(): string {
-        if (capturedJwtSecret === null) {
-                throw new Error(
-                        "jwtSecret() called before validateJwtSecret(). " +
-                        "validateJwtSecret() must run at server startup before any JWT sign/verify.",
-                );
-        }
-        return capturedJwtSecret;
+	if (capturedJwtSecret === null) {
+		throw new Error(
+			"jwtSecret() called before validateJwtSecret(). " +
+				"validateJwtSecret() must run at server startup before any JWT sign/verify.",
+		);
+	}
+	return capturedJwtSecret;
 }
 
 // Call at server startup. In production (NODE_ENV === "production") throws if
@@ -39,43 +39,43 @@ function jwtSecret(): string {
 // captures the secret into module state so jwtSecret() returns a value
 // frozen at validation time rather than re-reading process.env.
 export function validateJwtSecret(): void {
-        const raw = process.env.JWT_SECRET;
-        const missing = !raw;
-        const usingPlaceholder = raw === INSECURE_DEFAULT_JWT_SECRET;
-        if (process.env.NODE_ENV === "production" && (missing || usingPlaceholder)) {
-                throw new Error(
-                        "JWT_SECRET must be set to a non-default value in production. " +
-                        "Refusing to start with the insecure placeholder — anyone would be able to forge JWTs.",
-                );
-        }
-        if (missing) {
-                console.warn(
-                        "[auth] JWT_SECRET is not set — using the insecure default. " +
-                        "Set JWT_SECRET in your .env before any non-local use.",
-                );
-        } else if (usingPlaceholder) {
-                console.warn(
-                        "[auth] JWT_SECRET is set to the insecure placeholder value. " +
-                        "Replace it in your .env before any non-local use.",
-                );
-        }
-        // Use `||` (not `??`) so an empty-string JWT_SECRET= falls back to
-        // the default, matching the `missing = !raw` classification above.
-        // `??` only triggers on null/undefined and would leave "" captured,
-        // causing the server to sign tokens with an empty-string key in dev.
-        capturedJwtSecret = raw || INSECURE_DEFAULT_JWT_SECRET;
+	const raw = process.env.JWT_SECRET;
+	const missing = !raw;
+	const usingPlaceholder = raw === INSECURE_DEFAULT_JWT_SECRET;
+	if (process.env.NODE_ENV === "production" && (missing || usingPlaceholder)) {
+		throw new Error(
+			"JWT_SECRET must be set to a non-default value in production. " +
+				"Refusing to start with the insecure placeholder — anyone would be able to forge JWTs.",
+		);
+	}
+	if (missing) {
+		console.warn(
+			"[auth] JWT_SECRET is not set — using the insecure default. " +
+				"Set JWT_SECRET in your .env before any non-local use.",
+		);
+	} else if (usingPlaceholder) {
+		console.warn(
+			"[auth] JWT_SECRET is set to the insecure placeholder value. " +
+				"Replace it in your .env before any non-local use.",
+		);
+	}
+	// Use `||` (not `??`) so an empty-string JWT_SECRET= falls back to
+	// the default, matching the `missing = !raw` classification above.
+	// `??` only triggers on null/undefined and would leave "" captured,
+	// causing the server to sign tokens with an empty-string key in dev.
+	capturedJwtSecret = raw || INSECURE_DEFAULT_JWT_SECRET;
 }
 
 // Test-only: reset the captured secret so each test starts from the
 // "validateJwtSecret has not run yet" state. Must not be called from
 // production code paths.
 export function __resetJwtSecretForTests(): void {
-        capturedJwtSecret = null;
+	capturedJwtSecret = null;
 }
 
 export interface AuthedRequest extends Request {
-        userId: string;
-        username: string;
+	userId: string;
+	username: string;
 }
 
 // ── User management ─────────────────────────────────────────────────────────
@@ -83,165 +83,165 @@ export interface AuthedRequest extends Request {
 // Thrown when register is attempted without an invite code (and an account
 // already exists), or with a code that's invalid / already redeemed.
 export class InviteRequiredError extends Error {
-        constructor(message: string) {
-                super(message);
-                this.name = "InviteRequiredError";
-        }
+	constructor(message: string) {
+		super(message);
+		this.name = "InviteRequiredError";
+	}
 }
 
 export class UsernameTakenError extends Error {
-        constructor() {
-                super("Username already taken");
-                this.name = "UsernameTakenError";
-        }
+	constructor() {
+		super("Username already taken");
+		this.name = "UsernameTakenError";
+	}
 }
 
 export async function registerUser(
-        username: string,
-        password: string,
-        inviteCode: string | undefined,
+	username: string,
+	password: string,
+	inviteCode: string | undefined,
 ): Promise<{ userId: string; token: string }> {
-        const userId = uuidv4();
+	const userId = uuidv4();
 
-        // Bootstrap exception: the very first account doesn't need an invite,
-        // since there's nobody to issue one. Every subsequent register must
-        // claim an unused invite_codes row atomically.
-        //
-        // Only call hasAnyUsers() when no inviteCode was provided — the
-        // steady-state register-with-invite path doesn't need to know whether
-        // bootstrap is open, so skipping the round-trip cuts D1 chatter on
-        // the hot path. When the caller did supply a code, they couldn't be
-        // a bootstrap anyway (no codes exist yet), so skipping is also
-        // semantically correct.
-        if (!inviteCode) {
-                const isBootstrap = !(await hasAnyUsers());
-                if (!isBootstrap) {
-                        throw new InviteRequiredError("Invite code required");
-                }
-                // INSERT … WHERE NOT EXISTS closes the bootstrap TOCTOU window:
-                // hasAnyUsers() and INSERT are separate D1 round-trips, so two
-                // simultaneous first-ever registers could both observe zero users
-                // without this guard. Only one of them gets `meta.changes === 1`.
-                //
-                // Bootstrap is the one path where we hash before validating an
-                // invite — there's nothing to validate, and we need the hash for
-                // the conditional INSERT. The cost is one bcrypt per first-ever
-                // visit, which happens at most once per deployment. Async bcrypt
-                // here (and everywhere below) so the event loop keeps serving
-                // other requests while the hash runs on the libuv threadpool.
-                const bootstrapHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
-                const insert = await d1Query(
-                        "INSERT INTO users (id, username, password_hash) " +
-                        "SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
-                        [userId, username, bootstrapHash],
-                );
-                if (insert.meta.changes === 1) {
-                        return { userId, token: signToken(userId, username) };
-                }
-                // Race loser: a concurrent bootstrap got there first and we have
-                // no invite to fall back on. Match the steady-state response so
-                // the user can retry once they've been given a code.
-                throw new InviteRequiredError("Invite code required");
-        }
-        // Atomic claim: the WHERE used_at IS NULL clause prevents two concurrent
-        // registers from redeeming the same code. The race loser sees changes
-        // === 0 and is rejected. The claim happens BEFORE any check on the
-        // username so an unauthenticated caller without a valid invite always
-        // sees 403 — never a 409 that would let them probe for existing
-        // usernames. The expires_at filter rejects stale codes the same way.
-        // If the user INSERT below fails (UNIQUE collision), we best-effort
-        // release the claim so the invite isn't burned by a register that
-        // never produced an account.
-        const claim = await d1Query(
-                "UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
-                "WHERE code = ? AND used_at IS NULL " +
-                "AND (expires_at IS NULL OR expires_at > datetime('now'))",
-                [userId, inviteCode],
-        );
-        if (claim.meta.changes !== 1) {
-                throw new InviteRequiredError("Invite code is invalid, expired, or already used");
-        }
+	// Bootstrap exception: the very first account doesn't need an invite,
+	// since there's nobody to issue one. Every subsequent register must
+	// claim an unused invite_codes row atomically.
+	//
+	// Only call hasAnyUsers() when no inviteCode was provided — the
+	// steady-state register-with-invite path doesn't need to know whether
+	// bootstrap is open, so skipping the round-trip cuts D1 chatter on
+	// the hot path. When the caller did supply a code, they couldn't be
+	// a bootstrap anyway (no codes exist yet), so skipping is also
+	// semantically correct.
+	if (!inviteCode) {
+		const isBootstrap = !(await hasAnyUsers());
+		if (!isBootstrap) {
+			throw new InviteRequiredError("Invite code required");
+		}
+		// INSERT … WHERE NOT EXISTS closes the bootstrap TOCTOU window:
+		// hasAnyUsers() and INSERT are separate D1 round-trips, so two
+		// simultaneous first-ever registers could both observe zero users
+		// without this guard. Only one of them gets `meta.changes === 1`.
+		//
+		// Bootstrap is the one path where we hash before validating an
+		// invite — there's nothing to validate, and we need the hash for
+		// the conditional INSERT. The cost is one bcrypt per first-ever
+		// visit, which happens at most once per deployment. Async bcrypt
+		// here (and everywhere below) so the event loop keeps serving
+		// other requests while the hash runs on the libuv threadpool.
+		const bootstrapHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+		const insert = await d1Query(
+			"INSERT INTO users (id, username, password_hash) " +
+				"SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
+			[userId, username, bootstrapHash],
+		);
+		if (insert.meta.changes === 1) {
+			return { userId, token: signToken(userId, username) };
+		}
+		// Race loser: a concurrent bootstrap got there first and we have
+		// no invite to fall back on. Match the steady-state response so
+		// the user can retry once they've been given a code.
+		throw new InviteRequiredError("Invite code required");
+	}
+	// Atomic claim: the WHERE used_at IS NULL clause prevents two concurrent
+	// registers from redeeming the same code. The race loser sees changes
+	// === 0 and is rejected. The claim happens BEFORE any check on the
+	// username so an unauthenticated caller without a valid invite always
+	// sees 403 — never a 409 that would let them probe for existing
+	// usernames. The expires_at filter rejects stale codes the same way.
+	// If the user INSERT below fails (UNIQUE collision), we best-effort
+	// release the claim so the invite isn't burned by a register that
+	// never produced an account.
+	const claim = await d1Query(
+		"UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
+			"WHERE code = ? AND used_at IS NULL " +
+			"AND (expires_at IS NULL OR expires_at > datetime('now'))",
+		[userId, inviteCode],
+	);
+	if (claim.meta.changes !== 1) {
+		throw new InviteRequiredError("Invite code is invalid, expired, or already used");
+	}
 
-        // Hash only after the invite is confirmed valid. Even though async
-        // bcrypt runs off the main thread, the libuv threadpool is bounded
-        // (default 4 threads) — accepting un-gated hashes would let an
-        // unauth'd caller exhaust those threads just by spamming bogus codes,
-        // backing up every other async operation in the process.
-        const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+	// Hash only after the invite is confirmed valid. Even though async
+	// bcrypt runs off the main thread, the libuv threadpool is bounded
+	// (default 4 threads) — accepting un-gated hashes would let an
+	// unauth'd caller exhaust those threads just by spamming bogus codes,
+	// backing up every other async operation in the process.
+	const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
 
-        try {
-                await d1Query("INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)", [
-                        userId,
-                        username,
-                        passwordHash,
-                ]);
-        } catch (err) {
-                // Best-effort release. We scope by `used_by = userId` so we can't
-                // accidentally un-claim a code that some other concurrent register
-                // has since legitimately consumed.
-                try {
-                        await d1Query(
-                                "UPDATE invite_codes SET used_by = NULL, used_at = NULL " +
-                                "WHERE code = ? AND used_by = ?",
-                                [inviteCode, userId],
-                        );
-                } catch (releaseErr) {
-                        // The release UPDATE failed, so the invite is now permanently
-                        // consumed without producing an account. The invitee will see
-                        // a 409 (or 500) response and has no way of knowing the code
-                        // is burned — they'll have to ask whoever issued it for a new
-                        // one.
-                        //
-                        // Log a SHA-256 of the code, NOT the raw value (#51). The
-                        // earlier shape included the plaintext so an operator could
-                        // grep the invite_codes table — but any log aggregator /
-                        // SIEM that indexes this line would then hold a usable code:
-                        //
-                        //   - The "code is already consumed" reasoning assumed the
-                        //     UPDATE had landed (used_at IS NOT NULL). If the
-                        //     release UPDATE failed in a way that left the row
-                        //     claimable (write didn't reach D1 at all), the logged
-                        //     plaintext was still live.
-                        //   - Even in the consumed case, a rotated D1 admin token
-                        //     could let an attacker manually un-claim the row and
-                        //     redeem the code — defeating the "burned therefore
-                        //     safe" assumption.
-                        //
-                        // Recovery: D1/SQLite has no built-in sha256(), so the hash
-                        // can't be matched in SQL directly. Two-step procedure:
-                        //
-                        //   1. SELECT * FROM invite_codes
-                        //      WHERE used_at IS NOT NULL
-                        //        AND used_by NOT IN (SELECT id FROM users);
-                        //      — this yields exactly the orphan rows (claimed but
-                        //      with no corresponding user). Usually one.
-                        //   2. For each candidate, compute SHA-256 of `code`
-                        //      externally and compare to the hash from the log,
-                        //      e.g. `node -e 'console.log(require("crypto").createHash("sha256").update("CODE").digest("hex"))'`.
-                        //
-                        // Aligns with #49: if codes get hashed at rest later, the
-                        // column would already be the hash and step 2 collapses to
-                        // a direct equality.
-                        const codeHash = createHash("sha256").update(inviteCode).digest("hex");
-                        console.error(
-                                "[auth] CRITICAL: invite release failed — code hash %s is permanently consumed without an account. " +
-                                "Insert error: %s. Release error: %s",
-                                codeHash,
-                                (err as Error).message,
-                                (releaseErr as Error).message,
-                        );
-                }
-                // SQLite UNIQUE-constraint violation → username already taken.
-                // D1 surfaces the SQLite error message in the d1Query throw, so
-                // we sniff for it rather than introducing a typed-error layer
-                // around the whole D1 client.
-                if (/UNIQUE constraint failed: users\.username/i.test((err as Error).message)) {
-                        throw new UsernameTakenError();
-                }
-                throw err;
-        }
+	try {
+		await d1Query("INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)", [
+			userId,
+			username,
+			passwordHash,
+		]);
+	} catch (err) {
+		// Best-effort release. We scope by `used_by = userId` so we can't
+		// accidentally un-claim a code that some other concurrent register
+		// has since legitimately consumed.
+		try {
+			await d1Query(
+				"UPDATE invite_codes SET used_by = NULL, used_at = NULL " +
+					"WHERE code = ? AND used_by = ?",
+				[inviteCode, userId],
+			);
+		} catch (releaseErr) {
+			// The release UPDATE failed, so the invite is now permanently
+			// consumed without producing an account. The invitee will see
+			// a 409 (or 500) response and has no way of knowing the code
+			// is burned — they'll have to ask whoever issued it for a new
+			// one.
+			//
+			// Log a SHA-256 of the code, NOT the raw value (#51). The
+			// earlier shape included the plaintext so an operator could
+			// grep the invite_codes table — but any log aggregator /
+			// SIEM that indexes this line would then hold a usable code:
+			//
+			//   - The "code is already consumed" reasoning assumed the
+			//     UPDATE had landed (used_at IS NOT NULL). If the
+			//     release UPDATE failed in a way that left the row
+			//     claimable (write didn't reach D1 at all), the logged
+			//     plaintext was still live.
+			//   - Even in the consumed case, a rotated D1 admin token
+			//     could let an attacker manually un-claim the row and
+			//     redeem the code — defeating the "burned therefore
+			//     safe" assumption.
+			//
+			// Recovery: D1/SQLite has no built-in sha256(), so the hash
+			// can't be matched in SQL directly. Two-step procedure:
+			//
+			//   1. SELECT * FROM invite_codes
+			//      WHERE used_at IS NOT NULL
+			//        AND used_by NOT IN (SELECT id FROM users);
+			//      — this yields exactly the orphan rows (claimed but
+			//      with no corresponding user). Usually one.
+			//   2. For each candidate, compute SHA-256 of `code`
+			//      externally and compare to the hash from the log,
+			//      e.g. `node -e 'console.log(require("crypto").createHash("sha256").update("CODE").digest("hex"))'`.
+			//
+			// Aligns with #49: if codes get hashed at rest later, the
+			// column would already be the hash and step 2 collapses to
+			// a direct equality.
+			const codeHash = createHash("sha256").update(inviteCode).digest("hex");
+			console.error(
+				"[auth] CRITICAL: invite release failed — code hash %s is permanently consumed without an account. " +
+					"Insert error: %s. Release error: %s",
+				codeHash,
+				(err as Error).message,
+				(releaseErr as Error).message,
+			);
+		}
+		// SQLite UNIQUE-constraint violation → username already taken.
+		// D1 surfaces the SQLite error message in the d1Query throw, so
+		// we sniff for it rather than introducing a typed-error layer
+		// around the whole D1 client.
+		if (/UNIQUE constraint failed: users\.username/i.test((err as Error).message)) {
+			throw new UsernameTakenError();
+		}
+		throw err;
+	}
 
-        return { userId, token: signToken(userId, username) };
+	return { userId, token: signToken(userId, username) };
 }
 
 // ── Invites ────────────────────────────────────────────────────────────────
@@ -262,76 +262,78 @@ const MAX_UNUSED_INVITES_PER_USER = 20;
 // caps the steady-state rate at 20/min/user.
 const INVITE_EXPIRY_MIN_DAYS = 1 / 1440; // 1 minute
 const INVITE_EXPIRY_DAYS = ((): number => {
-        const raw = process.env.INVITE_EXPIRY_DAYS;
-        // Treat blank ("" or whitespace-only) the same as unset. Without this
-        // Number("") === 0 would slip past the finite/non-negative check and
-        // land at the 1-minute floor — an operator who blanks the variable in
-        // a secrets manager would silently get near-zero TTL.
-        if (raw === undefined || raw.trim() === "") return 30;
-        const n = Number(raw);
-        if (!Number.isFinite(n) || n < 0) return 30;
-        return Math.max(n, INVITE_EXPIRY_MIN_DAYS);
+	const raw = process.env.INVITE_EXPIRY_DAYS;
+	// Treat blank ("" or whitespace-only) the same as unset. Without this
+	// Number("") === 0 would slip past the finite/non-negative check and
+	// land at the 1-minute floor — an operator who blanks the variable in
+	// a secrets manager would silently get near-zero TTL.
+	if (raw === undefined || raw.trim() === "") return 30;
+	const n = Number(raw);
+	if (!Number.isFinite(n) || n < 0) return 30;
+	return Math.max(n, INVITE_EXPIRY_MIN_DAYS);
 })();
 
 export class InviteQuotaExceededError extends Error {
-        constructor() {
-                super(`You already have ${MAX_UNUSED_INVITES_PER_USER} active invite codes — revoke some, or wait for them to be used or expire, before minting more`);
-                this.name = "InviteQuotaExceededError";
-        }
+	constructor() {
+		super(
+			`You already have ${MAX_UNUSED_INVITES_PER_USER} active invite codes — revoke some, or wait for them to be used or expire, before minting more`,
+		);
+		this.name = "InviteQuotaExceededError";
+	}
 }
 
 // Wire shape intentionally omits created_by (always the authenticated caller,
 // so redundant) and used_by (exposes another user's internal UUID for no UI
 // benefit — the frontend derives used/unused from `usedAt !== null`).
 export interface Invite {
-        code: string;
-        createdAt: string;
-        usedAt: string | null;
-        expiresAt: string | null;
+	code: string;
+	createdAt: string;
+	usedAt: string | null;
+	expiresAt: string | null;
 }
 
 export async function createInvite(creatorUserId: string): Promise<Invite> {
-        // 16 hex chars = 64 bits of entropy — plenty for a single-use,
-        // typically short-lived invite code, and short enough to paste.
-        //
-        // Codes are stored in plaintext rather than hashed: they are
-        // single-use, expected to be short-lived, and the user needs to read
-        // them back from the UI to share with invitees. A D1 breach would
-        // expose unused codes immediately — an acceptable trade-off given
-        // those properties, but flagged here so it's a conscious choice.
-        const code = randomBytes(8).toString("hex");
-        // Pass created_at + expires_at explicitly so we can return them
-        // without a follow-up SELECT that could orphan a valid invite row on
-        // read failure. Format matches D1's `datetime('now')` output (UTC,
-        // no fractional seconds) so existing rows and new ones sort/compare
-        // consistently.
-        const now = new Date();
-        const createdAt = formatD1Datetime(now);
-        const expiresAt = formatD1Datetime(new Date(now.getTime() + INVITE_EXPIRY_DAYS * 86400_000));
-        // Atomic quota check: collapse the count + insert into one statement
-        // so two concurrent POST /invites requests can't both observe count
-        // < MAX and both insert. The WHERE clause is evaluated as part of the
-        // INSERT, so SQLite serialises the read+write. Same changes-based
-        // pattern as the bootstrap and invite-claim paths above.
-        //
-        // Expired codes are excluded from the count: the cap exists to bound
-        // *concurrently redeemable* invites (blast radius), and an expired
-        // code is no more redeemable than a used one. Without this filter, a
-        // forgetful user silently hits the cap 30 days after their last mint
-        // and an attacker could just wait out the expiry instead of revoking.
-        const insert = await d1Query(
-                "INSERT INTO invite_codes (code, created_by, created_at, expires_at) " +
-                "SELECT ?, ?, ?, ? WHERE (" +
-                "SELECT COUNT(*) FROM invite_codes " +
-                "WHERE created_by = ? AND used_at IS NULL " +
-                "AND (expires_at IS NULL OR expires_at > datetime('now'))" +
-                ") < ?",
-                [code, creatorUserId, createdAt, expiresAt, creatorUserId, MAX_UNUSED_INVITES_PER_USER],
-        );
-        if (insert.meta.changes !== 1) {
-                throw new InviteQuotaExceededError();
-        }
-        return { code, createdAt, usedAt: null, expiresAt };
+	// 16 hex chars = 64 bits of entropy — plenty for a single-use,
+	// typically short-lived invite code, and short enough to paste.
+	//
+	// Codes are stored in plaintext rather than hashed: they are
+	// single-use, expected to be short-lived, and the user needs to read
+	// them back from the UI to share with invitees. A D1 breach would
+	// expose unused codes immediately — an acceptable trade-off given
+	// those properties, but flagged here so it's a conscious choice.
+	const code = randomBytes(8).toString("hex");
+	// Pass created_at + expires_at explicitly so we can return them
+	// without a follow-up SELECT that could orphan a valid invite row on
+	// read failure. Format matches D1's `datetime('now')` output (UTC,
+	// no fractional seconds) so existing rows and new ones sort/compare
+	// consistently.
+	const now = new Date();
+	const createdAt = formatD1Datetime(now);
+	const expiresAt = formatD1Datetime(new Date(now.getTime() + INVITE_EXPIRY_DAYS * 86400_000));
+	// Atomic quota check: collapse the count + insert into one statement
+	// so two concurrent POST /invites requests can't both observe count
+	// < MAX and both insert. The WHERE clause is evaluated as part of the
+	// INSERT, so SQLite serialises the read+write. Same changes-based
+	// pattern as the bootstrap and invite-claim paths above.
+	//
+	// Expired codes are excluded from the count: the cap exists to bound
+	// *concurrently redeemable* invites (blast radius), and an expired
+	// code is no more redeemable than a used one. Without this filter, a
+	// forgetful user silently hits the cap 30 days after their last mint
+	// and an attacker could just wait out the expiry instead of revoking.
+	const insert = await d1Query(
+		"INSERT INTO invite_codes (code, created_by, created_at, expires_at) " +
+			"SELECT ?, ?, ?, ? WHERE (" +
+			"SELECT COUNT(*) FROM invite_codes " +
+			"WHERE created_by = ? AND used_at IS NULL " +
+			"AND (expires_at IS NULL OR expires_at > datetime('now'))" +
+			") < ?",
+		[code, creatorUserId, createdAt, expiresAt, creatorUserId, MAX_UNUSED_INVITES_PER_USER],
+	);
+	if (insert.meta.changes !== 1) {
+		throw new InviteQuotaExceededError();
+	}
+	return { code, createdAt, usedAt: null, expiresAt };
 }
 
 // LIMIT bounds the response size so historical used/expired rows can't
@@ -341,12 +343,12 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
 const INVITE_LIST_LIMIT = 100;
 
 export async function listInvites(creatorUserId: string): Promise<Invite[]> {
-        const result = await d1Query<InviteRow>(
-                "SELECT code, created_at, used_at, expires_at FROM invite_codes " +
-                "WHERE created_by = ? ORDER BY created_at DESC LIMIT ?",
-                [creatorUserId, INVITE_LIST_LIMIT],
-        );
-        return result.results.map(rowToInvite);
+	const result = await d1Query<InviteRow>(
+		"SELECT code, created_at, used_at, expires_at FROM invite_codes " +
+			"WHERE created_by = ? ORDER BY created_at DESC LIMIT ?",
+		[creatorUserId, INVITE_LIST_LIMIT],
+	);
+	return result.results.map(rowToInvite);
 }
 
 // Revoke an unused invite. Returns true if a row was removed, false if the
@@ -354,44 +356,44 @@ export async function listInvites(creatorUserId: string): Promise<Invite[]> {
 // surface is intentionally vague so a caller can't enumerate codes belonging
 // to other users.
 export async function revokeInvite(creatorUserId: string, code: string): Promise<boolean> {
-        const result = await d1Query(
-                "DELETE FROM invite_codes WHERE code = ? AND created_by = ? AND used_at IS NULL",
-                [code, creatorUserId],
-        );
-        return result.meta.changes === 1;
+	const result = await d1Query(
+		"DELETE FROM invite_codes WHERE code = ? AND created_by = ? AND used_at IS NULL",
+		[code, creatorUserId],
+	);
+	return result.meta.changes === 1;
 }
 
 interface InviteRow {
-        code: string;
-        created_at: string;
-        used_at: string | null;
-        expires_at: string | null;
+	code: string;
+	created_at: string;
+	used_at: string | null;
+	expires_at: string | null;
 }
 
 function rowToInvite(row: InviteRow): Invite {
-        return {
-                code: row.code,
-                createdAt: row.created_at,
-                usedAt: row.used_at,
-                expiresAt: row.expires_at,
-        };
+	return {
+		code: row.code,
+		createdAt: row.created_at,
+		usedAt: row.used_at,
+		expiresAt: row.expires_at,
+	};
 }
 
 // "YYYY-MM-DD HH:MM:SS" UTC, matching D1's datetime('now') format so direct
 // SQL comparisons (`expires_at > datetime('now')`) work without timezone
 // surprises.
 function formatD1Datetime(d: Date): string {
-        return d.toISOString().replace("T", " ").slice(0, 19);
+	return d.toISOString().replace("T", " ").slice(0, 19);
 }
 
 // Thrown on wrong-username-or-password, and only that. Infra failures (D1
 // timeouts, bcrypt crashes, …) propagate as regular Errors so the route
 // handler can 500 them instead of counting them toward the lockout budget.
 export class InvalidCredentialsError extends Error {
-        constructor() {
-                super("Invalid credentials");
-                this.name = "InvalidCredentialsError";
-        }
+	constructor() {
+		super("Invalid credentials");
+		this.name = "InvalidCredentialsError";
+	}
 }
 
 // Timing-parity dummy hash for the unknown-username path: bcrypt.compare
@@ -439,63 +441,66 @@ const DUMMY_PASSWORD_HASH_PROMISE: Promise<string> = bcrypt.hash("__dummy__", BC
 // Safe to call more than once; it returns the same settled promise on
 // every call.
 export async function ensureAuthReady(): Promise<void> {
-        await DUMMY_PASSWORD_HASH_PROMISE;
+	await DUMMY_PASSWORD_HASH_PROMISE;
 }
 
-export async function loginUser(username: string, password: string): Promise<{ userId: string; token: string }> {
-        const result = await d1Query<{ id: string; password_hash: string }>(
-                "SELECT id, password_hash FROM users WHERE username = ?",
-                [username],
-        );
+export async function loginUser(
+	username: string,
+	password: string,
+): Promise<{ userId: string; token: string }> {
+	const result = await d1Query<{ id: string; password_hash: string }>(
+		"SELECT id, password_hash FROM users WHERE username = ?",
+		[username],
+	);
 
-        const row = result.results[0];
-        // Always run a bcrypt compare, even if the user doesn't exist, so an
-        // attacker can't distinguish "unknown username" from "wrong password"
-        // by timing. The `??` short-circuits on the known-user path, so
-        // known-user logins don't pay the awaited-promise cost (negligible
-        // post-init anyway, but cleaner to avoid the microtask on the hot
-        // path). See DUMMY_PASSWORD_HASH_PROMISE above for the rationale.
-        const hashToCompare = row?.password_hash ?? (await DUMMY_PASSWORD_HASH_PROMISE);
-        const ok = await bcrypt.compare(password, hashToCompare);
-        if (!row || !ok) {
-                throw new InvalidCredentialsError();
-        }
+	const row = result.results[0];
+	// Always run a bcrypt compare, even if the user doesn't exist, so an
+	// attacker can't distinguish "unknown username" from "wrong password"
+	// by timing. The `??` short-circuits on the known-user path, so
+	// known-user logins don't pay the awaited-promise cost (negligible
+	// post-init anyway, but cleaner to avoid the microtask on the hot
+	// path). See DUMMY_PASSWORD_HASH_PROMISE above for the rationale.
+	const hashToCompare = row?.password_hash ?? (await DUMMY_PASSWORD_HASH_PROMISE);
+	const ok = await bcrypt.compare(password, hashToCompare);
+	if (!row || !ok) {
+		throw new InvalidCredentialsError();
+	}
 
-        const token = signToken(row.id, username);
-        return { userId: row.id, token };
+	const token = signToken(row.id, username);
+	return { userId: row.id, token };
 }
 
 function signToken(userId: string, username: string): string {
-        const payload: JwtPayload = { sub: userId, username };
-        // `expiresIn` in jsonwebtoken is typed as `number | StringValue`,
-        // where StringValue is a template-literal type from the `ms`
-        // package (e.g. "7d", "1h"). JWT_EXPIRES_IN comes from process.env
-        // as a plain string, so we cast through the library's own option
-        // type rather than `any` — keeps the check narrow to this one
-        // field and doesn't opt the whole sign-options shape out of
-        // type-checking.
-        const options: jwt.SignOptions = { expiresIn: JWT_EXPIRES_IN as jwt.SignOptions["expiresIn"] };
-        return jwt.sign(payload, jwtSecret(), options);
+	const payload: JwtPayload = { sub: userId, username };
+	// `expiresIn` in jsonwebtoken is typed as `number | StringValue`,
+	// where StringValue is a template-literal type from the `ms`
+	// package (e.g. "7d", "1h"). JWT_EXPIRES_IN comes from process.env
+	// as a plain string, so we cast through the library's own option
+	// type rather than `any` — keeps the check narrow to this one
+	// field and doesn't opt the whole sign-options shape out of
+	// type-checking.
+	const options: jwt.SignOptions = { expiresIn: JWT_EXPIRES_IN as jwt.SignOptions["expiresIn"] };
+	return jwt.sign(payload, jwtSecret(), options);
 }
 
 // ── Express middleware ──────────────────────────────────────────────────────
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
-        const header = req.headers.authorization;
-        if (!header?.startsWith("Bearer ")) {
-                res.status(401).json({ error: "Missing or invalid Authorization header" });
-                return;
-        }
+	const header = req.headers.authorization;
+	if (!header?.startsWith("Bearer ")) {
+		res.status(401).json({ error: "Missing or invalid Authorization header" });
+		return;
+	}
 
-        const token = header.slice(7);
-        try {
-                const payload = jwt.verify(token, jwtSecret()) as JwtPayload;
-                (req as AuthedRequest).userId = payload.sub;
-                (req as AuthedRequest).username = payload.username;
-                next();
-        } catch {
-                res.status(401).json({ error: "Invalid or expired token" });
-        }
+	const token = header.slice(7);
+	try {
+		const payload = jwt.verify(token, jwtSecret()) as JwtPayload;
+		(req as AuthedRequest).userId = payload.sub;
+		(req as AuthedRequest).username = payload.username;
+		next();
+	} catch {
+		res.status(401).json({ error: "Invalid or expired token" });
+	}
 }
 
 // ── WebSocket auth ──────────────────────────────────────────────────────────
@@ -512,58 +517,62 @@ const WS_AUTH_PROTOCOL_PREFIX = "auth.bearer.";
  * Then verify it and return the decoded payload, or null on any failure.
  */
 export function verifyWsToken(
-        protocolHeader: string | string[] | undefined,
-        requestUrl: string | undefined,
+	protocolHeader: string | string[] | undefined,
+	requestUrl: string | undefined,
 ): JwtPayload | null {
-        const fromProtocol = extractTokenFromProtocol(protocolHeader);
-        const fromUrl = fromProtocol ? null : extractTokenFromUrl(requestUrl);
-        const token = fromProtocol ?? fromUrl;
+	const fromProtocol = extractTokenFromProtocol(protocolHeader);
+	const fromUrl = fromProtocol ? null : extractTokenFromUrl(requestUrl);
+	const token = fromProtocol ?? fromUrl;
 
-        if (!token) {
-                // Help operators tell which channel(s) were tried. The subprotocol path
-                // is preferred; the query-string path only kicks in as a fallback for
-                // proxies that strip Sec-WebSocket-Protocol.
-                if (!protocolHeader && !requestUrl) {
-                        console.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no request URL");
-                } else if (!protocolHeader) {
-                        console.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no ?token= query param");
-                } else {
-                        const header = Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader;
-                        console.error(
-                                "[verifyWsToken] no usable auth.bearer.* subprotocol (got: %s) and no ?token= query param",
-                                header,
-                        );
-                }
-                return null;
-        }
+	if (!token) {
+		// Help operators tell which channel(s) were tried. The subprotocol path
+		// is preferred; the query-string path only kicks in as a fallback for
+		// proxies that strip Sec-WebSocket-Protocol.
+		if (!protocolHeader && !requestUrl) {
+			console.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no request URL");
+		} else if (!protocolHeader) {
+			console.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no ?token= query param");
+		} else {
+			const header = Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader;
+			console.error(
+				"[verifyWsToken] no usable auth.bearer.* subprotocol (got: %s) and no ?token= query param",
+				header,
+			);
+		}
+		return null;
+	}
 
-        try {
-                return jwt.verify(token, jwtSecret()) as JwtPayload;
-        } catch (err) {
-                console.error("[verifyWsToken] jwt verify failed:", (err as Error).name, (err as Error).message);
-                return null;
-        }
+	try {
+		return jwt.verify(token, jwtSecret()) as JwtPayload;
+	} catch (err) {
+		console.error(
+			"[verifyWsToken] jwt verify failed:",
+			(err as Error).name,
+			(err as Error).message,
+		);
+		return null;
+	}
 }
 
 function extractTokenFromProtocol(protocolHeader: string | string[] | undefined): string | null {
-        if (!protocolHeader) return null;
-        const header = Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader;
-        const protocols = header.split(",").map((s) => s.trim());
-        const authProto = protocols.find((p) => p.startsWith(WS_AUTH_PROTOCOL_PREFIX));
-        if (!authProto) return null;
-        const token = authProto.slice(WS_AUTH_PROTOCOL_PREFIX.length);
-        return token || null;
+	if (!protocolHeader) return null;
+	const header = Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader;
+	const protocols = header.split(",").map((s) => s.trim());
+	const authProto = protocols.find((p) => p.startsWith(WS_AUTH_PROTOCOL_PREFIX));
+	if (!authProto) return null;
+	const token = authProto.slice(WS_AUTH_PROTOCOL_PREFIX.length);
+	return token || null;
 }
 
 function extractTokenFromUrl(requestUrl: string | undefined): string | null {
-        if (!requestUrl) return null;
-        try {
-                const parsed = new URL(requestUrl, "http://localhost");
-                const token = parsed.searchParams.get("token");
-                return token || null;
-        } catch {
-                return null;
-        }
+	if (!requestUrl) return null;
+	try {
+		const parsed = new URL(requestUrl, "http://localhost");
+		const token = parsed.searchParams.get("token");
+		return token || null;
+	} catch {
+		return null;
+	}
 }
 
 /**
@@ -571,10 +580,10 @@ function extractTokenFromUrl(requestUrl: string | undefined): string | null {
  * can echo it back in the handshake response (required by RFC 6455).
  */
 export function selectWsAuthProtocol(protocols: Set<string>): string | false {
-        for (const p of protocols) {
-                if (p.startsWith(WS_AUTH_PROTOCOL_PREFIX)) return p;
-        }
-        return false;
+	for (const p of protocols) {
+		if (p.startsWith(WS_AUTH_PROTOCOL_PREFIX)) return p;
+	}
+	return false;
 }
 
 /**
@@ -600,11 +609,11 @@ export function selectWsAuthProtocol(protocols: Set<string>): string | false {
  * up the HTTP server.
  */
 export function parseCorsOrigins(raw: string | undefined): string[] {
-        if (raw === undefined) return ["*"];
-        return raw
-                .split(",")
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0);
+	if (raw === undefined) return ["*"];
+	return raw
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
 }
 
 /**
@@ -658,23 +667,23 @@ export function parseCorsOrigins(raw: string | undefined): string[] {
  * touching http.
  */
 export function isAllowedWsOrigin(
-        origin: string | undefined,
-        allowedOrigins: readonly string[],
-        nodeEnv: string | undefined,
+	origin: string | undefined,
+	allowedOrigins: readonly string[],
+	nodeEnv: string | undefined,
 ): boolean {
-        // Branch 1: not a browser, not a CSWSH vector.
-        if (!origin) return true;
+	// Branch 1: not a browser, not a CSWSH vector.
+	if (!origin) return true;
 
-        // Branch 2: explicitly whitelisted.
-        if (allowedOrigins.includes(origin)) return true;
+	// Branch 2: explicitly whitelisted.
+	if (allowedOrigins.includes(origin)) return true;
 
-        // Branch 3: "*" wildcard.
-        if (allowedOrigins.includes("*")) {
-                return nodeEnv !== "production";
-        }
+	// Branch 3: "*" wildcard.
+	if (allowedOrigins.includes("*")) {
+		return nodeEnv !== "production";
+	}
 
-        // Branch 4.
-        return false;
+	// Branch 4.
+	return false;
 }
 
 /**
@@ -689,21 +698,21 @@ export function isAllowedWsOrigin(
  * Logger is injectable for the test.
  */
 export function warnIfWildcardCorsInProduction(
-        allowedOrigins: readonly string[],
-        nodeEnv: string | undefined,
-        logger: Pick<Console, "warn"> = console,
+	allowedOrigins: readonly string[],
+	nodeEnv: string | undefined,
+	logger: Pick<Console, "warn"> = console,
 ): void {
-        if (nodeEnv !== "production") return;
-        if (!allowedOrigins.includes("*")) return;
-        logger.warn(
-                "[server] CORS_ORIGINS contains '*' in production. The HTTP layer " +
-                "still honours this, but the WebSocket upgrade handler refuses it " +
-                "(CSWSH protection). Set CORS_ORIGINS to an explicit origin list " +
-                "to re-enable WebSocket connections from production clients.",
-        );
+	if (nodeEnv !== "production") return;
+	if (!allowedOrigins.includes("*")) return;
+	logger.warn(
+		"[server] CORS_ORIGINS contains '*' in production. The HTTP layer " +
+			"still honours this, but the WebSocket upgrade handler refuses it " +
+			"(CSWSH protection). Set CORS_ORIGINS to an explicit origin list " +
+			"to re-enable WebSocket connections from production clients.",
+	);
 }
 
 export async function hasAnyUsers(): Promise<boolean> {
-        const result = await d1Query<{ count: number }>("SELECT COUNT(*) as count FROM users");
-        return result.results[0].count > 0;
+	const result = await d1Query<{ count: number }>("SELECT COUNT(*) as count FROM users");
+	return result.results[0].count > 0;
 }

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -15,15 +15,15 @@ const API_TOKEN = process.env.CLOUDFLARE_API_TOKEN ?? "";
 const DATABASE_ID = process.env.D1_DATABASE_ID ?? "";
 
 interface D1QueryResult<T = Record<string, unknown>> {
-        results: T[];
-        success: boolean;
-        meta: { changes: number; duration: number; last_row_id: number };
+	results: T[];
+	success: boolean;
+	meta: { changes: number; duration: number; last_row_id: number };
 }
 
 interface D1ApiResponse<T = Record<string, unknown>> {
-        result: D1QueryResult<T>[];
-        success: boolean;
-        errors: Array<{ code: number; message: string }>;
+	result: D1QueryResult<T>[];
+	success: boolean;
+	errors: Array<{ code: number; message: string }>;
 }
 
 /**
@@ -31,43 +31,43 @@ interface D1ApiResponse<T = Record<string, unknown>> {
  * Returns the results array for SELECT, or meta for INSERT/UPDATE/DELETE.
  */
 export async function d1Query<T = Record<string, unknown>>(
-        sql: string,
-        params?: unknown[],
+	sql: string,
+	params?: unknown[],
 ): Promise<D1QueryResult<T>> {
-        const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/d1/database/${DATABASE_ID}/query`;
+	const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/d1/database/${DATABASE_ID}/query`;
 
-        const res = await fetch(url, {
-                method: "POST",
-                headers: {
-                        Authorization: `Bearer ${API_TOKEN}`,
-                        "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ sql, params: params ?? [] }),
-        });
+	const res = await fetch(url, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${API_TOKEN}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ sql, params: params ?? [] }),
+	});
 
-        if (!res.ok) {
-                const text = await res.text();
-                throw new Error(`D1 API error (${res.status}): ${text}`);
-        }
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`D1 API error (${res.status}): ${text}`);
+	}
 
-        const data = (await res.json()) as D1ApiResponse<T>;
-        if (!data.success) {
-                throw new Error(`D1 query failed: ${data.errors.map((e) => e.message).join(", ")}`);
-        }
+	const data = (await res.json()) as D1ApiResponse<T>;
+	if (!data.success) {
+		throw new Error(`D1 query failed: ${data.errors.map((e) => e.message).join(", ")}`);
+	}
 
-        return data.result[0];
+	return data.result[0];
 }
 
 /**
  * Execute multiple SQL statements (for migrations).
  */
 export async function d1Batch(statements: string[]): Promise<void> {
-        // D1 doesn't have a batch endpoint via HTTP, so run sequentially
-        for (const sql of statements) {
-                const trimmed = sql.trim();
-                if (!trimmed) continue;
-                await d1Query(trimmed);
-        }
+	// D1 doesn't have a batch endpoint via HTTP, so run sequentially
+	for (const sql of statements) {
+		const trimmed = sql.trim();
+		if (!trimmed) continue;
+		await d1Query(trimmed);
+	}
 }
 
 /**
@@ -75,15 +75,15 @@ export async function d1Batch(statements: string[]): Promise<void> {
  * Call once on server startup.
  */
 export async function migrateDb(): Promise<void> {
-        console.log("[db] running D1 migrations…");
-        await d1Batch([
-                `CREATE TABLE IF NOT EXISTS users (
+	console.log("[db] running D1 migrations…");
+	await d1Batch([
+		`CREATE TABLE IF NOT EXISTS users (
                         id          TEXT PRIMARY KEY,
                         username    TEXT UNIQUE NOT NULL,
                         password_hash TEXT NOT NULL,
                         created_at  TEXT NOT NULL DEFAULT (datetime('now'))
                 )`,
-                `CREATE TABLE IF NOT EXISTS sessions (
+		`CREATE TABLE IF NOT EXISTS sessions (
                         session_id      TEXT PRIMARY KEY,
                         user_id         TEXT NOT NULL,
                         name            TEXT NOT NULL,
@@ -96,15 +96,15 @@ export async function migrateDb(): Promise<void> {
                         created_at      TEXT NOT NULL DEFAULT (datetime('now')),
                         last_connected_at TEXT
                 )`,
-                `CREATE INDEX IF NOT EXISTS idx_sessions_user
+		`CREATE INDEX IF NOT EXISTS idx_sessions_user
                         ON sessions(user_id, status)`,
-                // Invite-only registration. The first user is allowed to register
-                // without an invite (bootstrap); every subsequent register must
-                // claim a row here. Atomic claim is enforced by an UPDATE …
-                // WHERE used_at IS NULL with `meta.changes === 1` check, so two
-                // concurrent registers can't redeem the same code. expires_at
-                // bounds how long an unredeemed code stays valid (NULL = never).
-                `CREATE TABLE IF NOT EXISTS invite_codes (
+		// Invite-only registration. The first user is allowed to register
+		// without an invite (bootstrap); every subsequent register must
+		// claim a row here. Atomic claim is enforced by an UPDATE …
+		// WHERE used_at IS NULL with `meta.changes === 1` check, so two
+		// concurrent registers can't redeem the same code. expires_at
+		// bounds how long an unredeemed code stays valid (NULL = never).
+		`CREATE TABLE IF NOT EXISTS invite_codes (
                         code        TEXT PRIMARY KEY,
                         created_by  TEXT NOT NULL,
                         created_at  TEXT NOT NULL DEFAULT (datetime('now')),
@@ -112,29 +112,29 @@ export async function migrateDb(): Promise<void> {
                         used_at     TEXT,
                         expires_at  TEXT
                 )`,
-                `CREATE INDEX IF NOT EXISTS idx_invite_codes_creator
+		`CREATE INDEX IF NOT EXISTS idx_invite_codes_creator
                         ON invite_codes(created_by)`,
-        ]);
-        // ALTER for any table that pre-dates the expires_at column (e.g. a dev
-        // DB that ran the original migration before this column existed). SQLite
-        // has no ADD COLUMN IF NOT EXISTS, so we run it unguarded and swallow
-        // the "duplicate column" error. CREATE TABLE above already includes the
-        // column for fresh deploys, so this is a no-op there.
-        try {
-                await d1Query("ALTER TABLE invite_codes ADD COLUMN expires_at TEXT");
-        } catch (err) {
-                if (!/duplicate column name|already exists/i.test((err as Error).message)) {
-                        throw err;
-                }
-        }
-        console.log("[db] migrations complete");
+	]);
+	// ALTER for any table that pre-dates the expires_at column (e.g. a dev
+	// DB that ran the original migration before this column existed). SQLite
+	// has no ADD COLUMN IF NOT EXISTS, so we run it unguarded and swallow
+	// the "duplicate column" error. CREATE TABLE above already includes the
+	// column for fresh deploys, so this is a no-op there.
+	try {
+		await d1Query("ALTER TABLE invite_codes ADD COLUMN expires_at TEXT");
+	} catch (err) {
+		if (!/duplicate column name|already exists/i.test((err as Error).message)) {
+			throw err;
+		}
+	}
+	console.log("[db] migrations complete");
 }
 
 /** Validate that D1 credentials are configured. */
 export function validateD1Config(): void {
-        if (!ACCOUNT_ID || !API_TOKEN || !DATABASE_ID) {
-                throw new Error(
-                        "Missing Cloudflare D1 config. Set CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, and D1_DATABASE_ID env vars.",
-                );
-        }
+	if (!ACCOUNT_ID || !API_TOKEN || !DATABASE_ID) {
+		throw new Error(
+			"Missing Cloudflare D1 config. Set CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, and D1_DATABASE_ID env vars.",
+		);
+	}
 }

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import { PassThrough } from "stream";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // d1Query is the only direct D1 touch-point in DockerManager (reconcile()).
 // Every other path is reached through the fake SessionManager. Default to an
@@ -9,7 +9,12 @@ const dbStubs = vi.hoisted(() => ({
 }));
 vi.mock("./db.js", () => dbStubs);
 
-import { DockerManager, sanitiseHostname, sanitiseUploadName, type OutputListener } from "./dockerManager.js";
+import {
+	DockerManager,
+	type OutputListener,
+	sanitiseHostname,
+	sanitiseUploadName,
+} from "./dockerManager.js";
 import type { SessionManager } from "./sessionManager.js";
 
 // ── Test harness ────────────────────────────────────────────────────────────
@@ -33,10 +38,18 @@ function makeFakeSessions(containerId: string | null = "container-123"): Session
 	return {
 		getOrThrow: vi.fn(async () => meta),
 		get: vi.fn(async () => meta),
-		updateConnected: vi.fn(async () => { /* noop */ }),
-		updateStatus: vi.fn(async () => { /* noop */ }),
-		setContainerId: vi.fn(async () => { /* noop */ }),
-		recordContainerGone: vi.fn(async () => { /* noop */ }),
+		updateConnected: vi.fn(async () => {
+			/* noop */
+		}),
+		updateStatus: vi.fn(async () => {
+			/* noop */
+		}),
+		setContainerId: vi.fn(async () => {
+			/* noop */
+		}),
+		recordContainerGone: vi.fn(async () => {
+			/* noop */
+		}),
 	} as unknown as SessionManager;
 }
 
@@ -77,10 +90,7 @@ function makeFakeContainer(oneShot?: OneShotHook): FakeContainer {
 			// the test drives output by writing to `container._streams[...]`.
 			const isAttach =
 				opts.Cmd[0] === "tmux" &&
-				(
-					opts.Cmd[1] === "attach" ||
-					(opts.Cmd[1] === "new-session" && opts.Cmd.includes("-A"))
-				);
+				(opts.Cmd[1] === "attach" || (opts.Cmd[1] === "new-session" && opts.Cmd.includes("-A")));
 			// Every one-shot tmux command (capture-pane, list-sessions, kill-session,
 			// set-option, new-session -d, …) needs SOME canned response — otherwise
 			// execOneShot's `await stream.on("end")` hangs the test forever. If the
@@ -159,7 +169,8 @@ function makeDocker(opts?: { sessions?: SessionManager; oneShot?: OneShotHook })
 // may force container.exec to throw — in that case the exec object is never
 // pushed, but the CALL was still made and should be counted.
 function countAttachExecs(container: FakeContainer): number {
-	const calls = (container.exec as unknown as { mock: { calls: Array<[{ Cmd: string[] }]> } }).mock.calls;
+	const calls = (container.exec as unknown as { mock: { calls: Array<[{ Cmd: string[] }]> } }).mock
+		.calls;
 	return calls.filter(
 		([opts]) => opts.Cmd[0] === "tmux" && opts.Cmd[1] === "new-session" && opts.Cmd.includes("-A"),
 	).length;
@@ -175,8 +186,7 @@ function mustFind<T>(arr: readonly T[], pred: (v: T) => boolean, label: string):
 	return found;
 }
 
-const isAttachExec = (e: FakeExec): boolean =>
-	e._cmd[1] === "new-session" && e._cmd.includes("-A");
+const isAttachExec = (e: FakeExec): boolean => e._cmd[1] === "new-session" && e._cmd.includes("-A");
 
 // attach() now returns an armed listener (see dockerManager.attach() docs):
 // live bytes pile into a tail array until wsHandler calls flushTail(). Tests
@@ -200,8 +210,26 @@ describe("DockerManager shared-exec multiplexing", () => {
 	it("creates only one shared exec across multiple attaches to the same session", async () => {
 		const { dm, container } = makeDocker();
 
-		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test");
-		await dm.attach("s1", "a2", 80, 24, () => { /* noop */ }, "tab-test");
+		await dm.attach(
+			"s1",
+			"a1",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
+		await dm.attach(
+			"s1",
+			"a2",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
 
 		expect(countAttachExecs(container)).toBe(1);
 	});
@@ -238,9 +266,7 @@ describe("DockerManager shared-exec multiplexing", () => {
 		const origExec = container.exec;
 		container.exec = vi.fn(async (opts: { Cmd: string[] }) => {
 			const isAttach =
-				opts.Cmd[0] === "tmux"
-				&& opts.Cmd[1] === "new-session"
-				&& opts.Cmd.includes("-A");
+				opts.Cmd[0] === "tmux" && opts.Cmd[1] === "new-session" && opts.Cmd.includes("-A");
 			if (!isAttach) {
 				// Fall through to the default fake for one-shots.
 				return (origExec as (...a: unknown[]) => Promise<FakeExec>).apply(container, [opts]);
@@ -249,8 +275,15 @@ describe("DockerManager shared-exec multiplexing", () => {
 			const stream = new PassThrough();
 			container._streams.push(stream);
 			const exec: FakeExec = {
-				start: vi.fn(() => new Promise<PassThrough>((r) => { resolveAttachStart = r; })),
-				resize: vi.fn(async () => { /* noop */ }),
+				start: vi.fn(
+					() =>
+						new Promise<PassThrough>((r) => {
+							resolveAttachStart = r;
+						}),
+				),
+				resize: vi.fn(async () => {
+					/* noop */
+				}),
 				inspect: vi.fn(async () => ({ ExitCode: 0 })),
 				_resizes: [],
 				_stream: stream,
@@ -260,8 +293,26 @@ describe("DockerManager shared-exec multiplexing", () => {
 			return exec;
 		}) as typeof origExec;
 
-		const p1 = dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test");
-		const p2 = dm.attach("s1", "a2", 80, 24, () => { /* noop */ }, "tab-test");
+		const p1 = dm.attach(
+			"s1",
+			"a1",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
+		const p2 = dm.attach(
+			"s1",
+			"a2",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
 
 		// Both calls are now awaiting the same spawnSharedExec promise — exactly
 		// one attach exec has been requested on the wire.
@@ -312,9 +363,36 @@ describe("DockerManager shared-exec multiplexing", () => {
 	it("resizes the shared exec to min(cols) × min(rows) and recomputes on detach", async () => {
 		const { dm, container } = makeDocker();
 
-		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test");
-		await dm.attach("s1", "a2", 120, 36, () => { /* noop */ }, "tab-test");
-		await dm.attach("s1", "a3", 100, 30, () => { /* noop */ }, "tab-test");
+		await dm.attach(
+			"s1",
+			"a1",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
+		await dm.attach(
+			"s1",
+			"a2",
+			120,
+			36,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
+		await dm.attach(
+			"s1",
+			"a3",
+			100,
+			30,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
 
 		const resizes = container._execs[0]!._resizes;
 		expect(resizes[resizes.length - 1]).toEqual({ h: 24, w: 80 });
@@ -339,7 +417,16 @@ describe("DockerManager shared-exec multiplexing", () => {
 			},
 		});
 
-		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test");
+		await dm.attach(
+			"s1",
+			"a1",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
 		const attachStream = mustFind(container._execs, isAttachExec, "attach exec")._stream;
 		attachStream.write("abc");
 		await tick();
@@ -374,12 +461,22 @@ describe("DockerManager shared-exec multiplexing", () => {
 		// that nothing ever drains — unless attach() explicitly tears down
 		// on failure. Simulate that by making updateConnected reject.
 		const sessions = makeFakeSessions();
-		(sessions.updateConnected as unknown as ReturnType<typeof vi.fn>)
-			.mockRejectedValueOnce(new Error("db down"));
+		(sessions.updateConnected as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error("db down"),
+		);
 		const { dm, container } = makeDocker({ sessions });
 
 		await expect(
-			dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test"),
+			dm.attach(
+				"s1",
+				"a1",
+				80,
+				24,
+				() => {
+					/* noop */
+				},
+				"tab-test",
+			),
 		).rejects.toThrow("db down");
 		// detach() schedules the listeners.delete on a microtask via
 		// pending.then, so wait one tick before asserting. The "last
@@ -413,9 +510,7 @@ describe("DockerManager shared-exec multiplexing", () => {
 		const origExec = container.exec;
 		container.exec = vi.fn(async (opts: { Cmd: string[] }) => {
 			const isAttach =
-				opts.Cmd[0] === "tmux"
-				&& opts.Cmd[1] === "new-session"
-				&& opts.Cmd.includes("-A");
+				opts.Cmd[0] === "tmux" && opts.Cmd[1] === "new-session" && opts.Cmd.includes("-A");
 			if (isAttach && !rejectedOnce) {
 				rejectedOnce = true;
 				throw new Error("kaboom");
@@ -423,11 +518,31 @@ describe("DockerManager shared-exec multiplexing", () => {
 			return (origExec as (...a: unknown[]) => Promise<FakeExec>).apply(container, [opts]);
 		}) as typeof origExec;
 
-		await expect(dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-test")).rejects.toThrow("kaboom");
+		await expect(
+			dm.attach(
+				"s1",
+				"a1",
+				80,
+				24,
+				() => {
+					/* noop */
+				},
+				"tab-test",
+			),
+		).rejects.toThrow("kaboom");
 		// Let the .catch handler clear the slot.
 		await tick();
 
-		await dm.attach("s1", "a2", 80, 24, () => { /* noop */ }, "tab-test");
+		await dm.attach(
+			"s1",
+			"a2",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
 		// One throw + one success = two attach execs requested.
 		expect(countAttachExecs(container)).toBe(2);
 	});
@@ -529,7 +644,16 @@ describe("DockerManager tabs", () => {
 			oneShot: () => ({ stdout: "", exitCode: 0 }),
 		});
 
-		await dm.attach("s1", "a1", 80, 24, () => { /* noop */ }, "tab-x");
+		await dm.attach(
+			"s1",
+			"a1",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-x",
+		);
 
 		const bufKey = "s1:tab-x";
 		expect((dm as unknown as { shared: Map<string, unknown> }).shared.has(bufKey)).toBe(true);
@@ -538,7 +662,11 @@ describe("DockerManager tabs", () => {
 		await tick();
 
 		// tmux kill-session got called with the right target.
-		const killCmd = mustFind(container._execs, (e) => e._cmd.includes("kill-session"), "kill-session exec");
+		const killCmd = mustFind(
+			container._execs,
+			(e) => e._cmd.includes("kill-session"),
+			"kill-session exec",
+		);
 		expect(killCmd._cmd).toEqual(["tmux", "kill-session", "-t", "tab-x"]);
 
 		// The shared exec slot for that tab is gone.
@@ -546,7 +674,6 @@ describe("DockerManager tabs", () => {
 		// keyOf mapping for the detached attach is cleared.
 		expect((dm as unknown as { keyOf: Map<string, string> }).keyOf.has("a1")).toBe(false);
 	});
-
 });
 
 describe("DockerManager.reconcile", () => {
@@ -566,7 +693,9 @@ describe("DockerManager.reconcile", () => {
 		const dm = new DockerManager(sessions);
 		(dm as unknown as { docker: unknown }).docker = {
 			getContainer: vi.fn(() => ({
-				inspect: vi.fn(async () => { throw err; }),
+				inspect: vi.fn(async () => {
+					throw err;
+				}),
 			})),
 		};
 		return { dm, sessions };
@@ -624,7 +753,7 @@ describe("DockerManager.reconcile", () => {
 	}
 
 	it("warns when reconcile inspects a running pre-#15 container (no CapDrop/SecurityOpt)", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const { dm, sessions } = makeDockerWithInspectResult({
 			State: { Running: true },
 			HostConfig: { CapDrop: [], SecurityOpt: [] },
@@ -652,7 +781,7 @@ describe("DockerManager.reconcile", () => {
 		// migration footgun surfaces even on containers that happen to be
 		// dead at reconcile time — they'll be respawned later, and the
 		// operator needs to know the old image is involved.
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const { dm, sessions } = makeDockerWithInspectResult({
 			State: { Running: false },
 			HostConfig: { CapDrop: [], SecurityOpt: [] },
@@ -671,7 +800,7 @@ describe("DockerManager.reconcile", () => {
 	});
 
 	it("does not warn for properly hardened containers", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const { dm } = makeDockerWithInspectResult({
 			State: { Running: true },
 			HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
@@ -694,7 +823,7 @@ describe("DockerManager.startContainer", () => {
 	// reached this way must surface the same warn as reconcile so a future
 	// refactor can't silently drop the call.
 	it("warns when starting an existing pre-#15 container (Case 2)", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const sessions = makeFakeSessions();
 		const dm = new DockerManager(sessions);
 		(dm as unknown as { docker: unknown }).docker = {
@@ -703,7 +832,9 @@ describe("DockerManager.startContainer", () => {
 					State: { Running: false },
 					HostConfig: { CapDrop: [], SecurityOpt: [] },
 				})),
-				start: vi.fn(async () => { /* started */ }),
+				start: vi.fn(async () => {
+					/* started */
+				}),
 			})),
 		};
 
@@ -912,7 +1043,7 @@ describe("sanitiseHostname", () => {
 		// 62 'a's + '-' + 'rest' is 67 chars; charset-replace is a no-op,
 		// slice(0,63) cuts to "aa…aa-" (62 'a' + '-'), strip trims the
 		// trailing dash — Docker would otherwise refuse the hostname.
-		const longWithDashAtBoundary = "a".repeat(62) + "-rest";
+		const longWithDashAtBoundary = `${"a".repeat(62)}-rest`;
 		const out = sanitiseHostname(longWithDashAtBoundary, sid);
 		expect(out).toBe("a".repeat(62));
 		expect(out.length).toBe(62);

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -33,29 +33,29 @@ const WORKSPACE_GID = Number.parseInt(process.env.WORKSPACE_GID ?? "1000", 10);
 // (workspace files survive soft-delete). Default is 1 GB; ample for legit
 // "drop a few screenshots" usage, well below host-disk-fill range.
 const UPLOAD_QUOTA_BYTES = (() => {
-        const raw = process.env.UPLOAD_QUOTA_BYTES;
-        if (!raw) return 1024 * 1024 * 1024;
-        const n = Number.parseInt(raw, 10);
-        return Number.isFinite(n) && n > 0 ? n : 1024 * 1024 * 1024;
+	const raw = process.env.UPLOAD_QUOTA_BYTES;
+	if (!raw) return 1024 * 1024 * 1024;
+	const n = Number.parseInt(raw, 10);
+	return Number.isFinite(n) && n > 0 ? n : 1024 * 1024 * 1024;
 })();
 
 export class UploadQuotaExceededError extends Error {
-        readonly quota: number;
-        readonly used: number;
-        readonly attempted: number;
-        constructor(used: number, attempted: number, quota: number) {
-                // Generic, byte-count-free message — handleSessionError ships
-                // err.message verbatim as the 413 body, so anything precise
-                // here would leak the same per-session usage that route's
-                // structured-field suppression is meant to hide. Server-side
-                // logging happens in writeUploads at the throw site so the
-                // operator still has the detail for capacity planning.
-                super("Per-session upload quota exceeded. Delete files from uploads/ to free space.");
-                this.name = "UploadQuotaExceededError";
-                this.used = used;
-                this.attempted = attempted;
-                this.quota = quota;
-        }
+	readonly quota: number;
+	readonly used: number;
+	readonly attempted: number;
+	constructor(used: number, attempted: number, quota: number) {
+		// Generic, byte-count-free message — handleSessionError ships
+		// err.message verbatim as the 413 body, so anything precise
+		// here would leak the same per-session usage that route's
+		// structured-field suppression is meant to hide. Server-side
+		// logging happens in writeUploads at the throw site so the
+		// operator still has the detail for capacity planning.
+		super("Per-session upload quota exceeded. Delete files from uploads/ to free space.");
+		this.name = "UploadQuotaExceededError";
+		this.used = used;
+		this.attempted = attempted;
+		this.quota = quota;
+	}
 }
 
 // Opt-in: repair ownership on pre-existing *contents* under the session
@@ -69,22 +69,21 @@ export class UploadQuotaExceededError extends Error {
 //     want to pay that cost on every spawn.
 // Flip on for one boot, restart the affected sessions, flip off again.
 const WORKSPACE_CHOWN_RECURSIVE =
-        process.env.WORKSPACE_CHOWN_RECURSIVE === "true"
-        || process.env.WORKSPACE_CHOWN_RECURSIVE === "1";
+	process.env.WORKSPACE_CHOWN_RECURSIVE === "true" || process.env.WORKSPACE_CHOWN_RECURSIVE === "1";
 
 export interface ExecHandle {
-        execId: string;
-        stream: Duplex;
-        resize(cols: number, rows: number): Promise<void>;
-        destroy(): void;
+	execId: string;
+	stream: Duplex;
+	resize(cols: number, rows: number): Promise<void>;
+	destroy(): void;
 }
 
 export type OutputListener = (data: string) => void;
 
 export interface Tab {
-        tabId: string;      // tmux session name inside the container (e.g. "tab-abc12345")
-        label: string;      // display label (tmux user-option @tab-label)
-        createdAt: number;  // unix seconds
+	tabId: string; // tmux session name inside the container (e.g. "tab-abc12345")
+	label: string; // display label (tmux user-option @tab-label)
+	createdAt: number; // unix seconds
 }
 
 // One shared `tmux attach` exec per target key. All WS clients pointing at the
@@ -92,1142 +91,1260 @@ export interface Tab {
 // output to every attached client, so if we made one exec per client, each
 // byte would fan out N times.
 interface SharedExec {
-        execId: string;
-        stream: Duplex;
-        resize(cols: number, rows: number): Promise<void>;
-        listeners: Map<string /*attachId*/, OutputListener>;
-        clientSizes: Map<string /*attachId*/, { cols: number; rows: number }>;
-        appliedSize: { cols: number; rows: number };
+	execId: string;
+	stream: Duplex;
+	resize(cols: number, rows: number): Promise<void>;
+	listeners: Map<string /*attachId*/, OutputListener>;
+	clientSizes: Map<string /*attachId*/, { cols: number; rows: number }>;
+	appliedSize: { cols: number; rows: number };
 }
 
 export class DockerManager {
-        private docker: Dockerode;
-        private sessions: SessionManager;
-        private shared = new Map<string /*targetKey*/, Promise<SharedExec>>();
-        private keyOf = new Map<string /*attachId*/, string /*targetKey*/>();
-        // Serialises writeUploads calls per session so the quota check
-        // (read existing + add new) can't race two concurrent requests
-        // and let both pass with the same usedBytes snapshot. Entries
-        // self-clean when the chain head finishes.
-        private uploadLocks = new Map<string /*sessionId*/, Promise<void>>();
-
-        constructor(sessions: SessionManager, dockerOpts?: Dockerode.DockerOptions) {
-                // docker-modem reads DOCKER_HOST from the environment ONLY when the
-                // caller passes no connection options at all. The previous default
-                // of `{ socketPath: "/var/run/docker.sock" }` therefore silently
-                // shadowed DOCKER_HOST, which matters for the docker-socket-proxy
-                // deployment shape (overlay sets DOCKER_HOST=tcp://proxy:2375 and
-                // drops the bind mount). Behaviour: explicit `dockerOpts` always
-                // wins (tests rely on this); otherwise honour DOCKER_HOST when
-                // present; finally fall back to the canonical Unix socket so the
-                // default docker-compose.yml stack still works untouched.
-                const defaultOpts: Dockerode.DockerOptions | undefined = process.env.DOCKER_HOST
-                        ? undefined
-                        : { socketPath: "/var/run/docker.sock" };
-                this.docker = new Dockerode(dockerOpts ?? defaultOpts);
-                this.sessions = sessions;
-        }
-
-        // Each tab inside a session is its own tmux session in the container and
-        // gets its own shared exec. The targetKey is the join key; replay on
-        // reconnect is a tmux capture-pane snapshot (see capturePane()), not a
-        // server-side byte buffer.
-        private targetKey(sessionId: string, tabId: string): string {
-                return `${sessionId}:${tabId}`;
-        }
-
-        // ── Container lifecycle ─────────────────────────────────────────────────
-
-        async spawn(sessionId: string): Promise<string> {
-                const meta = await this.sessions.getOrThrow(sessionId);
-                const envArray = Object.entries(meta.envVars).map(([k, v]) => `${k}=${v}`);
-
-                // Pre-create the bind-mount target so Docker doesn't auto-create it
-                // as root. See `ensureWorkspaceOwnership` for the full story and the
-                // non-recursive invariant.
-                const workspaceDir = path.join(WORKSPACE_ROOT, sessionId);
-                await fs.mkdir(workspaceDir, { recursive: true });
-                await this.ensureWorkspaceOwnership(workspaceDir);
-
-                // Pre-create the per-session uploads dir at its OUT-OF-WORKSPACE
-                // location and bind-mount it read-only into the container at
-                // /home/developer/workspace/uploads/. Critical TOCTOU defence:
-                // because the container's view is a mount point, the container
-                // can NOT replace, rename, or rmdir the uploads/ entry from
-                // inside (the kernel rejects any modification to a mount point
-                // from the mount user's namespace). Read-only also stops the
-                // container from writing/modifying uploaded files, so an
-                // attacker can't poison files between writes — combined with
-                // writeUploads' atomic rename from .tmp-uploads/ into
-                // .uploads/<sessionId>/, the symlink-swap attack window the
-                // older in-workspace layout had is closed structurally.
-                const uploadsHostDir = path.join(WORKSPACE_ROOT, ".uploads", sessionId);
-                await fs.mkdir(uploadsHostDir, { recursive: true });
-                // No chown — backend (typically root) owns the dir, container
-                // reads via the read-only mount; no need for it to own anything.
-
-                const hostname = sanitiseHostname(meta.name, sessionId);
-                const container = await this.docker.createContainer({
-                        Image: SESSION_IMAGE,
-                        name: meta.containerName,
-                        Hostname: hostname,
-                        Env: [
-                                `SESSION_ID=${sessionId}`,
-                                `SESSION_NAME=${meta.name}`,
-                                `TERM=xterm-256color`,
-                                `COLORTERM=truecolor`,
-                                ...envArray,
-                        ],
-                        HostConfig: {
-                                Binds: [
-                                        `${WORKSPACE_ROOT}/${sessionId}:/home/developer/workspace`,
-                                        `${uploadsHostDir}:/home/developer/workspace/uploads:ro`,
-                                ],
-                                Memory: 2 * 1024 * 1024 * 1024,
-                                NanoCpus: 2_000_000_000,
-                                RestartPolicy: { Name: "unless-stopped" },
-                                // Defense-in-depth (issue #15): the image already runs as
-                                // unprivileged UID 1000 with no sudo, but we still strip
-                                // every Linux capability from the bounding set Docker
-                                // hands the container. None of tmux, node, git,
-                                // claude-code, or `code tunnel` need any of the default
-                                // bag (e.g. CAP_NET_RAW for raw sockets / ICMP,
-                                // CAP_NET_BIND_SERVICE for ports < 1024, CAP_AUDIT_WRITE,
-                                // CAP_MKNOD), so dropping ALL is the tightest baseline.
-                                // Note: this is about the *container's* bounding set,
-                                // not the backend host process — host-side chowns in
-                                // ensureWorkspaceOwnership rely on the backend's own
-                                // CAP_CHOWN and are unaffected. Pair with
-                                // no-new-privileges so even if a future image change
-                                // reintroduces a setuid binary it cannot raise
-                                // effective UID/caps at exec time.
-                                CapDrop: ["ALL"],
-                                SecurityOpt: ["no-new-privileges:true"],
-                        },
-                        OpenStdin: true,
-                        Tty: true,
-                });
-
-                await container.start();
-                const containerId = container.id;
-                await this.sessions.setContainerId(sessionId, containerId);
-
-                console.log(`[docker] spawned container ${meta.containerName} (${containerId.slice(0, 12)}) for session ${sessionId}`);
-                return containerId;
-        }
-
-        /**
-         * Apply `WORKSPACE_UID:WORKSPACE_GID` to the session workspace.
-         *
-         * By default this chowns only the top-level directory, not its contents.
-         * The invariant is "freshly-created or already correctly-owned": nested
-         * files are assumed to have been written by the container itself (so they
-         * already have the right owner). If the operator set
-         * WORKSPACE_CHOWN_RECURSIVE=true we also walk descendants — useful for
-         * one-shot repair of workspaces left inconsistent by an earlier version
-         * that let Docker create the bind source root-owned.
-         *
-         * All chown calls downgrade EPERM/ENOSYS to a warning so unprivileged
-         * dev mode still works; any other errno is re-thrown so we don't
-         * silently boot a session with a broken workspace.
-         */
-        private async ensureWorkspaceOwnership(dir: string): Promise<void> {
-                await this.chownToWorkspaceUser(dir);
-
-                if (!WORKSPACE_CHOWN_RECURSIVE) return;
-
-                // Walk the tree iteratively (not recursively) to avoid stack
-                // growth on deep workspaces. `withFileTypes: true` avoids a stat
-                // per entry. Symlinks are chowned in place (lchown-equivalent)
-                // so we don't follow them out of the workspace root.
-                const stack: string[] = [dir];
-                while (stack.length > 0) {
-                        // `pop()` returns `T | undefined`. The while condition
-                        // already guarantees the stack is non-empty, so the
-                        // undefined branch is unreachable — but we check anyway to
-                        // satisfy biome's no-non-null-assertion rule and to keep
-                        // the code safe if the loop header is ever refactored (e.g.
-                        // changed to `while (true)`) without re-analysing the
-                        // invariant.
-                        const current = stack.pop();
-                        if (current === undefined) break;
-                        let entries: Dirent[];
-                        try {
-                                entries = await fs.readdir(current, { withFileTypes: true });
-                        } catch (err) {
-                                const code = (err as NodeJS.ErrnoException).code;
-                                // A sibling-modified workspace (file removed mid-walk) shouldn't
-                                // abort the whole repair; log and keep going.
-                                if (code === "ENOENT" || code === "ENOTDIR") continue;
-                                throw err;
-                        }
-                        for (const entry of entries) {
-                                const full = path.join(current, entry.name);
-                                await this.chownToWorkspaceUser(full);
-                                if (entry.isDirectory() && !entry.isSymbolicLink()) {
-                                        stack.push(full);
-                                }
-                        }
-                }
-        }
-
-        /**
-         * chown a single path to WORKSPACE_UID:WORKSPACE_GID. Downgrades
-         * EPERM/ENOSYS to a warning (unprivileged dev mode), re-throws
-         * everything else so a real broken-workspace error doesn't get
-         * swallowed. Shared by the spawn-time ownership pass and the
-         * upload writer below.
-         */
-        private async chownToWorkspaceUser(target: string): Promise<void> {
-                try {
-                        await fs.chown(target, WORKSPACE_UID, WORKSPACE_GID);
-                } catch (err) {
-                        const code = (err as NodeJS.ErrnoException).code;
-                        if (code === "EPERM" || code === "ENOSYS") {
-                                console.warn(
-                                        `[docker] couldn't chown ${target} to ${WORKSPACE_UID}:${WORKSPACE_GID} (${code}); ` +
-                                        `run the backend as root or pre-create paths with matching ownership.`,
-                                );
-                        } else {
-                                throw err;
-                        }
-                }
-        }
-
-        /**
-         * Save uploaded files into the session workspace under `uploads/`
-         * and return their in-container paths. Caller must have already
-         * verified ownership of `sessionId`.
-         *
-         * Filenames are sanitised to a safe basename and prefixed with a
-         * monotonic timestamp + short random suffix so concurrent uploads
-         * of the same name don't clobber each other. The host path of
-         * every write is `path.resolve()`d and verified to sit inside the
-         * uploads directory before any rename — the sanitiser already
-         * strips path separators, but the resolve-and-check is a defence-
-         * in-depth belt against a future regression. Concurrent calls for
-         * the same session are serialised via `uploadLocks` so the quota
-         * check (read-then-write) can't race itself.
-         */
-        async writeUploads(
-                sessionId: string,
-                files: ReadonlyArray<{ originalname: string; path: string }>,
-        ): Promise<string[]> {
-                if (files.length === 0) return [];
-                // Per-session serialisation. Synchronously chain a new lock
-                // *before* awaiting the prior one, so a concurrent call sees
-                // the chained lock — not an empty slot — and waits behind us.
-                const prior = this.uploadLocks.get(sessionId);
-                let release: () => void = () => { /* set below */ };
-                const ours = new Promise<void>((r) => { release = r; });
-                const newLock = prior ? prior.then(() => ours, () => ours) : ours;
-                this.uploadLocks.set(sessionId, newLock);
-                if (prior) await prior.catch(() => { /* ignore prior errors */ });
-                try {
-                        return await this.writeUploadsImpl(sessionId, files);
-                } finally {
-                        release();
-                        // Clean up if we're still the head — i.e. no later caller
-                        // chained on. Stops the map from growing without bound
-                        // for sessions that aren't actively uploading.
-                        if (this.uploadLocks.get(sessionId) === newLock) {
-                                this.uploadLocks.delete(sessionId);
-                        }
-                }
-        }
-
-        private async writeUploadsImpl(
-                sessionId: string,
-                files: ReadonlyArray<{ originalname: string; path: string }>,
-        ): Promise<string[]> {
-                // Architectural TOCTOU fix: the uploads directory lives at
-                // <WORKSPACE_ROOT>/.uploads/<sessionId>/ — OUTSIDE the
-                // container's bind-mount tree. spawn() bind-mounts this dir
-                // read-only into the container at /home/developer/workspace/
-                // uploads/, so:
-                //   1. The container CANNOT remove or replace /home/developer/
-                //      workspace/uploads (it's a mount point — kernel rejects
-                //      modification from the mount user's namespace).
-                //   2. The container CANNOT write into uploads/ (read-only mount).
-                //   3. The container's bind mount on /home/developer/workspace/
-                //      doesn't reach .uploads/ on the host, so nothing inside
-                //      the container can plant symlinks at the upload destination.
-                // The earlier in-workspace layout needed a stack of defences
-                // (realpath, O_DIRECTORY|O_NOFOLLOW, pre+post inode sentinels)
-                // because the container could replace uploads/ with a symlink
-                // and race rename(2). With the new layout that whole class of
-                // attacks is structurally impossible, so the per-rename TOCTOU
-                // machinery is gone. The lexical containment check stays as a
-                // belt against any future regression that lets a non-UUID
-                // sessionId reach this method.
-                const uploadsHostDir = path.join(WORKSPACE_ROOT, ".uploads", sessionId);
-                // Containment check: must resolve under <WORKSPACE_ROOT>/.uploads/,
-                // not just under WORKSPACE_ROOT. A traversal-shaped sessionId
-                // like "../escape" would otherwise let path.join collapse to
-                // <WORKSPACE_ROOT>/escape — still under WORKSPACE_ROOT but
-                // outside the per-session uploads namespace.
-                const uploadsBaseAbs = path.resolve(WORKSPACE_ROOT, ".uploads");
-                const uploadsHostDirAbs = path.resolve(uploadsHostDir);
-                if (!uploadsHostDirAbs.startsWith(`${uploadsBaseAbs}${path.sep}`)) {
-                        await this.cleanupTmp(files);
-                        throw new Error(`unsafe session path resolved outside ${uploadsBaseAbs}: ${uploadsHostDirAbs}`);
-                }
-                // spawn() pre-creates this dir, but a writeUploads call for a
-                // session that has been spawned but not running (or for one
-                // started before this code shipped) needs us to create it
-                // here too. recursive: true is a no-op when it already exists.
-                await fs.mkdir(uploadsHostDir, { recursive: true });
-
-                // Per-session disk-quota check: count current bytes in
-                // uploads/ + bytes about to be added; reject before moving any
-                // tmp file if the cap would be exceeded. Sum-of-statSize is a
-                // tight enough approximation — uploads/ is always one level
-                // deep (writeUploads only writes flat) so no recursion.
-                // lstat (not stat) so any stale symlink left over from the
-                // previous in-workspace layout — or one a future bug plants
-                // here — counts as zero bytes (st.isFile() is false for
-                // symlinks) rather than inflating the quota with the
-                // target's size.
-                let usedBytes = 0;
-                try {
-                        const existing = await fs.readdir(uploadsHostDir);
-                        for (const entry of existing) {
-                                const st = await fs.lstat(path.join(uploadsHostDir, entry));
-                                if (st.isFile()) usedBytes += st.size;
-                        }
-                } catch (err) {
-                        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-                }
-                let attemptedBytes = 0;
-                for (const file of files) {
-                        const stat = await fs.stat(file.path);
-                        attemptedBytes += stat.size;
-                }
-                if (usedBytes + attemptedBytes > UPLOAD_QUOTA_BYTES) {
-                        // Log the detail server-side; the thrown error carries
-                        // a generic message so byte counts don't ride out in
-                        // the 413 body to the client.
-                        console.warn(
-                                `[docker] upload quota rejected for session ${sessionId}: ` +
-                                `${usedBytes} used + ${attemptedBytes} attempted > ${UPLOAD_QUOTA_BYTES} cap`,
-                        );
-                        await this.cleanupTmp(files);
-                        throw new UploadQuotaExceededError(usedBytes, attemptedBytes, UPLOAD_QUOTA_BYTES);
-                }
-
-                const containerPaths: string[] = [];
-                const now = Date.now().toString(36);
-                // Track which multer tmp files we've successfully moved so
-                // the finally block can clean up anything we didn't get to.
-                const remaining = new Set(files.map((f) => f.path));
-                try {
-                        for (const file of files) {
-                                const safeBase = sanitiseUploadName(file.originalname);
-                                // Random suffix on top of the timestamp so two
-                                // uploads landing in the same millisecond don't
-                                // collide.
-                                const suffix = randomBytes(3).toString("hex");
-                                const filename = `${now}-${suffix}-${safeBase}`;
-                                const finalPath = path.join(uploadsHostDir, filename);
-                                const finalPathAbs = path.resolve(finalPath);
-                                // Defence-in-depth per-file containment: the
-                                // sanitiser already strips path separators so
-                                // sanitiseUploadName(x) can never escape the
-                                // dir, but resolve+startsWith is one extra
-                                // line of insurance against a future regression
-                                // in the sanitiser.
-                                if (!finalPathAbs.startsWith(`${uploadsHostDirAbs}${path.sep}`)) {
-                                        throw new Error(`unsafe upload path resolved outside ${uploadsHostDirAbs}: ${finalPathAbs}`);
-                                }
-                                // chmod + chown the multer tmp file BEFORE the
-                                // rename. rename(2) preserves mode + owner at
-                                // the destination, so the file lands in
-                                // uploads/ with mode 0644 owned by uid 1000
-                                // (the container user). With the read-only
-                                // bind mount the container can read but not
-                                // modify the file — chowning to uid 1000 is
-                                // mostly cosmetic now but keeps the in-
-                                // container `ls -l` output consistent with the
-                                // rest of the workspace.
-                                await fs.chmod(file.path, 0o644);
-                                await this.chownToWorkspaceUser(file.path);
-                                // Atomic same-filesystem move from the multer
-                                // tmp dir to the per-session uploads dir.
-                                await fs.rename(file.path, finalPath);
-                                remaining.delete(file.path);
-                                containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
-                        }
-                } finally {
-                        await this.cleanupTmp([...remaining].map((p) => ({ originalname: "", path: p })));
-                }
-                return containerPaths;
-        }
-
-        /**
-         * Absolute host path where multer streams uploaded bodies before
-         * `writeUploads` moves them to their final per-session location.
-         * Lives directly under WORKSPACE_ROOT (NOT inside any session
-         * subdirectory) so it's never bind-mounted into a container, and
-         * `fs.rename` from here to the final path is a same-filesystem
-         * atomic move.
-         */
-        getUploadTmpDir(): string {
-                return path.join(WORKSPACE_ROOT, ".tmp-uploads");
-        }
-
-        // Best-effort cleanup of multer's on-disk temp files. Used on the
-        // bail-out paths in writeUploads (containment-check failure, mid-loop
-        // throw). Each unlink is independently swallowed because the only
-        // failure modes here are "file already gone" or "no permission" —
-        // neither is something the upload caller should hear about.
-        private async cleanupTmp(
-                files: ReadonlyArray<{ path: string }>,
-        ): Promise<void> {
-                await Promise.allSettled(files.map((f) => fs.unlink(f.path)));
-        }
-
-        async kill(sessionId: string): Promise<void> {
-                const meta = await this.sessions.get(sessionId);
-
-                if (meta?.containerId) {
-                        try {
-                                const container = this.docker.getContainer(meta.containerId);
-                                try { await container.stop({ t: 5 }); } catch { /* already stopped */ }
-                                // `v: true` also removes any anonymous volumes attached to the
-                                // container (bind mounts are unaffected — those are cleaned by
-                                // purgeWorkspace on hard delete).
-                                try { await container.remove({ force: true, v: true }); } catch { /* already removed */ }
-                        } catch (err) {
-                                console.error(`[docker] error killing container for session ${sessionId}:`, (err as Error).message);
-                        }
-                        // The container no longer exists in Docker — reflect that in D1 so any
-                        // later lookup doesn't chase a dead container id.
-                        try {
-                                await this.sessions.setContainerId(sessionId, null);
-                        } catch (err) {
-                                console.error(`[docker] failed to null container_id for session ${sessionId}:`, (err as Error).message);
-                        }
-                }
-
-                // Destroy any shared exec and per-attach routing for this session.
-                // Match on equality or on `sessionId:…` prefix so this keeps working
-                // once per-tab targetKeys (sessionId:windowId) exist.
-                const prefix = `${sessionId}:`;
-                for (const [key, pending] of this.shared) {
-                        if (key === sessionId || key.startsWith(prefix)) {
-                                this.shared.delete(key);
-                                pending.then(
-                                        (s) => { try { s.stream.destroy(); } catch { /* already destroyed */ } },
-                                        () => { /* spawn rejected — nothing to destroy */ },
-                                );
-                        }
-                }
-                for (const [attachId, key] of this.keyOf) {
-                        if (key === sessionId || key.startsWith(prefix)) {
-                                this.keyOf.delete(attachId);
-                        }
-                }
-                console.log(`[docker] killed container for session ${sessionId}`);
-        }
-
-        /**
-         * Delete the bind-mounted workspace directory for a session.
-         *
-         * This is intentionally strict about the path it will remove: it refuses
-         * to touch anything that does not resolve to a child of WORKSPACE_ROOT.
-         * Missing directories are a no-op (idempotent hard delete).
-         */
-        async purgeWorkspace(sessionId: string): Promise<void> {
-                const rootAbs = path.resolve(WORKSPACE_ROOT);
-                const sessionAbs = path.resolve(path.join(WORKSPACE_ROOT, sessionId));
-                const uploadsAbs = path.resolve(path.join(WORKSPACE_ROOT, ".uploads", sessionId));
-
-                // Safety: both resolved dirs must be strict children of rootAbs.
-                if (!sessionAbs.startsWith(rootAbs + path.sep)) {
-                        throw new Error(
-                                `[docker] refusing to purge workspace outside root (root=${rootAbs}, target=${sessionAbs})`,
-                        );
-                }
-                if (!uploadsAbs.startsWith(rootAbs + path.sep)) {
-                        throw new Error(
-                                `[docker] refusing to purge uploads outside root (root=${rootAbs}, target=${uploadsAbs})`,
-                        );
-                }
-
-                try {
-                        await fs.rm(sessionAbs, { recursive: true, force: true });
-                        console.log(`[docker] purged workspace dir ${sessionAbs}`);
-                } catch (err) {
-                        console.error(`[docker] failed to purge workspace ${sessionAbs}:`, (err as Error).message);
-                        throw err;
-                }
-                // Per-session uploads dir lives at <WORKSPACE_ROOT>/.uploads/<sessionId>/
-                // (out-of-workspace TOCTOU isolation — see writeUploadsImpl). Hard
-                // delete must clean this too or uploaded files would persist
-                // forever for a row that no longer exists in D1.
-                try {
-                        await fs.rm(uploadsAbs, { recursive: true, force: true });
-                        console.log(`[docker] purged uploads dir ${uploadsAbs}`);
-                } catch (err) {
-                        console.error(`[docker] failed to purge uploads ${uploadsAbs}:`, (err as Error).message);
-                        throw err;
-                }
-        }
-
-        async isAlive(sessionId: string): Promise<boolean> {
-                const meta = await this.sessions.get(sessionId);
-                if (!meta?.containerId) return false;
-                try {
-                        const info = await this.docker.getContainer(meta.containerId).inspect();
-                        return info.State.Running === true;
-                } catch {
-                        return false;
-                }
-        }
-
-        async startContainer(sessionId: string): Promise<void> {
-                const meta = await this.sessions.getOrThrow(sessionId);
-
-                // Case 1: no container exists (terminated session, or one whose container
-                // was removed out-of-band). Spawn a fresh container reusing the existing
-                // container name + workspace bind mount.
-                if (!meta.containerId) {
-                        await this.spawn(sessionId);
-                        await this.sessions.updateStatus(sessionId, "running");
-                        console.log(`[docker] respawned container for session ${sessionId}`);
-                        return;
-                }
-
-                // Case 2: container id is on file. Check it still exists in Docker; if it
-                // does, just start it. If Docker has no record of it, forget the stale id
-                // and spawn a replacement.
-                try {
-                        const info = await this.docker.getContainer(meta.containerId).inspect();
-                        this.warnIfPreHardened(sessionId, meta.containerId, info.HostConfig);
-                        if (!info.State.Running) {
-                                await this.docker.getContainer(meta.containerId).start();
-                        }
-                        await this.sessions.updateStatus(sessionId, "running");
-                        console.log(`[docker] restarted container for session ${sessionId}`);
-                } catch {
-                        console.log(`[docker] stale container_id for session ${sessionId}, respawning`);
-                        await this.sessions.setContainerId(sessionId, null);
-                        await this.spawn(sessionId);
-                        await this.sessions.updateStatus(sessionId, "running");
-                }
-        }
-
-        // Detects containers that predate the issue-#15 hardening. Docker pins
-        // HostConfig at create time, so `container.start()` re-uses the original
-        // CapDrop / SecurityOpt regardless of what spawn() would set today. An
-        // operator who deploys this build and only stop+starts (instead of
-        // DELETE + POST /start) ends up with sessions that look fine but still
-        // have full Linux caps and a setuid sudo from the old image. This helper
-        // is the choke point for surfacing that mistake — call it from any code
-        // path that inspects an existing container so the migration footgun
-        // shows up in `docker logs` instead of failing silently.
-        private warnIfPreHardened(
-                sessionId: string,
-                containerId: string,
-                hostConfig: { CapDrop?: string[] | null; SecurityOpt?: string[] | null } | undefined,
-        ): void {
-                const capDrop = hostConfig?.CapDrop ?? [];
-                const securityOpt = hostConfig?.SecurityOpt ?? [];
-                if (capDrop.includes("ALL") && securityOpt.includes("no-new-privileges:true")) return;
-                console.warn(
-                        `[docker] session ${sessionId} container ${containerId.slice(0, 12)} ` +
-                        `predates issue-#15 hardening (CapDrop=${JSON.stringify(capDrop)}, ` +
-                        `SecurityOpt=${JSON.stringify(securityOpt)}). ` +
-                        `Recycle via DELETE /api/sessions/${sessionId} then POST /start to apply current HostConfig.`,
-                );
-        }
-
-        async stopContainer(sessionId: string): Promise<void> {
-                const meta = await this.sessions.getOrThrow(sessionId);
-                if (!meta.containerId) return;
-                try {
-                        await this.docker.getContainer(meta.containerId).stop({ t: 5 });
-                } catch { /* already stopped */ }
-                await this.sessions.updateStatus(sessionId, "stopped");
-                console.log(`[docker] stopped container for session ${sessionId}`);
-        }
-
-        // ── Exec attach ────────────────────────────────────────────────────────
-
-        async attach(
-                sessionId: string,
-                attachId: string,
-                cols: number,
-                rows: number,
-                onOutput: OutputListener,
-                tabId: string,
-        ): Promise<{ handle: ExecHandle; replay: string | null; flushTail: () => void }> {
-                const key = this.targetKey(sessionId, tabId);
-
-                // Reuse the shared exec if one already exists (or is being spawned).
-                // Concurrent first-attach calls await the same promise → exactly one
-                // `container.exec` on the wire.
-                let pending = this.shared.get(key);
-                if (!pending) {
-                        pending = this.spawnSharedExec(sessionId, key, tabId);
-                        // Clear the slot on rejection so the next attach retries.
-                        // `.catch` here doesn't consume the rejection — awaiters on the
-                        // original promise still see it; this handler exists so Node
-                        // doesn't flag an unhandledRejection if the awaiter finishes
-                        // before this microtask.
-                        pending.catch((err) => {
-                                if (this.shared.get(key) === pending) this.shared.delete(key);
-                                console.error(`[docker] shared exec spawn failed for ${key}:`, (err as Error).message);
-                        });
-                        this.shared.set(key, pending);
-                }
-
-                const s = await pending;
-
-                // ── Replay strategy ───────────────────────────────────────────────
-                // We capture the pane's canonical state via `tmux capture-pane -p -e`
-                // and use *that* as the replay payload. This replaces the old
-                // ring-buffer-of-raw-bytes strategy that had two known defects:
-                //
-                //   (a) a 64 KB byte ring hands the client a mid-sequence tail of
-                //       escape codes, so xterm's state (cursor pos, attrs, alt
-                //       screen) could be left inconsistent after replay — classic
-                //       "junk redraw" on reconnect;
-                //   (b) the ring needed bytes accumulated *while at least one other
-                //       client was attached* — reconnecting after a quiet period
-                //       replayed nothing, leaving the user looking at a blank term.
-                //
-                // capture-pane is tmux's own idea of "what is on screen right now"
-                // including colours and cursor attrs (the -e flag), so the replay
-                // is always a valid, self-contained redraw.
-                //
-                // Cost note: capture-pane is a separate `docker exec` per joiner.
-                // N simultaneous reconnecters to a popular session fire N sequential
-                // one-shots against the same container — there's no dedup window.
-                // The per-call cost is small (tens of ms each in practice) and the
-                // joiner already awaited spawnSharedExec, so this isn't on a path
-                // that blocks live bytes for other clients. If it ever becomes an
-                // amplifier we can cache a snapshot per-tab with a short TTL and
-                // hand it out to co-arriving joiners. Not worth the state today.
-                //
-                // ── Live-vs-replay ordering ───────────────────────────────────────
-                // We have to deliver bytes to the client in the correct order: the
-                // replay must land BEFORE any live bytes that arrive afterwards —
-                // otherwise the user sees fresh output get overwritten by a stale
-                // snapshot. Without buffering, these two concurrent streams race:
-                //
-                //   attach() returns → wsHandler sends replay → [live bytes can
-                //   fire between these two steps] → wsHandler sends live delta →
-                //   client paints replay on top of the delta it just rendered.
-                //
-                // To serialise them we arm an "until-flushed" listener BELOW: while
-                // armed it piles live bytes into a local `tail` array instead of
-                // calling onOutput. wsHandler sends the replay payload and THEN
-                // calls flushTail(), which drains the tail in order and flips the
-                // listener to forward-directly. Because flushTail is synchronous
-                // (no awaits, ws.send is sync too) the client-visible sequence
-                // from the moment the listener is registered onward is deterministic:
-                // [captured screen][every live delta in arrival order].
-                //
-                // Residual race we accept: there is a narrow window between when
-                // capture-pane is issued and when the listener below is registered.
-                // Bytes tmux emits during that window are not in the snapshot (they
-                // weren't on the pane when capture-pane ran) AND not in the tail
-                // (the listener wasn't armed yet). The client won't see them until
-                // the next live byte forces a redraw.
-                //
-                // Self-heal timing depends on what the pane is doing:
-                //   - Interactive shell / TUI: the next keystroke echo or cursor
-                //     blink redraws within ~seconds — bytes are deferred, not
-                //     permanently lost.
-                //   - Non-interactive output (a running `tail -f`, a build log, a
-                //     background process writing periodically): the deferred bytes
-                //     stay deferred until the next spontaneous write, which could
-                //     be seconds or minutes away. They DO eventually repaint (the
-                //     missing chars are still on the pane; any subsequent redraw
-                //     of those cells shows them), but the snapshot the joining
-                //     client initially sees is stale for the duration.
-                //   - Fully quiet pane: deferred bytes stay missing from the
-                //     client's view until *something* forces a redraw — e.g. a
-                //     resize, a keystroke, or next attach. The pane is still
-                //     correct server-side; only this client's initial view is
-                //     behind.
-                //
-                // We deliberately don't close this window by arming the listener
-                // BEFORE capture-pane: that would double-render every byte tmux
-                // emitted between `listener registered` and `snapshot captured`,
-                // because those bytes already updated the pane state that ends up
-                // in the snapshot — so the client would see them once in the
-                // snapshot and again in the tail. A byte-correct fix would need
-                // position-aware dedup (snapshot cursor at capture time vs tail
-                // start), which is more machinery than the lost-bytes symptom
-                // warrants in a terminal product.
-                const snapshot = await this.capturePane(sessionId, tabId);
-
-                const tail: string[] = [];
-                let armed = true;
-                const bufferedListener: OutputListener = (data) => {
-                        if (armed) {
-                                tail.push(data);
-                        } else {
-                                try { onOutput(data); } catch { /* downstream error */ }
-                        }
-                };
-
-                s.listeners.set(attachId, bufferedListener);
-                s.clientSizes.set(attachId, { cols, rows });
-                this.keyOf.set(attachId, key);
-
-                // Once the listener is in `s.listeners`, any throw before we return
-                // a handle to the caller would orphan it: wsHandler closes the
-                // socket without knowing attach() got partway through, so detach()
-                // is never called, and the armed `bufferedListener` keeps piling
-                // live bytes into a `tail` array that nothing will ever drain.
-                // recomputeSize swallows exec.resize errors internally today, but
-                // updateConnected is a D1 write that CAN reject — and a future
-                // refactor of either path might start propagating. Make the
-                // post-register teardown explicit instead of hoping the callees
-                // stay infallible.
-                try {
-                        await this.recomputeSize(s);
-                        await this.sessions.updateConnected(sessionId);
-                } catch (err) {
-                        this.detach(attachId);
-                        throw err;
-                }
-                console.log(`[docker] attached ${attachId} to session ${sessionId} (listeners=${s.listeners.size})`);
-
-                const flushTail = () => {
-                        // Drain in arrival order, then flip the gate. Node is
-                        // single-threaded so the for-of loop runs atomically w.r.t.
-                        // stream 'data' events (they queue on the event loop and can't
-                        // interleave with synchronous JS). The order still matters at
-                        // source level though: if we flipped `armed` before draining,
-                        // a later refactor that inserted an await inside the loop (say
-                        // for async onOutput) would let queued 'data' events wake up
-                        // mid-drain and race the tail. Drain-then-flip makes that
-                        // refactor-safe without needing to re-audit the invariant.
-                        for (const chunk of tail) {
-                                try { onOutput(chunk); } catch { /* downstream error */ }
-                        }
-                        tail.length = 0;
-                        armed = false;
-                };
-
-                const handle: ExecHandle = {
-                        execId: attachId,
-                        stream: s.stream,
-                        resize: (c: number, r: number) => this.resize(attachId, c, r),
-                        destroy: () => this.detach(attachId),
-                };
-                return { handle, replay: snapshot.length > 0 ? snapshot : null, flushTail };
-        }
-
-        /**
-         * Dump the tab's active pane as an escape-sequence-preserving snapshot
-         * ready to write directly to an xterm. Returns "" on any failure so
-         * attach() stays robust — a failed snapshot just means the client starts
-         * blank and gets redrawn by the next live activity.
-         *
-         * `-p` prints to stdout (no paste-buffer staging), `-e` preserves colours
-         * and attributes. We deliberately DON'T pass `-S -` to include scrollback:
-         * the client's xterm already has its own scrollback, and dumping a full
-         * history on every reconnect is both expensive and surprising (stale
-         * lines moving up at connect time).
-         */
-        private async capturePane(sessionId: string, tabId: string): Promise<string> {
-                try {
-                        const { stdout, exitCode } = await this.execOneShot(sessionId, [
-                                "tmux", "capture-pane", "-t", tabId, "-p", "-e",
-                        ]);
-                        // A non-zero exit is the common "benign race" path: when
-                        // spawnSharedExec's `new-session -A` has just restarted tmux,
-                        // the server socket may not be ready when capture-pane races
-                        // it — tmux prints "no server running" and exits 1. Returning
-                        // "" here means the client starts with a blank pane and the
-                        // very next byte of live output redraws it. Intentional.
-                        if (exitCode !== 0) return "";
-                        // execOneShot returns clean stdout (no PTY, no \r). For a screen
-                        // dump xterm needs CRLF line terminators — add the \r back.
-                        return stdout.replace(/\n/g, "\r\n");
-                } catch (err) {
-                        console.warn(`[docker] capture-pane failed for ${this.targetKey(sessionId, tabId)}:`, (err as Error).message);
-                        return "";
-                }
-        }
-
-        write(attachId: string, data: string): void {
-                const key = this.keyOf.get(attachId);
-                if (!key) return;
-                const pending = this.shared.get(key);
-                if (!pending) return;
-                // By the time a client sends input, attach() has awaited `pending`,
-                // so it's already resolved — the .then just defensively handles the
-                // not-yet-resolved path. No error handler needed: a rejected spawn
-                // clears the slot above; pending would already be gone.
-                pending.then((s) => {
-                        if (!s.stream.destroyed) s.stream.write(data);
-                }, () => { /* spawn failed; nothing to write to */ });
-        }
-
-        async resize(attachId: string, cols: number, rows: number): Promise<void> {
-                const key = this.keyOf.get(attachId);
-                if (!key) return;
-                const pending = this.shared.get(key);
-                if (!pending) return;
-                const s = await pending.catch(() => null);
-                if (!s) return;
-                if (!s.clientSizes.has(attachId)) return;
-                s.clientSizes.set(attachId, { cols, rows });
-                await this.recomputeSize(s);
-        }
-
-        detach(attachId: string): void {
-                const key = this.keyOf.get(attachId);
-                if (!key) return;
-                this.keyOf.delete(attachId);
-                const pending = this.shared.get(key);
-                if (!pending) return;
-
-                pending.then((s) => {
-                        s.listeners.delete(attachId);
-                        s.clientSizes.delete(attachId);
-
-                        if (s.listeners.size === 0) {
-                                // Last client gone — tear down the shared exec. On next
-                                // attach we respawn and capture-pane replays whatever
-                                // state tmux has kept alive in the container.
-                                if (this.shared.get(key) === pending) this.shared.delete(key);
-                                try { s.stream.destroy(); } catch { /* already destroyed */ }
-                                console.log(`[docker] detached ${attachId}; last client, shared exec closed`);
-                        } else {
-                                // Someone else may have had a smaller terminal; recompute so
-                                // the survivors don't stay pinned to a too-small size.
-                                void this.recomputeSize(s);
-                                console.log(`[docker] detached ${attachId}; ${s.listeners.size} listener(s) remain`);
-                        }
-                }, () => { /* spawn rejected; nothing to detach from */ });
-        }
-
-        // ── Shared exec internals ──────────────────────────────────────────────
-
-        private async spawnSharedExec(sessionId: string, key: string, tabId: string): Promise<SharedExec> {
-                const meta = await this.sessions.getOrThrow(sessionId);
-                if (!meta.containerId) throw new Error("No container for this session");
-
-                const container = this.docker.getContainer(meta.containerId);
-                // `new-session -A` attaches if the tmux session exists, creates it
-                // if not. This is the self-healing path: if the tmux server died
-                // (OOM, user `exit`ed the last pane, crash) the very next WS attach
-                // respawns it transparently instead of hitting "no server running"
-                // and surfacing an error toast. The `-c` keeps the freshly-created
-                // session pointed at the workspace so a recreated tab doesn't land
-                // next to the entrypoint script.
-                //
-                // Trade-off: a recreated tab loses its @tab-label user-option (the
-                // label is stored in tmux memory, not D1, so a tmux restart wipes
-                // it). `listTabs` falls back to `session_name` for that case, which
-                // is an acceptable degradation — it's still reachable, just named
-                // after its id.
-                const exec = await container.exec({
-                        Cmd: [
-                                "tmux", "new-session", "-A",
-                                "-s", tabId,
-                                "-c", "/home/developer/workspace",
-                        ],
-                        AttachStdin: true,
-                        AttachStdout: true,
-                        AttachStderr: true,
-                        Tty: true,
-                        // Initial env size is a placeholder — recomputeSize applies the real
-                        // min-of-all-clients size as soon as the first attach() registers.
-                        Env: [`COLUMNS=80`, `LINES=24`],
-                });
-
-                const stream = await exec.start({ hijack: true, stdin: true, Tty: true });
-
-                const s: SharedExec = {
-                        execId: key,
-                        stream,
-                        resize: async (c: number, r: number) => {
-                                try { await exec.resize({ h: r, w: c }); } catch { /* ignore */ }
-                        },
-                        listeners: new Map(),
-                        clientSizes: new Map(),
-                        // Sentinel {0,0} forces the first recomputeSize to actually call
-                        // exec.resize — any real client size differs from this.
-                        appliedSize: { cols: 0, rows: 0 },
-                };
-
-                // Single fan-out for the entire session. Each byte from tmux fires this
-                // exactly once, regardless of how many clients are attached. StringDecoder
-                // buffers partial multi-byte UTF-8 sequences across chunk boundaries.
-                const decoder = new StringDecoder("utf8");
-                const broadcast = (data: string) => {
-                        if (!data) return;
-                        for (const l of s.listeners.values()) {
-                                try { l(data); } catch { /* listener error */ }
-                        }
-                };
-                stream.on("data", (chunk: Buffer) => { broadcast(decoder.write(chunk)); });
-
-                // If the stream dies on its own (tmux server exits, container restarted,
-                // docker daemon hiccup), forget the shared entry so the next attach will
-                // respawn. We guard the delete with a stream-identity check so we never
-                // clobber a newer spawn that replaced us. Orphaned listeners clean
-                // themselves up when their WS closes and detach() runs.
-                const forgetIfCurrent = async () => {
-                        const currentP = this.shared.get(key);
-                        if (!currentP) return;
-                        try {
-                                const currentS = await currentP;
-                                if (currentS.stream === stream) this.shared.delete(key);
-                        } catch { /* newer spawn rejected; not our concern */ }
-                };
-                stream.on("end", () => { broadcast(decoder.end()); void forgetIfCurrent(); });
-                // "close" fires on abrupt destroy (container killed). We intentionally
-                // skip decoder.end() here — calling it would emit U+FFFD for any bytes
-                // stranded in the decoder, and a partial sequence at hard close is
-                // unrecoverable anyway.
-                stream.on("close", () => { void forgetIfCurrent(); });
-                stream.on("error", (err) => {
-                        console.error(`[docker] shared exec stream error for ${key}:`, (err as Error).message);
-                        void forgetIfCurrent();
-                });
-
-                console.log(`[docker] spawned shared exec for ${key}`);
-                return s;
-        }
-
-        // ── Tabs (tmux session per tab) ────────────────────────────────────────
-
-        async listTabs(sessionId: string): Promise<Tab[]> {
-                const { stdout, exitCode } = await this.execOneShot(sessionId, [
-                        "tmux", "list-sessions", "-F",
-                        "#{session_name}\t#{?@tab-label,#{@tab-label},#{session_name}}\t#{session_created}",
-                ]);
-                // tmux returns 1 with "no server running" when the server died. That is
-                // an unusable container for us — surface as empty so callers can recover.
-                if (exitCode !== 0) return [];
-                return stdout
-                        .split("\n")
-                        .map((line) => line.trim())
-                        .filter((line) => line.length > 0)
-                        .map((line): Tab => {
-                                const [tabId = "", label = "", createdAt = "0"] = line.split("\t");
-                                return { tabId, label, createdAt: Number(createdAt) || 0 };
-                        });
-        }
-
-        /**
-         * Create a new tmux session inside the container, tagged with a
-         * user-visible label stored as a tmux user-option (`@tab-label`).
-         *
-         * ## Label contract
-         *
-         * Callers must hand in a label that's already been validated — no
-         * leading/trailing whitespace, no ASCII control chars, 1–64 chars, or
-         * `undefined` to auto-default to the generated tabId. The REST route
-         * enforces this (see `validateTabLabel` in routes.ts); this method
-         * does NO normalisation and stores the label verbatim.
-         *
-         * Why the strictness matters: `listTabs` reads labels back via
-         * `tmux list-sessions -F "…#{@tab-label}…"` which emits results in a
-         * TSV format (\t-separated fields, \n-separated rows). A \t or \n
-         * inside the stored label silently corrupts that parser — the
-         * createdAt field ends up holding label fragments (timestamp parses
-         * as 0) or phantom tabs appear that don't exist in tmux. \r is
-         * stripped by execOneShot's demuxer, which would make the stored
-         * label mismatch the sent one. Rejecting the whole 0x00–0x1F, 0x7F
-         * range at the API boundary keeps all three paths sound. Higher code
-         * points (emoji, accented letters, non-Latin scripts) are opaque to
-         * the TSV parser and safe. See issue #92.
-         *
-         * Avoiding `.trim()` here is deliberate: a silent trim would let a
-         * client observe "what I sent ≠ what came back" (send " foo", get
-         * "foo" from listTabs). The API rejects leading/trailing whitespace
-         * instead, so the value stored equals the value accepted.
-         */
-        async createTab(sessionId: string, label?: string): Promise<Tab> {
-                const tabId = `tab-${randomBytes(4).toString("hex")}`;
-                // `label` is pre-validated by the route handler (non-empty,
-                // trimmed, no control chars). No normalisation here — the
-                // round-trip stored == sent invariant depends on it.
-                const displayLabel = label ?? tabId;
-
-                // `-c` pins the new tab's starting directory to the bind-mounted
-                // workspace. Without it, tmux inherits cwd from docker exec, which
-                // uses the image's WORKDIR (/home/developer) and dumps the user
-                // next to entrypoint.sh instead of in their project files.
-                const create = await this.execOneShot(sessionId, [
-                        "tmux", "new-session", "-d", "-s", tabId,
-                        "-c", "/home/developer/workspace",
-                        "-x", "120", "-y", "36",
-                ]);
-                if (create.exitCode !== 0) {
-                        throw new Error(`tmux new-session failed (exit ${create.exitCode}): ${create.stdout}`);
-                }
-
-                // User-option stays with the tmux session for its lifetime — survives
-                // backend restarts, doesn't need a D1 table.
-                await this.execOneShot(sessionId, [
-                        "tmux", "set-option", "-t", tabId, "@tab-label", displayLabel,
-                ]);
-
-                const now = Math.floor(Date.now() / 1000);
-                console.log(`[docker] created tab ${tabId} (${displayLabel}) in session ${sessionId}`);
-                return { tabId, label: displayLabel, createdAt: now };
-        }
-
-        async deleteTab(sessionId: string, tabId: string): Promise<void> {
-                // Tear down any shared exec for this tab first so we don't leave
-                // dangling handles pointing at a dead tmux session.
-                const key = this.targetKey(sessionId, tabId);
-                const pending = this.shared.get(key);
-                if (pending) {
-                        this.shared.delete(key);
-                        pending.then(
-                                (s) => { try { s.stream.destroy(); } catch { /* already destroyed */ } },
-                                () => { /* spawn rejected — nothing to destroy */ },
-                        );
-                }
-                for (const [attachId, k] of this.keyOf) {
-                        if (k === key) this.keyOf.delete(attachId);
-                }
-
-                const { exitCode } = await this.execOneShot(sessionId, ["tmux", "kill-session", "-t", tabId]);
-                if (exitCode !== 0) {
-                        // kill-session returns non-zero if the target doesn't exist — OK for
-                        // the idempotent case; caller has already validated it existed.
-                        console.warn(`[docker] kill-session ${tabId} exited ${exitCode}`);
-                }
-                console.log(`[docker] deleted tab ${tabId} from session ${sessionId}`);
-        }
-
-        private async execOneShot(
-                sessionId: string,
-                cmd: string[],
-        ): Promise<{ stdout: string; exitCode: number }> {
-                const meta = await this.sessions.getOrThrow(sessionId);
-                if (!meta.containerId) throw new Error("No container for this session");
-                const container = this.docker.getContainer(meta.containerId);
-
-                const exec = await container.exec({
-                        Cmd: cmd,
-                        AttachStdin: false,
-                        AttachStdout: true,
-                        AttachStderr: true,
-                        // Tty:false keeps stdout in Docker multiplexed frames (type=1).
-                        // Tty:true would allocate a PTY which expands \t → spaces,
-                        // corrupting the tab-separated output from tmux list-sessions.
-                        Tty: false,
-                });
-                const stream = await exec.start({ hijack: false, stdin: false });
-                const chunks: Buffer[] = [];
-                stream.on("data", (c: Buffer) => chunks.push(c));
-                await new Promise<void>((resolve, reject) => {
-                        stream.on("end", () => resolve());
-                        stream.on("close", () => resolve());
-                        stream.on("error", reject);
-                });
-                const info = await exec.inspect();
-                return {
-                        stdout: demuxDockerOutput(Buffer.concat(chunks), 1),
-                        exitCode: info.ExitCode ?? 0,
-                };
-        }
-
-        private async recomputeSize(s: SharedExec): Promise<void> {
-                if (s.clientSizes.size === 0) return;
-                let minCols = Number.POSITIVE_INFINITY;
-                let minRows = Number.POSITIVE_INFINITY;
-                for (const { cols, rows } of s.clientSizes.values()) {
-                        if (cols < minCols) minCols = cols;
-                        if (rows < minRows) minRows = rows;
-                }
-                if (minCols !== s.appliedSize.cols || minRows !== s.appliedSize.rows) {
-                        s.appliedSize = { cols: minCols, rows: minRows };
-                        await s.resize(minCols, minRows);
-                }
-        }
-
-        // ── Helpers ─────────────────────────────────────────────────────────────
-
-        /**
-         * Best-effort sweep of the multer tmp directory at startup. If the
-         * backend was OOM-killed or crashed mid-upload, multer's tmp files
-         * (which the upload route would normally rename or unlink) are left
-         * behind forever — harmless to security but accumulates on disk
-         * over crash/restart cycles. Called from reconcile() so the same
-         * startup hook handles both forms of stale state.
-         */
-        async sweepUploadTmp(): Promise<void> {
-                const dir = this.getUploadTmpDir();
-                let entries: Dirent[];
-                try {
-                        entries = await fs.readdir(dir, { withFileTypes: true });
-                } catch (err) {
-                        // ENOENT is expected on a fresh deployment — nothing to sweep.
-                        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-                                console.warn(`[docker] sweepUploadTmp readdir failed for ${dir}: ${(err as Error).message}`);
-                        }
-                        return;
-                }
-                // Filter to plain files. `fs.unlink` on a directory returns
-                // EISDIR — not actionable here and would skew the
-                // success/failure log. No code path in this module creates
-                // subdirs under .tmp-uploads today, but a future regression
-                // (or operator dropping something there) would silently
-                // accumulate without this guard.
-                const fileEntries = entries.filter((e) => e.isFile());
-                if (fileEntries.length === 0) return;
-                const results = await Promise.allSettled(
-                        fileEntries.map((e) => fs.unlink(path.join(dir, e.name))),
-                );
-                const failed = results.filter((r) => r.status === "rejected").length;
-                console.log(`[docker] sweepUploadTmp removed ${fileEntries.length - failed}/${fileEntries.length} stale tmp files`);
-        }
-
-        async reconcile(): Promise<void> {
-                console.log("[docker] reconciling session state with Docker…");
-                await this.sweepUploadTmp();
-                const result = await d1Query<{ session_id: string; container_id: string | null }>(
-                        "SELECT session_id, container_id FROM sessions WHERE status = 'running'",
-                );
-
-                for (const row of result.results) {
-                        if (!row.container_id) {
-                                await this.sessions.updateStatus(row.session_id, "stopped");
-                                continue;
-                        }
-                        try {
-                                const info = await this.docker.getContainer(row.container_id).inspect();
-                                // reconcile() runs on every backend boot, which is the
-                                // most-likely deploy moment. Surface pre-#15 containers
-                                // here regardless of running state — operators who stop
-                                // all sessions before deploying still need the warning,
-                                // since the next `/start` would be the only other place
-                                // it'd surface and that requires the operator to remember
-                                // to start each one.
-                                this.warnIfPreHardened(row.session_id, row.container_id, info.HostConfig);
-                                if (!info.State.Running) {
-                                        await this.sessions.updateStatus(row.session_id, "stopped");
-                                }
-                        } catch (err) {
-                                // Only 404 means container is actually gone (atomic null+stopped).
-                                // Non-404 (daemon unreachable, etc.) might be transient — keep the
-                                // id so /start can retry the real container, don't orphan it.
-                                const statusCode = (err as { statusCode?: number }).statusCode;
-                                if (statusCode === 404) {
-                                        await this.sessions.recordContainerGone(row.session_id);
-                                } else {
-                                        console.warn(`[docker] reconcile inspect failed for session ${row.session_id}: ${(err as Error).message}`);
-                                        await this.sessions.updateStatus(row.session_id, "stopped");
-                                }
-                        }
-                }
-                console.log("[docker] reconciliation complete");
-        }
+	private docker: Dockerode;
+	private sessions: SessionManager;
+	private shared = new Map<string /*targetKey*/, Promise<SharedExec>>();
+	private keyOf = new Map<string /*attachId*/, string /*targetKey*/>();
+	// Serialises writeUploads calls per session so the quota check
+	// (read existing + add new) can't race two concurrent requests
+	// and let both pass with the same usedBytes snapshot. Entries
+	// self-clean when the chain head finishes.
+	private uploadLocks = new Map<string /*sessionId*/, Promise<void>>();
+
+	constructor(sessions: SessionManager, dockerOpts?: Dockerode.DockerOptions) {
+		// docker-modem reads DOCKER_HOST from the environment ONLY when the
+		// caller passes no connection options at all. The previous default
+		// of `{ socketPath: "/var/run/docker.sock" }` therefore silently
+		// shadowed DOCKER_HOST, which matters for the docker-socket-proxy
+		// deployment shape (overlay sets DOCKER_HOST=tcp://proxy:2375 and
+		// drops the bind mount). Behaviour: explicit `dockerOpts` always
+		// wins (tests rely on this); otherwise honour DOCKER_HOST when
+		// present; finally fall back to the canonical Unix socket so the
+		// default docker-compose.yml stack still works untouched.
+		const defaultOpts: Dockerode.DockerOptions | undefined = process.env.DOCKER_HOST
+			? undefined
+			: { socketPath: "/var/run/docker.sock" };
+		this.docker = new Dockerode(dockerOpts ?? defaultOpts);
+		this.sessions = sessions;
+	}
+
+	// Each tab inside a session is its own tmux session in the container and
+	// gets its own shared exec. The targetKey is the join key; replay on
+	// reconnect is a tmux capture-pane snapshot (see capturePane()), not a
+	// server-side byte buffer.
+	private targetKey(sessionId: string, tabId: string): string {
+		return `${sessionId}:${tabId}`;
+	}
+
+	// ── Container lifecycle ─────────────────────────────────────────────────
+
+	async spawn(sessionId: string): Promise<string> {
+		const meta = await this.sessions.getOrThrow(sessionId);
+		const envArray = Object.entries(meta.envVars).map(([k, v]) => `${k}=${v}`);
+
+		// Pre-create the bind-mount target so Docker doesn't auto-create it
+		// as root. See `ensureWorkspaceOwnership` for the full story and the
+		// non-recursive invariant.
+		const workspaceDir = path.join(WORKSPACE_ROOT, sessionId);
+		await fs.mkdir(workspaceDir, { recursive: true });
+		await this.ensureWorkspaceOwnership(workspaceDir);
+
+		// Pre-create the per-session uploads dir at its OUT-OF-WORKSPACE
+		// location and bind-mount it read-only into the container at
+		// /home/developer/workspace/uploads/. Critical TOCTOU defence:
+		// because the container's view is a mount point, the container
+		// can NOT replace, rename, or rmdir the uploads/ entry from
+		// inside (the kernel rejects any modification to a mount point
+		// from the mount user's namespace). Read-only also stops the
+		// container from writing/modifying uploaded files, so an
+		// attacker can't poison files between writes — combined with
+		// writeUploads' atomic rename from .tmp-uploads/ into
+		// .uploads/<sessionId>/, the symlink-swap attack window the
+		// older in-workspace layout had is closed structurally.
+		const uploadsHostDir = path.join(WORKSPACE_ROOT, ".uploads", sessionId);
+		await fs.mkdir(uploadsHostDir, { recursive: true });
+		// No chown — backend (typically root) owns the dir, container
+		// reads via the read-only mount; no need for it to own anything.
+
+		const hostname = sanitiseHostname(meta.name, sessionId);
+		const container = await this.docker.createContainer({
+			Image: SESSION_IMAGE,
+			name: meta.containerName,
+			Hostname: hostname,
+			Env: [
+				`SESSION_ID=${sessionId}`,
+				`SESSION_NAME=${meta.name}`,
+				`TERM=xterm-256color`,
+				`COLORTERM=truecolor`,
+				...envArray,
+			],
+			HostConfig: {
+				Binds: [
+					`${WORKSPACE_ROOT}/${sessionId}:/home/developer/workspace`,
+					`${uploadsHostDir}:/home/developer/workspace/uploads:ro`,
+				],
+				Memory: 2 * 1024 * 1024 * 1024,
+				NanoCpus: 2_000_000_000,
+				RestartPolicy: { Name: "unless-stopped" },
+				// Defense-in-depth (issue #15): the image already runs as
+				// unprivileged UID 1000 with no sudo, but we still strip
+				// every Linux capability from the bounding set Docker
+				// hands the container. None of tmux, node, git,
+				// claude-code, or `code tunnel` need any of the default
+				// bag (e.g. CAP_NET_RAW for raw sockets / ICMP,
+				// CAP_NET_BIND_SERVICE for ports < 1024, CAP_AUDIT_WRITE,
+				// CAP_MKNOD), so dropping ALL is the tightest baseline.
+				// Note: this is about the *container's* bounding set,
+				// not the backend host process — host-side chowns in
+				// ensureWorkspaceOwnership rely on the backend's own
+				// CAP_CHOWN and are unaffected. Pair with
+				// no-new-privileges so even if a future image change
+				// reintroduces a setuid binary it cannot raise
+				// effective UID/caps at exec time.
+				CapDrop: ["ALL"],
+				SecurityOpt: ["no-new-privileges:true"],
+			},
+			OpenStdin: true,
+			Tty: true,
+		});
+
+		await container.start();
+		const containerId = container.id;
+		await this.sessions.setContainerId(sessionId, containerId);
+
+		console.log(
+			`[docker] spawned container ${meta.containerName} (${containerId.slice(0, 12)}) for session ${sessionId}`,
+		);
+		return containerId;
+	}
+
+	/**
+	 * Apply `WORKSPACE_UID:WORKSPACE_GID` to the session workspace.
+	 *
+	 * By default this chowns only the top-level directory, not its contents.
+	 * The invariant is "freshly-created or already correctly-owned": nested
+	 * files are assumed to have been written by the container itself (so they
+	 * already have the right owner). If the operator set
+	 * WORKSPACE_CHOWN_RECURSIVE=true we also walk descendants — useful for
+	 * one-shot repair of workspaces left inconsistent by an earlier version
+	 * that let Docker create the bind source root-owned.
+	 *
+	 * All chown calls downgrade EPERM/ENOSYS to a warning so unprivileged
+	 * dev mode still works; any other errno is re-thrown so we don't
+	 * silently boot a session with a broken workspace.
+	 */
+	private async ensureWorkspaceOwnership(dir: string): Promise<void> {
+		await this.chownToWorkspaceUser(dir);
+
+		if (!WORKSPACE_CHOWN_RECURSIVE) return;
+
+		// Walk the tree iteratively (not recursively) to avoid stack
+		// growth on deep workspaces. `withFileTypes: true` avoids a stat
+		// per entry. Symlinks are chowned in place (lchown-equivalent)
+		// so we don't follow them out of the workspace root.
+		const stack: string[] = [dir];
+		while (stack.length > 0) {
+			// `pop()` returns `T | undefined`. The while condition
+			// already guarantees the stack is non-empty, so the
+			// undefined branch is unreachable — but we check anyway to
+			// satisfy biome's no-non-null-assertion rule and to keep
+			// the code safe if the loop header is ever refactored (e.g.
+			// changed to `while (true)`) without re-analysing the
+			// invariant.
+			const current = stack.pop();
+			if (current === undefined) break;
+			let entries: Dirent[];
+			try {
+				entries = await fs.readdir(current, { withFileTypes: true });
+			} catch (err) {
+				const code = (err as NodeJS.ErrnoException).code;
+				// A sibling-modified workspace (file removed mid-walk) shouldn't
+				// abort the whole repair; log and keep going.
+				if (code === "ENOENT" || code === "ENOTDIR") continue;
+				throw err;
+			}
+			for (const entry of entries) {
+				const full = path.join(current, entry.name);
+				await this.chownToWorkspaceUser(full);
+				if (entry.isDirectory() && !entry.isSymbolicLink()) {
+					stack.push(full);
+				}
+			}
+		}
+	}
+
+	/**
+	 * chown a single path to WORKSPACE_UID:WORKSPACE_GID. Downgrades
+	 * EPERM/ENOSYS to a warning (unprivileged dev mode), re-throws
+	 * everything else so a real broken-workspace error doesn't get
+	 * swallowed. Shared by the spawn-time ownership pass and the
+	 * upload writer below.
+	 */
+	private async chownToWorkspaceUser(target: string): Promise<void> {
+		try {
+			await fs.chown(target, WORKSPACE_UID, WORKSPACE_GID);
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === "EPERM" || code === "ENOSYS") {
+				console.warn(
+					`[docker] couldn't chown ${target} to ${WORKSPACE_UID}:${WORKSPACE_GID} (${code}); ` +
+						`run the backend as root or pre-create paths with matching ownership.`,
+				);
+			} else {
+				throw err;
+			}
+		}
+	}
+
+	/**
+	 * Save uploaded files into the session workspace under `uploads/`
+	 * and return their in-container paths. Caller must have already
+	 * verified ownership of `sessionId`.
+	 *
+	 * Filenames are sanitised to a safe basename and prefixed with a
+	 * monotonic timestamp + short random suffix so concurrent uploads
+	 * of the same name don't clobber each other. The host path of
+	 * every write is `path.resolve()`d and verified to sit inside the
+	 * uploads directory before any rename — the sanitiser already
+	 * strips path separators, but the resolve-and-check is a defence-
+	 * in-depth belt against a future regression. Concurrent calls for
+	 * the same session are serialised via `uploadLocks` so the quota
+	 * check (read-then-write) can't race itself.
+	 */
+	async writeUploads(
+		sessionId: string,
+		files: ReadonlyArray<{ originalname: string; path: string }>,
+	): Promise<string[]> {
+		if (files.length === 0) return [];
+		// Per-session serialisation. Synchronously chain a new lock
+		// *before* awaiting the prior one, so a concurrent call sees
+		// the chained lock — not an empty slot — and waits behind us.
+		const prior = this.uploadLocks.get(sessionId);
+		let release: () => void = () => {
+			/* set below */
+		};
+		const ours = new Promise<void>((r) => {
+			release = r;
+		});
+		const newLock = prior
+			? prior.then(
+					() => ours,
+					() => ours,
+				)
+			: ours;
+		this.uploadLocks.set(sessionId, newLock);
+		if (prior)
+			await prior.catch(() => {
+				/* ignore prior errors */
+			});
+		try {
+			return await this.writeUploadsImpl(sessionId, files);
+		} finally {
+			release();
+			// Clean up if we're still the head — i.e. no later caller
+			// chained on. Stops the map from growing without bound
+			// for sessions that aren't actively uploading.
+			if (this.uploadLocks.get(sessionId) === newLock) {
+				this.uploadLocks.delete(sessionId);
+			}
+		}
+	}
+
+	private async writeUploadsImpl(
+		sessionId: string,
+		files: ReadonlyArray<{ originalname: string; path: string }>,
+	): Promise<string[]> {
+		// Architectural TOCTOU fix: the uploads directory lives at
+		// <WORKSPACE_ROOT>/.uploads/<sessionId>/ — OUTSIDE the
+		// container's bind-mount tree. spawn() bind-mounts this dir
+		// read-only into the container at /home/developer/workspace/
+		// uploads/, so:
+		//   1. The container CANNOT remove or replace /home/developer/
+		//      workspace/uploads (it's a mount point — kernel rejects
+		//      modification from the mount user's namespace).
+		//   2. The container CANNOT write into uploads/ (read-only mount).
+		//   3. The container's bind mount on /home/developer/workspace/
+		//      doesn't reach .uploads/ on the host, so nothing inside
+		//      the container can plant symlinks at the upload destination.
+		// The earlier in-workspace layout needed a stack of defences
+		// (realpath, O_DIRECTORY|O_NOFOLLOW, pre+post inode sentinels)
+		// because the container could replace uploads/ with a symlink
+		// and race rename(2). With the new layout that whole class of
+		// attacks is structurally impossible, so the per-rename TOCTOU
+		// machinery is gone. The lexical containment check stays as a
+		// belt against any future regression that lets a non-UUID
+		// sessionId reach this method.
+		const uploadsHostDir = path.join(WORKSPACE_ROOT, ".uploads", sessionId);
+		// Containment check: must resolve under <WORKSPACE_ROOT>/.uploads/,
+		// not just under WORKSPACE_ROOT. A traversal-shaped sessionId
+		// like "../escape" would otherwise let path.join collapse to
+		// <WORKSPACE_ROOT>/escape — still under WORKSPACE_ROOT but
+		// outside the per-session uploads namespace.
+		const uploadsBaseAbs = path.resolve(WORKSPACE_ROOT, ".uploads");
+		const uploadsHostDirAbs = path.resolve(uploadsHostDir);
+		if (!uploadsHostDirAbs.startsWith(`${uploadsBaseAbs}${path.sep}`)) {
+			await this.cleanupTmp(files);
+			throw new Error(
+				`unsafe session path resolved outside ${uploadsBaseAbs}: ${uploadsHostDirAbs}`,
+			);
+		}
+		// spawn() pre-creates this dir, but a writeUploads call for a
+		// session that has been spawned but not running (or for one
+		// started before this code shipped) needs us to create it
+		// here too. recursive: true is a no-op when it already exists.
+		await fs.mkdir(uploadsHostDir, { recursive: true });
+
+		// Per-session disk-quota check: count current bytes in
+		// uploads/ + bytes about to be added; reject before moving any
+		// tmp file if the cap would be exceeded. Sum-of-statSize is a
+		// tight enough approximation — uploads/ is always one level
+		// deep (writeUploads only writes flat) so no recursion.
+		// lstat (not stat) so any stale symlink left over from the
+		// previous in-workspace layout — or one a future bug plants
+		// here — counts as zero bytes (st.isFile() is false for
+		// symlinks) rather than inflating the quota with the
+		// target's size.
+		let usedBytes = 0;
+		try {
+			const existing = await fs.readdir(uploadsHostDir);
+			for (const entry of existing) {
+				const st = await fs.lstat(path.join(uploadsHostDir, entry));
+				if (st.isFile()) usedBytes += st.size;
+			}
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+		}
+		let attemptedBytes = 0;
+		for (const file of files) {
+			const stat = await fs.stat(file.path);
+			attemptedBytes += stat.size;
+		}
+		if (usedBytes + attemptedBytes > UPLOAD_QUOTA_BYTES) {
+			// Log the detail server-side; the thrown error carries
+			// a generic message so byte counts don't ride out in
+			// the 413 body to the client.
+			console.warn(
+				`[docker] upload quota rejected for session ${sessionId}: ` +
+					`${usedBytes} used + ${attemptedBytes} attempted > ${UPLOAD_QUOTA_BYTES} cap`,
+			);
+			await this.cleanupTmp(files);
+			throw new UploadQuotaExceededError(usedBytes, attemptedBytes, UPLOAD_QUOTA_BYTES);
+		}
+
+		const containerPaths: string[] = [];
+		const now = Date.now().toString(36);
+		// Track which multer tmp files we've successfully moved so
+		// the finally block can clean up anything we didn't get to.
+		const remaining = new Set(files.map((f) => f.path));
+		try {
+			for (const file of files) {
+				const safeBase = sanitiseUploadName(file.originalname);
+				// Random suffix on top of the timestamp so two
+				// uploads landing in the same millisecond don't
+				// collide.
+				const suffix = randomBytes(3).toString("hex");
+				const filename = `${now}-${suffix}-${safeBase}`;
+				const finalPath = path.join(uploadsHostDir, filename);
+				const finalPathAbs = path.resolve(finalPath);
+				// Defence-in-depth per-file containment: the
+				// sanitiser already strips path separators so
+				// sanitiseUploadName(x) can never escape the
+				// dir, but resolve+startsWith is one extra
+				// line of insurance against a future regression
+				// in the sanitiser.
+				if (!finalPathAbs.startsWith(`${uploadsHostDirAbs}${path.sep}`)) {
+					throw new Error(
+						`unsafe upload path resolved outside ${uploadsHostDirAbs}: ${finalPathAbs}`,
+					);
+				}
+				// chmod + chown the multer tmp file BEFORE the
+				// rename. rename(2) preserves mode + owner at
+				// the destination, so the file lands in
+				// uploads/ with mode 0644 owned by uid 1000
+				// (the container user). With the read-only
+				// bind mount the container can read but not
+				// modify the file — chowning to uid 1000 is
+				// mostly cosmetic now but keeps the in-
+				// container `ls -l` output consistent with the
+				// rest of the workspace.
+				await fs.chmod(file.path, 0o644);
+				await this.chownToWorkspaceUser(file.path);
+				// Atomic same-filesystem move from the multer
+				// tmp dir to the per-session uploads dir.
+				await fs.rename(file.path, finalPath);
+				remaining.delete(file.path);
+				containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
+			}
+		} finally {
+			await this.cleanupTmp([...remaining].map((p) => ({ originalname: "", path: p })));
+		}
+		return containerPaths;
+	}
+
+	/**
+	 * Absolute host path where multer streams uploaded bodies before
+	 * `writeUploads` moves them to their final per-session location.
+	 * Lives directly under WORKSPACE_ROOT (NOT inside any session
+	 * subdirectory) so it's never bind-mounted into a container, and
+	 * `fs.rename` from here to the final path is a same-filesystem
+	 * atomic move.
+	 */
+	getUploadTmpDir(): string {
+		return path.join(WORKSPACE_ROOT, ".tmp-uploads");
+	}
+
+	// Best-effort cleanup of multer's on-disk temp files. Used on the
+	// bail-out paths in writeUploads (containment-check failure, mid-loop
+	// throw). Each unlink is independently swallowed because the only
+	// failure modes here are "file already gone" or "no permission" —
+	// neither is something the upload caller should hear about.
+	private async cleanupTmp(files: ReadonlyArray<{ path: string }>): Promise<void> {
+		await Promise.allSettled(files.map((f) => fs.unlink(f.path)));
+	}
+
+	async kill(sessionId: string): Promise<void> {
+		const meta = await this.sessions.get(sessionId);
+
+		if (meta?.containerId) {
+			try {
+				const container = this.docker.getContainer(meta.containerId);
+				try {
+					await container.stop({ t: 5 });
+				} catch {
+					/* already stopped */
+				}
+				// `v: true` also removes any anonymous volumes attached to the
+				// container (bind mounts are unaffected — those are cleaned by
+				// purgeWorkspace on hard delete).
+				try {
+					await container.remove({ force: true, v: true });
+				} catch {
+					/* already removed */
+				}
+			} catch (err) {
+				console.error(
+					`[docker] error killing container for session ${sessionId}:`,
+					(err as Error).message,
+				);
+			}
+			// The container no longer exists in Docker — reflect that in D1 so any
+			// later lookup doesn't chase a dead container id.
+			try {
+				await this.sessions.setContainerId(sessionId, null);
+			} catch (err) {
+				console.error(
+					`[docker] failed to null container_id for session ${sessionId}:`,
+					(err as Error).message,
+				);
+			}
+		}
+
+		// Destroy any shared exec and per-attach routing for this session.
+		// Match on equality or on `sessionId:…` prefix so this keeps working
+		// once per-tab targetKeys (sessionId:windowId) exist.
+		const prefix = `${sessionId}:`;
+		for (const [key, pending] of this.shared) {
+			if (key === sessionId || key.startsWith(prefix)) {
+				this.shared.delete(key);
+				pending.then(
+					(s) => {
+						try {
+							s.stream.destroy();
+						} catch {
+							/* already destroyed */
+						}
+					},
+					() => {
+						/* spawn rejected — nothing to destroy */
+					},
+				);
+			}
+		}
+		for (const [attachId, key] of this.keyOf) {
+			if (key === sessionId || key.startsWith(prefix)) {
+				this.keyOf.delete(attachId);
+			}
+		}
+		console.log(`[docker] killed container for session ${sessionId}`);
+	}
+
+	/**
+	 * Delete the bind-mounted workspace directory for a session.
+	 *
+	 * This is intentionally strict about the path it will remove: it refuses
+	 * to touch anything that does not resolve to a child of WORKSPACE_ROOT.
+	 * Missing directories are a no-op (idempotent hard delete).
+	 */
+	async purgeWorkspace(sessionId: string): Promise<void> {
+		const rootAbs = path.resolve(WORKSPACE_ROOT);
+		const sessionAbs = path.resolve(path.join(WORKSPACE_ROOT, sessionId));
+		const uploadsAbs = path.resolve(path.join(WORKSPACE_ROOT, ".uploads", sessionId));
+
+		// Safety: both resolved dirs must be strict children of rootAbs.
+		if (!sessionAbs.startsWith(rootAbs + path.sep)) {
+			throw new Error(
+				`[docker] refusing to purge workspace outside root (root=${rootAbs}, target=${sessionAbs})`,
+			);
+		}
+		if (!uploadsAbs.startsWith(rootAbs + path.sep)) {
+			throw new Error(
+				`[docker] refusing to purge uploads outside root (root=${rootAbs}, target=${uploadsAbs})`,
+			);
+		}
+
+		try {
+			await fs.rm(sessionAbs, { recursive: true, force: true });
+			console.log(`[docker] purged workspace dir ${sessionAbs}`);
+		} catch (err) {
+			console.error(`[docker] failed to purge workspace ${sessionAbs}:`, (err as Error).message);
+			throw err;
+		}
+		// Per-session uploads dir lives at <WORKSPACE_ROOT>/.uploads/<sessionId>/
+		// (out-of-workspace TOCTOU isolation — see writeUploadsImpl). Hard
+		// delete must clean this too or uploaded files would persist
+		// forever for a row that no longer exists in D1.
+		try {
+			await fs.rm(uploadsAbs, { recursive: true, force: true });
+			console.log(`[docker] purged uploads dir ${uploadsAbs}`);
+		} catch (err) {
+			console.error(`[docker] failed to purge uploads ${uploadsAbs}:`, (err as Error).message);
+			throw err;
+		}
+	}
+
+	async isAlive(sessionId: string): Promise<boolean> {
+		const meta = await this.sessions.get(sessionId);
+		if (!meta?.containerId) return false;
+		try {
+			const info = await this.docker.getContainer(meta.containerId).inspect();
+			return info.State.Running === true;
+		} catch {
+			return false;
+		}
+	}
+
+	async startContainer(sessionId: string): Promise<void> {
+		const meta = await this.sessions.getOrThrow(sessionId);
+
+		// Case 1: no container exists (terminated session, or one whose container
+		// was removed out-of-band). Spawn a fresh container reusing the existing
+		// container name + workspace bind mount.
+		if (!meta.containerId) {
+			await this.spawn(sessionId);
+			await this.sessions.updateStatus(sessionId, "running");
+			console.log(`[docker] respawned container for session ${sessionId}`);
+			return;
+		}
+
+		// Case 2: container id is on file. Check it still exists in Docker; if it
+		// does, just start it. If Docker has no record of it, forget the stale id
+		// and spawn a replacement.
+		try {
+			const info = await this.docker.getContainer(meta.containerId).inspect();
+			this.warnIfPreHardened(sessionId, meta.containerId, info.HostConfig);
+			if (!info.State.Running) {
+				await this.docker.getContainer(meta.containerId).start();
+			}
+			await this.sessions.updateStatus(sessionId, "running");
+			console.log(`[docker] restarted container for session ${sessionId}`);
+		} catch {
+			console.log(`[docker] stale container_id for session ${sessionId}, respawning`);
+			await this.sessions.setContainerId(sessionId, null);
+			await this.spawn(sessionId);
+			await this.sessions.updateStatus(sessionId, "running");
+		}
+	}
+
+	// Detects containers that predate the issue-#15 hardening. Docker pins
+	// HostConfig at create time, so `container.start()` re-uses the original
+	// CapDrop / SecurityOpt regardless of what spawn() would set today. An
+	// operator who deploys this build and only stop+starts (instead of
+	// DELETE + POST /start) ends up with sessions that look fine but still
+	// have full Linux caps and a setuid sudo from the old image. This helper
+	// is the choke point for surfacing that mistake — call it from any code
+	// path that inspects an existing container so the migration footgun
+	// shows up in `docker logs` instead of failing silently.
+	private warnIfPreHardened(
+		sessionId: string,
+		containerId: string,
+		hostConfig: { CapDrop?: string[] | null; SecurityOpt?: string[] | null } | undefined,
+	): void {
+		const capDrop = hostConfig?.CapDrop ?? [];
+		const securityOpt = hostConfig?.SecurityOpt ?? [];
+		if (capDrop.includes("ALL") && securityOpt.includes("no-new-privileges:true")) return;
+		console.warn(
+			`[docker] session ${sessionId} container ${containerId.slice(0, 12)} ` +
+				`predates issue-#15 hardening (CapDrop=${JSON.stringify(capDrop)}, ` +
+				`SecurityOpt=${JSON.stringify(securityOpt)}). ` +
+				`Recycle via DELETE /api/sessions/${sessionId} then POST /start to apply current HostConfig.`,
+		);
+	}
+
+	async stopContainer(sessionId: string): Promise<void> {
+		const meta = await this.sessions.getOrThrow(sessionId);
+		if (!meta.containerId) return;
+		try {
+			await this.docker.getContainer(meta.containerId).stop({ t: 5 });
+		} catch {
+			/* already stopped */
+		}
+		await this.sessions.updateStatus(sessionId, "stopped");
+		console.log(`[docker] stopped container for session ${sessionId}`);
+	}
+
+	// ── Exec attach ────────────────────────────────────────────────────────
+
+	async attach(
+		sessionId: string,
+		attachId: string,
+		cols: number,
+		rows: number,
+		onOutput: OutputListener,
+		tabId: string,
+	): Promise<{ handle: ExecHandle; replay: string | null; flushTail: () => void }> {
+		const key = this.targetKey(sessionId, tabId);
+
+		// Reuse the shared exec if one already exists (or is being spawned).
+		// Concurrent first-attach calls await the same promise → exactly one
+		// `container.exec` on the wire.
+		let pending = this.shared.get(key);
+		if (!pending) {
+			pending = this.spawnSharedExec(sessionId, key, tabId);
+			// Clear the slot on rejection so the next attach retries.
+			// `.catch` here doesn't consume the rejection — awaiters on the
+			// original promise still see it; this handler exists so Node
+			// doesn't flag an unhandledRejection if the awaiter finishes
+			// before this microtask.
+			pending.catch((err) => {
+				if (this.shared.get(key) === pending) this.shared.delete(key);
+				console.error(`[docker] shared exec spawn failed for ${key}:`, (err as Error).message);
+			});
+			this.shared.set(key, pending);
+		}
+
+		const s = await pending;
+
+		// ── Replay strategy ───────────────────────────────────────────────
+		// We capture the pane's canonical state via `tmux capture-pane -p -e`
+		// and use *that* as the replay payload. This replaces the old
+		// ring-buffer-of-raw-bytes strategy that had two known defects:
+		//
+		//   (a) a 64 KB byte ring hands the client a mid-sequence tail of
+		//       escape codes, so xterm's state (cursor pos, attrs, alt
+		//       screen) could be left inconsistent after replay — classic
+		//       "junk redraw" on reconnect;
+		//   (b) the ring needed bytes accumulated *while at least one other
+		//       client was attached* — reconnecting after a quiet period
+		//       replayed nothing, leaving the user looking at a blank term.
+		//
+		// capture-pane is tmux's own idea of "what is on screen right now"
+		// including colours and cursor attrs (the -e flag), so the replay
+		// is always a valid, self-contained redraw.
+		//
+		// Cost note: capture-pane is a separate `docker exec` per joiner.
+		// N simultaneous reconnecters to a popular session fire N sequential
+		// one-shots against the same container — there's no dedup window.
+		// The per-call cost is small (tens of ms each in practice) and the
+		// joiner already awaited spawnSharedExec, so this isn't on a path
+		// that blocks live bytes for other clients. If it ever becomes an
+		// amplifier we can cache a snapshot per-tab with a short TTL and
+		// hand it out to co-arriving joiners. Not worth the state today.
+		//
+		// ── Live-vs-replay ordering ───────────────────────────────────────
+		// We have to deliver bytes to the client in the correct order: the
+		// replay must land BEFORE any live bytes that arrive afterwards —
+		// otherwise the user sees fresh output get overwritten by a stale
+		// snapshot. Without buffering, these two concurrent streams race:
+		//
+		//   attach() returns → wsHandler sends replay → [live bytes can
+		//   fire between these two steps] → wsHandler sends live delta →
+		//   client paints replay on top of the delta it just rendered.
+		//
+		// To serialise them we arm an "until-flushed" listener BELOW: while
+		// armed it piles live bytes into a local `tail` array instead of
+		// calling onOutput. wsHandler sends the replay payload and THEN
+		// calls flushTail(), which drains the tail in order and flips the
+		// listener to forward-directly. Because flushTail is synchronous
+		// (no awaits, ws.send is sync too) the client-visible sequence
+		// from the moment the listener is registered onward is deterministic:
+		// [captured screen][every live delta in arrival order].
+		//
+		// Residual race we accept: there is a narrow window between when
+		// capture-pane is issued and when the listener below is registered.
+		// Bytes tmux emits during that window are not in the snapshot (they
+		// weren't on the pane when capture-pane ran) AND not in the tail
+		// (the listener wasn't armed yet). The client won't see them until
+		// the next live byte forces a redraw.
+		//
+		// Self-heal timing depends on what the pane is doing:
+		//   - Interactive shell / TUI: the next keystroke echo or cursor
+		//     blink redraws within ~seconds — bytes are deferred, not
+		//     permanently lost.
+		//   - Non-interactive output (a running `tail -f`, a build log, a
+		//     background process writing periodically): the deferred bytes
+		//     stay deferred until the next spontaneous write, which could
+		//     be seconds or minutes away. They DO eventually repaint (the
+		//     missing chars are still on the pane; any subsequent redraw
+		//     of those cells shows them), but the snapshot the joining
+		//     client initially sees is stale for the duration.
+		//   - Fully quiet pane: deferred bytes stay missing from the
+		//     client's view until *something* forces a redraw — e.g. a
+		//     resize, a keystroke, or next attach. The pane is still
+		//     correct server-side; only this client's initial view is
+		//     behind.
+		//
+		// We deliberately don't close this window by arming the listener
+		// BEFORE capture-pane: that would double-render every byte tmux
+		// emitted between `listener registered` and `snapshot captured`,
+		// because those bytes already updated the pane state that ends up
+		// in the snapshot — so the client would see them once in the
+		// snapshot and again in the tail. A byte-correct fix would need
+		// position-aware dedup (snapshot cursor at capture time vs tail
+		// start), which is more machinery than the lost-bytes symptom
+		// warrants in a terminal product.
+		const snapshot = await this.capturePane(sessionId, tabId);
+
+		const tail: string[] = [];
+		let armed = true;
+		const bufferedListener: OutputListener = (data) => {
+			if (armed) {
+				tail.push(data);
+			} else {
+				try {
+					onOutput(data);
+				} catch {
+					/* downstream error */
+				}
+			}
+		};
+
+		s.listeners.set(attachId, bufferedListener);
+		s.clientSizes.set(attachId, { cols, rows });
+		this.keyOf.set(attachId, key);
+
+		// Once the listener is in `s.listeners`, any throw before we return
+		// a handle to the caller would orphan it: wsHandler closes the
+		// socket without knowing attach() got partway through, so detach()
+		// is never called, and the armed `bufferedListener` keeps piling
+		// live bytes into a `tail` array that nothing will ever drain.
+		// recomputeSize swallows exec.resize errors internally today, but
+		// updateConnected is a D1 write that CAN reject — and a future
+		// refactor of either path might start propagating. Make the
+		// post-register teardown explicit instead of hoping the callees
+		// stay infallible.
+		try {
+			await this.recomputeSize(s);
+			await this.sessions.updateConnected(sessionId);
+		} catch (err) {
+			this.detach(attachId);
+			throw err;
+		}
+		console.log(
+			`[docker] attached ${attachId} to session ${sessionId} (listeners=${s.listeners.size})`,
+		);
+
+		const flushTail = () => {
+			// Drain in arrival order, then flip the gate. Node is
+			// single-threaded so the for-of loop runs atomically w.r.t.
+			// stream 'data' events (they queue on the event loop and can't
+			// interleave with synchronous JS). The order still matters at
+			// source level though: if we flipped `armed` before draining,
+			// a later refactor that inserted an await inside the loop (say
+			// for async onOutput) would let queued 'data' events wake up
+			// mid-drain and race the tail. Drain-then-flip makes that
+			// refactor-safe without needing to re-audit the invariant.
+			for (const chunk of tail) {
+				try {
+					onOutput(chunk);
+				} catch {
+					/* downstream error */
+				}
+			}
+			tail.length = 0;
+			armed = false;
+		};
+
+		const handle: ExecHandle = {
+			execId: attachId,
+			stream: s.stream,
+			resize: (c: number, r: number) => this.resize(attachId, c, r),
+			destroy: () => this.detach(attachId),
+		};
+		return { handle, replay: snapshot.length > 0 ? snapshot : null, flushTail };
+	}
+
+	/**
+	 * Dump the tab's active pane as an escape-sequence-preserving snapshot
+	 * ready to write directly to an xterm. Returns "" on any failure so
+	 * attach() stays robust — a failed snapshot just means the client starts
+	 * blank and gets redrawn by the next live activity.
+	 *
+	 * `-p` prints to stdout (no paste-buffer staging), `-e` preserves colours
+	 * and attributes. We deliberately DON'T pass `-S -` to include scrollback:
+	 * the client's xterm already has its own scrollback, and dumping a full
+	 * history on every reconnect is both expensive and surprising (stale
+	 * lines moving up at connect time).
+	 */
+	private async capturePane(sessionId: string, tabId: string): Promise<string> {
+		try {
+			const { stdout, exitCode } = await this.execOneShot(sessionId, [
+				"tmux",
+				"capture-pane",
+				"-t",
+				tabId,
+				"-p",
+				"-e",
+			]);
+			// A non-zero exit is the common "benign race" path: when
+			// spawnSharedExec's `new-session -A` has just restarted tmux,
+			// the server socket may not be ready when capture-pane races
+			// it — tmux prints "no server running" and exits 1. Returning
+			// "" here means the client starts with a blank pane and the
+			// very next byte of live output redraws it. Intentional.
+			if (exitCode !== 0) return "";
+			// execOneShot returns clean stdout (no PTY, no \r). For a screen
+			// dump xterm needs CRLF line terminators — add the \r back.
+			return stdout.replace(/\n/g, "\r\n");
+		} catch (err) {
+			console.warn(
+				`[docker] capture-pane failed for ${this.targetKey(sessionId, tabId)}:`,
+				(err as Error).message,
+			);
+			return "";
+		}
+	}
+
+	write(attachId: string, data: string): void {
+		const key = this.keyOf.get(attachId);
+		if (!key) return;
+		const pending = this.shared.get(key);
+		if (!pending) return;
+		// By the time a client sends input, attach() has awaited `pending`,
+		// so it's already resolved — the .then just defensively handles the
+		// not-yet-resolved path. No error handler needed: a rejected spawn
+		// clears the slot above; pending would already be gone.
+		pending.then(
+			(s) => {
+				if (!s.stream.destroyed) s.stream.write(data);
+			},
+			() => {
+				/* spawn failed; nothing to write to */
+			},
+		);
+	}
+
+	async resize(attachId: string, cols: number, rows: number): Promise<void> {
+		const key = this.keyOf.get(attachId);
+		if (!key) return;
+		const pending = this.shared.get(key);
+		if (!pending) return;
+		const s = await pending.catch(() => null);
+		if (!s) return;
+		if (!s.clientSizes.has(attachId)) return;
+		s.clientSizes.set(attachId, { cols, rows });
+		await this.recomputeSize(s);
+	}
+
+	detach(attachId: string): void {
+		const key = this.keyOf.get(attachId);
+		if (!key) return;
+		this.keyOf.delete(attachId);
+		const pending = this.shared.get(key);
+		if (!pending) return;
+
+		pending.then(
+			(s) => {
+				s.listeners.delete(attachId);
+				s.clientSizes.delete(attachId);
+
+				if (s.listeners.size === 0) {
+					// Last client gone — tear down the shared exec. On next
+					// attach we respawn and capture-pane replays whatever
+					// state tmux has kept alive in the container.
+					if (this.shared.get(key) === pending) this.shared.delete(key);
+					try {
+						s.stream.destroy();
+					} catch {
+						/* already destroyed */
+					}
+					console.log(`[docker] detached ${attachId}; last client, shared exec closed`);
+				} else {
+					// Someone else may have had a smaller terminal; recompute so
+					// the survivors don't stay pinned to a too-small size.
+					void this.recomputeSize(s);
+					console.log(`[docker] detached ${attachId}; ${s.listeners.size} listener(s) remain`);
+				}
+			},
+			() => {
+				/* spawn rejected; nothing to detach from */
+			},
+		);
+	}
+
+	// ── Shared exec internals ──────────────────────────────────────────────
+
+	private async spawnSharedExec(
+		sessionId: string,
+		key: string,
+		tabId: string,
+	): Promise<SharedExec> {
+		const meta = await this.sessions.getOrThrow(sessionId);
+		if (!meta.containerId) throw new Error("No container for this session");
+
+		const container = this.docker.getContainer(meta.containerId);
+		// `new-session -A` attaches if the tmux session exists, creates it
+		// if not. This is the self-healing path: if the tmux server died
+		// (OOM, user `exit`ed the last pane, crash) the very next WS attach
+		// respawns it transparently instead of hitting "no server running"
+		// and surfacing an error toast. The `-c` keeps the freshly-created
+		// session pointed at the workspace so a recreated tab doesn't land
+		// next to the entrypoint script.
+		//
+		// Trade-off: a recreated tab loses its @tab-label user-option (the
+		// label is stored in tmux memory, not D1, so a tmux restart wipes
+		// it). `listTabs` falls back to `session_name` for that case, which
+		// is an acceptable degradation — it's still reachable, just named
+		// after its id.
+		const exec = await container.exec({
+			Cmd: ["tmux", "new-session", "-A", "-s", tabId, "-c", "/home/developer/workspace"],
+			AttachStdin: true,
+			AttachStdout: true,
+			AttachStderr: true,
+			Tty: true,
+			// Initial env size is a placeholder — recomputeSize applies the real
+			// min-of-all-clients size as soon as the first attach() registers.
+			Env: [`COLUMNS=80`, `LINES=24`],
+		});
+
+		const stream = await exec.start({ hijack: true, stdin: true, Tty: true });
+
+		const s: SharedExec = {
+			execId: key,
+			stream,
+			resize: async (c: number, r: number) => {
+				try {
+					await exec.resize({ h: r, w: c });
+				} catch {
+					/* ignore */
+				}
+			},
+			listeners: new Map(),
+			clientSizes: new Map(),
+			// Sentinel {0,0} forces the first recomputeSize to actually call
+			// exec.resize — any real client size differs from this.
+			appliedSize: { cols: 0, rows: 0 },
+		};
+
+		// Single fan-out for the entire session. Each byte from tmux fires this
+		// exactly once, regardless of how many clients are attached. StringDecoder
+		// buffers partial multi-byte UTF-8 sequences across chunk boundaries.
+		const decoder = new StringDecoder("utf8");
+		const broadcast = (data: string) => {
+			if (!data) return;
+			for (const l of s.listeners.values()) {
+				try {
+					l(data);
+				} catch {
+					/* listener error */
+				}
+			}
+		};
+		stream.on("data", (chunk: Buffer) => {
+			broadcast(decoder.write(chunk));
+		});
+
+		// If the stream dies on its own (tmux server exits, container restarted,
+		// docker daemon hiccup), forget the shared entry so the next attach will
+		// respawn. We guard the delete with a stream-identity check so we never
+		// clobber a newer spawn that replaced us. Orphaned listeners clean
+		// themselves up when their WS closes and detach() runs.
+		const forgetIfCurrent = async () => {
+			const currentP = this.shared.get(key);
+			if (!currentP) return;
+			try {
+				const currentS = await currentP;
+				if (currentS.stream === stream) this.shared.delete(key);
+			} catch {
+				/* newer spawn rejected; not our concern */
+			}
+		};
+		stream.on("end", () => {
+			broadcast(decoder.end());
+			void forgetIfCurrent();
+		});
+		// "close" fires on abrupt destroy (container killed). We intentionally
+		// skip decoder.end() here — calling it would emit U+FFFD for any bytes
+		// stranded in the decoder, and a partial sequence at hard close is
+		// unrecoverable anyway.
+		stream.on("close", () => {
+			void forgetIfCurrent();
+		});
+		stream.on("error", (err) => {
+			console.error(`[docker] shared exec stream error for ${key}:`, (err as Error).message);
+			void forgetIfCurrent();
+		});
+
+		console.log(`[docker] spawned shared exec for ${key}`);
+		return s;
+	}
+
+	// ── Tabs (tmux session per tab) ────────────────────────────────────────
+
+	async listTabs(sessionId: string): Promise<Tab[]> {
+		const { stdout, exitCode } = await this.execOneShot(sessionId, [
+			"tmux",
+			"list-sessions",
+			"-F",
+			"#{session_name}\t#{?@tab-label,#{@tab-label},#{session_name}}\t#{session_created}",
+		]);
+		// tmux returns 1 with "no server running" when the server died. That is
+		// an unusable container for us — surface as empty so callers can recover.
+		if (exitCode !== 0) return [];
+		return stdout
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0)
+			.map((line): Tab => {
+				const [tabId = "", label = "", createdAt = "0"] = line.split("\t");
+				return { tabId, label, createdAt: Number(createdAt) || 0 };
+			});
+	}
+
+	/**
+	 * Create a new tmux session inside the container, tagged with a
+	 * user-visible label stored as a tmux user-option (`@tab-label`).
+	 *
+	 * ## Label contract
+	 *
+	 * Callers must hand in a label that's already been validated — no
+	 * leading/trailing whitespace, no ASCII control chars, 1–64 chars, or
+	 * `undefined` to auto-default to the generated tabId. The REST route
+	 * enforces this (see `validateTabLabel` in routes.ts); this method
+	 * does NO normalisation and stores the label verbatim.
+	 *
+	 * Why the strictness matters: `listTabs` reads labels back via
+	 * `tmux list-sessions -F "…#{@tab-label}…"` which emits results in a
+	 * TSV format (\t-separated fields, \n-separated rows). A \t or \n
+	 * inside the stored label silently corrupts that parser — the
+	 * createdAt field ends up holding label fragments (timestamp parses
+	 * as 0) or phantom tabs appear that don't exist in tmux. \r is
+	 * stripped by execOneShot's demuxer, which would make the stored
+	 * label mismatch the sent one. Rejecting the whole 0x00–0x1F, 0x7F
+	 * range at the API boundary keeps all three paths sound. Higher code
+	 * points (emoji, accented letters, non-Latin scripts) are opaque to
+	 * the TSV parser and safe. See issue #92.
+	 *
+	 * Avoiding `.trim()` here is deliberate: a silent trim would let a
+	 * client observe "what I sent ≠ what came back" (send " foo", get
+	 * "foo" from listTabs). The API rejects leading/trailing whitespace
+	 * instead, so the value stored equals the value accepted.
+	 */
+	async createTab(sessionId: string, label?: string): Promise<Tab> {
+		const tabId = `tab-${randomBytes(4).toString("hex")}`;
+		// `label` is pre-validated by the route handler (non-empty,
+		// trimmed, no control chars). No normalisation here — the
+		// round-trip stored == sent invariant depends on it.
+		const displayLabel = label ?? tabId;
+
+		// `-c` pins the new tab's starting directory to the bind-mounted
+		// workspace. Without it, tmux inherits cwd from docker exec, which
+		// uses the image's WORKDIR (/home/developer) and dumps the user
+		// next to entrypoint.sh instead of in their project files.
+		const create = await this.execOneShot(sessionId, [
+			"tmux",
+			"new-session",
+			"-d",
+			"-s",
+			tabId,
+			"-c",
+			"/home/developer/workspace",
+			"-x",
+			"120",
+			"-y",
+			"36",
+		]);
+		if (create.exitCode !== 0) {
+			throw new Error(`tmux new-session failed (exit ${create.exitCode}): ${create.stdout}`);
+		}
+
+		// User-option stays with the tmux session for its lifetime — survives
+		// backend restarts, doesn't need a D1 table.
+		await this.execOneShot(sessionId, [
+			"tmux",
+			"set-option",
+			"-t",
+			tabId,
+			"@tab-label",
+			displayLabel,
+		]);
+
+		const now = Math.floor(Date.now() / 1000);
+		console.log(`[docker] created tab ${tabId} (${displayLabel}) in session ${sessionId}`);
+		return { tabId, label: displayLabel, createdAt: now };
+	}
+
+	async deleteTab(sessionId: string, tabId: string): Promise<void> {
+		// Tear down any shared exec for this tab first so we don't leave
+		// dangling handles pointing at a dead tmux session.
+		const key = this.targetKey(sessionId, tabId);
+		const pending = this.shared.get(key);
+		if (pending) {
+			this.shared.delete(key);
+			pending.then(
+				(s) => {
+					try {
+						s.stream.destroy();
+					} catch {
+						/* already destroyed */
+					}
+				},
+				() => {
+					/* spawn rejected — nothing to destroy */
+				},
+			);
+		}
+		for (const [attachId, k] of this.keyOf) {
+			if (k === key) this.keyOf.delete(attachId);
+		}
+
+		const { exitCode } = await this.execOneShot(sessionId, ["tmux", "kill-session", "-t", tabId]);
+		if (exitCode !== 0) {
+			// kill-session returns non-zero if the target doesn't exist — OK for
+			// the idempotent case; caller has already validated it existed.
+			console.warn(`[docker] kill-session ${tabId} exited ${exitCode}`);
+		}
+		console.log(`[docker] deleted tab ${tabId} from session ${sessionId}`);
+	}
+
+	private async execOneShot(
+		sessionId: string,
+		cmd: string[],
+	): Promise<{ stdout: string; exitCode: number }> {
+		const meta = await this.sessions.getOrThrow(sessionId);
+		if (!meta.containerId) throw new Error("No container for this session");
+		const container = this.docker.getContainer(meta.containerId);
+
+		const exec = await container.exec({
+			Cmd: cmd,
+			AttachStdin: false,
+			AttachStdout: true,
+			AttachStderr: true,
+			// Tty:false keeps stdout in Docker multiplexed frames (type=1).
+			// Tty:true would allocate a PTY which expands \t → spaces,
+			// corrupting the tab-separated output from tmux list-sessions.
+			Tty: false,
+		});
+		const stream = await exec.start({ hijack: false, stdin: false });
+		const chunks: Buffer[] = [];
+		stream.on("data", (c: Buffer) => chunks.push(c));
+		await new Promise<void>((resolve, reject) => {
+			stream.on("end", () => resolve());
+			stream.on("close", () => resolve());
+			stream.on("error", reject);
+		});
+		const info = await exec.inspect();
+		return {
+			stdout: demuxDockerOutput(Buffer.concat(chunks), 1),
+			exitCode: info.ExitCode ?? 0,
+		};
+	}
+
+	private async recomputeSize(s: SharedExec): Promise<void> {
+		if (s.clientSizes.size === 0) return;
+		let minCols = Number.POSITIVE_INFINITY;
+		let minRows = Number.POSITIVE_INFINITY;
+		for (const { cols, rows } of s.clientSizes.values()) {
+			if (cols < minCols) minCols = cols;
+			if (rows < minRows) minRows = rows;
+		}
+		if (minCols !== s.appliedSize.cols || minRows !== s.appliedSize.rows) {
+			s.appliedSize = { cols: minCols, rows: minRows };
+			await s.resize(minCols, minRows);
+		}
+	}
+
+	// ── Helpers ─────────────────────────────────────────────────────────────
+
+	/**
+	 * Best-effort sweep of the multer tmp directory at startup. If the
+	 * backend was OOM-killed or crashed mid-upload, multer's tmp files
+	 * (which the upload route would normally rename or unlink) are left
+	 * behind forever — harmless to security but accumulates on disk
+	 * over crash/restart cycles. Called from reconcile() so the same
+	 * startup hook handles both forms of stale state.
+	 */
+	async sweepUploadTmp(): Promise<void> {
+		const dir = this.getUploadTmpDir();
+		let entries: Dirent[];
+		try {
+			entries = await fs.readdir(dir, { withFileTypes: true });
+		} catch (err) {
+			// ENOENT is expected on a fresh deployment — nothing to sweep.
+			if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+				console.warn(
+					`[docker] sweepUploadTmp readdir failed for ${dir}: ${(err as Error).message}`,
+				);
+			}
+			return;
+		}
+		// Filter to plain files. `fs.unlink` on a directory returns
+		// EISDIR — not actionable here and would skew the
+		// success/failure log. No code path in this module creates
+		// subdirs under .tmp-uploads today, but a future regression
+		// (or operator dropping something there) would silently
+		// accumulate without this guard.
+		const fileEntries = entries.filter((e) => e.isFile());
+		if (fileEntries.length === 0) return;
+		const results = await Promise.allSettled(
+			fileEntries.map((e) => fs.unlink(path.join(dir, e.name))),
+		);
+		const failed = results.filter((r) => r.status === "rejected").length;
+		console.log(
+			`[docker] sweepUploadTmp removed ${fileEntries.length - failed}/${fileEntries.length} stale tmp files`,
+		);
+	}
+
+	async reconcile(): Promise<void> {
+		console.log("[docker] reconciling session state with Docker…");
+		await this.sweepUploadTmp();
+		const result = await d1Query<{ session_id: string; container_id: string | null }>(
+			"SELECT session_id, container_id FROM sessions WHERE status = 'running'",
+		);
+
+		for (const row of result.results) {
+			if (!row.container_id) {
+				await this.sessions.updateStatus(row.session_id, "stopped");
+				continue;
+			}
+			try {
+				const info = await this.docker.getContainer(row.container_id).inspect();
+				// reconcile() runs on every backend boot, which is the
+				// most-likely deploy moment. Surface pre-#15 containers
+				// here regardless of running state — operators who stop
+				// all sessions before deploying still need the warning,
+				// since the next `/start` would be the only other place
+				// it'd surface and that requires the operator to remember
+				// to start each one.
+				this.warnIfPreHardened(row.session_id, row.container_id, info.HostConfig);
+				if (!info.State.Running) {
+					await this.sessions.updateStatus(row.session_id, "stopped");
+				}
+			} catch (err) {
+				// Only 404 means container is actually gone (atomic null+stopped).
+				// Non-404 (daemon unreachable, etc.) might be transient — keep the
+				// id so /start can retry the real container, don't orphan it.
+				const statusCode = (err as { statusCode?: number }).statusCode;
+				if (statusCode === 404) {
+					await this.sessions.recordContainerGone(row.session_id);
+				} else {
+					console.warn(
+						`[docker] reconcile inspect failed for session ${row.session_id}: ${(err as Error).message}`,
+					);
+					await this.sessions.updateStatus(row.session_id, "stopped");
+				}
+			}
+		}
+		console.log("[docker] reconciliation complete");
+	}
 }
 
 // ── Module-level helpers ─────────────────────────────────────────────────────
@@ -1239,12 +1356,12 @@ export class DockerManager {
 // short-session-id label if every char gets stripped (e.g. "---", "中文").
 // Exported for tests.
 export function sanitiseHostname(name: string, sessionId: string): string {
-        return (
-                name
-                        .replace(/[^a-zA-Z0-9-]/g, "-")
-                        .slice(0, 63)
-                        .replace(/^-+|-+$/g, "") || `session-${sessionId.slice(0, 8)}`
-        );
+	return (
+		name
+			.replace(/[^a-zA-Z0-9-]/g, "-")
+			.slice(0, 63)
+			.replace(/^-+|-+$/g, "") || `session-${sessionId.slice(0, 8)}`
+	);
 }
 
 // Sanitise an uploaded file's original name into a safe basename that's
@@ -1252,40 +1369,40 @@ export function sanitiseHostname(name: string, sessionId: string): string {
 // components, restricts the character set, preserves a short extension,
 // and falls back to "file" if everything got stripped. Exported for tests.
 export function sanitiseUploadName(original: string): string {
-        const base = path.basename(original ?? "");
-        // Restrict to a small Latin set so the path is shell-safe (the user
-        // pastes it into the terminal as-is) and filesystem-portable.
-        // Anything else is collapsed to underscore.
-        // Strip leading [._-] so the sanitised name can never start with a
-        // dash. Today the result is always pasted as part of an absolute
-        // path (so a leading "-" wouldn't matter as a shell flag), but a
-        // future caller passing safeBase as a bare argument would otherwise
-        // be vulnerable to flag injection (`-rf.sh` parsed as `-r -f .sh`).
-        const cleaned = base.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._-]+/, "");
-        if (!cleaned) return "file";
-        // Preserve the extension up to a max stem length so names stay
-        // readable in `ls` and don't blow past common filesystem limits.
-        const MAX_LEN = 80;
-        if (cleaned.length <= MAX_LEN) return cleaned;
-        const dot = cleaned.lastIndexOf(".");
-        if (dot < 0 || dot >= cleaned.length - 1) return cleaned.slice(0, MAX_LEN);
-        const ext = cleaned.slice(dot).slice(0, 16); // also cap extension
-        return cleaned.slice(0, MAX_LEN - ext.length) + ext;
+	const base = path.basename(original ?? "");
+	// Restrict to a small Latin set so the path is shell-safe (the user
+	// pastes it into the terminal as-is) and filesystem-portable.
+	// Anything else is collapsed to underscore.
+	// Strip leading [._-] so the sanitised name can never start with a
+	// dash. Today the result is always pasted as part of an absolute
+	// path (so a leading "-" wouldn't matter as a shell flag), but a
+	// future caller passing safeBase as a bare argument would otherwise
+	// be vulnerable to flag injection (`-rf.sh` parsed as `-r -f .sh`).
+	const cleaned = base.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._-]+/, "");
+	if (!cleaned) return "file";
+	// Preserve the extension up to a max stem length so names stay
+	// readable in `ls` and don't blow past common filesystem limits.
+	const MAX_LEN = 80;
+	if (cleaned.length <= MAX_LEN) return cleaned;
+	const dot = cleaned.lastIndexOf(".");
+	if (dot < 0 || dot >= cleaned.length - 1) return cleaned.slice(0, MAX_LEN);
+	const ext = cleaned.slice(dot).slice(0, 16); // also cap extension
+	return cleaned.slice(0, MAX_LEN - ext.length) + ext;
 }
 
 // Parse the Docker multiplexed stream format used when Tty:false.
 // Frame layout: [type(1)][pad(3)][size(4 BE)] followed by `size` payload bytes.
 // type 1 = stdout, type 2 = stderr. We collect only the requested type.
 function demuxDockerOutput(raw: Buffer, type: 1 | 2): string {
-        const chunks: Buffer[] = [];
-        let off = 0;
-        while (off + 8 <= raw.length) {
-                const frameType = raw[off]!;
-                const size = raw.readUInt32BE(off + 4);
-                off += 8;
-                if (off + size > raw.length) break;
-                if (frameType === type) chunks.push(raw.subarray(off, off + size));
-                off += size;
-        }
-        return Buffer.concat(chunks).toString("utf-8");
+	const chunks: Buffer[] = [];
+	let off = 0;
+	while (off + 8 <= raw.length) {
+		const frameType = raw[off]!;
+		const size = raw.readUInt32BE(off + 4);
+		off += 8;
+		if (off + size > raw.length) break;
+		if (frameType === type) chunks.push(raw.subarray(off, off + size));
+		off += size;
+	}
+	return Buffer.concat(chunks).toString("utf-8");
 }

--- a/backend/src/dockerManager.uploads.test.ts
+++ b/backend/src/dockerManager.uploads.test.ts
@@ -10,17 +10,17 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 // The quota is set tight (10 KB) so we can deterministically trigger
 // UploadQuotaExceededError with a single ~15 KB tmp file.
 const WORKSPACE_ROOT = vi.hoisted(() => {
-        const dir = `/tmp/st-uploads-test-${process.pid}-${Date.now()}`;
-        process.env.WORKSPACE_ROOT = dir;
-        process.env.UPLOAD_QUOTA_BYTES = "10000";
-        return dir;
+	const dir = `/tmp/st-uploads-test-${process.pid}-${Date.now()}`;
+	process.env.WORKSPACE_ROOT = dir;
+	process.env.UPLOAD_QUOTA_BYTES = "10000";
+	return dir;
 });
 
 // dockerode tries to lazy-connect on first call, not at construction —
 // passing a bogus socket keeps the constructor happy and these tests
 // never exercise any docker.* path.
 const dbStubs = vi.hoisted(() => ({
-        d1Query: vi.fn(async () => ({ results: [], meta: { changes: 0 } })),
+	d1Query: vi.fn(async () => ({ results: [], meta: { changes: 0 } })),
 }));
 vi.mock("./db.js", () => dbStubs);
 
@@ -28,202 +28,205 @@ import { DockerManager, UploadQuotaExceededError } from "./dockerManager.js";
 import type { SessionManager } from "./sessionManager.js";
 
 function makeDocker(): DockerManager {
-        const fakeSessions = {} as unknown as SessionManager;
-        return new DockerManager(fakeSessions, { socketPath: "/dev/null" });
+	const fakeSessions = {} as unknown as SessionManager;
+	return new DockerManager(fakeSessions, { socketPath: "/dev/null" });
 }
 
 // Drop a file in the multer tmp dir as if multer's diskStorage had just
 // streamed an upload there. Returns the shape writeUploads consumes.
 async function makeTmpFile(
-        dm: DockerManager,
-        originalname: string,
-        content: string | Buffer,
+	dm: DockerManager,
+	originalname: string,
+	content: string | Buffer,
 ): Promise<{ originalname: string; path: string }> {
-        const tmpDir = dm.getUploadTmpDir();
-        await fs.mkdir(tmpDir, { recursive: true });
-        const tmpPath = path.join(tmpDir, `tmp-${Math.random().toString(36).slice(2)}`);
-        await fs.writeFile(tmpPath, content);
-        return { originalname, path: tmpPath };
+	const tmpDir = dm.getUploadTmpDir();
+	await fs.mkdir(tmpDir, { recursive: true });
+	const tmpPath = path.join(tmpDir, `tmp-${Math.random().toString(36).slice(2)}`);
+	await fs.writeFile(tmpPath, content);
+	return { originalname, path: tmpPath };
 }
 
 async function rmRf(p: string): Promise<void> {
-        await fs.rm(p, { recursive: true, force: true });
+	await fs.rm(p, { recursive: true, force: true });
 }
 
 beforeAll(async () => {
-        await fs.mkdir(WORKSPACE_ROOT, { recursive: true });
+	await fs.mkdir(WORKSPACE_ROOT, { recursive: true });
 });
 
 afterAll(async () => {
-        await rmRf(WORKSPACE_ROOT);
+	await rmRf(WORKSPACE_ROOT);
 });
 
 describe("writeUploads", () => {
-        let dm: DockerManager;
+	let dm: DockerManager;
 
-        beforeEach(async () => {
-                // Wipe per-test state — the prior test's session dirs and any
-                // stragglers in the tmp dir would otherwise pollute the next
-                // test's expectations.
-                const entries = await fs.readdir(WORKSPACE_ROOT).catch(() => [] as string[]);
-                for (const e of entries) await rmRf(path.join(WORKSPACE_ROOT, e));
-                dm = makeDocker();
-        });
+	beforeEach(async () => {
+		// Wipe per-test state — the prior test's session dirs and any
+		// stragglers in the tmp dir would otherwise pollute the next
+		// test's expectations.
+		const entries = await fs.readdir(WORKSPACE_ROOT).catch(() => [] as string[]);
+		for (const e of entries) await rmRf(path.join(WORKSPACE_ROOT, e));
+		dm = makeDocker();
+	});
 
-        // Helper: per-session uploads dir on host, where writeUploads
-        // actually moves files to. Lives at <WORKSPACE_ROOT>/.uploads/
-        // <sessionId>/ — out-of-workspace by design (TOCTOU isolation,
-        // see writeUploadsImpl). spawn() bind-mounts this dir read-only
-        // into the container at /home/developer/workspace/uploads/, but
-        // these tests never construct containers — they only exercise
-        // host-side state.
-        const uploadsHostDir = (sid: string) => path.join(WORKSPACE_ROOT, ".uploads", sid);
+	// Helper: per-session uploads dir on host, where writeUploads
+	// actually moves files to. Lives at <WORKSPACE_ROOT>/.uploads/
+	// <sessionId>/ — out-of-workspace by design (TOCTOU isolation,
+	// see writeUploadsImpl). spawn() bind-mounts this dir read-only
+	// into the container at /home/developer/workspace/uploads/, but
+	// these tests never construct containers — they only exercise
+	// host-side state.
+	const uploadsHostDir = (sid: string) => path.join(WORKSPACE_ROOT, ".uploads", sid);
 
-        it("writes each file under .uploads/<session>/ and returns the in-container path", async () => {
-                // Two small files, well under the 10 KB quota.
-                const a = await makeTmpFile(dm, "alpha.png", "alpha-bytes");
-                const b = await makeTmpFile(dm, "beta.txt", "beta-bytes");
+	it("writes each file under .uploads/<session>/ and returns the in-container path", async () => {
+		// Two small files, well under the 10 KB quota.
+		const a = await makeTmpFile(dm, "alpha.png", "alpha-bytes");
+		const b = await makeTmpFile(dm, "beta.txt", "beta-bytes");
 
-                const result = await dm.writeUploads("session-happy", [a, b]);
+		const result = await dm.writeUploads("session-happy", [a, b]);
 
-                expect(result).toHaveLength(2);
-                for (const p of result) {
-                        expect(p.startsWith("/home/developer/workspace/uploads/")).toBe(true);
-                }
-                // The container paths' filenames map directly onto the
-                // host-side basenames — useful guarantee for tests that want
-                // to spot-check on-disk state.
-                const onDisk = await fs.readdir(uploadsHostDir("session-happy"));
-                expect(onDisk).toHaveLength(2);
-                for (const p of result) {
-                        expect(onDisk).toContain(path.basename(p));
-                }
+		expect(result).toHaveLength(2);
+		for (const p of result) {
+			expect(p.startsWith("/home/developer/workspace/uploads/")).toBe(true);
+		}
+		// The container paths' filenames map directly onto the
+		// host-side basenames — useful guarantee for tests that want
+		// to spot-check on-disk state.
+		const onDisk = await fs.readdir(uploadsHostDir("session-happy"));
+		expect(onDisk).toHaveLength(2);
+		for (const p of result) {
+			expect(onDisk).toContain(path.basename(p));
+		}
 
-                // Tmp dir should be empty — every file got renamed (moved),
-                // not copied; orphans here would leak under the rate limiter.
-                const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
-                expect(tmpEntries).toHaveLength(0);
-        });
+		// Tmp dir should be empty — every file got renamed (moved),
+		// not copied; orphans here would leak under the rate limiter.
+		const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
+		expect(tmpEntries).toHaveLength(0);
+	});
 
-        it("preserves file content across the rename(2) move", async () => {
-                const payload = Buffer.from("the quick brown fox jumps over the lazy dog");
-                const f = await makeTmpFile(dm, "phrase.txt", payload);
+	it("preserves file content across the rename(2) move", async () => {
+		const payload = Buffer.from("the quick brown fox jumps over the lazy dog");
+		const f = await makeTmpFile(dm, "phrase.txt", payload);
 
-                const [containerPath] = await dm.writeUploads("session-content", [f]);
-                expect(containerPath).toBeDefined();
-                const hostPath = path.join(
-                        uploadsHostDir("session-content"),
-                        path.basename(containerPath as string),
-                );
-                const written = await fs.readFile(hostPath);
-                expect(written.equals(payload)).toBe(true);
-        });
+		const [containerPath] = await dm.writeUploads("session-content", [f]);
+		expect(containerPath).toBeDefined();
+		const hostPath = path.join(
+			uploadsHostDir("session-content"),
+			path.basename(containerPath as string),
+		);
+		const written = await fs.readFile(hostPath);
+		expect(written.equals(payload)).toBe(true);
+	});
 
-        it("throws UploadQuotaExceededError and cleans tmp files when batch exceeds quota", async () => {
-                // 15 KB > 10 KB cap, in a single file.
-                const big = await makeTmpFile(dm, "log.txt", "x".repeat(15000));
+	it("throws UploadQuotaExceededError and cleans tmp files when batch exceeds quota", async () => {
+		// 15 KB > 10 KB cap, in a single file.
+		const big = await makeTmpFile(dm, "log.txt", "x".repeat(15000));
 
-                await expect(dm.writeUploads("session-quota", [big])).rejects.toBeInstanceOf(
-                        UploadQuotaExceededError,
-                );
+		await expect(dm.writeUploads("session-quota", [big])).rejects.toBeInstanceOf(
+			UploadQuotaExceededError,
+		);
 
-                // Tmp file unlinked on the bail-out path.
-                const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
-                expect(tmpEntries).toHaveLength(0);
+		// Tmp file unlinked on the bail-out path.
+		const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
+		expect(tmpEntries).toHaveLength(0);
 
-                // Nothing landed in the session's uploads dir.
-                const onDisk = await fs.readdir(uploadsHostDir("session-quota")).catch(() => [] as string[]);
-                expect(onDisk).toHaveLength(0);
-        });
+		// Nothing landed in the session's uploads dir.
+		const onDisk = await fs.readdir(uploadsHostDir("session-quota")).catch(() => [] as string[]);
+		expect(onDisk).toHaveLength(0);
+	});
 
-        it("counts pre-existing uploads against the quota across requests", async () => {
-                // First request: 6 KB succeeds.
-                const first = await makeTmpFile(dm, "a.txt", "x".repeat(6000));
-                await dm.writeUploads("session-cumulative", [first]);
+	it("counts pre-existing uploads against the quota across requests", async () => {
+		// First request: 6 KB succeeds.
+		const first = await makeTmpFile(dm, "a.txt", "x".repeat(6000));
+		await dm.writeUploads("session-cumulative", [first]);
 
-                // Second request: 5 KB would push total to 11 KB > 10 KB cap.
-                const second = await makeTmpFile(dm, "b.txt", "x".repeat(5000));
-                await expect(dm.writeUploads("session-cumulative", [second])).rejects.toBeInstanceOf(
-                        UploadQuotaExceededError,
-                );
+		// Second request: 5 KB would push total to 11 KB > 10 KB cap.
+		const second = await makeTmpFile(dm, "b.txt", "x".repeat(5000));
+		await expect(dm.writeUploads("session-cumulative", [second])).rejects.toBeInstanceOf(
+			UploadQuotaExceededError,
+		);
 
-                // First file is still in place; only the second was rejected.
-                const onDisk = await fs.readdir(uploadsHostDir("session-cumulative"));
-                expect(onDisk).toHaveLength(1);
-        });
+		// First file is still in place; only the second was rejected.
+		const onDisk = await fs.readdir(uploadsHostDir("session-cumulative"));
+		expect(onDisk).toHaveLength(1);
+	});
 
-        it("serialises concurrent writeUploads for the same session so two batches can't both pass the quota check", async () => {
-                // Each batch is 6 KB on its own; either alone fits under the
-                // 10 KB cap. Together they would push to 12 KB and break the
-                // cap — but only if the two reads of usedBytes both saw
-                // zero. The per-session lock guarantees the second batch
-                // reads the first's bytes, so exactly one wins.
-                const a = await makeTmpFile(dm, "a.txt", "x".repeat(6000));
-                const b = await makeTmpFile(dm, "b.txt", "x".repeat(6000));
+	it("serialises concurrent writeUploads for the same session so two batches can't both pass the quota check", async () => {
+		// Each batch is 6 KB on its own; either alone fits under the
+		// 10 KB cap. Together they would push to 12 KB and break the
+		// cap — but only if the two reads of usedBytes both saw
+		// zero. The per-session lock guarantees the second batch
+		// reads the first's bytes, so exactly one wins.
+		const a = await makeTmpFile(dm, "a.txt", "x".repeat(6000));
+		const b = await makeTmpFile(dm, "b.txt", "x".repeat(6000));
 
-                const results = await Promise.allSettled([
-                        dm.writeUploads("session-concurrent", [a]),
-                        dm.writeUploads("session-concurrent", [b]),
-                ]);
+		const results = await Promise.allSettled([
+			dm.writeUploads("session-concurrent", [a]),
+			dm.writeUploads("session-concurrent", [b]),
+		]);
 
-                const fulfilled = results.filter((r) => r.status === "fulfilled");
-                const rejected = results.filter((r) => r.status === "rejected");
-                expect(fulfilled).toHaveLength(1);
-                expect(rejected).toHaveLength(1);
-                expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
-                        UploadQuotaExceededError,
-                );
+		const fulfilled = results.filter((r) => r.status === "fulfilled");
+		const rejected = results.filter((r) => r.status === "rejected");
+		expect(fulfilled).toHaveLength(1);
+		expect(rejected).toHaveLength(1);
+		expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(UploadQuotaExceededError);
 
-                // Exactly one file on disk under uploads/.
-                const onDisk = await fs.readdir(uploadsHostDir("session-concurrent"));
-                expect(onDisk).toHaveLength(1);
-                // Both tmp files cleaned up — winner via rename, loser via cleanupTmp.
-                const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
-                expect(tmpEntries).toHaveLength(0);
-        });
+		// Exactly one file on disk under uploads/.
+		const onDisk = await fs.readdir(uploadsHostDir("session-concurrent"));
+		expect(onDisk).toHaveLength(1);
+		// Both tmp files cleaned up — winner via rename, loser via cleanupTmp.
+		const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
+		expect(tmpEntries).toHaveLength(0);
+	});
 
-        it("rejects when the resolved session path escapes the .uploads/ namespace", async () => {
-                // sessionId "../escape" makes path.join collapse one level —
-                // path.join(WORKSPACE_ROOT, ".uploads", "../escape") is
-                // <WORKSPACE_ROOT>/escape, still under WORKSPACE_ROOT but
-                // outside .uploads/. The containment check below is scoped to
-                // .uploads/ specifically (NOT just WORKSPACE_ROOT) so the
-                // traversal is caught before any fs op runs.
-                const f = await makeTmpFile(dm, "evil.txt", "payload");
-                await expect(dm.writeUploads("../escape", [f])).rejects.toThrow(/unsafe session path/);
-                // Tmp file cleaned up on the bail-out.
-                const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
-                expect(tmpEntries).toHaveLength(0);
-        });
+	it("rejects when the resolved session path escapes the .uploads/ namespace", async () => {
+		// sessionId "../escape" makes path.join collapse one level —
+		// path.join(WORKSPACE_ROOT, ".uploads", "../escape") is
+		// <WORKSPACE_ROOT>/escape, still under WORKSPACE_ROOT but
+		// outside .uploads/. The containment check below is scoped to
+		// .uploads/ specifically (NOT just WORKSPACE_ROOT) so the
+		// traversal is caught before any fs op runs.
+		const f = await makeTmpFile(dm, "evil.txt", "payload");
+		await expect(dm.writeUploads("../escape", [f])).rejects.toThrow(/unsafe session path/);
+		// Tmp file cleaned up on the bail-out.
+		const tmpEntries = await fs.readdir(dm.getUploadTmpDir());
+		expect(tmpEntries).toHaveLength(0);
+	});
 
-        it("returns an empty array (and writes nothing) for an empty file list", async () => {
-                const result = await dm.writeUploads("session-empty", []);
-                expect(result).toEqual([]);
-                // Should not even mkdir the uploads dir for an empty batch.
-                const sessionDir = uploadsHostDir("session-empty");
-                const exists = await fs.stat(sessionDir).then(() => true, () => false);
-                expect(exists).toBe(false);
-        });
+	it("returns an empty array (and writes nothing) for an empty file list", async () => {
+		const result = await dm.writeUploads("session-empty", []);
+		expect(result).toEqual([]);
+		// Should not even mkdir the uploads dir for an empty batch.
+		const sessionDir = uploadsHostDir("session-empty");
+		const exists = await fs.stat(sessionDir).then(
+			() => true,
+			() => false,
+		);
+		expect(exists).toBe(false);
+	});
 });
 
 describe("sweepUploadTmp", () => {
-        let dm: DockerManager;
-        beforeEach(() => { dm = makeDocker(); });
+	let dm: DockerManager;
+	beforeEach(() => {
+		dm = makeDocker();
+	});
 
-        it("removes every file in the tmp dir", async () => {
-                const tmpDir = dm.getUploadTmpDir();
-                await fs.mkdir(tmpDir, { recursive: true });
-                await fs.writeFile(path.join(tmpDir, "stale1"), "x");
-                await fs.writeFile(path.join(tmpDir, "stale2"), "y");
+	it("removes every file in the tmp dir", async () => {
+		const tmpDir = dm.getUploadTmpDir();
+		await fs.mkdir(tmpDir, { recursive: true });
+		await fs.writeFile(path.join(tmpDir, "stale1"), "x");
+		await fs.writeFile(path.join(tmpDir, "stale2"), "y");
 
-                await dm.sweepUploadTmp();
+		await dm.sweepUploadTmp();
 
-                const remaining = await fs.readdir(tmpDir);
-                expect(remaining).toEqual([]);
-        });
+		const remaining = await fs.readdir(tmpDir);
+		expect(remaining).toEqual([]);
+	});
 
-        it("no-ops when the tmp dir doesn't exist (fresh deployment)", async () => {
-                await rmRf(dm.getUploadTmpDir());
-                await expect(dm.sweepUploadTmp()).resolves.toBeUndefined();
-        });
+	it("no-ops when the tmp dir doesn't exist (fresh deployment)", async () => {
+		await rmRf(dm.getUploadTmpDir());
+		await expect(dm.sweepUploadTmp()).resolves.toBeUndefined();
+	});
 });

--- a/backend/src/envVarValidation.test.ts
+++ b/backend/src/envVarValidation.test.ts
@@ -1,288 +1,288 @@
 import { describe, expect, it } from "vitest";
 import {
-        EnvVarValidationError,
-        MAX_ENV_VAR_COUNT,
-        MAX_ENV_VAR_NAME_LENGTH,
-        MAX_ENV_VAR_VALUE_LENGTH,
-        MAX_ENV_VARS_TOTAL_BYTES,
-        validateEnvVars,
+	EnvVarValidationError,
+	MAX_ENV_VAR_COUNT,
+	MAX_ENV_VAR_NAME_LENGTH,
+	MAX_ENV_VAR_VALUE_LENGTH,
+	MAX_ENV_VARS_TOTAL_BYTES,
+	validateEnvVars,
 } from "./envVarValidation.js";
 
 describe("validateEnvVars", () => {
-        it("returns an empty object for undefined or empty-object input", () => {
-                // `undefined` means the field was omitted from the body (POST
-                // /sessions allows that; the route defaults to an empty env).
-                // `{}` is the explicit "clear everything" shape used by the
-                // PATCH route. `null` is deliberately excluded — see the next
-                // test for why.
-                expect(validateEnvVars(undefined)).toEqual({});
-                expect(validateEnvVars({})).toEqual({});
-        });
+	it("returns an empty object for undefined or empty-object input", () => {
+		// `undefined` means the field was omitted from the body (POST
+		// /sessions allows that; the route defaults to an empty env).
+		// `{}` is the explicit "clear everything" shape used by the
+		// PATCH route. `null` is deliberately excluded — see the next
+		// test for why.
+		expect(validateEnvVars(undefined)).toEqual({});
+		expect(validateEnvVars({})).toEqual({});
+	});
 
-        it("rejects null so a client bug can't silently wipe env on PATCH", () => {
-                // The PATCH /sessions/:id/env handler rejects `undefined`
-                // with a 400 ("body.envVars is required") so callers are
-                // forced to be explicit. But `null` slips past that check
-                // (null !== undefined) — if we collapsed null to {} here,
-                // a frontend that forgot to guard a nullable field would
-                // silently wipe the user's env vars instead of 400ing.
-                // Reject null as invalid shape.
-                expect(() => validateEnvVars(null)).toThrow(/must be an object/);
-        });
+	it("rejects null so a client bug can't silently wipe env on PATCH", () => {
+		// The PATCH /sessions/:id/env handler rejects `undefined`
+		// with a 400 ("body.envVars is required") so callers are
+		// forced to be explicit. But `null` slips past that check
+		// (null !== undefined) — if we collapsed null to {} here,
+		// a frontend that forgot to guard a nullable field would
+		// silently wipe the user's env vars instead of 400ing.
+		// Reject null as invalid shape.
+		expect(() => validateEnvVars(null)).toThrow(/must be an object/);
+	});
 
-        it("accepts conventional env var shapes", () => {
-                const input = {
-                        DATABASE_URL: "postgres://localhost/db",
-                        _LEADING_UNDERSCORE: "ok",
-                        WITH_DIGITS_123: "v1",
-                        ONE_CHAR_NAME: "x",
-                        A: "minimal",
-                };
-                // Result should be strictly equal by value (same keys, same values).
-                expect(validateEnvVars(input)).toEqual(input);
-        });
+	it("accepts conventional env var shapes", () => {
+		const input = {
+			DATABASE_URL: "postgres://localhost/db",
+			_LEADING_UNDERSCORE: "ok",
+			WITH_DIGITS_123: "v1",
+			ONE_CHAR_NAME: "x",
+			A: "minimal",
+		};
+		// Result should be strictly equal by value (same keys, same values).
+		expect(validateEnvVars(input)).toEqual(input);
+	});
 
-        it("strips prototype-chain properties", () => {
-                // Constructing an object with an inherited property so we can verify
-                // the validator only looks at own enumerable keys — a conventional
-                // POST body won't carry this, but a malicious client could.
-                const parent = { INHERITED: "should-not-appear" };
-                const child = Object.create(parent);
-                child.OWN = "visible";
-                const result = validateEnvVars(child);
-                expect(result).toEqual({ OWN: "visible" });
-                // Object.hasOwn (ES2022) is biome's preferred form over
-                // Object.prototype.hasOwnProperty.call — same semantics, no
-                // prototype-chain surprise if the object itself defines a
-                // `hasOwnProperty` key. Node 16.9+ ships it; our backend is on
-                // Node 20, so unconditionally safe.
-                expect(Object.hasOwn(result, "INHERITED")).toBe(false);
-        });
+	it("strips prototype-chain properties", () => {
+		// Constructing an object with an inherited property so we can verify
+		// the validator only looks at own enumerable keys — a conventional
+		// POST body won't carry this, but a malicious client could.
+		const parent = { INHERITED: "should-not-appear" };
+		const child = Object.create(parent);
+		child.OWN = "visible";
+		const result = validateEnvVars(child);
+		expect(result).toEqual({ OWN: "visible" });
+		// Object.hasOwn (ES2022) is biome's preferred form over
+		// Object.prototype.hasOwnProperty.call — same semantics, no
+		// prototype-chain surprise if the object itself defines a
+		// `hasOwnProperty` key. Node 16.9+ ships it; our backend is on
+		// Node 20, so unconditionally safe.
+		expect(Object.hasOwn(result, "INHERITED")).toBe(false);
+	});
 
-        // ── type/shape errors ──────────────────────────────────────────────
+	// ── type/shape errors ──────────────────────────────────────────────
 
-        it("rejects non-object inputs", () => {
-                expect(() => validateEnvVars("foo")).toThrow(EnvVarValidationError);
-                expect(() => validateEnvVars(42)).toThrow(EnvVarValidationError);
-                expect(() => validateEnvVars(true)).toThrow(EnvVarValidationError);
-                expect(() => validateEnvVars([])).toThrow(EnvVarValidationError);
-        });
+	it("rejects non-object inputs", () => {
+		expect(() => validateEnvVars("foo")).toThrow(EnvVarValidationError);
+		expect(() => validateEnvVars(42)).toThrow(EnvVarValidationError);
+		expect(() => validateEnvVars(true)).toThrow(EnvVarValidationError);
+		expect(() => validateEnvVars([])).toThrow(EnvVarValidationError);
+	});
 
-        it("rejects non-string values", () => {
-                expect(() => validateEnvVars({ FOO: 123 })).toThrow(/must be a string/);
-                expect(() => validateEnvVars({ FOO: null })).toThrow(/must be a string/);
-                expect(() => validateEnvVars({ FOO: { nested: "obj" } })).toThrow(/must be a string/);
-        });
+	it("rejects non-string values", () => {
+		expect(() => validateEnvVars({ FOO: 123 })).toThrow(/must be a string/);
+		expect(() => validateEnvVars({ FOO: null })).toThrow(/must be a string/);
+		expect(() => validateEnvVars({ FOO: { nested: "obj" } })).toThrow(/must be a string/);
+	});
 
-        // ── name-shape errors ──────────────────────────────────────────────
+	// ── name-shape errors ──────────────────────────────────────────────
 
-        it("rejects keys that start with a digit", () => {
-                expect(() => validateEnvVars({ "1FOO": "v" })).toThrow(/not a valid POSIX/);
-        });
+	it("rejects keys that start with a digit", () => {
+		expect(() => validateEnvVars({ "1FOO": "v" })).toThrow(/not a valid POSIX/);
+	});
 
-        it("rejects keys containing '=' or whitespace", () => {
-                expect(() => validateEnvVars({ "FOO=BAR": "v" })).toThrow(/not a valid POSIX/);
-                expect(() => validateEnvVars({ "FOO BAR": "v" })).toThrow(/not a valid POSIX/);
-                expect(() => validateEnvVars({ "FOO\tBAR": "v" })).toThrow(/not a valid POSIX/);
-                expect(() => validateEnvVars({ "FOO\nBAR": "v" })).toThrow(/not a valid POSIX/);
-        });
+	it("rejects keys containing '=' or whitespace", () => {
+		expect(() => validateEnvVars({ "FOO=BAR": "v" })).toThrow(/not a valid POSIX/);
+		expect(() => validateEnvVars({ "FOO BAR": "v" })).toThrow(/not a valid POSIX/);
+		expect(() => validateEnvVars({ "FOO\tBAR": "v" })).toThrow(/not a valid POSIX/);
+		expect(() => validateEnvVars({ "FOO\nBAR": "v" })).toThrow(/not a valid POSIX/);
+	});
 
-        it("rejects keys with dashes, dots, or non-ASCII", () => {
-                expect(() => validateEnvVars({ "FOO-BAR": "v" })).toThrow(/not a valid POSIX/);
-                expect(() => validateEnvVars({ "FOO.BAR": "v" })).toThrow(/not a valid POSIX/);
-                expect(() => validateEnvVars({ "FÖO": "v" })).toThrow(/not a valid POSIX/);
-        });
+	it("rejects keys with dashes, dots, or non-ASCII", () => {
+		expect(() => validateEnvVars({ "FOO-BAR": "v" })).toThrow(/not a valid POSIX/);
+		expect(() => validateEnvVars({ "FOO.BAR": "v" })).toThrow(/not a valid POSIX/);
+		expect(() => validateEnvVars({ FÖO: "v" })).toThrow(/not a valid POSIX/);
+	});
 
-        it("rejects empty-string keys", () => {
-                expect(() => validateEnvVars({ "": "v" })).toThrow(/non-empty/);
-        });
+	it("rejects empty-string keys", () => {
+		expect(() => validateEnvVars({ "": "v" })).toThrow(/non-empty/);
+	});
 
-        // ── length/size caps ───────────────────────────────────────────────
+	// ── length/size caps ───────────────────────────────────────────────
 
-        it("rejects keys longer than MAX_ENV_VAR_NAME_LENGTH", () => {
-                const longKey = "A".repeat(MAX_ENV_VAR_NAME_LENGTH + 1);
-                expect(() => validateEnvVars({ [longKey]: "v" })).toThrow(
-                        new RegExp(`exceeds ${MAX_ENV_VAR_NAME_LENGTH} characters`),
-                );
-        });
+	it("rejects keys longer than MAX_ENV_VAR_NAME_LENGTH", () => {
+		const longKey = "A".repeat(MAX_ENV_VAR_NAME_LENGTH + 1);
+		expect(() => validateEnvVars({ [longKey]: "v" })).toThrow(
+			new RegExp(`exceeds ${MAX_ENV_VAR_NAME_LENGTH} characters`),
+		);
+	});
 
-        it("accepts keys exactly at MAX_ENV_VAR_NAME_LENGTH", () => {
-                const boundaryKey = "A".repeat(MAX_ENV_VAR_NAME_LENGTH);
-                expect(() => validateEnvVars({ [boundaryKey]: "v" })).not.toThrow();
-        });
+	it("accepts keys exactly at MAX_ENV_VAR_NAME_LENGTH", () => {
+		const boundaryKey = "A".repeat(MAX_ENV_VAR_NAME_LENGTH);
+		expect(() => validateEnvVars({ [boundaryKey]: "v" })).not.toThrow();
+	});
 
-        it("rejects values longer than MAX_ENV_VAR_VALUE_LENGTH", () => {
-                const longValue = "x".repeat(MAX_ENV_VAR_VALUE_LENGTH + 1);
-                expect(() => validateEnvVars({ FOO: longValue })).toThrow(
-                        new RegExp(`exceeds ${MAX_ENV_VAR_VALUE_LENGTH} characters`),
-                );
-        });
+	it("rejects values longer than MAX_ENV_VAR_VALUE_LENGTH", () => {
+		const longValue = "x".repeat(MAX_ENV_VAR_VALUE_LENGTH + 1);
+		expect(() => validateEnvVars({ FOO: longValue })).toThrow(
+			new RegExp(`exceeds ${MAX_ENV_VAR_VALUE_LENGTH} characters`),
+		);
+	});
 
-        it("rejects payloads with more than MAX_ENV_VAR_COUNT entries", () => {
-                const tooMany: Record<string, string> = {};
-                for (let i = 0; i <= MAX_ENV_VAR_COUNT; i++) tooMany[`VAR_${i}`] = "v";
-                expect(() => validateEnvVars(tooMany)).toThrow(
-                        new RegExp(`not contain more than ${MAX_ENV_VAR_COUNT} entries`),
-                );
-        });
+	it("rejects payloads with more than MAX_ENV_VAR_COUNT entries", () => {
+		const tooMany: Record<string, string> = {};
+		for (let i = 0; i <= MAX_ENV_VAR_COUNT; i++) tooMany[`VAR_${i}`] = "v";
+		expect(() => validateEnvVars(tooMany)).toThrow(
+			new RegExp(`not contain more than ${MAX_ENV_VAR_COUNT} entries`),
+		);
+	});
 
-        it("accepts exactly MAX_ENV_VAR_COUNT entries", () => {
-                const maxed: Record<string, string> = {};
-                for (let i = 0; i < MAX_ENV_VAR_COUNT; i++) maxed[`VAR_${i}`] = "v";
-                expect(() => validateEnvVars(maxed)).not.toThrow();
-        });
+	it("accepts exactly MAX_ENV_VAR_COUNT entries", () => {
+		const maxed: Record<string, string> = {};
+		for (let i = 0; i < MAX_ENV_VAR_COUNT; i++) maxed[`VAR_${i}`] = "v";
+		expect(() => validateEnvVars(maxed)).not.toThrow();
+	});
 
-        it("rejects payloads whose total serialised size exceeds MAX_ENV_VARS_TOTAL_BYTES", () => {
-                // Pack values up to the per-value cap and count entries until we clear
-                // the total-bytes threshold. Keeps the test honest against the exact
-                // constant values without hard-coding sizes.
-                const bigValue = "x".repeat(MAX_ENV_VAR_VALUE_LENGTH);
-                const bigPayload: Record<string, string> = {};
-                let i = 0;
-                while (JSON.stringify(bigPayload).length <= MAX_ENV_VARS_TOTAL_BYTES && i < MAX_ENV_VAR_COUNT) {
-                        bigPayload[`V_${i}`] = bigValue;
-                        i++;
-                }
-                expect(() => validateEnvVars(bigPayload)).toThrow(/total size/);
-        });
+	it("rejects payloads whose total serialised size exceeds MAX_ENV_VARS_TOTAL_BYTES", () => {
+		// Pack values up to the per-value cap and count entries until we clear
+		// the total-bytes threshold. Keeps the test honest against the exact
+		// constant values without hard-coding sizes.
+		const bigValue = "x".repeat(MAX_ENV_VAR_VALUE_LENGTH);
+		const bigPayload: Record<string, string> = {};
+		let i = 0;
+		while (JSON.stringify(bigPayload).length <= MAX_ENV_VARS_TOTAL_BYTES && i < MAX_ENV_VAR_COUNT) {
+			bigPayload[`V_${i}`] = bigValue;
+			i++;
+		}
+		expect(() => validateEnvVars(bigPayload)).toThrow(/total size/);
+	});
 
-        // ── structural / content hazards ───────────────────────────────────
+	// ── structural / content hazards ───────────────────────────────────
 
-        it("rejects values containing NUL bytes", () => {
-                expect(() => validateEnvVars({ FOO: "a\0b" })).toThrow(/NUL byte/);
-        });
+	it("rejects values containing NUL bytes", () => {
+		expect(() => validateEnvVars({ FOO: "a\0b" })).toThrow(/NUL byte/);
+	});
 
-        it("permits values with newlines and shell metacharacters", () => {
-                // Docker passes env directly to execve — no shell parsing — so these
-                // are safe to store. Test pins the behaviour so a future validator
-                // change doesn't silently break users with multi-line PEM keys etc.
-                const result = validateEnvVars({
-                        CERT: "-----BEGIN-----\nline2\nline3\n-----END-----",
-                        QUOTE_ME: `"double" 'single' $VAR;rm -rf /`,
-                });
-                expect(result.CERT).toContain("line2");
-                expect(result.QUOTE_ME).toContain("rm -rf");
-        });
+	it("permits values with newlines and shell metacharacters", () => {
+		// Docker passes env directly to execve — no shell parsing — so these
+		// are safe to store. Test pins the behaviour so a future validator
+		// change doesn't silently break users with multi-line PEM keys etc.
+		const result = validateEnvVars({
+			CERT: "-----BEGIN-----\nline2\nline3\n-----END-----",
+			QUOTE_ME: `"double" 'single' $VAR;rm -rf /`,
+		});
+		expect(result.CERT).toContain("line2");
+		expect(result.QUOTE_ME).toContain("rm -rf");
+	});
 
-        // ── denylist ───────────────────────────────────────────────────────
+	// ── denylist ───────────────────────────────────────────────────────
 
-        it("rejects reserved names that would hijack the shell's environment", () => {
-                // Not a privilege boundary in a single-tenant shell (the user
-                // can `export` these anyway), but baking them into the session
-                // config would silently affect every process the session
-                // spawns. Explicit reject keeps session env transparent.
-                expect(() => validateEnvVars({ PATH: "/evil" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ HOME: "/tmp/x" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ USER: "root" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ LOGNAME: "root" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ SHELL: "/bin/sh" })).toThrow(/reserved/);
-        });
+	it("rejects reserved names that would hijack the shell's environment", () => {
+		// Not a privilege boundary in a single-tenant shell (the user
+		// can `export` these anyway), but baking them into the session
+		// config would silently affect every process the session
+		// spawns. Explicit reject keeps session env transparent.
+		expect(() => validateEnvVars({ PATH: "/evil" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ HOME: "/tmp/x" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ USER: "root" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ LOGNAME: "root" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ SHELL: "/bin/sh" })).toThrow(/reserved/);
+	});
 
-        it("rejects all LD_* dynamic-linker variables (prefix match)", () => {
-                // LD_PRELOAD and friends are the obvious ones; the prefix
-                // match also catches less-well-known vectors (LD_AUDIT,
-                // LD_DEBUG, LD_ORIGIN_PATH) and future additions we haven't
-                // enumerated individually.
-                expect(() => validateEnvVars({ LD_PRELOAD: "/x.so" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ LD_LIBRARY_PATH: "/x" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ LD_AUDIT: "/x.so" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ LD_DEBUG: "symbols" })).toThrow(/reserved/);
-                // Catch-all: any LD_-prefixed name, even one we don't know
-                // about, is rejected. Guards against future linker additions.
-                expect(() => validateEnvVars({ LD_MADE_UP_TOMORROW: "x" })).toThrow(/reserved/);
-        });
+	it("rejects all LD_* dynamic-linker variables (prefix match)", () => {
+		// LD_PRELOAD and friends are the obvious ones; the prefix
+		// match also catches less-well-known vectors (LD_AUDIT,
+		// LD_DEBUG, LD_ORIGIN_PATH) and future additions we haven't
+		// enumerated individually.
+		expect(() => validateEnvVars({ LD_PRELOAD: "/x.so" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ LD_LIBRARY_PATH: "/x" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ LD_AUDIT: "/x.so" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ LD_DEBUG: "symbols" })).toThrow(/reserved/);
+		// Catch-all: any LD_-prefixed name, even one we don't know
+		// about, is rejected. Guards against future linker additions.
+		expect(() => validateEnvVars({ LD_MADE_UP_TOMORROW: "x" })).toThrow(/reserved/);
+	});
 
-        it("does NOT reject names that merely look similar to reserved ones", () => {
-                // The denylist is exact-match on names and prefix-match on
-                // LD_*. A user's own `PATHS`, `HOMEBREW_*`, or `LD` (no
-                // underscore) aren't linker/identity vectors and must still
-                // be allowed.
-                const result = validateEnvVars({
-                        PATHS: "ok",
-                        HOMEBREW_PREFIX: "/opt/homebrew",
-                        LD: "not-a-linker-var",
-                        MYPATH: "ok",
-                        USERLAND: "ok",
-                });
-                expect(result.PATHS).toBe("ok");
-                expect(result.HOMEBREW_PREFIX).toBe("/opt/homebrew");
-                expect(result.LD).toBe("not-a-linker-var");
-                expect(result.MYPATH).toBe("ok");
-                expect(result.USERLAND).toBe("ok");
-        });
+	it("does NOT reject names that merely look similar to reserved ones", () => {
+		// The denylist is exact-match on names and prefix-match on
+		// LD_*. A user's own `PATHS`, `HOMEBREW_*`, or `LD` (no
+		// underscore) aren't linker/identity vectors and must still
+		// be allowed.
+		const result = validateEnvVars({
+			PATHS: "ok",
+			HOMEBREW_PREFIX: "/opt/homebrew",
+			LD: "not-a-linker-var",
+			MYPATH: "ok",
+			USERLAND: "ok",
+		});
+		expect(result.PATHS).toBe("ok");
+		expect(result.HOMEBREW_PREFIX).toBe("/opt/homebrew");
+		expect(result.LD).toBe("not-a-linker-var");
+		expect(result.MYPATH).toBe("ok");
+		expect(result.USERLAND).toBe("ok");
+	});
 
-        it("denylist fires AFTER the POSIX-name check, so garbage keys get the real error", () => {
-                // A caller sending 'LD-PRELOAD' (dash, not underscore) should
-                // see "not a valid POSIX env var name" — the actual problem —
-                // not the less-specific "reserved" message. Preserves error
-                // clarity and makes debugging client bugs easier.
-                expect(() => validateEnvVars({ "LD-PRELOAD": "x" })).toThrow(/not a valid POSIX/);
-        });
+	it("denylist fires AFTER the POSIX-name check, so garbage keys get the real error", () => {
+		// A caller sending 'LD-PRELOAD' (dash, not underscore) should
+		// see "not a valid POSIX env var name" — the actual problem —
+		// not the less-specific "reserved" message. Preserves error
+		// clarity and makes debugging client bugs easier.
+		expect(() => validateEnvVars({ "LD-PRELOAD": "x" })).toThrow(/not a valid POSIX/);
+	});
 
-        it("rejects interpreter/runtime injection vars (Node, Python, JVM, Ruby, Perl)", () => {
-                // Round-2 reviewer noted the denylist's stated goal — "no silent
-                // hooks in the shell startup" — was incomplete while NODE_OPTIONS,
-                // PYTHONSTARTUP, JAVA_TOOL_OPTIONS, RUBYOPT, PERL5OPT etc. could
-                // still slip through. Each of these is honoured by its runtime at
-                // interpreter startup and could inject code into every invocation.
-                expect(() => validateEnvVars({ NODE_OPTIONS: "--require /evil.js" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ NODE_PATH: "/evil" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ PYTHONPATH: "/evil" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ PYTHONSTARTUP: "/evil.py" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ PYTHONINSPECT: "1" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ PYTHONHOME: "/evil" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ PYTHONBREAKPOINT: "sys.exit" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ JAVA_TOOL_OPTIONS: "-javaagent:/x.jar" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ _JAVA_OPTIONS: "-Dfoo=bar" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ JDK_JAVA_OPTIONS: "-Xmx1g" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ RUBYOPT: "-r/evil" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ RUBYLIB: "/evil" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ PERL5OPT: "-Mevil" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ PERL5LIB: "/evil" })).toThrow(/reserved/);
-        });
+	it("rejects interpreter/runtime injection vars (Node, Python, JVM, Ruby, Perl)", () => {
+		// Round-2 reviewer noted the denylist's stated goal — "no silent
+		// hooks in the shell startup" — was incomplete while NODE_OPTIONS,
+		// PYTHONSTARTUP, JAVA_TOOL_OPTIONS, RUBYOPT, PERL5OPT etc. could
+		// still slip through. Each of these is honoured by its runtime at
+		// interpreter startup and could inject code into every invocation.
+		expect(() => validateEnvVars({ NODE_OPTIONS: "--require /evil.js" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ NODE_PATH: "/evil" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ PYTHONPATH: "/evil" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ PYTHONSTARTUP: "/evil.py" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ PYTHONINSPECT: "1" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ PYTHONHOME: "/evil" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ PYTHONBREAKPOINT: "sys.exit" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ JAVA_TOOL_OPTIONS: "-javaagent:/x.jar" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ _JAVA_OPTIONS: "-Dfoo=bar" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ JDK_JAVA_OPTIONS: "-Xmx1g" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ RUBYOPT: "-r/evil" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ RUBYLIB: "/evil" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ PERL5OPT: "-Mevil" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ PERL5LIB: "/evil" })).toThrow(/reserved/);
+	});
 
-        it("rejects all DYLD_* dynamic-linker variables (macOS prefix match)", () => {
-                // macOS counterpart to LD_*. Our runtime is Linux, but we want a
-                // clear 400 rather than a silently-ignored value when somebody
-                // pastes a DYLD_* var from habit.
-                expect(() => validateEnvVars({ DYLD_INSERT_LIBRARIES: "/x.dylib" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ DYLD_LIBRARY_PATH: "/x" })).toThrow(/reserved/);
-                expect(() => validateEnvVars({ DYLD_MADE_UP_TOMORROW: "x" })).toThrow(/reserved/);
-        });
+	it("rejects all DYLD_* dynamic-linker variables (macOS prefix match)", () => {
+		// macOS counterpart to LD_*. Our runtime is Linux, but we want a
+		// clear 400 rather than a silently-ignored value when somebody
+		// pastes a DYLD_* var from habit.
+		expect(() => validateEnvVars({ DYLD_INSERT_LIBRARIES: "/x.dylib" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ DYLD_LIBRARY_PATH: "/x" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ DYLD_MADE_UP_TOMORROW: "x" })).toThrow(/reserved/);
+	});
 
-        // ── prototype-pollution vector names ──────────────────────────────
+	// ── prototype-pollution vector names ──────────────────────────────
 
-        it("rejects __proto__, constructor, prototype with a specific message", () => {
-                // These pass the POSIX-identifier regex (all letters/underscores)
-                // and so would otherwise be accepted by the POSIX check. Rejecting
-                // them explicitly gives the caller a specific error and means the
-                // normalised output object can safely be a plain {} without being
-                // hit by the Object.prototype setter dance on assignment.
-                for (const name of ["__proto__", "constructor", "prototype"]) {
-                        expect(() => validateEnvVars({ [name]: "x" })).toThrow(EnvVarValidationError);
-                        expect(() => validateEnvVars({ [name]: "x" })).toThrow(/conflicts with JS object semantics/);
-                }
-        });
+	it("rejects __proto__, constructor, prototype with a specific message", () => {
+		// These pass the POSIX-identifier regex (all letters/underscores)
+		// and so would otherwise be accepted by the POSIX check. Rejecting
+		// them explicitly gives the caller a specific error and means the
+		// normalised output object can safely be a plain {} without being
+		// hit by the Object.prototype setter dance on assignment.
+		for (const name of ["__proto__", "constructor", "prototype"]) {
+			expect(() => validateEnvVars({ [name]: "x" })).toThrow(EnvVarValidationError);
+			expect(() => validateEnvVars({ [name]: "x" })).toThrow(/conflicts with JS object semantics/);
+		}
+	});
 
-        it("returns a plain object — Object.prototype methods work directly on the result", () => {
-                // The previous implementation returned an Object.create(null) map,
-                // which would TypeError if a future caller did `.hasOwnProperty`,
-                // `.toString`, etc. directly. Switched to plain {} now that
-                // __proto__ is rejected at validation time; this test pins that
-                // direct Object.prototype calls work.
-                const result = validateEnvVars({ FOO: "bar" });
-                // These would all throw "is not a function" on a null-proto
-                // object. The direct `.hasOwnProperty` method call is the
-                // exact pattern this test exists to pin — swapping to
-                // Object.hasOwn would still pass on a null-proto object
-                // (Object.hasOwn doesn't consult the prototype) and so would
-                // defeat the purpose. We want to catch the day someone
-                // re-introduces Object.create(null) and breaks callers that
-                // use the native method form. Hence the biome-ignore on the
-                // next line only.
-                // biome-ignore lint/suspicious/noPrototypeBuiltins: see comment above — this test intentionally exercises the prototype-method form.
-                expect(result.hasOwnProperty("FOO")).toBe(true);
-                expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
-                expect(typeof result.toString).toBe("function");
-        });
+	it("returns a plain object — Object.prototype methods work directly on the result", () => {
+		// The previous implementation returned an Object.create(null) map,
+		// which would TypeError if a future caller did `.hasOwnProperty`,
+		// `.toString`, etc. directly. Switched to plain {} now that
+		// __proto__ is rejected at validation time; this test pins that
+		// direct Object.prototype calls work.
+		const result = validateEnvVars({ FOO: "bar" });
+		// These would all throw "is not a function" on a null-proto
+		// object. The direct `.hasOwnProperty` method call is the
+		// exact pattern this test exists to pin — swapping to
+		// Object.hasOwn would still pass on a null-proto object
+		// (Object.hasOwn doesn't consult the prototype) and so would
+		// defeat the purpose. We want to catch the day someone
+		// re-introduces Object.create(null) and breaks callers that
+		// use the native method form. Hence the biome-ignore on the
+		// next line only.
+		// biome-ignore lint/suspicious/noPrototypeBuiltins: see comment above — this test intentionally exercises the prototype-method form.
+		expect(result.hasOwnProperty("FOO")).toBe(true);
+		expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+		expect(typeof result.toString).toBe("function");
+	});
 });

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -68,46 +68,46 @@ const ENV_VAR_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 // SEES at startup, with no silent linker/interpreter hooks for the
 // known injection surfaces.
 const DENIED_ENV_VAR_NAMES = new Set([
-        // Identity / shell config
-        "PATH",
-        "HOME",
-        "USER",
-        "LOGNAME",
-        "SHELL",
+	// Identity / shell config
+	"PATH",
+	"HOME",
+	"USER",
+	"LOGNAME",
+	"SHELL",
 
-        // Node.js — NODE_OPTIONS accepts --require/--import which runs
-        // arbitrary JS at every `node` invocation. NODE_PATH changes the
-        // module resolver and would let an env set shadow stdlib requires.
-        "NODE_OPTIONS",
-        "NODE_PATH",
+	// Node.js — NODE_OPTIONS accepts --require/--import which runs
+	// arbitrary JS at every `node` invocation. NODE_PATH changes the
+	// module resolver and would let an env set shadow stdlib requires.
+	"NODE_OPTIONS",
+	"NODE_PATH",
 
-        // Python — PYTHONSTARTUP runs a file at REPL startup;
-        // PYTHONINSPECT drops into a REPL after script exit (side-channel
-        // for persistent code exec); PYTHONBREAKPOINT routes breakpoint()
-        // through an arbitrary callable; PYTHONPATH changes module
-        // resolution; PYTHONHOME relocates the interpreter stdlib.
-        "PYTHONPATH",
-        "PYTHONSTARTUP",
-        "PYTHONINSPECT",
-        "PYTHONHOME",
-        "PYTHONBREAKPOINT",
+	// Python — PYTHONSTARTUP runs a file at REPL startup;
+	// PYTHONINSPECT drops into a REPL after script exit (side-channel
+	// for persistent code exec); PYTHONBREAKPOINT routes breakpoint()
+	// through an arbitrary callable; PYTHONPATH changes module
+	// resolution; PYTHONHOME relocates the interpreter stdlib.
+	"PYTHONPATH",
+	"PYTHONSTARTUP",
+	"PYTHONINSPECT",
+	"PYTHONHOME",
+	"PYTHONBREAKPOINT",
 
-        // JVM — _JAVA_OPTIONS / JAVA_TOOL_OPTIONS / JDK_JAVA_OPTIONS are
-        // all honoured by the launcher and can `-javaagent:` arbitrary
-        // JARs or flip security-relevant flags.
-        "JAVA_TOOL_OPTIONS",
-        "_JAVA_OPTIONS",
-        "JDK_JAVA_OPTIONS",
+	// JVM — _JAVA_OPTIONS / JAVA_TOOL_OPTIONS / JDK_JAVA_OPTIONS are
+	// all honoured by the launcher and can `-javaagent:` arbitrary
+	// JARs or flip security-relevant flags.
+	"JAVA_TOOL_OPTIONS",
+	"_JAVA_OPTIONS",
+	"JDK_JAVA_OPTIONS",
 
-        // Ruby — RUBYOPT prepends arbitrary flags (incl. `-r<file>`)
-        // to every `ruby` invocation; RUBYLIB extends $LOAD_PATH.
-        "RUBYOPT",
-        "RUBYLIB",
+	// Ruby — RUBYOPT prepends arbitrary flags (incl. `-r<file>`)
+	// to every `ruby` invocation; RUBYLIB extends $LOAD_PATH.
+	"RUBYOPT",
+	"RUBYLIB",
 
-        // Perl — PERL5OPT is the Perl analogue of RUBYOPT; PERL5LIB
-        // extends @INC.
-        "PERL5OPT",
-        "PERL5LIB",
+	// Perl — PERL5OPT is the Perl analogue of RUBYOPT; PERL5LIB
+	// extends @INC.
+	"PERL5OPT",
+	"PERL5LIB",
 ]);
 
 // Prefix matches for categories that grow over time (new LD_* / DYLD_*
@@ -138,10 +138,10 @@ const DENIED_ENV_VAR_PREFIXES = ["LD_", "DYLD_"];
 const PROTOTYPE_POLLUTION_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 
 export class EnvVarValidationError extends Error {
-        constructor(message: string) {
-                super(message);
-                this.name = "EnvVarValidationError";
-        }
+	constructor(message: string) {
+		super(message);
+		this.name = "EnvVarValidationError";
+	}
 }
 
 /**
@@ -169,135 +169,130 @@ export class EnvVarValidationError extends Error {
  * silently-dropped `__proto__` entries (those are rejected explicitly).
  * Safe to JSON-stringify, iterate, or call Object.prototype methods on.
  */
-export function validateEnvVars(
-        envVars: unknown,
-): Record<string, string> {
-        if (envVars === undefined) return {};
+export function validateEnvVars(envVars: unknown): Record<string, string> {
+	if (envVars === undefined) return {};
 
-        // Must be a plain object. `null` trips this branch (typeof null ===
-        // "object") along with arrays and other exotics; refuse all of them
-        // up front with the same "must be an object" message. The important
-        // case is `null` — accepting it as an empty map would let a PATCH
-        // bug silently wipe a user's env instead of 400ing.
-        if (envVars === null || typeof envVars !== "object" || Array.isArray(envVars)) {
-                throw new EnvVarValidationError("envVars must be an object");
-        }
+	// Must be a plain object. `null` trips this branch (typeof null ===
+	// "object") along with arrays and other exotics; refuse all of them
+	// up front with the same "must be an object" message. The important
+	// case is `null` — accepting it as an empty map would let a PATCH
+	// bug silently wipe a user's env instead of 400ing.
+	if (envVars === null || typeof envVars !== "object" || Array.isArray(envVars)) {
+		throw new EnvVarValidationError("envVars must be an object");
+	}
 
-        // Use Object.entries so we only see the object's own enumerable string-keyed
-        // properties — not anything from the prototype chain. This also matches the
-        // iteration order we'd get from JSON.parse output. `Object.entries` always
-        // yields string keys by spec (ES2017 §19.1.2.5), so the loop below doesn't
-        // need to re-check `typeof name === "string"`.
-        const entries = Object.entries(envVars as Record<string, unknown>);
+	// Use Object.entries so we only see the object's own enumerable string-keyed
+	// properties — not anything from the prototype chain. This also matches the
+	// iteration order we'd get from JSON.parse output. `Object.entries` always
+	// yields string keys by spec (ES2017 §19.1.2.5), so the loop below doesn't
+	// need to re-check `typeof name === "string"`.
+	const entries = Object.entries(envVars as Record<string, unknown>);
 
-        if (entries.length > MAX_ENV_VAR_COUNT) {
-                throw new EnvVarValidationError(
-                        `envVars may not contain more than ${MAX_ENV_VAR_COUNT} entries (got ${entries.length})`,
-                );
-        }
+	if (entries.length > MAX_ENV_VAR_COUNT) {
+		throw new EnvVarValidationError(
+			`envVars may not contain more than ${MAX_ENV_VAR_COUNT} entries (got ${entries.length})`,
+		);
+	}
 
-        // Plain object. Previous versions used Object.create(null) to dodge
-        // the edge case where `normalised["__proto__"] = value` would invoke
-        // the Object.prototype setter (silently dropping non-object values)
-        // — but that traded a security non-issue for a real footgun:
-        // callers can't invoke .hasOwnProperty, .toString, etc. directly on
-        // the result without a TypeError. Instead we reject `__proto__` et
-        // al. at the key-validation step below, which closes the original
-        // concern and lets this be a normal object.
-        const normalised: Record<string, string> = {};
-        for (const [name, value] of entries) {
-                if (name.length === 0) {
-                        throw new EnvVarValidationError("envVars keys must be non-empty strings");
-                }
-                if (name.length > MAX_ENV_VAR_NAME_LENGTH) {
-                        throw new EnvVarValidationError(
-                                `envVars key '${name.slice(0, 32)}…' exceeds ${MAX_ENV_VAR_NAME_LENGTH} characters`,
-                        );
-                }
+	// Plain object. Previous versions used Object.create(null) to dodge
+	// the edge case where `normalised["__proto__"] = value` would invoke
+	// the Object.prototype setter (silently dropping non-object values)
+	// — but that traded a security non-issue for a real footgun:
+	// callers can't invoke .hasOwnProperty, .toString, etc. directly on
+	// the result without a TypeError. Instead we reject `__proto__` et
+	// al. at the key-validation step below, which closes the original
+	// concern and lets this be a normal object.
+	const normalised: Record<string, string> = {};
+	for (const [name, value] of entries) {
+		if (name.length === 0) {
+			throw new EnvVarValidationError("envVars keys must be non-empty strings");
+		}
+		if (name.length > MAX_ENV_VAR_NAME_LENGTH) {
+			throw new EnvVarValidationError(
+				`envVars key '${name.slice(0, 32)}…' exceeds ${MAX_ENV_VAR_NAME_LENGTH} characters`,
+			);
+		}
 
-                // Reject prototype-pollution vector names BEFORE the POSIX
-                // check: `__proto__` (and friends) match the identifier
-                // regex, so the POSIX check would accept them. We want a
-                // specific error message here so the caller sees *why* this
-                // particular name is rejected rather than a generic "not a
-                // valid name". Also means the next assignment below can be
-                // a plain `normalised[name] = value` without hitting the
-                // Object.prototype setter dance.
-                if (PROTOTYPE_POLLUTION_NAMES.has(name)) {
-                        throw new EnvVarValidationError(
-                                `envVars key '${name}' is reserved (conflicts with JS object semantics)`,
-                        );
-                }
+		// Reject prototype-pollution vector names BEFORE the POSIX
+		// check: `__proto__` (and friends) match the identifier
+		// regex, so the POSIX check would accept them. We want a
+		// specific error message here so the caller sees *why* this
+		// particular name is rejected rather than a generic "not a
+		// valid name". Also means the next assignment below can be
+		// a plain `normalised[name] = value` without hitting the
+		// Object.prototype setter dance.
+		if (PROTOTYPE_POLLUTION_NAMES.has(name)) {
+			throw new EnvVarValidationError(
+				`envVars key '${name}' is reserved (conflicts with JS object semantics)`,
+			);
+		}
 
-                if (!ENV_VAR_NAME_PATTERN.test(name)) {
-                        // Include the offending key in the error so the caller can fix
-                        // their payload — it came from them, so there's no leakage.
-                        throw new EnvVarValidationError(
-                                `envVars key '${name}' is not a valid POSIX env var name ` +
-                                `(must match /^[A-Za-z_][A-Za-z0-9_]*$/)`,
-                        );
-                }
+		if (!ENV_VAR_NAME_PATTERN.test(name)) {
+			// Include the offending key in the error so the caller can fix
+			// their payload — it came from them, so there's no leakage.
+			throw new EnvVarValidationError(
+				`envVars key '${name}' is not a valid POSIX env var name ` +
+					`(must match /^[A-Za-z_][A-Za-z0-9_]*$/)`,
+			);
+		}
 
-                // Apply the denylist AFTER the POSIX-name check: a name that
-                // isn't a valid identifier couldn't match anyway, so we'd just
-                // be hiding the real problem behind a less-specific error.
-                if (
-                        DENIED_ENV_VAR_NAMES.has(name) ||
-                        DENIED_ENV_VAR_PREFIXES.some((p) => name.startsWith(p))
-                ) {
-                        throw new EnvVarValidationError(
-                                `envVars key '${name}' is reserved and cannot be set via session config. ` +
-                                `Set it inside the shell if needed.`,
-                        );
-                }
+		// Apply the denylist AFTER the POSIX-name check: a name that
+		// isn't a valid identifier couldn't match anyway, so we'd just
+		// be hiding the real problem behind a less-specific error.
+		if (DENIED_ENV_VAR_NAMES.has(name) || DENIED_ENV_VAR_PREFIXES.some((p) => name.startsWith(p))) {
+			throw new EnvVarValidationError(
+				`envVars key '${name}' is reserved and cannot be set via session config. ` +
+					`Set it inside the shell if needed.`,
+			);
+		}
 
-                // Reject any form of duplicate (including prototype-chain shadowing,
-                // which Object.entries already filters, and plain repeat keys, which
-                // JSON.parse collapses — but we check for completeness in case a
-                // future caller constructs the object programmatically).
-                //
-                // Ideally this would use Object.hasOwn (ES2022) — biome's
-                // preferred form — but tsconfig lib is currently ES2020 and
-                // Object.hasOwn isn't in that lib. Using the
-                // Object.prototype.hasOwnProperty.call idiom for now, which
-                // is the safe form (direct `.hasOwnProperty` could collide
-                // with a user-supplied key named `hasOwnProperty`, though in
-                // practice that's already rejected by the POSIX-name check).
-                // If tsconfig ever bumps to ES2022 (Node 22 runtime already
-                // supports it), this line should be simplified to
-                // `Object.hasOwn(normalised, name)` and the ignore dropped.
-                // biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn unavailable under ES2020 lib; Object.prototype.hasOwnProperty.call is the safe idiom on this target.
-                if (Object.prototype.hasOwnProperty.call(normalised, name)) {
-                        throw new EnvVarValidationError(`envVars contains duplicate key '${name}'`);
-                }
+		// Reject any form of duplicate (including prototype-chain shadowing,
+		// which Object.entries already filters, and plain repeat keys, which
+		// JSON.parse collapses — but we check for completeness in case a
+		// future caller constructs the object programmatically).
+		//
+		// Ideally this would use Object.hasOwn (ES2022) — biome's
+		// preferred form — but tsconfig lib is currently ES2020 and
+		// Object.hasOwn isn't in that lib. Using the
+		// Object.prototype.hasOwnProperty.call idiom for now, which
+		// is the safe form (direct `.hasOwnProperty` could collide
+		// with a user-supplied key named `hasOwnProperty`, though in
+		// practice that's already rejected by the POSIX-name check).
+		// If tsconfig ever bumps to ES2022 (Node 22 runtime already
+		// supports it), this line should be simplified to
+		// `Object.hasOwn(normalised, name)` and the ignore dropped.
+		// biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn unavailable under ES2020 lib; Object.prototype.hasOwnProperty.call is the safe idiom on this target.
+		if (Object.prototype.hasOwnProperty.call(normalised, name)) {
+			throw new EnvVarValidationError(`envVars contains duplicate key '${name}'`);
+		}
 
-                if (typeof value !== "string") {
-                        throw new EnvVarValidationError(`envVars['${name}'] must be a string (got ${typeof value})`);
-                }
-                if (value.length > MAX_ENV_VAR_VALUE_LENGTH) {
-                        throw new EnvVarValidationError(
-                                `envVars['${name}'] exceeds ${MAX_ENV_VAR_VALUE_LENGTH} characters`,
-                        );
-                }
-                // NUL bytes are illegal in environment values on POSIX (execve treats
-                // `NUL` as the terminator). Silently accepting them would truncate the
-                // value the container sees, so caller sees one thing and container sees
-                // another — exactly the kind of desync a validator should catch.
-                if (value.includes("\0")) {
-                        throw new EnvVarValidationError(`envVars['${name}'] contains a NUL byte`);
-                }
-                normalised[name] = value;
-        }
+		if (typeof value !== "string") {
+			throw new EnvVarValidationError(`envVars['${name}'] must be a string (got ${typeof value})`);
+		}
+		if (value.length > MAX_ENV_VAR_VALUE_LENGTH) {
+			throw new EnvVarValidationError(
+				`envVars['${name}'] exceeds ${MAX_ENV_VAR_VALUE_LENGTH} characters`,
+			);
+		}
+		// NUL bytes are illegal in environment values on POSIX (execve treats
+		// `NUL` as the terminator). Silently accepting them would truncate the
+		// value the container sees, so caller sees one thing and container sees
+		// another — exactly the kind of desync a validator should catch.
+		if (value.includes("\0")) {
+			throw new EnvVarValidationError(`envVars['${name}'] contains a NUL byte`);
+		}
+		normalised[name] = value;
+	}
 
-        // Total-size cap applies to the serialised form since that's what lands in
-        // D1 and flows over the network. Using Buffer.byteLength catches multi-byte
-        // UTF-8 that string.length would under-count.
-        const serialisedBytes = Buffer.byteLength(JSON.stringify(normalised), "utf8");
-        if (serialisedBytes > MAX_ENV_VARS_TOTAL_BYTES) {
-                throw new EnvVarValidationError(
-                        `envVars total size (${serialisedBytes} bytes) exceeds ${MAX_ENV_VARS_TOTAL_BYTES} bytes`,
-                );
-        }
+	// Total-size cap applies to the serialised form since that's what lands in
+	// D1 and flows over the network. Using Buffer.byteLength catches multi-byte
+	// UTF-8 that string.length would under-count.
+	const serialisedBytes = Buffer.byteLength(JSON.stringify(normalised), "utf8");
+	if (serialisedBytes > MAX_ENV_VARS_TOTAL_BYTES) {
+		throw new EnvVarValidationError(
+			`envVars total size (${serialisedBytes} bytes) exceeds ${MAX_ENV_VARS_TOTAL_BYTES} bytes`,
+		);
+	}
 
-        return normalised;
+	return normalised;
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,12 +9,12 @@ import http from "node:http";
 import express from "express";
 import { WebSocketServer } from "ws";
 import {
-        ensureAuthReady,
-        isAllowedWsOrigin,
-        parseCorsOrigins,
-        selectWsAuthProtocol,
-        validateJwtSecret,
-        warnIfWildcardCorsInProduction,
+	ensureAuthReady,
+	isAllowedWsOrigin,
+	parseCorsOrigins,
+	selectWsAuthProtocol,
+	validateJwtSecret,
+	warnIfWildcardCorsInProduction,
 } from "./auth.js";
 import { migrateDb, validateD1Config } from "./db.js";
 import { DockerManager } from "./dockerManager.js";
@@ -59,13 +59,13 @@ warnIfWildcardCorsInProduction(CORS_ORIGINS, process.env.NODE_ENV);
 // silently serving traffic with req.ip derived from the wrong source.
 let trustProxyValue: boolean | number | string | undefined;
 try {
-        trustProxyValue = parseTrustProxy(TRUST_PROXY_RAW);
+	trustProxyValue = parseTrustProxy(TRUST_PROXY_RAW);
 } catch (err) {
-        if (err instanceof TrustProxyError) {
-                console.error("[server]", err.message);
-                process.exit(1);
-        }
-        throw err;
+	if (err instanceof TrustProxyError) {
+		console.error("[server]", err.message);
+		process.exit(1);
+	}
+	throw err;
 }
 
 // ── Singletons ────────────────────────────────────────────────────────────────
@@ -77,29 +77,29 @@ const docker = new DockerManager(sessions);
 
 const app = express();
 if (trustProxyValue !== undefined) {
-        app.set("trust proxy", trustProxyValue);
-        // Log the effective value so ops can spot a misconfigured prod
-        // (e.g. TRUST_PROXY=0 behind a tunnel would silently collapse
-        // per-IP rate limits into one bucket).
-        console.log(`[server] trust proxy = ${JSON.stringify(trustProxyValue)}`);
+	app.set("trust proxy", trustProxyValue);
+	// Log the effective value so ops can spot a misconfigured prod
+	// (e.g. TRUST_PROXY=0 behind a tunnel would silently collapse
+	// per-IP rate limits into one bucket).
+	console.log(`[server] trust proxy = ${JSON.stringify(trustProxyValue)}`);
 } else {
-        console.log("[server] trust proxy = unset (req.ip will be the socket address)");
+	console.log("[server] trust proxy = unset (req.ip will be the socket address)");
 }
 app.use(express.json());
 
 // CORS — allow frontend from Cloudflare Pages (or any configured origin)
 app.use((_req, res, next) => {
-        const origin = _req.headers.origin ?? "";
-        if (CORS_ORIGINS.includes("*") || CORS_ORIGINS.includes(origin)) {
-                res.setHeader("Access-Control-Allow-Origin", origin || "*");
-        }
-        res.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,PATCH,OPTIONS");
-        res.setHeader("Access-Control-Allow-Headers", "Content-Type,Authorization");
-        if (_req.method === "OPTIONS") {
-                res.sendStatus(204);
-                return;
-        }
-        next();
+	const origin = _req.headers.origin ?? "";
+	if (CORS_ORIGINS.includes("*") || CORS_ORIGINS.includes(origin)) {
+		res.setHeader("Access-Control-Allow-Origin", origin || "*");
+	}
+	res.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,PATCH,OPTIONS");
+	res.setHeader("Access-Control-Allow-Headers", "Content-Type,Authorization");
+	if (_req.method === "OPTIONS") {
+		res.sendStatus(204);
+		return;
+	}
+	next();
 });
 
 app.use("/api", buildRouter(sessions, docker));
@@ -109,89 +109,89 @@ app.get("/health", (_req, res) => res.json({ ok: true }));
 
 const server = http.createServer(app);
 const wss = new WebSocketServer({
-        noServer: true,
-        handleProtocols: (protocols) => selectWsAuthProtocol(protocols),
+	noServer: true,
+	handleProtocols: (protocols) => selectWsAuthProtocol(protocols),
 });
 
 server.on("upgrade", (req, socket, head) => {
-        const url = req.url ?? "";
-        if (!url.startsWith("/ws/sessions/")) {
-                // socket.end() drains the write buffer before closing, so the
-                // 404 line actually reaches the client. socket.write() +
-                // socket.destroy() (the previous form) issues immediate
-                // teardown with no drain guarantee — the status line can be
-                // dropped, making "why did my WS fail" harder to debug.
-                // The bounded-destroy timer in endUpgradeSocketWithReply
-                // closes the CLOSE_WAIT window a half-close otherwise opens
-                // up against a peer that never FINs (#67).
-                endUpgradeSocketWithReply(socket, "HTTP/1.1 404 Not Found\r\n\r\n");
-                return;
-        }
+	const url = req.url ?? "";
+	if (!url.startsWith("/ws/sessions/")) {
+		// socket.end() drains the write buffer before closing, so the
+		// 404 line actually reaches the client. socket.write() +
+		// socket.destroy() (the previous form) issues immediate
+		// teardown with no drain guarantee — the status line can be
+		// dropped, making "why did my WS fail" harder to debug.
+		// The bounded-destroy timer in endUpgradeSocketWithReply
+		// closes the CLOSE_WAIT window a half-close otherwise opens
+		// up against a peer that never FINs (#67).
+		endUpgradeSocketWithReply(socket, "HTTP/1.1 404 Not Found\r\n\r\n");
+		return;
+	}
 
-        // CSWSH defence: reject the upgrade BEFORE the handshake completes
-        // when the Origin header isn't allowed. Done here (not inside the
-        // `wss.on("connection")` handler) so a rejected origin never gets
-        // a WebSocket object, never runs verifyWsToken, and never appears
-        // in wss.clients — closes the window where a CSWSH'd socket could
-        // do anything observable before the server hung up.
-        //
-        // See isAllowedWsOrigin in auth.ts for the policy (in particular:
-        // missing Origin is allowed because it indicates non-browser
-        // clients, and "*" in CORS_ORIGINS is denied in production).
-        //
-        // No per-request log in PRODUCTION: an attacker can flood the
-        // upgrade handler with garbage Origin headers and drown out signal.
-        // The CORS_ORIGINS=* case is already covered by warnIfWildcard-
-        // CorsInProduction at startup; deliberate operator misconfiguration
-        // surfaces through the 403 status code + the boot warning, not
-        // through per-request log spam. In dev/staging we DO log (gated
-        // below) so an operator deploying a typo'd Origin can grep for it.
-        if (!isAllowedWsOrigin(req.headers.origin, CORS_ORIGINS, process.env.NODE_ENV)) {
-                // Dev/staging only: see the block comment above and issue #66.
-                if (process.env.NODE_ENV !== "production") {
-                        console.log(
-                                "[ws] rejecting upgrade: Origin=%s not in allowlist %j",
-                                req.headers.origin ?? "<absent>",
-                                CORS_ORIGINS,
-                        );
-                }
-                endUpgradeSocketWithReply(socket, "HTTP/1.1 403 Forbidden\r\n\r\n");
-                return;
-        }
+	// CSWSH defence: reject the upgrade BEFORE the handshake completes
+	// when the Origin header isn't allowed. Done here (not inside the
+	// `wss.on("connection")` handler) so a rejected origin never gets
+	// a WebSocket object, never runs verifyWsToken, and never appears
+	// in wss.clients — closes the window where a CSWSH'd socket could
+	// do anything observable before the server hung up.
+	//
+	// See isAllowedWsOrigin in auth.ts for the policy (in particular:
+	// missing Origin is allowed because it indicates non-browser
+	// clients, and "*" in CORS_ORIGINS is denied in production).
+	//
+	// No per-request log in PRODUCTION: an attacker can flood the
+	// upgrade handler with garbage Origin headers and drown out signal.
+	// The CORS_ORIGINS=* case is already covered by warnIfWildcard-
+	// CorsInProduction at startup; deliberate operator misconfiguration
+	// surfaces through the 403 status code + the boot warning, not
+	// through per-request log spam. In dev/staging we DO log (gated
+	// below) so an operator deploying a typo'd Origin can grep for it.
+	if (!isAllowedWsOrigin(req.headers.origin, CORS_ORIGINS, process.env.NODE_ENV)) {
+		// Dev/staging only: see the block comment above and issue #66.
+		if (process.env.NODE_ENV !== "production") {
+			console.log(
+				"[ws] rejecting upgrade: Origin=%s not in allowlist %j",
+				req.headers.origin ?? "<absent>",
+				CORS_ORIGINS,
+			);
+		}
+		endUpgradeSocketWithReply(socket, "HTTP/1.1 403 Forbidden\r\n\r\n");
+		return;
+	}
 
-        wss.handleUpgrade(req, socket, head, (ws) => {
-                wss.emit("connection", ws, req);
-        });
+	wss.handleUpgrade(req, socket, head, (ws) => {
+		wss.emit("connection", ws, req);
+	});
 });
 
 wss.on("connection", (ws, req) => {
-        handleWsConnection(ws, req, sessions, docker);
+	handleWsConnection(ws, req, sessions, docker);
 });
 
 // ── Startup ───────────────────────────────────────────────────────────────────
 
 async function start() {
-        await migrateDb();
-        await docker.reconcile();
-        // Wait for the timing-parity dummy bcrypt hash to finish computing
-        // before accepting requests. Without this, the first unknown-user
-        // login would block on the ~2^BCRYPT_ROUNDS-ms hash computation,
-        // producing a latency signal distinguishable from a known-user
-        // login (which short-circuits the dummy path) — exactly the
-        // timing leak the dummy is supposed to prevent.
-        await ensureAuthReady();
+	await migrateDb();
+	await docker.reconcile();
+	// Wait for the timing-parity dummy bcrypt hash to finish computing
+	// before accepting requests. Without this, the first unknown-user
+	// login would block on the ~2^BCRYPT_ROUNDS-ms hash computation,
+	// producing a latency signal distinguishable from a known-user
+	// login (which short-circuits the dummy path) — exactly the
+	// timing leak the dummy is supposed to prevent.
+	await ensureAuthReady();
 
-        server.listen(PORT, () => {
-                console.log(`[server] listening on http://localhost:${PORT}`);
-                console.log(`[server] WebSocket: ws://localhost:${PORT}/ws/sessions/:id`);
-                console.log(`[server] CORS origins: ${CORS_ORIGINS.join(", ")}`);
-                console.log(`[server] Database: Cloudflare D1`);
-        });
+	server.listen(PORT, () => {
+		console.log(`[server] listening on http://localhost:${PORT}`);
+		console.log(`[server] WebSocket: ws://localhost:${PORT}/ws/sessions/:id`);
+		console.log(`[server] CORS origins: ${CORS_ORIGINS.join(", ")}`);
+		console.log(`[server] Database: Cloudflare D1`);
+	});
 }
 
 start().catch((err) => {
-        console.error("[server] failed to start:", err);
-        process.exit(1);
+	console.error("[server] failed to start:", err);
+	process.exit(1);
 });
 
 // ── Graceful shutdown ─────────────────────────────────────────────────────────
@@ -205,31 +205,35 @@ process.on("SIGINT", shutdown);
 let shuttingDown = false;
 
 function shutdown() {
-        if (shuttingDown) return;
-        shuttingDown = true;
-        console.log("[server] shutting down…");
+	if (shuttingDown) return;
+	shuttingDown = true;
+	console.log("[server] shutting down…");
 
-        // Actively close live WS clients. `wss.close()` alone only stops accepting
-        // new upgrades — existing connections stay open, which keeps `server.close()`
-        // hanging on its keepalive-held sockets until the OS eventually kills the
-        // process. Send 1001 ("going away") so the browser surfaces a clean reason
-        // rather than "connection error".
-        for (const client of wss.clients) {
-                try { client.close(1001, "server shutting down"); } catch { /* already closed */ }
-        }
-        wss.close();
+	// Actively close live WS clients. `wss.close()` alone only stops accepting
+	// new upgrades — existing connections stay open, which keeps `server.close()`
+	// hanging on its keepalive-held sockets until the OS eventually kills the
+	// process. Send 1001 ("going away") so the browser surfaces a clean reason
+	// rather than "connection error".
+	for (const client of wss.clients) {
+		try {
+			client.close(1001, "server shutting down");
+		} catch {
+			/* already closed */
+		}
+	}
+	wss.close();
 
-        // Watchdog: if a client stalls its close handshake (or some other handle
-        // keeps the event loop alive), exit anyway after a grace period instead of
-        // hanging the orchestrator's stop timeout.
-        const watchdog = setTimeout(() => {
-                console.warn("[server] shutdown watchdog fired — forcing exit");
-                process.exit(1);
-        }, 10_000);
-        watchdog.unref();
+	// Watchdog: if a client stalls its close handshake (or some other handle
+	// keeps the event loop alive), exit anyway after a grace period instead of
+	// hanging the orchestrator's stop timeout.
+	const watchdog = setTimeout(() => {
+		console.warn("[server] shutdown watchdog fired — forcing exit");
+		process.exit(1);
+	}, 10_000);
+	watchdog.unref();
 
-        server.close(() => {
-                clearTimeout(watchdog);
-                process.exit(0);
-        });
+	server.close(() => {
+		clearTimeout(watchdog);
+		process.exit(0);
+	});
 }

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -20,7 +20,10 @@ const authStubs = vi.hoisted(() => ({
 	// `vi.mock` the whole module, both the handler's import and the stub's
 	// throw resolve to this same constructor.
 	InvalidCredentialsError: class extends Error {
-		constructor() { super("Invalid credentials"); this.name = "InvalidCredentialsError"; }
+		constructor() {
+			super("Invalid credentials");
+			this.name = "InvalidCredentialsError";
+		}
 	},
 }));
 vi.mock("./auth.js", () => authStubs);
@@ -203,14 +206,14 @@ describe("UsernameRateLimiter", () => {
 		try {
 			const rl = new UsernameRateLimiter(5, 60_000, 3);
 			rl.recordFailure("alice"); // t=0, resetAt=60_000
-			rl.recordFailure("bob");   // t=0, resetAt=60_000
+			rl.recordFailure("bob"); // t=0, resetAt=60_000
 			rl.recordFailure("carol"); // t=0, resetAt=60_000
 			expect(rl.sizeForTesting()).toBe(3);
 
 			// Expire alice alone.
 			vi.setSystemTime(30_000);
 			// Refresh bob and carol so they stay live past alice's resetAt.
-			rl.recordFailure("bob");   // live, count=2
+			rl.recordFailure("bob"); // live, count=2
 			rl.recordFailure("carol"); // live, count=2
 			vi.setSystemTime(60_001); // alice expired; bob/carol still live
 
@@ -323,7 +326,7 @@ describe("UsernameRateLimiter", () => {
 			vi.advanceTimersByTime(60_001); // everyone expired
 
 			rl.recordFailure("alice"); // fresh bucket — should land at end
-			rl.recordFailure("dave");  // new — triggers overflow logic
+			rl.recordFailure("dave"); // new — triggers overflow logic
 			rl.recordFailure("eve");
 
 			// Size is capped at 3; bob and carol should have been evicted

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -154,7 +154,10 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		limit: cfg.invitesRevoke.ipMax,
 		standardHeaders: "draft-7",
 		legacyHeaders: false,
-		message: { error: "Too many invite-revoke requests from this IP, try again later", scope: "ip" },
+		message: {
+			error: "Too many invite-revoke requests from this IP, try again later",
+			scope: "ip",
+		},
 	});
 	const fileUploadIp = rateLimit({
 		windowMs: cfg.fileUpload.ipWindowMs,
@@ -168,9 +171,7 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 
 // ── Per-username limiter ────────────────────────────────────────────────────
 
-export type UsernameCheckResult =
-	| { allowed: true }
-	| { allowed: false; retryAfterSeconds: number };
+export type UsernameCheckResult = { allowed: true } | { allowed: false; retryAfterSeconds: number };
 
 interface FailedAttempts {
 	count: number;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -9,689 +9,702 @@ import { Router } from "express";
 import multer from "multer";
 import type { AuthedRequest } from "./auth.js";
 import {
-        createInvite,
-        hasAnyUsers,
-        InvalidCredentialsError,
-        InviteQuotaExceededError,
-        InviteRequiredError,
-        listInvites,
-        loginUser,
-        registerUser,
-        requireAuth,
-        revokeInvite,
-        UsernameTakenError,
+	createInvite,
+	hasAnyUsers,
+	InvalidCredentialsError,
+	InviteQuotaExceededError,
+	InviteRequiredError,
+	listInvites,
+	loginUser,
+	registerUser,
+	requireAuth,
+	revokeInvite,
+	UsernameTakenError,
 } from "./auth.js";
 import type { DockerManager } from "./dockerManager.js";
 import { UploadQuotaExceededError } from "./dockerManager.js";
 import { EnvVarValidationError, validateEnvVars } from "./envVarValidation.js";
 import type { RateLimitConfig } from "./rateLimit.js";
 import {
-        createAuthRateLimiters,
-        DEFAULT_RATE_LIMIT_CONFIG,
-        UsernameRateLimiter,
+	createAuthRateLimiters,
+	DEFAULT_RATE_LIMIT_CONFIG,
+	UsernameRateLimiter,
 } from "./rateLimit.js";
 import type { SessionManager } from "./sessionManager.js";
-import {
-        ForbiddenError,
-        NotFoundError,
-        SessionQuotaExceededError,
-} from "./sessionManager.js";
+import { ForbiddenError, NotFoundError, SessionQuotaExceededError } from "./sessionManager.js";
 import type { SessionMeta } from "./types.js";
 
 export function buildRouter(
-        sessions: SessionManager,
-        docker: DockerManager,
-        rateLimitConfig: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG,
+	sessions: SessionManager,
+	docker: DockerManager,
+	rateLimitConfig: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG,
 ): Router {
-        const router = Router();
+	const router = Router();
 
-        // ── Auth routes (public) ────────────────────────────────────────────────
+	// ── Auth routes (public) ────────────────────────────────────────────────
 
-        const { loginIp, registerIp, invitesCreateIp, invitesListIp, invitesRevokeIp, fileUploadIp } = createAuthRateLimiters(rateLimitConfig);
-        const usernameLimiter = new UsernameRateLimiter(
-                rateLimitConfig.login.usernameMax,
-                rateLimitConfig.login.usernameWindowMs,
-        );
-        // Cap username length at the request boundary so huge strings can't
-        // land in the limiter map or D1.
-        const USERNAME_MAX_LEN = 64;
+	const { loginIp, registerIp, invitesCreateIp, invitesListIp, invitesRevokeIp, fileUploadIp } =
+		createAuthRateLimiters(rateLimitConfig);
+	const usernameLimiter = new UsernameRateLimiter(
+		rateLimitConfig.login.usernameMax,
+		rateLimitConfig.login.usernameWindowMs,
+	);
+	// Cap username length at the request boundary so huge strings can't
+	// land in the limiter map or D1.
+	const USERNAME_MAX_LEN = 64;
 
-        router.get("/auth/status", async (_req: Request, res: Response) => {
-                res.json({ needsSetup: !(await hasAnyUsers()) });
-        });
+	router.get("/auth/status", async (_req: Request, res: Response) => {
+		res.json({ needsSetup: !(await hasAnyUsers()) });
+	});
 
-        router.post("/auth/register", registerIp, async (req: Request, res: Response) => {
-                const { username, password, inviteCode } = req.body as {
-                        username?: string; password?: string; inviteCode?: string;
-                };
-                if (!username || !password || password.length < 6) {
-                        res.status(400).json({ error: "username and password (min 6 chars) required" });
-                        return;
-                }
-                if (username.length > USERNAME_MAX_LEN) {
-                        res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
-                        return;
-                }
-                // The frontend always sends a string or omits the field, but a hand-
-                // crafted POST with `inviteCode: 123` would crash `.trim()` and
-                // surface as a 500. Guard at the boundary so callers get a clear 400.
-                if (inviteCode !== undefined && typeof inviteCode !== "string") {
-                        res.status(400).json({ error: "inviteCode must be a string" });
-                        return;
-                }
-                // Cap length too — invite codes mint at 16 hex chars, so anything
-                // larger is a client bug or a probe. Without this, a megabyte-long
-                // string would still hit D1 as a parameter.
-                if (inviteCode !== undefined && inviteCode.length > 64) {
-                        res.status(400).json({ error: "inviteCode must be at most 64 characters" });
-                        return;
-                }
-                // Distinguish "field absent" from "field present but whitespace-only".
-                // Without this, `inviteCode = "   "` would trim to "" and `|| undefined`
-                // would coerce it to absent, surfacing as "Invite code required" instead
-                // of "invalid". Whitespace-only is an explicit attempt — treat it as
-                // an invalid code so the user sees the right error.
-                let trimmedInviteCode: string | undefined;
-                if (inviteCode === undefined) {
-                        trimmedInviteCode = undefined;
-                } else if (inviteCode.trim() === "") {
-                        res.status(403).json({ error: "Invite code is invalid, expired, or already used" });
-                        return;
-                } else {
-                        trimmedInviteCode = inviteCode.trim();
-                }
-                try {
-                        const result = await registerUser(username, password, trimmedInviteCode);
-                        res.status(201).json(result);
-                } catch (err) {
-                        if (err instanceof InviteRequiredError) {
-                                // 403 — caller authenticated nothing yet, but the action is
-                                // forbidden without a valid invite. Distinct from 409 so the
-                                // frontend can render the invite-code field instead of a
-                                // username-taken message.
-                                res.status(403).json({ error: err.message });
-                                return;
-                        }
-                        if (err instanceof UsernameTakenError) {
-                                res.status(409).json({ error: err.message });
-                                return;
-                        }
-                        console.error(`[auth] register failed unexpectedly:`, (err as Error).message);
-                        res.status(500).json({ error: "Internal server error" });
-                }
-        });
+	router.post("/auth/register", registerIp, async (req: Request, res: Response) => {
+		const { username, password, inviteCode } = req.body as {
+			username?: string;
+			password?: string;
+			inviteCode?: string;
+		};
+		if (!username || !password || password.length < 6) {
+			res.status(400).json({ error: "username and password (min 6 chars) required" });
+			return;
+		}
+		if (username.length > USERNAME_MAX_LEN) {
+			res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
+			return;
+		}
+		// The frontend always sends a string or omits the field, but a hand-
+		// crafted POST with `inviteCode: 123` would crash `.trim()` and
+		// surface as a 500. Guard at the boundary so callers get a clear 400.
+		if (inviteCode !== undefined && typeof inviteCode !== "string") {
+			res.status(400).json({ error: "inviteCode must be a string" });
+			return;
+		}
+		// Cap length too — invite codes mint at 16 hex chars, so anything
+		// larger is a client bug or a probe. Without this, a megabyte-long
+		// string would still hit D1 as a parameter.
+		if (inviteCode !== undefined && inviteCode.length > 64) {
+			res.status(400).json({ error: "inviteCode must be at most 64 characters" });
+			return;
+		}
+		// Distinguish "field absent" from "field present but whitespace-only".
+		// Without this, `inviteCode = "   "` would trim to "" and `|| undefined`
+		// would coerce it to absent, surfacing as "Invite code required" instead
+		// of "invalid". Whitespace-only is an explicit attempt — treat it as
+		// an invalid code so the user sees the right error.
+		let trimmedInviteCode: string | undefined;
+		if (inviteCode === undefined) {
+			trimmedInviteCode = undefined;
+		} else if (inviteCode.trim() === "") {
+			res.status(403).json({ error: "Invite code is invalid, expired, or already used" });
+			return;
+		} else {
+			trimmedInviteCode = inviteCode.trim();
+		}
+		try {
+			const result = await registerUser(username, password, trimmedInviteCode);
+			res.status(201).json(result);
+		} catch (err) {
+			if (err instanceof InviteRequiredError) {
+				// 403 — caller authenticated nothing yet, but the action is
+				// forbidden without a valid invite. Distinct from 409 so the
+				// frontend can render the invite-code field instead of a
+				// username-taken message.
+				res.status(403).json({ error: err.message });
+				return;
+			}
+			if (err instanceof UsernameTakenError) {
+				res.status(409).json({ error: err.message });
+				return;
+			}
+			console.error(`[auth] register failed unexpectedly:`, (err as Error).message);
+			res.status(500).json({ error: "Internal server error" });
+		}
+	});
 
-        router.post("/auth/login", loginIp, async (req: Request, res: Response) => {
-                const { username, password } = req.body as { username?: string; password?: string };
-                if (!username || !password) {
-                        res.status(400).json({ error: "username and password required" });
-                        return;
-                }
-                if (username.length > USERNAME_MAX_LEN) {
-                        res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
-                        return;
-                }
+	router.post("/auth/login", loginIp, async (req: Request, res: Response) => {
+		const { username, password } = req.body as { username?: string; password?: string };
+		if (!username || !password) {
+			res.status(400).json({ error: "username and password required" });
+			return;
+		}
+		if (username.length > USERNAME_MAX_LEN) {
+			res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
+			return;
+		}
 
-                // Per-username gate runs before bcrypt. `scope` distinguishes an
-                // account lockout from the IP-layer 429 above. Emits the same
-                // draft-7 RateLimit-* headers as express-rate-limit does on the
-                // IP 429 so clients parsing them see a consistent shape.
-                //
-                // beginAttempt reserves an in-flight slot atomically — important
-                // now that loginUser uses async bcrypt.compare (no longer blocks
-                // the event loop). Without the reservation, a burst of N requests
-                // against the same username could all pass check() and all start
-                // bcrypt before any recordFailure lands, breaking the bound.
-                const check = usernameLimiter.beginAttempt(username);
-                if (!check.allowed) {
-                        const windowSeconds = Math.ceil(rateLimitConfig.login.usernameWindowMs / 1000);
-                        res.setHeader("Retry-After", String(check.retryAfterSeconds));
-                        res.setHeader(
-                                "RateLimit-Policy",
-                                `${rateLimitConfig.login.usernameMax};w=${windowSeconds}`,
-                        );
-                        res.setHeader(
-                                "RateLimit",
-                                `limit=${rateLimitConfig.login.usernameMax}, remaining=0, reset=${check.retryAfterSeconds}`,
-                        );
-                        res.status(429).json({
-                                error: "Too many failed login attempts for this account, try again later",
-                                scope: "username",
-                        });
-                        return;
-                }
+		// Per-username gate runs before bcrypt. `scope` distinguishes an
+		// account lockout from the IP-layer 429 above. Emits the same
+		// draft-7 RateLimit-* headers as express-rate-limit does on the
+		// IP 429 so clients parsing them see a consistent shape.
+		//
+		// beginAttempt reserves an in-flight slot atomically — important
+		// now that loginUser uses async bcrypt.compare (no longer blocks
+		// the event loop). Without the reservation, a burst of N requests
+		// against the same username could all pass check() and all start
+		// bcrypt before any recordFailure lands, breaking the bound.
+		const check = usernameLimiter.beginAttempt(username);
+		if (!check.allowed) {
+			const windowSeconds = Math.ceil(rateLimitConfig.login.usernameWindowMs / 1000);
+			res.setHeader("Retry-After", String(check.retryAfterSeconds));
+			res.setHeader("RateLimit-Policy", `${rateLimitConfig.login.usernameMax};w=${windowSeconds}`);
+			res.setHeader(
+				"RateLimit",
+				`limit=${rateLimitConfig.login.usernameMax}, remaining=0, reset=${check.retryAfterSeconds}`,
+			);
+			res.status(429).json({
+				error: "Too many failed login attempts for this account, try again later",
+				scope: "username",
+			});
+			return;
+		}
 
-                let result: { userId: string; token: string };
-                try {
-                        try {
-                                result = await loginUser(username, password);
-                        } catch (err) {
-                                if (err instanceof InvalidCredentialsError) {
-                                        // Only bad creds count — infra errors must not lock real users out.
-                                        usernameLimiter.recordFailure(username);
-                                        res.status(401).json({ error: err.message });
-                                        return;
-                                }
-                                // Username omitted from the log to avoid an enumeration vector.
-                                console.error(`[auth] login failed unexpectedly:`, (err as Error).message);
-                                res.status(500).json({ error: "Internal server error" });
-                                return;
-                        }
-                        usernameLimiter.reset(username);
-                        res.json(result);
-                } finally {
-                        // Always release the in-flight slot — success, invalid creds,
-                        // or infra error alike. `reset()` above wipes the failure
-                        // counter but not this slot; pairing it with endAttempt keeps
-                        // the invariant that every beginAttempt has exactly one
-                        // endAttempt.
-                        usernameLimiter.endAttempt(username);
-                }
-        });
+		let result: { userId: string; token: string };
+		try {
+			try {
+				result = await loginUser(username, password);
+			} catch (err) {
+				if (err instanceof InvalidCredentialsError) {
+					// Only bad creds count — infra errors must not lock real users out.
+					usernameLimiter.recordFailure(username);
+					res.status(401).json({ error: err.message });
+					return;
+				}
+				// Username omitted from the log to avoid an enumeration vector.
+				console.error(`[auth] login failed unexpectedly:`, (err as Error).message);
+				res.status(500).json({ error: "Internal server error" });
+				return;
+			}
+			usernameLimiter.reset(username);
+			res.json(result);
+		} finally {
+			// Always release the in-flight slot — success, invalid creds,
+			// or infra error alike. `reset()` above wipes the failure
+			// counter but not this slot; pairing it with endAttempt keeps
+			// the invariant that every beginAttempt has exactly one
+			// endAttempt.
+			usernameLimiter.endAttempt(username);
+		}
+	});
 
-        // ── Authenticated route prefixes ────────────────────────────────────────
+	// ── Authenticated route prefixes ────────────────────────────────────────
 
-        router.use("/invites", requireAuth);
-        router.use("/sessions", requireAuth);
+	router.use("/invites", requireAuth);
+	router.use("/sessions", requireAuth);
 
-        // ── Invite routes ───────────────────────────────────────────────────────
-        // Any authenticated user can mint invites — there is no admin tier yet.
-        // If you ever want to gate this to specific accounts, add an is_admin
-        // column to users and a middleware check here.
+	// ── Invite routes ───────────────────────────────────────────────────────
+	// Any authenticated user can mint invites — there is no admin tier yet.
+	// If you ever want to gate this to specific accounts, add an is_admin
+	// column to users and a middleware check here.
 
-        // GET is rate-limited symmetrically with POST/DELETE (issue #47):
-        // a much higher cap because reads are cheap, but the same per-IP
-        // shape so the asymmetry doesn't read as accidental and a runaway
-        // client polling in a loop can't hammer D1 unbounded.
-        router.get("/invites", invitesListIp, async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                try {
-                        const invites = await listInvites(userId);
-                        res.json(invites);
-                } catch (err) {
-                        console.error(`[invites] list failed:`, (err as Error).message);
-                        res.status(500).json({ error: "Internal server error" });
-                }
-        });
+	// GET is rate-limited symmetrically with POST/DELETE (issue #47):
+	// a much higher cap because reads are cheap, but the same per-IP
+	// shape so the asymmetry doesn't read as accidental and a runaway
+	// client polling in a loop can't hammer D1 unbounded.
+	router.get("/invites", invitesListIp, async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			const invites = await listInvites(userId);
+			res.json(invites);
+		} catch (err) {
+			console.error(`[invites] list failed:`, (err as Error).message);
+			res.status(500).json({ error: "Internal server error" });
+		}
+	});
 
-        router.post("/invites", invitesCreateIp, async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                try {
-                        const invite = await createInvite(userId);
-                        res.status(201).json(invite);
-                } catch (err) {
-                        if (err instanceof InviteQuotaExceededError) {
-                                res.status(429).json({ error: err.message });
-                                return;
-                        }
-                        console.error(`[invites] create failed:`, (err as Error).message);
-                        res.status(500).json({ error: "Internal server error" });
-                }
-        });
+	router.post("/invites", invitesCreateIp, async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			const invite = await createInvite(userId);
+			res.status(201).json(invite);
+		} catch (err) {
+			if (err instanceof InviteQuotaExceededError) {
+				res.status(429).json({ error: err.message });
+				return;
+			}
+			console.error(`[invites] create failed:`, (err as Error).message);
+			res.status(500).json({ error: "Internal server error" });
+		}
+	});
 
-        router.delete("/invites/:code", invitesRevokeIp, async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                const { code } = req.params;
-                // Same 64-char ceiling as the inviteCode body field at register —
-                // codes mint at 16 hex chars, anything larger is a probe and
-                // shouldn't reach D1 even as a parameterized arg.
-                if (code.length > 64) {
-                        res.status(400).json({ error: "code must be at most 64 characters" });
-                        return;
-                }
-                try {
-                        const removed = await revokeInvite(userId, code);
-                        if (!removed) {
-                                // Vague on purpose: don't distinguish missing / already-used /
-                                // owned-by-someone-else, since that would let a caller probe for
-                                // codes outside their ownership.
-                                res.status(404).json({ error: "Invite not found or already used" });
-                                return;
-                        }
-                        res.status(204).send();
-                } catch (err) {
-                        console.error(`[invites] revoke failed:`, (err as Error).message);
-                        res.status(500).json({ error: "Internal server error" });
-                }
-        });
+	router.delete("/invites/:code", invitesRevokeIp, async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		const { code } = req.params;
+		// Same 64-char ceiling as the inviteCode body field at register —
+		// codes mint at 16 hex chars, anything larger is a probe and
+		// shouldn't reach D1 even as a parameterized arg.
+		if (code.length > 64) {
+			res.status(400).json({ error: "code must be at most 64 characters" });
+			return;
+		}
+		try {
+			const removed = await revokeInvite(userId, code);
+			if (!removed) {
+				// Vague on purpose: don't distinguish missing / already-used /
+				// owned-by-someone-else, since that would let a caller probe for
+				// codes outside their ownership.
+				res.status(404).json({ error: "Invite not found or already used" });
+				return;
+			}
+			res.status(204).send();
+		} catch (err) {
+			console.error(`[invites] revoke failed:`, (err as Error).message);
+			res.status(500).json({ error: "Internal server error" });
+		}
+	});
 
-        // ── Session routes ──────────────────────────────────────────────────────
+	// ── Session routes ──────────────────────────────────────────────────────
 
-        router.post("/sessions", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                const { name, cols, rows, envVars } = req.body as {
-                        name?: string; cols?: number; rows?: number; envVars?: unknown;
-                };
-                if (!name || typeof name !== "string") {
-                        res.status(400).json({ error: "body.name is required" });
-                        return;
-                }
-                let validatedEnvVars: Record<string, string>;
-                try {
-                        validatedEnvVars = validateEnvVars(envVars);
-                } catch (err) {
-                        if (err instanceof EnvVarValidationError) {
-                                res.status(400).json({ error: err.message });
-                                return;
-                        }
-                        throw err;
-                }
-                // `sessions.create` writes a D1 row BEFORE `docker.spawn` runs, so a
-                // spawn failure (missing image, docker daemon down, name collision on
-                // the 12-char container-name prefix, workspace chown EACCES) would
-                // otherwise leak a phantom `running` session with a null container_id.
-                // reconcile() would later flip it to `stopped`, but the row stays
-                // forever and users see a zombie entry in their sidebar. Roll back
-                // the D1 row explicitly on any spawn failure.
-                let meta: Awaited<ReturnType<SessionManager["create"]>> | null = null;
-                try {
-                        meta = await sessions.create({ userId, name, cols, rows, envVars: validatedEnvVars });
-                        await docker.spawn(meta.sessionId);
-                        const updated = await sessions.get(meta.sessionId);
-                        if (!updated) {
-                                // Shouldn't happen: sessions.create above just inserted this row,
-                                // and nothing in this handler deletes it. Guard so serializeMeta
-                                // doesn't get null. The throw falls into the catch below which
-                                // runs the spawn rollback and returns 500 — correct disposition
-                                // for a server-side invariant violation.
-                                throw new Error(`session ${meta.sessionId} missing from D1 after create`);
-                        }
-                        res.status(201).json(serializeMeta(updated));
-                } catch (err) {
-                        // Quota errors come from sessions.create before any D1 row or
-                        // container is written, so there's nothing to roll back — return
-                        // 429 directly. Checking before the generic error log too, so a
-                        // routine quota hit doesn't spam the logs as a "session create
-                        // failed" line.
-                        if (err instanceof SessionQuotaExceededError) {
-                                res.status(429).json({ error: err.message, quota: err.quota });
-                                return;
-                        }
-                        console.error(`[routes] session create failed:`, (err as Error).message);
-                        if (meta) {
-                                // Best-effort rollback. If deleteRow itself fails (D1 blip),
-                                // the reconciler will eventually flip status to stopped but
-                                // the row remains — we log loudly so an operator can clean
-                                // it up manually.
-                                try {
-                                        await sessions.deleteRow(meta.sessionId);
-                                } catch (cleanupErr) {
-                                        console.error(
-                                                `[routes] CRITICAL: spawn rollback failed for session ${meta.sessionId}:`,
-                                                (cleanupErr as Error).message,
-                                        );
-                                }
-                        }
-                        res.status(500).json({ error: (err as Error).message });
-                }
-        });
+	router.post("/sessions", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		const { name, cols, rows, envVars } = req.body as {
+			name?: string;
+			cols?: number;
+			rows?: number;
+			envVars?: unknown;
+		};
+		if (!name || typeof name !== "string") {
+			res.status(400).json({ error: "body.name is required" });
+			return;
+		}
+		let validatedEnvVars: Record<string, string>;
+		try {
+			validatedEnvVars = validateEnvVars(envVars);
+		} catch (err) {
+			if (err instanceof EnvVarValidationError) {
+				res.status(400).json({ error: err.message });
+				return;
+			}
+			throw err;
+		}
+		// `sessions.create` writes a D1 row BEFORE `docker.spawn` runs, so a
+		// spawn failure (missing image, docker daemon down, name collision on
+		// the 12-char container-name prefix, workspace chown EACCES) would
+		// otherwise leak a phantom `running` session with a null container_id.
+		// reconcile() would later flip it to `stopped`, but the row stays
+		// forever and users see a zombie entry in their sidebar. Roll back
+		// the D1 row explicitly on any spawn failure.
+		let meta: Awaited<ReturnType<SessionManager["create"]>> | null = null;
+		try {
+			meta = await sessions.create({ userId, name, cols, rows, envVars: validatedEnvVars });
+			await docker.spawn(meta.sessionId);
+			const updated = await sessions.get(meta.sessionId);
+			if (!updated) {
+				// Shouldn't happen: sessions.create above just inserted this row,
+				// and nothing in this handler deletes it. Guard so serializeMeta
+				// doesn't get null. The throw falls into the catch below which
+				// runs the spawn rollback and returns 500 — correct disposition
+				// for a server-side invariant violation.
+				throw new Error(`session ${meta.sessionId} missing from D1 after create`);
+			}
+			res.status(201).json(serializeMeta(updated));
+		} catch (err) {
+			// Quota errors come from sessions.create before any D1 row or
+			// container is written, so there's nothing to roll back — return
+			// 429 directly. Checking before the generic error log too, so a
+			// routine quota hit doesn't spam the logs as a "session create
+			// failed" line.
+			if (err instanceof SessionQuotaExceededError) {
+				res.status(429).json({ error: err.message, quota: err.quota });
+				return;
+			}
+			console.error(`[routes] session create failed:`, (err as Error).message);
+			if (meta) {
+				// Best-effort rollback. If deleteRow itself fails (D1 blip),
+				// the reconciler will eventually flip status to stopped but
+				// the row remains — we log loudly so an operator can clean
+				// it up manually.
+				try {
+					await sessions.deleteRow(meta.sessionId);
+				} catch (cleanupErr) {
+					console.error(
+						`[routes] CRITICAL: spawn rollback failed for session ${meta.sessionId}:`,
+						(cleanupErr as Error).message,
+					);
+				}
+			}
+			res.status(500).json({ error: (err as Error).message });
+		}
+	});
 
-        router.get("/sessions", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                const includeTerminated = req.query.all === "true";
-                const list = includeTerminated
-                        ? await sessions.listAllForUser(userId)
-                        : await sessions.listForUser(userId);
-                res.json(list.map(serializeMeta));
-        });
+	router.get("/sessions", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		const includeTerminated = req.query.all === "true";
+		const list = includeTerminated
+			? await sessions.listAllForUser(userId)
+			: await sessions.listForUser(userId);
+		res.json(list.map(serializeMeta));
+	});
 
-        router.get("/sessions/:id", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                try {
-                        const meta = await sessions.assertOwnership(req.params.id, userId);
-                        res.json(serializeMeta(meta));
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        });
+	router.get("/sessions/:id", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			const meta = await sessions.assertOwnership(req.params.id, userId);
+			res.json(serializeMeta(meta));
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
 
-        router.delete("/sessions/:id", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                // `?hard=true` turns this into a hard delete: container is killed,
-                // workspace files are wiped from disk, and the D1 row is removed.
-                // Without it, we do a soft delete — container goes away but the row
-                // stays (status=terminated) and the workspace dir is preserved so
-                // the user can later restore the session.
-                const hard = req.query.hard === "true" || req.query.hard === "1";
+	router.delete("/sessions/:id", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		// `?hard=true` turns this into a hard delete: container is killed,
+		// workspace files are wiped from disk, and the D1 row is removed.
+		// Without it, we do a soft delete — container goes away but the row
+		// stays (status=terminated) and the workspace dir is preserved so
+		// the user can later restore the session.
+		const hard = req.query.hard === "true" || req.query.hard === "1";
 
-                try {
-                        const meta = await sessions.assertOwnership(req.params.id, userId);
+		try {
+			const meta = await sessions.assertOwnership(req.params.id, userId);
 
-                        // Idempotent path: only tear down the container + flip to
-                        // terminated the first time. Subsequent calls skip this.
-                        if (meta.status !== "terminated") {
-                                await docker.kill(req.params.id);
-                                await sessions.terminate(req.params.id);
-                        }
+			// Idempotent path: only tear down the container + flip to
+			// terminated the first time. Subsequent calls skip this.
+			if (meta.status !== "terminated") {
+				await docker.kill(req.params.id);
+				await sessions.terminate(req.params.id);
+			}
 
-                        if (hard) {
-                                // Wipe workspace files and drop the row entirely.
-                                try {
-                                        await docker.purgeWorkspace(req.params.id);
-                                } catch (err) {
-                                        console.error(`[routes] purgeWorkspace failed for ${req.params.id}:`, (err as Error).message);
-                                        // Fall through — we still want to remove the row.
-                                }
-                                await sessions.deleteRow(req.params.id);
-                        }
+			if (hard) {
+				// Wipe workspace files and drop the row entirely.
+				try {
+					await docker.purgeWorkspace(req.params.id);
+				} catch (err) {
+					console.error(
+						`[routes] purgeWorkspace failed for ${req.params.id}:`,
+						(err as Error).message,
+					);
+					// Fall through — we still want to remove the row.
+				}
+				await sessions.deleteRow(req.params.id);
+			}
 
-                        res.status(204).send();
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        });
+			res.status(204).send();
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
 
-        router.post("/sessions/:id/stop", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                try {
-                        await sessions.assertOwnership(req.params.id, userId);
-                        await docker.stopContainer(req.params.id);
-                        const updated = await sessions.get(req.params.id);
-                        if (!updated) {
-                                // Race: the session was deleted between assertOwnership
-                                // above and this re-read. Return 404 rather than TypeError
-                                // on serializeMeta(null).
-                                res.status(404).json({ error: "Session not found" });
-                                return;
-                        }
-                        res.json(serializeMeta(updated));
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        });
+	router.post("/sessions/:id/stop", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			await sessions.assertOwnership(req.params.id, userId);
+			await docker.stopContainer(req.params.id);
+			const updated = await sessions.get(req.params.id);
+			if (!updated) {
+				// Race: the session was deleted between assertOwnership
+				// above and this re-read. Return 404 rather than TypeError
+				// on serializeMeta(null).
+				res.status(404).json({ error: "Session not found" });
+				return;
+			}
+			res.json(serializeMeta(updated));
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
 
-        router.post("/sessions/:id/start", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                try {
-                        await sessions.assertOwnership(req.params.id, userId);
-                        await docker.startContainer(req.params.id);
-                        const updated = await sessions.get(req.params.id);
-                        if (!updated) {
-                                // Race: deleted between assertOwnership and get. See
-                                // stopContainer handler above for the full explanation.
-                                res.status(404).json({ error: "Session not found" });
-                                return;
-                        }
-                        res.json(serializeMeta(updated));
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        });
+	router.post("/sessions/:id/start", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			await sessions.assertOwnership(req.params.id, userId);
+			await docker.startContainer(req.params.id);
+			const updated = await sessions.get(req.params.id);
+			if (!updated) {
+				// Race: deleted between assertOwnership and get. See
+				// stopContainer handler above for the full explanation.
+				res.status(404).json({ error: "Session not found" });
+				return;
+			}
+			res.json(serializeMeta(updated));
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
 
-        router.patch("/sessions/:id/env", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                const { envVars } = req.body as { envVars?: unknown };
-                // Require envVars to be explicitly present. An omitted body field here
-                // is almost certainly a client bug — if the user really wants to clear
-                // their vars they should PATCH with `{ envVars: {} }`.
-                if (envVars === undefined) {
-                        res.status(400).json({ error: "body.envVars is required" });
-                        return;
-                }
-                let validatedEnvVars: Record<string, string>;
-                try {
-                        validatedEnvVars = validateEnvVars(envVars);
-                } catch (err) {
-                        if (err instanceof EnvVarValidationError) {
-                                res.status(400).json({ error: err.message });
-                                return;
-                        }
-                        throw err;
-                }
-                try {
-                        await sessions.assertOwnership(req.params.id, userId);
-                        await sessions.updateEnvVars(req.params.id, validatedEnvVars);
-                        const updated = await sessions.get(req.params.id);
-                        if (!updated) {
-                                // Race: deleted between assertOwnership and get. See
-                                // stopContainer handler above for the full explanation.
-                                res.status(404).json({ error: "Session not found" });
-                                return;
-                        }
-                        res.json(serializeMeta(updated));
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        });
+	router.patch("/sessions/:id/env", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		const { envVars } = req.body as { envVars?: unknown };
+		// Require envVars to be explicitly present. An omitted body field here
+		// is almost certainly a client bug — if the user really wants to clear
+		// their vars they should PATCH with `{ envVars: {} }`.
+		if (envVars === undefined) {
+			res.status(400).json({ error: "body.envVars is required" });
+			return;
+		}
+		let validatedEnvVars: Record<string, string>;
+		try {
+			validatedEnvVars = validateEnvVars(envVars);
+		} catch (err) {
+			if (err instanceof EnvVarValidationError) {
+				res.status(400).json({ error: err.message });
+				return;
+			}
+			throw err;
+		}
+		try {
+			await sessions.assertOwnership(req.params.id, userId);
+			await sessions.updateEnvVars(req.params.id, validatedEnvVars);
+			const updated = await sessions.get(req.params.id);
+			if (!updated) {
+				// Race: deleted between assertOwnership and get. See
+				// stopContainer handler above for the full explanation.
+				res.status(404).json({ error: "Session not found" });
+				return;
+			}
+			res.json(serializeMeta(updated));
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
 
-        // ── Tabs within a session ──────────────────────────────────────────────
-        // Each tab is a tmux session inside the container. The backend owns the
-        // tabId → tmux session name mapping; the UI treats tabId as an opaque
-        // string. Deleting a tab SIGHUPs everything inside it.
+	// ── Tabs within a session ──────────────────────────────────────────────
+	// Each tab is a tmux session inside the container. The backend owns the
+	// tabId → tmux session name mapping; the UI treats tabId as an opaque
+	// string. Deleting a tab SIGHUPs everything inside it.
 
-        router.get("/sessions/:id/tabs", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                try {
-                        await sessions.assertOwnership(req.params.id, userId);
-                        const tabs = await docker.listTabs(req.params.id);
-                        res.json(tabs);
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        });
+	router.get("/sessions/:id/tabs", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			await sessions.assertOwnership(req.params.id, userId);
+			const tabs = await docker.listTabs(req.params.id);
+			res.json(tabs);
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
 
-        router.post("/sessions/:id/tabs", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                const { label } = (req.body ?? {}) as { label?: unknown };
-                // Tab-label invariants for the tmux TSV listTabs parser — see
-                // the JSDoc on DockerManager.createTab for the full rationale
-                // (issue #92). Enforced here so dockerManager can trust its
-                // input and avoid silent normalisation (a .trim() there would
-                // cause "what you sent ≠ what's stored").
-                const labelValidation = validateTabLabel(label);
-                if (labelValidation) {
-                        res.status(400).json({ error: labelValidation });
-                        return;
-                }
-                try {
-                        await sessions.assertOwnership(req.params.id, userId);
-                        const tab = await docker.createTab(req.params.id, label as string | undefined);
-                        res.status(201).json(tab);
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        });
+	router.post("/sessions/:id/tabs", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		const { label } = (req.body ?? {}) as { label?: unknown };
+		// Tab-label invariants for the tmux TSV listTabs parser — see
+		// the JSDoc on DockerManager.createTab for the full rationale
+		// (issue #92). Enforced here so dockerManager can trust its
+		// input and avoid silent normalisation (a .trim() there would
+		// cause "what you sent ≠ what's stored").
+		const labelValidation = validateTabLabel(label);
+		if (labelValidation) {
+			res.status(400).json({ error: labelValidation });
+			return;
+		}
+		try {
+			await sessions.assertOwnership(req.params.id, userId);
+			const tab = await docker.createTab(req.params.id, label as string | undefined);
+			res.status(201).json(tab);
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
 
-        router.delete("/sessions/:id/tabs/:tabId", async (req: Request, res: Response) => {
-                const { userId } = req as AuthedRequest;
-                const { id, tabId } = req.params;
-                try {
-                        await sessions.assertOwnership(id, userId);
+	router.delete("/sessions/:id/tabs/:tabId", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		const { id, tabId } = req.params;
+		try {
+			await sessions.assertOwnership(id, userId);
 
-                        // Closing all tabs is allowed — the container lifecycle is
-                        // independent of tmux now, so a session with zero tabs is a
-                        // valid state (the user creates a new tab from the +).
-                        const tabs = await docker.listTabs(id);
-                        if (!tabs.some((t) => t.tabId === tabId)) {
-                                res.status(404).json({ error: "tab not found" });
-                                return;
-                        }
+			// Closing all tabs is allowed — the container lifecycle is
+			// independent of tmux now, so a session with zero tabs is a
+			// valid state (the user creates a new tab from the +).
+			const tabs = await docker.listTabs(id);
+			if (!tabs.some((t) => t.tabId === tabId)) {
+				res.status(404).json({ error: "tab not found" });
+				return;
+			}
 
-                        await docker.deleteTab(id, tabId);
-                        res.status(204).send();
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        });
+			await docker.deleteTab(id, tabId);
+			res.status(204).send();
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
 
-        // ── File uploads ────────────────────────────────────────────────────────
-        // Drop user-uploaded files into the session's bind-mounted workspace
-        // (under uploads/) so the container — and Claude CLI in it — can read
-        // them.
-        //
-        // Disk storage (NOT memoryStorage) is the load-bearing choice here.
-        // 8 × 25 MB = 200 MB of body per request, and the per-IP rate
-        // limiter (30/5min) doesn't bound concurrency — 30 concurrent
-        // requests with memoryStorage would peak at ~6 GB of heap and
-        // OOM-kill the backend. Disk storage streams bytes through Node
-        // into the OS page cache, then `writeUploads` atomically renames
-        // the temp file into the final per-session location.
-        //
-        // Caps:
-        //   - 25 MB per file: covers the images / PDFs Claude actually
-        //     accepts without forcing chunked upload UI.
-        //   - 8 files per request: enough for a typical "drop a few
-        //     screenshots" gesture, low enough to bound peak disk usage
-        //     per request.
-        const uploadTmpDir = docker.getUploadTmpDir();
-        const upload = multer({
-                storage: multer.diskStorage({
-                        destination: (_req, _file, cb) => {
-                                // Idempotent — the dir often already exists; recursive: true
-                                // makes mkdir a no-op in that case.
-                                fs.mkdir(uploadTmpDir, { recursive: true })
-                                        .then(() => cb(null, uploadTmpDir))
-                                        .catch((err: Error) => cb(err, ""));
-                        },
-                        filename: (_req, _file, cb) => {
-                                // multer-internal name only; writeUploads renames to the
-                                // user-facing `<ts>-<rand>-<safeBase>` form when it moves
-                                // the file into the per-session uploads/ dir.
-                                cb(null, `${Date.now().toString(36)}-${randomBytes(8).toString("hex")}`);
-                        },
-                }),
-                limits: {
-                        fileSize: 25 * 1024 * 1024,
-                        files: 8,
-                        // Endpoint accepts only file parts (named "files"), no
-                        // text fields. Cap fields/parts so a JWT holder can't
-                        // make busboy parse thousands of throwaway parts before
-                        // the file count hits its limit. parts = files (8) + 1
-                        // headroom; fields = 0 means any non-file part trips
-                        // LIMIT_PART_COUNT immediately.
-                        fields: 0,
-                        parts: 9,
-                        fieldNameSize: 64,
-                },
-        });
+	// ── File uploads ────────────────────────────────────────────────────────
+	// Drop user-uploaded files into the session's bind-mounted workspace
+	// (under uploads/) so the container — and Claude CLI in it — can read
+	// them.
+	//
+	// Disk storage (NOT memoryStorage) is the load-bearing choice here.
+	// 8 × 25 MB = 200 MB of body per request, and the per-IP rate
+	// limiter (30/5min) doesn't bound concurrency — 30 concurrent
+	// requests with memoryStorage would peak at ~6 GB of heap and
+	// OOM-kill the backend. Disk storage streams bytes through Node
+	// into the OS page cache, then `writeUploads` atomically renames
+	// the temp file into the final per-session location.
+	//
+	// Caps:
+	//   - 25 MB per file: covers the images / PDFs Claude actually
+	//     accepts without forcing chunked upload UI.
+	//   - 8 files per request: enough for a typical "drop a few
+	//     screenshots" gesture, low enough to bound peak disk usage
+	//     per request.
+	const uploadTmpDir = docker.getUploadTmpDir();
+	const upload = multer({
+		storage: multer.diskStorage({
+			destination: (_req, _file, cb) => {
+				// Idempotent — the dir often already exists; recursive: true
+				// makes mkdir a no-op in that case.
+				fs.mkdir(uploadTmpDir, { recursive: true })
+					.then(() => cb(null, uploadTmpDir))
+					.catch((err: Error) => cb(err, ""));
+			},
+			filename: (_req, _file, cb) => {
+				// multer-internal name only; writeUploads renames to the
+				// user-facing `<ts>-<rand>-<safeBase>` form when it moves
+				// the file into the per-session uploads/ dir.
+				cb(null, `${Date.now().toString(36)}-${randomBytes(8).toString("hex")}`);
+			},
+		}),
+		limits: {
+			fileSize: 25 * 1024 * 1024,
+			files: 8,
+			// Endpoint accepts only file parts (named "files"), no
+			// text fields. Cap fields/parts so a JWT holder can't
+			// make busboy parse thousands of throwaway parts before
+			// the file count hits its limit. parts = files (8) + 1
+			// headroom; fields = 0 means any non-file part trips
+			// LIMIT_PART_COUNT immediately.
+			fields: 0,
+			parts: 9,
+			fieldNameSize: 64,
+		},
+	});
 
-        // Wrap multer so its async-throw errors land in our handleSessionError-style
-        // responder instead of Express's default HTML 500 page.
-        const handleUploadMiddleware = (req: Request, res: Response, next: NextFunction): void => {
-                upload.array("files", 8)(req, res, (err: unknown) => {
-                        if (!err) { next(); return; }
-                        // When multer aborts mid-batch (e.g. file 8 trips
-                        // LIMIT_FILE_SIZE after files 1–7 already streamed to
-                        // .tmp-uploads/), it auto-removes only the partial
-                        // file for the entry that errored. The earlier
-                        // successfully-streamed files sit in req.files and
-                        // would otherwise leak — at 30 reqs / 5min × 7 ×
-                        // ~25 MB = ~5 GB/window of orphaned tmp files. Clear
-                        // them on every error branch before returning.
-                        const partial = (req.files as Express.Multer.File[] | undefined) ?? [];
-                        if (partial.length > 0) {
-                                void Promise.allSettled(partial.map((f) => fs.unlink(f.path))).then((results) => {
-                                        // Log unlink failures (e.g. EPERM from a misconfigured
-                                        // tmp dir owner) so a real filesystem problem doesn't
-                                        // sit invisible until the next startup sweep. ENOENT
-                                        // is the expected outcome on a never-streamed entry
-                                        // and gets logged too — noise here is a clearer
-                                        // signal than silence.
-                                        for (const r of results) {
-                                                if (r.status === "rejected") {
-                                                        console.warn("[routes] tmp unlink failed:", (r.reason as Error).message);
-                                                }
-                                        }
-                                });
-                        }
-                        if (err instanceof multer.MulterError) {
-                                if (err.code === "LIMIT_FILE_SIZE") {
-                                        res.status(413).json({ error: `Upload rejected: ${err.message}` });
-                                        return;
-                                }
-                                if (err.code === "LIMIT_FILE_COUNT" || err.code === "LIMIT_PART_COUNT") {
-                                        // Both are payload-too-large in spirit: the request
-                                        // exceeds a server cap (8 files / 9 parts). 413 is
-                                        // the spec answer and lets clients distinguish
-                                        // "retry-may-help" 4xxs from this hard cap.
-                                        res.status(413).json({ error: `Upload rejected: ${err.message}` });
-                                        return;
-                                }
-                                if (err.code === "LIMIT_UNEXPECTED_FILE") {
-                                        // Default message ("Unexpected field") doesn't tell the
-                                        // caller what field name we DO expect — name it explicitly.
-                                        res.status(400).json({ error: "Upload rejected: field must be named 'files' (multipart/form-data)" });
-                                        return;
-                                }
-                                res.status(400).json({ error: `Upload rejected: ${err.message}` });
-                                return;
-                        }
-                        console.error("[routes] upload middleware error:", (err as Error).message);
-                        res.status(500).json({ error: "Upload failed" });
-                });
-        };
+	// Wrap multer so its async-throw errors land in our handleSessionError-style
+	// responder instead of Express's default HTML 500 page.
+	const handleUploadMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+		upload.array("files", 8)(req, res, (err: unknown) => {
+			if (!err) {
+				next();
+				return;
+			}
+			// When multer aborts mid-batch (e.g. file 8 trips
+			// LIMIT_FILE_SIZE after files 1–7 already streamed to
+			// .tmp-uploads/), it auto-removes only the partial
+			// file for the entry that errored. The earlier
+			// successfully-streamed files sit in req.files and
+			// would otherwise leak — at 30 reqs / 5min × 7 ×
+			// ~25 MB = ~5 GB/window of orphaned tmp files. Clear
+			// them on every error branch before returning.
+			const partial = (req.files as Express.Multer.File[] | undefined) ?? [];
+			if (partial.length > 0) {
+				void Promise.allSettled(partial.map((f) => fs.unlink(f.path))).then((results) => {
+					// Log unlink failures (e.g. EPERM from a misconfigured
+					// tmp dir owner) so a real filesystem problem doesn't
+					// sit invisible until the next startup sweep. ENOENT
+					// is the expected outcome on a never-streamed entry
+					// and gets logged too — noise here is a clearer
+					// signal than silence.
+					for (const r of results) {
+						if (r.status === "rejected") {
+							console.warn("[routes] tmp unlink failed:", (r.reason as Error).message);
+						}
+					}
+				});
+			}
+			if (err instanceof multer.MulterError) {
+				if (err.code === "LIMIT_FILE_SIZE") {
+					res.status(413).json({ error: `Upload rejected: ${err.message}` });
+					return;
+				}
+				if (err.code === "LIMIT_FILE_COUNT" || err.code === "LIMIT_PART_COUNT") {
+					// Both are payload-too-large in spirit: the request
+					// exceeds a server cap (8 files / 9 parts). 413 is
+					// the spec answer and lets clients distinguish
+					// "retry-may-help" 4xxs from this hard cap.
+					res.status(413).json({ error: `Upload rejected: ${err.message}` });
+					return;
+				}
+				if (err.code === "LIMIT_UNEXPECTED_FILE") {
+					// Default message ("Unexpected field") doesn't tell the
+					// caller what field name we DO expect — name it explicitly.
+					res
+						.status(400)
+						.json({ error: "Upload rejected: field must be named 'files' (multipart/form-data)" });
+					return;
+				}
+				res.status(400).json({ error: `Upload rejected: ${err.message}` });
+				return;
+			}
+			console.error("[routes] upload middleware error:", (err as Error).message);
+			res.status(500).json({ error: "Upload failed" });
+		});
+	};
 
-        // Verify ownership BEFORE multer reads any bytes from the wire. With
-        // up to 200 MB (8 × 25 MB) per request, running the ownership check
-        // in the route handler — i.e. after multer has already buffered
-        // everything into the Node heap — let an authenticated user with a
-        // valid JWT but a foreign session ID cause N × 200 MB allocations
-        // bounded only by the per-IP rate limiter. Doing it here means
-        // unauthorised requests close the socket on the 403 with no body
-        // ever buffered.
-        const requireSessionOwnership = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-                try {
-                        await sessions.assertOwnership(req.params.id, (req as AuthedRequest).userId);
-                        next();
-                } catch (err) {
-                        handleSessionError(err, res);
-                }
-        };
+	// Verify ownership BEFORE multer reads any bytes from the wire. With
+	// up to 200 MB (8 × 25 MB) per request, running the ownership check
+	// in the route handler — i.e. after multer has already buffered
+	// everything into the Node heap — let an authenticated user with a
+	// valid JWT but a foreign session ID cause N × 200 MB allocations
+	// bounded only by the per-IP rate limiter. Doing it here means
+	// unauthorised requests close the socket on the 403 with no body
+	// ever buffered.
+	const requireSessionOwnership = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	): Promise<void> => {
+		try {
+			await sessions.assertOwnership(req.params.id, (req as AuthedRequest).userId);
+			next();
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	};
 
-        router.post(
-                "/sessions/:id/files",
-                // Explicit requireAuth so the route doesn't silently inherit
-                // its auth gate from `router.use("/sessions", requireAuth)`
-                // earlier in this file. If a future refactor lifts this
-                // route out of the /sessions prefix, the explicit guard
-                // makes the failure mode a 401 (loud) instead of an
-                // anon-userId reaching assertOwnership and surfacing as a
-                // confusing 404.
-                requireAuth,
-                fileUploadIp,
-                requireSessionOwnership,
-                handleUploadMiddleware,
-                async (req: Request, res: Response) => {
-                        const files = (req.files as Express.Multer.File[] | undefined) ?? [];
-                        try {
-                                if (files.length === 0) {
-                                        res.status(400).json({ error: "no files provided (use 'files' field, multipart/form-data)" });
-                                        return;
-                                }
-                                const paths = await docker.writeUploads(
-                                        req.params.id,
-                                        // diskStorage — pass the on-disk tmp path, not a buffer.
-                                        files.map((f) => ({ originalname: f.originalname, path: f.path })),
-                                );
-                                res.status(201).json({ paths });
-                        } catch (err) {
-                                // No tmp cleanup needed here — writeUploads owns
-                                // its own finally block that unlinks every tmp file
-                                // it didn't move. The empty-files 400 above returns
-                                // before the writeUploads call (and only triggers
-                                // when multer parsed zero files, in which case
-                                // there's nothing on disk to clean either way).
-                                handleSessionError(err, res);
-                        }
-                },
-        );
+	router.post(
+		"/sessions/:id/files",
+		// Explicit requireAuth so the route doesn't silently inherit
+		// its auth gate from `router.use("/sessions", requireAuth)`
+		// earlier in this file. If a future refactor lifts this
+		// route out of the /sessions prefix, the explicit guard
+		// makes the failure mode a 401 (loud) instead of an
+		// anon-userId reaching assertOwnership and surfacing as a
+		// confusing 404.
+		requireAuth,
+		fileUploadIp,
+		requireSessionOwnership,
+		handleUploadMiddleware,
+		async (req: Request, res: Response) => {
+			const files = (req.files as Express.Multer.File[] | undefined) ?? [];
+			try {
+				if (files.length === 0) {
+					res
+						.status(400)
+						.json({ error: "no files provided (use 'files' field, multipart/form-data)" });
+					return;
+				}
+				const paths = await docker.writeUploads(
+					req.params.id,
+					// diskStorage — pass the on-disk tmp path, not a buffer.
+					files.map((f) => ({ originalname: f.originalname, path: f.path })),
+				);
+				res.status(201).json({ paths });
+			} catch (err) {
+				// No tmp cleanup needed here — writeUploads owns
+				// its own finally block that unlinks every tmp file
+				// it didn't move. The empty-files 400 above returns
+				// before the writeUploads call (and only triggers
+				// when multer parsed zero files, in which case
+				// there's nothing on disk to clean either way).
+				handleSessionError(err, res);
+			}
+		},
+	);
 
-        return router;
+	return router;
 }
 
 function serializeMeta(m: SessionMeta) {
-        return {
-                sessionId: m.sessionId,
-                name: m.name,
-                status: m.status,
-                containerId: m.containerId?.slice(0, 12) ?? null,
-                containerName: m.containerName,
-                createdAt: m.createdAt.toISOString(),
-                lastConnectedAt: m.lastConnectedAt?.toISOString() ?? null,
-                cols: m.cols,
-                rows: m.rows,
-                envVars: m.envVars,
-        };
+	return {
+		sessionId: m.sessionId,
+		name: m.name,
+		status: m.status,
+		containerId: m.containerId?.slice(0, 12) ?? null,
+		containerName: m.containerName,
+		createdAt: m.createdAt.toISOString(),
+		lastConnectedAt: m.lastConnectedAt?.toISOString() ?? null,
+		cols: m.cols,
+		rows: m.rows,
+		envVars: m.envVars,
+	};
 }
 
 /**
@@ -706,46 +719,45 @@ function serializeMeta(m: SessionMeta) {
  * regex.
  */
 function validateTabLabel(label: unknown): string | null {
-        if (label === undefined) return null;
-        if (typeof label !== "string") return "label must be a string";
-        if (label.length === 0) return "label must not be empty";
-        if (label.length > 64) return "label must be at most 64 characters";
-        // Reject leading/trailing whitespace explicitly rather than silently
-        // trimming downstream. If we trimmed we'd have "what the client sent
-        // ≠ what's stored", and future GETs would surface the normalised form
-        // — a surprise the client can't see coming. A strict 400 lets the
-        // caller fix its own UX (e.g. trim the input field) instead.
-        if (label !== label.trim()) return "label must not have leading or trailing whitespace";
-        // ASCII-control block rejection. \t and \n break the TSV parser in
-        // listTabs; \r is silently stripped by execOneShot's demux (stored
-        // label wouldn't match the sent label). Higher code points (emoji,
-        // non-Latin scripts, typographic punctuation) are opaque to the
-        // parser and kept as-is.
-        // biome-ignore lint/suspicious/noControlCharactersInRegex: matching control chars IS the rejection criterion
-        if (/[\u0000-\u001F\u007F]/.test(label)) {
-                return "label must not contain control characters (tab, newline, etc.)";
-        }
-        return null;
+	if (label === undefined) return null;
+	if (typeof label !== "string") return "label must be a string";
+	if (label.length === 0) return "label must not be empty";
+	if (label.length > 64) return "label must be at most 64 characters";
+	// Reject leading/trailing whitespace explicitly rather than silently
+	// trimming downstream. If we trimmed we'd have "what the client sent
+	// ≠ what's stored", and future GETs would surface the normalised form
+	// — a surprise the client can't see coming. A strict 400 lets the
+	// caller fix its own UX (e.g. trim the input field) instead.
+	if (label !== label.trim()) return "label must not have leading or trailing whitespace";
+	// ASCII-control block rejection. \t and \n break the TSV parser in
+	// listTabs; \r is silently stripped by execOneShot's demux (stored
+	// label wouldn't match the sent label). Higher code points (emoji,
+	// non-Latin scripts, typographic punctuation) are opaque to the
+	// parser and kept as-is.
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: matching control chars IS the rejection criterion
+	if (/[\u0000-\u001F\u007F]/.test(label)) {
+		return "label must not contain control characters (tab, newline, etc.)";
+	}
+	return null;
 }
 
 function handleSessionError(err: unknown, res: Response): void {
-
-        if (err instanceof NotFoundError) {
-                res.status(404).json({ error: err.message });
-        } else if (err instanceof ForbiddenError) {
-                res.status(403).json({ error: err.message });
-        } else if (err instanceof UploadQuotaExceededError) {
-                // 413 Payload Too Large is the HTTP-spec answer for "request
-                // would push you past a server-enforced size cap".
-                // err.message is intentionally generic — no byte counts —
-                // and the structured used/attempted/quota fields are logged
-                // server-side by writeUploads at the throw site, never
-                // surfaced in the response. Two-layer suppression so a
-                // future tweak to either side doesn't silently leak per-
-                // session usage to the client.
-                res.status(413).json({ error: err.message });
-        } else {
-                console.error("[routes] unexpected error:", (err as Error).message);
-                res.status(500).json({ error: "Internal server error" });
-        }
+	if (err instanceof NotFoundError) {
+		res.status(404).json({ error: err.message });
+	} else if (err instanceof ForbiddenError) {
+		res.status(403).json({ error: err.message });
+	} else if (err instanceof UploadQuotaExceededError) {
+		// 413 Payload Too Large is the HTTP-spec answer for "request
+		// would push you past a server-enforced size cap".
+		// err.message is intentionally generic — no byte counts —
+		// and the structured used/attempted/quota fields are logged
+		// server-side by writeUploads at the throw site, never
+		// surfaced in the response. Two-layer suppression so a
+		// future tweak to either side doesn't silently leak per-
+		// session usage to the client.
+		res.status(413).json({ error: err.message });
+	} else {
+		console.error("[routes] unexpected error:", (err as Error).message);
+		res.status(500).json({ error: "Internal server error" });
+	}
 }

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -11,17 +11,17 @@ import type { CreateSessionOpts, SessionMeta, SessionStatus } from "./types.js";
 // ── Custom errors ───────────────────────────────────────────────────────────
 
 export class NotFoundError extends Error {
-        constructor(msg = "Session not found") {
-                super(msg);
-                this.name = "NotFoundError";
-        }
+	constructor(msg = "Session not found") {
+		super(msg);
+		this.name = "NotFoundError";
+	}
 }
 
 export class ForbiddenError extends Error {
-        constructor(msg = "Access denied") {
-                super(msg);
-                this.name = "ForbiddenError";
-        }
+	constructor(msg = "Access denied") {
+		super(msg);
+		this.name = "ForbiddenError";
+	}
 }
 
 // Caps the number of concurrently *active* sessions (running / stopped /
@@ -41,62 +41,59 @@ export class ForbiddenError extends Error {
 // ops-visible signal.
 const DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER = 20;
 const MAX_ACTIVE_SESSIONS_PER_USER = ((): number => {
-        const raw = process.env.MAX_ACTIVE_SESSIONS_PER_USER;
-        if (raw === undefined || raw.trim() === "") return DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER;
-        const n = Number(raw);
-        if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
-                // Surface the original value (quoted, so "  " etc. stay visible)
-                // and the effective fallback — ops should be able to tell at a
-                // glance which variable was wrong and what the server is
-                // actually running with. Uses console.warn rather than throw
-                // because a startup abort here would gate the whole server on
-                // a non-critical config typo, which is worse than running with
-                // the documented default.
-                console.warn(
-                        `[sessionManager] MAX_ACTIVE_SESSIONS_PER_USER=${JSON.stringify(raw)} ` +
-                        `is not a positive integer; falling back to ${DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER}`,
-                );
-                return DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER;
-        }
-        return n;
+	const raw = process.env.MAX_ACTIVE_SESSIONS_PER_USER;
+	if (raw === undefined || raw.trim() === "") return DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER;
+	const n = Number(raw);
+	if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+		// Surface the original value (quoted, so "  " etc. stay visible)
+		// and the effective fallback — ops should be able to tell at a
+		// glance which variable was wrong and what the server is
+		// actually running with. Uses console.warn rather than throw
+		// because a startup abort here would gate the whole server on
+		// a non-critical config typo, which is worse than running with
+		// the documented default.
+		console.warn(
+			`[sessionManager] MAX_ACTIVE_SESSIONS_PER_USER=${JSON.stringify(raw)} ` +
+				`is not a positive integer; falling back to ${DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER}`,
+		);
+		return DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER;
+	}
+	return n;
 })();
 
 export class SessionQuotaExceededError extends Error {
-        // Passed through to the HTTP response — include the effective cap so the
-        // user knows what "too many" means without asking support.
-        readonly quota: number;
+	// Passed through to the HTTP response — include the effective cap so the
+	// user knows what "too many" means without asking support.
+	readonly quota: number;
 
-        constructor(quota: number) {
-                // Phrase as "limit reached" rather than "you already have N
-                // active sessions". When this throws, the count is exactly
-                // `quota` (the atomic INSERT's WHERE clause guarantees that),
-                // so "you already have 20" reads as a count statement — but
-                // the purpose of the message is to communicate the *cap*, not
-                // a tally. Naming the number as a limit makes the fix
-                // (terminate something) obvious.
-                super(
-                        `Active session limit (${quota}) reached — terminate a session ` +
-                        `before creating more`,
-                );
-                this.name = "SessionQuotaExceededError";
-                this.quota = quota;
-        }
+	constructor(quota: number) {
+		// Phrase as "limit reached" rather than "you already have N
+		// active sessions". When this throws, the count is exactly
+		// `quota` (the atomic INSERT's WHERE clause guarantees that),
+		// so "you already have 20" reads as a count statement — but
+		// the purpose of the message is to communicate the *cap*, not
+		// a tally. Naming the number as a limit makes the fix
+		// (terminate something) obvious.
+		super(`Active session limit (${quota}) reached — terminate a session before creating more`);
+		this.name = "SessionQuotaExceededError";
+		this.quota = quota;
+	}
 }
 
 // ── Row → domain mapper ────────────────────────────────────────────────────
 
 interface SessionRow {
-        session_id: string;
-        user_id: string;
-        name: string;
-        status: string;
-        container_id: string | null;
-        container_name: string;
-        cols: number;
-        rows: number;
-        env_vars: string;
-        created_at: string;
-        last_connected_at: string | null;
+	session_id: string;
+	user_id: string;
+	name: string;
+	status: string;
+	container_id: string | null;
+	container_name: string;
+	cols: number;
+	rows: number;
+	env_vars: string;
+	created_at: string;
+	last_connected_at: string | null;
 }
 
 // D1's `datetime('now')` returns SQLite's canonical UTC format — no 'Z' or
@@ -107,164 +104,170 @@ interface SessionRow {
 // already — double-Z is an invalid date and silently NaNs. Also catch full
 // ISO 8601 offsets like `+00:00`.
 function parseD1UtcTimestamp(raw: string): Date {
-        const hasSuffix = /[zZ]$/.test(raw) || /[+-]\d{2}:?\d{2}$/.test(raw);
-        const d = new Date(hasSuffix ? raw : `${raw}Z`);
-        if (Number.isNaN(d.getTime())) {
-                // Better to crash loudly here than return "Invalid Date" that
-                // would later serialize to null in JSON.
-                throw new Error(`D1 returned unparseable timestamp: ${raw}`);
-        }
-        return d;
+	const hasSuffix = /[zZ]$/.test(raw) || /[+-]\d{2}:?\d{2}$/.test(raw);
+	const d = new Date(hasSuffix ? raw : `${raw}Z`);
+	if (Number.isNaN(d.getTime())) {
+		// Better to crash loudly here than return "Invalid Date" that
+		// would later serialize to null in JSON.
+		throw new Error(`D1 returned unparseable timestamp: ${raw}`);
+	}
+	return d;
 }
 
 function rowToMeta(row: SessionRow): SessionMeta {
-        return {
-                sessionId: row.session_id,
-                userId: row.user_id,
-                name: row.name,
-                status: row.status as SessionStatus,
-                containerId: row.container_id,
-                containerName: row.container_name,
-                cols: row.cols,
-                rows: row.rows,
-                envVars: JSON.parse(row.env_vars),
-                createdAt: parseD1UtcTimestamp(row.created_at),
-                lastConnectedAt: row.last_connected_at ? parseD1UtcTimestamp(row.last_connected_at) : null,
-        };
+	return {
+		sessionId: row.session_id,
+		userId: row.user_id,
+		name: row.name,
+		status: row.status as SessionStatus,
+		containerId: row.container_id,
+		containerName: row.container_name,
+		cols: row.cols,
+		rows: row.rows,
+		envVars: JSON.parse(row.env_vars),
+		createdAt: parseD1UtcTimestamp(row.created_at),
+		lastConnectedAt: row.last_connected_at ? parseD1UtcTimestamp(row.last_connected_at) : null,
+	};
 }
 
 // ── SessionManager ──────────────────────────────────────────────────────────
 
 export class SessionManager {
-        async create(opts: CreateSessionOpts): Promise<SessionMeta> {
-                const sessionId = uuidv4();
-                const containerName = `st-${sessionId.slice(0, 12)}`;
-                const cols = opts.cols ?? 120;
-                const rows = opts.rows ?? 36;
-                const envVars = opts.envVars ?? {};
+	async create(opts: CreateSessionOpts): Promise<SessionMeta> {
+		const sessionId = uuidv4();
+		const containerName = `st-${sessionId.slice(0, 12)}`;
+		const cols = opts.cols ?? 120;
+		const rows = opts.rows ?? 36;
+		const envVars = opts.envVars ?? {};
 
-                // Atomic quota check: fold the per-user count into the INSERT so two
-                // concurrent POST /sessions from the same user can't both read
-                // `count = cap-1` and both insert. Same SQLite-serialised pattern as
-                // invite mint and bootstrap-register elsewhere in the codebase. The
-                // race loser observes `meta.changes === 0` and raises a typed error
-                // the route can map to 429.
-                //
-                // The count filter matches `listForUser`, which is what the UI shows —
-                // so "active" here means the same thing the user sees in their sidebar.
-                // Terminated rows don't count against the cap; they'll be garbage-
-                // collected by the hard-delete path or left as history.
-                const insert = await d1Query(
-                        `INSERT INTO sessions (session_id, user_id, name, container_name, cols, rows, env_vars)
+		// Atomic quota check: fold the per-user count into the INSERT so two
+		// concurrent POST /sessions from the same user can't both read
+		// `count = cap-1` and both insert. Same SQLite-serialised pattern as
+		// invite mint and bootstrap-register elsewhere in the codebase. The
+		// race loser observes `meta.changes === 0` and raises a typed error
+		// the route can map to 429.
+		//
+		// The count filter matches `listForUser`, which is what the UI shows —
+		// so "active" here means the same thing the user sees in their sidebar.
+		// Terminated rows don't count against the cap; they'll be garbage-
+		// collected by the hard-delete path or left as history.
+		const insert = await d1Query(
+			`INSERT INTO sessions (session_id, user_id, name, container_name, cols, rows, env_vars)
                          SELECT ?, ?, ?, ?, ?, ?, ?
                          WHERE (
                                  SELECT COUNT(*) FROM sessions
                                  WHERE user_id = ? AND status != 'terminated'
                          ) < ?`,
-                        [
-                                sessionId, opts.userId, opts.name, containerName, cols, rows, JSON.stringify(envVars),
-                                opts.userId, MAX_ACTIVE_SESSIONS_PER_USER,
-                        ],
-                );
-                if (insert.meta.changes !== 1) {
-                        throw new SessionQuotaExceededError(MAX_ACTIVE_SESSIONS_PER_USER);
-                }
+			[
+				sessionId,
+				opts.userId,
+				opts.name,
+				containerName,
+				cols,
+				rows,
+				JSON.stringify(envVars),
+				opts.userId,
+				MAX_ACTIVE_SESSIONS_PER_USER,
+			],
+		);
+		if (insert.meta.changes !== 1) {
+			throw new SessionQuotaExceededError(MAX_ACTIVE_SESSIONS_PER_USER);
+		}
 
-                const meta = await this.get(sessionId);
-                if (!meta) {
-                        // Unreachable in practice: we just inserted this row and
-                        // confirmed changes === 1. Guard anyway so the return type
-                        // is honest (no non-null assertion) and a hypothetical
-                        // read-after-write hiccup becomes a loud error rather than
-                        // a TypeError downstream when callers access .sessionId.
-                        throw new Error(
-                                `sessionManager.create: session ${sessionId} missing from D1 after insert`,
-                        );
-                }
-                return meta;
-        }
+		const meta = await this.get(sessionId);
+		if (!meta) {
+			// Unreachable in practice: we just inserted this row and
+			// confirmed changes === 1. Guard anyway so the return type
+			// is honest (no non-null assertion) and a hypothetical
+			// read-after-write hiccup becomes a loud error rather than
+			// a TypeError downstream when callers access .sessionId.
+			throw new Error(`sessionManager.create: session ${sessionId} missing from D1 after insert`);
+		}
+		return meta;
+	}
 
-        async get(sessionId: string): Promise<SessionMeta | null> {
-                const result = await d1Query<SessionRow>(
-                        "SELECT * FROM sessions WHERE session_id = ?",
-                        [sessionId],
-                );
-                return result.results.length > 0 ? rowToMeta(result.results[0]) : null;
-        }
+	async get(sessionId: string): Promise<SessionMeta | null> {
+		const result = await d1Query<SessionRow>("SELECT * FROM sessions WHERE session_id = ?", [
+			sessionId,
+		]);
+		return result.results.length > 0 ? rowToMeta(result.results[0]) : null;
+	}
 
-        async getOrThrow(sessionId: string): Promise<SessionMeta> {
-                const meta = await this.get(sessionId);
-                if (!meta) throw new NotFoundError();
-                return meta;
-        }
+	async getOrThrow(sessionId: string): Promise<SessionMeta> {
+		const meta = await this.get(sessionId);
+		if (!meta) throw new NotFoundError();
+		return meta;
+	}
 
-        async assertOwnership(sessionId: string, userId: string): Promise<SessionMeta> {
-                const meta = await this.getOrThrow(sessionId);
-                if (meta.userId !== userId) throw new ForbiddenError();
-                return meta;
-        }
+	async assertOwnership(sessionId: string, userId: string): Promise<SessionMeta> {
+		const meta = await this.getOrThrow(sessionId);
+		if (meta.userId !== userId) throw new ForbiddenError();
+		return meta;
+	}
 
-        async listForUser(userId: string): Promise<SessionMeta[]> {
-                const result = await d1Query<SessionRow>(
-                        "SELECT * FROM sessions WHERE user_id = ? AND status != 'terminated' ORDER BY created_at DESC",
-                        [userId],
-                );
-                return result.results.map(rowToMeta);
-        }
+	async listForUser(userId: string): Promise<SessionMeta[]> {
+		const result = await d1Query<SessionRow>(
+			"SELECT * FROM sessions WHERE user_id = ? AND status != 'terminated' ORDER BY created_at DESC",
+			[userId],
+		);
+		return result.results.map(rowToMeta);
+	}
 
-        async listAllForUser(userId: string): Promise<SessionMeta[]> {
-                const result = await d1Query<SessionRow>(
-                        "SELECT * FROM sessions WHERE user_id = ? ORDER BY created_at DESC",
-                        [userId],
-                );
-                return result.results.map(rowToMeta);
-        }
+	async listAllForUser(userId: string): Promise<SessionMeta[]> {
+		const result = await d1Query<SessionRow>(
+			"SELECT * FROM sessions WHERE user_id = ? ORDER BY created_at DESC",
+			[userId],
+		);
+		return result.results.map(rowToMeta);
+	}
 
-        async setContainerId(sessionId: string, containerId: string | null): Promise<void> {
-                await d1Query("UPDATE sessions SET container_id = ? WHERE session_id = ?", [containerId, sessionId]);
-        }
+	async setContainerId(sessionId: string, containerId: string | null): Promise<void> {
+		await d1Query("UPDATE sessions SET container_id = ? WHERE session_id = ?", [
+			containerId,
+			sessionId,
+		]);
+	}
 
-        async updateStatus(sessionId: string, status: SessionStatus): Promise<void> {
-                await d1Query("UPDATE sessions SET status = ? WHERE session_id = ?", [status, sessionId]);
-        }
+	async updateStatus(sessionId: string, status: SessionStatus): Promise<void> {
+		await d1Query("UPDATE sessions SET status = ? WHERE session_id = ?", [status, sessionId]);
+	}
 
-        // Atomic "container was removed out-of-band" write. Collapsing the two
-        // fields into one UPDATE closes the crash window where nulling the id
-        // would succeed but the status flip wouldn't — leaving the row at
-        // (null, running), which a subsequent `WHERE status='running'` reconcile
-        // would re-pick up anyway, but a /start or WS attach in between would
-        // misread.
-        async recordContainerGone(sessionId: string): Promise<void> {
-                await d1Query(
-                        "UPDATE sessions SET status = 'stopped', container_id = NULL WHERE session_id = ?",
-                        [sessionId],
-                );
-        }
+	// Atomic "container was removed out-of-band" write. Collapsing the two
+	// fields into one UPDATE closes the crash window where nulling the id
+	// would succeed but the status flip wouldn't — leaving the row at
+	// (null, running), which a subsequent `WHERE status='running'` reconcile
+	// would re-pick up anyway, but a /start or WS attach in between would
+	// misread.
+	async recordContainerGone(sessionId: string): Promise<void> {
+		await d1Query(
+			"UPDATE sessions SET status = 'stopped', container_id = NULL WHERE session_id = ?",
+			[sessionId],
+		);
+	}
 
-        async updateConnected(sessionId: string): Promise<void> {
-                await d1Query(
-                        "UPDATE sessions SET last_connected_at = datetime('now') WHERE session_id = ?",
-                        [sessionId],
-                );
-        }
+	async updateConnected(sessionId: string): Promise<void> {
+		await d1Query("UPDATE sessions SET last_connected_at = datetime('now') WHERE session_id = ?", [
+			sessionId,
+		]);
+	}
 
-        async updateEnvVars(sessionId: string, envVars: Record<string, string>): Promise<void> {
-                await d1Query("UPDATE sessions SET env_vars = ? WHERE session_id = ?", [
-                        JSON.stringify(envVars),
-                        sessionId,
-                ]);
-        }
+	async updateEnvVars(sessionId: string, envVars: Record<string, string>): Promise<void> {
+		await d1Query("UPDATE sessions SET env_vars = ? WHERE session_id = ?", [
+			JSON.stringify(envVars),
+			sessionId,
+		]);
+	}
 
-        async terminate(sessionId: string): Promise<void> {
-                await this.updateStatus(sessionId, "terminated");
-        }
+	async terminate(sessionId: string): Promise<void> {
+		await this.updateStatus(sessionId, "terminated");
+	}
 
-        /**
-         * Permanently delete the session row (hard delete). Caller is responsible
-         * for having already killed any running container and for cleaning up any
-         * workspace data on disk.
-         */
-        async deleteRow(sessionId: string): Promise<void> {
-                await d1Query("DELETE FROM sessions WHERE session_id = ?", [sessionId]);
-        }
+	/**
+	 * Permanently delete the session row (hard delete). Caller is responsible
+	 * for having already killed any running container and for cleaning up any
+	 * workspace data on disk.
+	 */
+	async deleteRow(sessionId: string): Promise<void> {
+		await d1Query("DELETE FROM sessions WHERE session_id = ?", [sessionId]);
+	}
 }

--- a/backend/src/trustProxy.test.ts
+++ b/backend/src/trustProxy.test.ts
@@ -1,144 +1,140 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-        parseTrustProxy,
-        TrustProxyError,
-        warnIfProductionMisconfigured,
-} from "./trustProxy.js";
+import { parseTrustProxy, TrustProxyError, warnIfProductionMisconfigured } from "./trustProxy.js";
 
 describe("parseTrustProxy", () => {
-        // ── unset / blank ──────────────────────────────────────────────────
+	// ── unset / blank ──────────────────────────────────────────────────
 
-        it("returns undefined for unset / empty / whitespace-only input", () => {
-                expect(parseTrustProxy(undefined)).toBeUndefined();
-                expect(parseTrustProxy("")).toBeUndefined();
-                expect(parseTrustProxy("   ")).toBeUndefined();
-                expect(parseTrustProxy("\t\n")).toBeUndefined();
-        });
+	it("returns undefined for unset / empty / whitespace-only input", () => {
+		expect(parseTrustProxy(undefined)).toBeUndefined();
+		expect(parseTrustProxy("")).toBeUndefined();
+		expect(parseTrustProxy("   ")).toBeUndefined();
+		expect(parseTrustProxy("\t\n")).toBeUndefined();
+	});
 
-        // ── foot-gun: "true" ───────────────────────────────────────────────
+	// ── foot-gun: "true" ───────────────────────────────────────────────
 
-        it("rejects the literal string 'true' with an actionable message", () => {
-                // Covers the most likely mistake — an operator reading
-                // 'trust proxy' as a boolean. Message must name the correct
-                // alternative so the fix is obvious from the error alone.
-                expect(() => parseTrustProxy("true")).toThrow(TrustProxyError);
-                try {
-                        parseTrustProxy("true");
-                } catch (err) {
-                        expect((err as Error).message).toMatch(/leftmost.*X-Forwarded-For/);
-                        expect((err as Error).message).toMatch(/TRUST_PROXY=1/);
-                }
-        });
+	it("rejects the literal string 'true' with an actionable message", () => {
+		// Covers the most likely mistake — an operator reading
+		// 'trust proxy' as a boolean. Message must name the correct
+		// alternative so the fix is obvious from the error alone.
+		expect(() => parseTrustProxy("true")).toThrow(TrustProxyError);
+		try {
+			parseTrustProxy("true");
+		} catch (err) {
+			expect((err as Error).message).toMatch(/leftmost.*X-Forwarded-For/);
+			expect((err as Error).message).toMatch(/TRUST_PROXY=1/);
+		}
+	});
 
-        // ── falsy forms ────────────────────────────────────────────────────
+	// ── falsy forms ────────────────────────────────────────────────────
 
-        it("coerces '0' and 'false' to the literal boolean false", () => {
-                // We deliberately emit boolean false instead of relying on
-                // Express's compileTrust(0) behaviour, which is undocumented.
-                expect(parseTrustProxy("0")).toBe(false);
-                expect(parseTrustProxy("false")).toBe(false);
-                expect(parseTrustProxy(" false ")).toBe(false);
-        });
+	it("coerces '0' and 'false' to the literal boolean false", () => {
+		// We deliberately emit boolean false instead of relying on
+		// Express's compileTrust(0) behaviour, which is undocumented.
+		expect(parseTrustProxy("0")).toBe(false);
+		expect(parseTrustProxy("false")).toBe(false);
+		expect(parseTrustProxy(" false ")).toBe(false);
+	});
 
-        // ── hop counts ─────────────────────────────────────────────────────
+	// ── hop counts ─────────────────────────────────────────────────────
 
-        it("parses non-negative integer hop counts to numbers", () => {
-                expect(parseTrustProxy("1")).toBe(1);
-                expect(parseTrustProxy("2")).toBe(2);
-                expect(parseTrustProxy("10")).toBe(10);
-                expect(parseTrustProxy(" 1 ")).toBe(1);
-        });
+	it("parses non-negative integer hop counts to numbers", () => {
+		expect(parseTrustProxy("1")).toBe(1);
+		expect(parseTrustProxy("2")).toBe(2);
+		expect(parseTrustProxy("10")).toBe(10);
+		expect(parseTrustProxy(" 1 ")).toBe(1);
+	});
 
-        it("rejects signed, fractional, or scientific-notation numbers", () => {
-                // These slip past a naive `Number("…")` check but aren't
-                // legitimate hop counts.
-                expect(() => parseTrustProxy("-1")).toThrow(TrustProxyError);
-                expect(() => parseTrustProxy("+1")).toThrow(TrustProxyError);
-                expect(() => parseTrustProxy("1.5")).toThrow(TrustProxyError);
-                expect(() => parseTrustProxy("1e2")).toThrow(TrustProxyError);
-        });
+	it("rejects signed, fractional, or scientific-notation numbers", () => {
+		// These slip past a naive `Number("…")` check but aren't
+		// legitimate hop counts.
+		expect(() => parseTrustProxy("-1")).toThrow(TrustProxyError);
+		expect(() => parseTrustProxy("+1")).toThrow(TrustProxyError);
+		expect(() => parseTrustProxy("1.5")).toThrow(TrustProxyError);
+		expect(() => parseTrustProxy("1e2")).toThrow(TrustProxyError);
+	});
 
-        // ── named presets ──────────────────────────────────────────────────
+	// ── named presets ──────────────────────────────────────────────────
 
-        it("accepts Express's documented named presets", () => {
-                expect(parseTrustProxy("loopback")).toBe("loopback");
-                expect(parseTrustProxy("linklocal")).toBe("linklocal");
-                expect(parseTrustProxy("uniquelocal")).toBe("uniquelocal");
-        });
+	it("accepts Express's documented named presets", () => {
+		expect(parseTrustProxy("loopback")).toBe("loopback");
+		expect(parseTrustProxy("linklocal")).toBe("linklocal");
+		expect(parseTrustProxy("uniquelocal")).toBe("uniquelocal");
+	});
 
-        it("rejects typos of preset names", () => {
-                // Without this guard, Express would silently treat 'loopbakc'
-                // as a literal hostname to trust — which is worse than
-                // failing loudly.
-                expect(() => parseTrustProxy("loopbakc")).toThrow(TrustProxyError);
-                expect(() => parseTrustProxy("link-local")).toThrow(TrustProxyError); // dash not allowed
-                expect(() => parseTrustProxy("unique_local")).toThrow(TrustProxyError);
-        });
+	it("rejects typos of preset names", () => {
+		// Without this guard, Express would silently treat 'loopbakc'
+		// as a literal hostname to trust — which is worse than
+		// failing loudly.
+		expect(() => parseTrustProxy("loopbakc")).toThrow(TrustProxyError);
+		expect(() => parseTrustProxy("link-local")).toThrow(TrustProxyError); // dash not allowed
+		expect(() => parseTrustProxy("unique_local")).toThrow(TrustProxyError);
+	});
 
-        // ── IPs and CIDRs ──────────────────────────────────────────────────
+	// ── IPs and CIDRs ──────────────────────────────────────────────────
 
-        it("accepts IPv4, IPv6, and CIDR shapes", () => {
-                expect(parseTrustProxy("10.0.0.1")).toBe("10.0.0.1");
-                expect(parseTrustProxy("10.0.0.0/8")).toBe("10.0.0.0/8");
-                expect(parseTrustProxy("::1")).toBe("::1");
-                expect(parseTrustProxy("2001:db8::/32")).toBe("2001:db8::/32");
-        });
+	it("accepts IPv4, IPv6, and CIDR shapes", () => {
+		expect(parseTrustProxy("10.0.0.1")).toBe("10.0.0.1");
+		expect(parseTrustProxy("10.0.0.0/8")).toBe("10.0.0.0/8");
+		expect(parseTrustProxy("::1")).toBe("::1");
+		expect(parseTrustProxy("2001:db8::/32")).toBe("2001:db8::/32");
+	});
 
-        it("accepts comma-separated lists of IPs / presets", () => {
-                expect(parseTrustProxy("10.0.0.0/8, loopback")).toBe("10.0.0.0/8, loopback");
-                expect(parseTrustProxy("loopback,linklocal")).toBe("loopback,linklocal");
-        });
+	it("accepts comma-separated lists of IPs / presets", () => {
+		expect(parseTrustProxy("10.0.0.0/8, loopback")).toBe("10.0.0.0/8, loopback");
+		expect(parseTrustProxy("loopback,linklocal")).toBe("loopback,linklocal");
+	});
 
-        it("rejects a list if any single token is unrecognised", () => {
-                // Wholesale refuse the whole value rather than silently
-                // accepting the good tokens — the unrecognised one is almost
-                // certainly the bug that needs fixing.
-                expect(() => parseTrustProxy("loopback,not-a-thing")).toThrow(TrustProxyError);
-                expect(() => parseTrustProxy("yes")).toThrow(TrustProxyError);
-                expect(() => parseTrustProxy("cloudflare")).toThrow(TrustProxyError);
-        });
+	it("rejects a list if any single token is unrecognised", () => {
+		// Wholesale refuse the whole value rather than silently
+		// accepting the good tokens — the unrecognised one is almost
+		// certainly the bug that needs fixing.
+		expect(() => parseTrustProxy("loopback,not-a-thing")).toThrow(TrustProxyError);
+		expect(() => parseTrustProxy("yes")).toThrow(TrustProxyError);
+		expect(() => parseTrustProxy("cloudflare")).toThrow(TrustProxyError);
+	});
 
-        it("error message names the offending token so ops can fix it fast", () => {
-                try {
-                        parseTrustProxy("loopback,not-a-thing,10.0.0.0/8");
-                        expect.fail("should have thrown");
-                } catch (err) {
-                        expect((err as Error).message).toContain("not-a-thing");
-                }
-        });
+	it("error message names the offending token so ops can fix it fast", () => {
+		try {
+			parseTrustProxy("loopback,not-a-thing,10.0.0.0/8");
+			expect.fail("should have thrown");
+		} catch (err) {
+			expect((err as Error).message).toContain("not-a-thing");
+		}
+	});
 });
 
 describe("warnIfProductionMisconfigured", () => {
-        it("warns when NODE_ENV=production and TRUST_PROXY is unset", () => {
-                const logger = { warn: vi.fn() };
-                warnIfProductionMisconfigured(undefined, "production", logger);
-                expect(logger.warn).toHaveBeenCalledOnce();
-                expect(logger.warn.mock.calls[0][0]).toMatch(/TRUST_PROXY is unset/);
-        });
+	it("warns when NODE_ENV=production and TRUST_PROXY is unset", () => {
+		const logger = { warn: vi.fn() };
+		warnIfProductionMisconfigured(undefined, "production", logger);
+		expect(logger.warn).toHaveBeenCalledOnce();
+		expect(logger.warn.mock.calls[0][0]).toMatch(/TRUST_PROXY is unset/);
+	});
 
-        it("warns when NODE_ENV=production and TRUST_PROXY is whitespace-only", () => {
-                // Common manifestation in k8s / docker-compose when a secret
-                // is defined but unset — the value surfaces as "" or "   ".
-                const logger = { warn: vi.fn() };
-                warnIfProductionMisconfigured("   ", "production", logger);
-                expect(logger.warn).toHaveBeenCalledOnce();
-        });
+	it("warns when NODE_ENV=production and TRUST_PROXY is whitespace-only", () => {
+		// Common manifestation in k8s / docker-compose when a secret
+		// is defined but unset — the value surfaces as "" or "   ".
+		const logger = { warn: vi.fn() };
+		warnIfProductionMisconfigured("   ", "production", logger);
+		expect(logger.warn).toHaveBeenCalledOnce();
+	});
 
-        it("stays quiet when NODE_ENV is anything other than production", () => {
-                const logger = { warn: vi.fn() };
-                warnIfProductionMisconfigured(undefined, "development", logger);
-                warnIfProductionMisconfigured(undefined, "test", logger);
-                warnIfProductionMisconfigured(undefined, undefined, logger);
-                expect(logger.warn).not.toHaveBeenCalled();
-        });
+	it("stays quiet when NODE_ENV is anything other than production", () => {
+		const logger = { warn: vi.fn() };
+		warnIfProductionMisconfigured(undefined, "development", logger);
+		warnIfProductionMisconfigured(undefined, "test", logger);
+		warnIfProductionMisconfigured(undefined, undefined, logger);
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
 
-        it("stays quiet when TRUST_PROXY is set in production", () => {
-                // We don't re-validate here — that's parseTrustProxy's job.
-                // The warning is strictly about the "unset" case.
-                const logger = { warn: vi.fn() };
-                warnIfProductionMisconfigured("1", "production", logger);
-                warnIfProductionMisconfigured("loopback", "production", logger);
-                warnIfProductionMisconfigured("false", "production", logger);
-                expect(logger.warn).not.toHaveBeenCalled();
-        });
+	it("stays quiet when TRUST_PROXY is set in production", () => {
+		// We don't re-validate here — that's parseTrustProxy's job.
+		// The warning is strictly about the "unset" case.
+		const logger = { warn: vi.fn() };
+		warnIfProductionMisconfigured("1", "production", logger);
+		warnIfProductionMisconfigured("loopback", "production", logger);
+		warnIfProductionMisconfigured("false", "production", logger);
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
 });

--- a/backend/src/trustProxy.ts
+++ b/backend/src/trustProxy.ts
@@ -17,10 +17,10 @@
 export type TrustProxyValue = boolean | number | string;
 
 export class TrustProxyError extends Error {
-        constructor(message: string) {
-                super(message);
-                this.name = "TrustProxyError";
-        }
+	constructor(message: string) {
+		super(message);
+		this.name = "TrustProxyError";
+	}
 }
 
 // Express's named presets. Anything outside this set that isn't a number,
@@ -56,58 +56,61 @@ const IP_OR_CIDR = /^(?:\d{1,3}(?:\.\d{1,3}){3}|[\da-fA-F]*:[\da-fA-F:]*)(?:\/\d
  *   - unrecognised strings (typos in preset names, non-IP-shaped tokens)
  */
 export function parseTrustProxy(raw: string | undefined): TrustProxyValue | undefined {
-        if (raw === undefined || raw.trim() === "") return undefined;
-        const trimmed = raw.trim();
+	if (raw === undefined || raw.trim() === "") return undefined;
+	const trimmed = raw.trim();
 
-        // "true" is the single most common wrong value — it looks right to
-        // anyone who reads "trust proxy" as a boolean knob, but Express then
-        // takes the LEFTMOST X-Forwarded-For entry, which the client controls.
-        // Refuse it with a message that names the correct alternative.
-        if (trimmed === "true") {
-                throw new TrustProxyError(
-                        "TRUST_PROXY=true is refused: Express would take the leftmost " +
-                        "X-Forwarded-For entry (attacker-controlled), bypassing per-IP " +
-                        "rate limiting. Use a hop count (e.g. TRUST_PROXY=1) instead.",
-                );
-        }
+	// "true" is the single most common wrong value — it looks right to
+	// anyone who reads "trust proxy" as a boolean knob, but Express then
+	// takes the LEFTMOST X-Forwarded-For entry, which the client controls.
+	// Refuse it with a message that names the correct alternative.
+	if (trimmed === "true") {
+		throw new TrustProxyError(
+			"TRUST_PROXY=true is refused: Express would take the leftmost " +
+				"X-Forwarded-For entry (attacker-controlled), bypassing per-IP " +
+				"rate limiting. Use a hop count (e.g. TRUST_PROXY=1) instead.",
+		);
+	}
 
-        // Explicit "0"/"false" → boolean false so we don't rely on Express's
-        // (undocumented) compileTrust(0) returning "never trust". If that
-        // internal ever changes, a string mistakenly treated as an IP would
-        // silently mis-trust; the explicit boolean keeps us pinned.
-        if (trimmed === "false" || trimmed === "0") return false;
+	// Explicit "0"/"false" → boolean false so we don't rely on Express's
+	// (undocumented) compileTrust(0) returning "never trust". If that
+	// internal ever changes, a string mistakenly treated as an IP would
+	// silently mis-trust; the explicit boolean keeps us pinned.
+	if (trimmed === "false" || trimmed === "0") return false;
 
-        // Hop-count form. Reject a leading "+", scientific notation, or
-        // anything else that Number("…") would happily coerce but isn't a
-        // legitimate count.
-        if (/^\d+$/.test(trimmed)) {
-                const n = Number(trimmed);
-                if (!Number.isSafeInteger(n) || n < 0) {
-                        throw new TrustProxyError(
-                                `TRUST_PROXY="${raw}" is not a valid non-negative integer hop count`,
-                        );
-                }
-                return n;
-        }
+	// Hop-count form. Reject a leading "+", scientific notation, or
+	// anything else that Number("…") would happily coerce but isn't a
+	// legitimate count.
+	if (/^\d+$/.test(trimmed)) {
+		const n = Number(trimmed);
+		if (!Number.isSafeInteger(n) || n < 0) {
+			throw new TrustProxyError(
+				`TRUST_PROXY="${raw}" is not a valid non-negative integer hop count`,
+			);
+		}
+		return n;
+	}
 
-        // Comma-separated list of named presets, IPs, or CIDRs. Express accepts
-        // all three in the same comma-separated format, so we validate every
-        // token before passing the whole string through.
-        const tokens = trimmed.split(",").map((t) => t.trim()).filter(Boolean);
-        if (tokens.length === 0) {
-                throw new TrustProxyError(`TRUST_PROXY="${raw}" has no valid tokens after splitting`);
-        }
-        for (const token of tokens) {
-                if (NAMED_PRESETS.has(token)) continue;
-                if (IP_OR_CIDR.test(token)) continue;
-                throw new TrustProxyError(
-                        `TRUST_PROXY contains unrecognised value "${token}". ` +
-                        `Expected a non-negative integer hop count (e.g. "1"), "false"/"0", ` +
-                        `one of [${[...NAMED_PRESETS].join(", ")}], an IP/CIDR, ` +
-                        `or a comma-separated list of those.`,
-                );
-        }
-        return trimmed;
+	// Comma-separated list of named presets, IPs, or CIDRs. Express accepts
+	// all three in the same comma-separated format, so we validate every
+	// token before passing the whole string through.
+	const tokens = trimmed
+		.split(",")
+		.map((t) => t.trim())
+		.filter(Boolean);
+	if (tokens.length === 0) {
+		throw new TrustProxyError(`TRUST_PROXY="${raw}" has no valid tokens after splitting`);
+	}
+	for (const token of tokens) {
+		if (NAMED_PRESETS.has(token)) continue;
+		if (IP_OR_CIDR.test(token)) continue;
+		throw new TrustProxyError(
+			`TRUST_PROXY contains unrecognised value "${token}". ` +
+				`Expected a non-negative integer hop count (e.g. "1"), "false"/"0", ` +
+				`one of [${[...NAMED_PRESETS].join(", ")}], an IP/CIDR, ` +
+				`or a comma-separated list of those.`,
+		);
+	}
+	return trimmed;
 }
 
 /**
@@ -150,18 +153,18 @@ export function parseTrustProxy(raw: string | undefined): TrustProxyValue | unde
 // ('stays quiet when TRUST_PROXY is set in production') would also need
 // to drop its `"false"` case.
 export function warnIfProductionMisconfigured(
-        raw: string | undefined,
-        nodeEnv: string | undefined,
-        logger: Pick<Console, "warn"> = console,
+	raw: string | undefined,
+	nodeEnv: string | undefined,
+	logger: Pick<Console, "warn"> = console,
 ): void {
-        if (nodeEnv !== "production") return;
-        if (raw !== undefined && raw.trim() !== "") return;
-        logger.warn(
-                "[server] NODE_ENV=production but TRUST_PROXY is unset. " +
-                "If the backend is behind a reverse proxy, CDN, or tunnel, " +
-                "req.ip will be the proxy's socket address — collapsing per-IP " +
-                "rate limits into a single global bucket. Set TRUST_PROXY to the " +
-                "hop count (e.g. 1 for a single Cloudflare Tunnel), or leave unset " +
-                "ONLY if the backend is directly internet-facing.",
-        );
+	if (nodeEnv !== "production") return;
+	if (raw !== undefined && raw.trim() !== "") return;
+	logger.warn(
+		"[server] NODE_ENV=production but TRUST_PROXY is unset. " +
+			"If the backend is behind a reverse proxy, CDN, or tunnel, " +
+			"req.ip will be the proxy's socket address — collapsing per-IP " +
+			"rate limits into a single global bucket. Set TRUST_PROXY to the " +
+			"hop count (e.g. 1 for a single Cloudflare Tunnel), or leave unset " +
+			"ONLY if the backend is directly internet-facing.",
+	);
 }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -7,59 +7,59 @@
 export type SessionStatus = "running" | "stopped" | "terminated";
 
 export interface SessionMeta {
-        sessionId: string;
-        userId: string;
-        name: string;
-        status: SessionStatus;
-        containerId: string | null;
-        containerName: string;
-        createdAt: Date;
-        lastConnectedAt: Date | null;
-        cols: number;
-        rows: number;
-        /** Per-session environment variables (key=value pairs). */
-        envVars: Record<string, string>;
+	sessionId: string;
+	userId: string;
+	name: string;
+	status: SessionStatus;
+	containerId: string | null;
+	containerName: string;
+	createdAt: Date;
+	lastConnectedAt: Date | null;
+	cols: number;
+	rows: number;
+	/** Per-session environment variables (key=value pairs). */
+	envVars: Record<string, string>;
 }
 
 export interface CreateSessionOpts {
-        userId: string;
-        name: string;
-        cols?: number;
-        rows?: number;
-        envVars?: Record<string, string>;
+	userId: string;
+	name: string;
+	cols?: number;
+	rows?: number;
+	envVars?: Record<string, string>;
 }
 
 // ── Auth ────────────────────────────────────────────────────────────────────
 
 export interface UserRecord {
-        id: string;
-        username: string;
-        passwordHash: string;
-        createdAt: Date;
+	id: string;
+	username: string;
+	passwordHash: string;
+	createdAt: Date;
 }
 
 export interface JwtPayload {
-        sub: string;        // userId
-        username: string;
-        iat?: number;
-        exp?: number;
+	sub: string; // userId
+	username: string;
+	iat?: number;
+	exp?: number;
 }
 
 // ── WebSocket client → server messages ──────────────────────────────────────
 
 export interface WsInputMessage {
-        type: "input";
-        data: string;
+	type: "input";
+	data: string;
 }
 
 export interface WsResizeMessage {
-        type: "resize";
-        cols: number;
-        rows: number;
+	type: "resize";
+	cols: number;
+	rows: number;
 }
 
 export interface WsPingMessage {
-        type: "ping";
+	type: "ping";
 }
 
 export type WsClientMessage = WsInputMessage | WsResizeMessage | WsPingMessage;
@@ -67,26 +67,22 @@ export type WsClientMessage = WsInputMessage | WsResizeMessage | WsPingMessage;
 // ── WebSocket server → client messages ──────────────────────────────────────
 
 export interface WsOutputMessage {
-        type: "output";
-        data: string;
+	type: "output";
+	data: string;
 }
 
 export interface WsPongMessage {
-        type: "pong";
+	type: "pong";
 }
 
 export interface WsErrorMessage {
-        type: "error";
-        message: string;
+	type: "error";
+	message: string;
 }
 
 export interface WsStatusMessage {
-        type: "status";
-        status: SessionStatus;
+	type: "status";
+	status: SessionStatus;
 }
 
-export type WsServerMessage =
-        | WsOutputMessage
-        | WsPongMessage
-        | WsErrorMessage
-        | WsStatusMessage;
+export type WsServerMessage = WsOutputMessage | WsPongMessage | WsErrorMessage | WsStatusMessage;

--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -1,9 +1,9 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import jwt from "jsonwebtoken";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { __resetJwtSecretForTests, validateJwtSecret } from "./auth.js";
-import { endUpgradeSocketWithReply, handleWsConnection } from "./wsHandler.js";
-import type { SessionManager } from "./sessionManager.js";
 import type { DockerManager } from "./dockerManager.js";
+import type { SessionManager } from "./sessionManager.js";
+import { endUpgradeSocketWithReply, handleWsConnection } from "./wsHandler.js";
 
 // ── Test harness ────────────────────────────────────────────────────────────
 
@@ -36,7 +36,10 @@ function makeFakeWs(): FakeWs {
 	};
 }
 
-function makeReq(url: string, withToken: boolean): {
+function makeReq(
+	url: string,
+	withToken: boolean,
+): {
 	url: string;
 	headers: Record<string, string | undefined>;
 } {
@@ -117,7 +120,9 @@ describe("handleWsConnection auth-first ordering", () => {
 
 		expect(ws.close).toHaveBeenCalledWith(1008, "Invalid path");
 		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
-		expect(errPayloads).toContain(JSON.stringify({ type: "error", message: "Invalid WebSocket path" }));
+		expect(errPayloads).toContain(
+			JSON.stringify({ type: "error", message: "Invalid WebSocket path" }),
+		);
 	});
 
 	it("authenticated caller missing the tab param receives 'Missing tab'", () => {

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -2,14 +2,14 @@
  * wsHandler.ts — WebSocket connection handler for Docker-based sessions.
  */
 
-import { IncomingMessage } from "http";
+import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
-import { WebSocket } from "ws";
 import { v4 as uuidv4 } from "uuid";
+import { WebSocket } from "ws";
 import { verifyWsToken } from "./auth.js";
-import { SessionManager, NotFoundError, ForbiddenError } from "./sessionManager.js";
-import { DockerManager } from "./dockerManager.js";
-import { WsClientMessage, WsServerMessage } from "./types.js";
+import type { DockerManager } from "./dockerManager.js";
+import { ForbiddenError, NotFoundError, type SessionManager } from "./sessionManager.js";
+import type { WsClientMessage, WsServerMessage } from "./types.js";
 
 // Send a tiny HTTP error response on the raw upgrade socket and tear it
 // down with a bounded grace window.
@@ -28,179 +28,190 @@ import { WsClientMessage, WsServerMessage } from "./types.js";
 // `Duplex` matches the upgrade-event signature for http.Server and a
 // hypothetical https.Server (TLSSocket extends Duplex too).
 export function endUpgradeSocketWithReply(socket: Duplex, reply: string): void {
-        // socket.end() on an already-destroyed socket is a no-op in Node 20+,
-        // so the asymmetry with the guarded destroy() below is intentional —
-        // the only failure mode worth swallowing is a peer that RST'd between
-        // the upgrade event and our 500 ms timer firing.
-        socket.end(reply);
-        setTimeout(() => {
-                try { socket.destroy(); } catch { /* already destroyed */ }
-        }, 500).unref();
+	// socket.end() on an already-destroyed socket is a no-op in Node 20+,
+	// so the asymmetry with the guarded destroy() below is intentional —
+	// the only failure mode worth swallowing is a peer that RST'd between
+	// the upgrade event and our 500 ms timer firing.
+	socket.end(reply);
+	setTimeout(() => {
+		try {
+			socket.destroy();
+		} catch {
+			/* already destroyed */
+		}
+	}, 500).unref();
 }
 
 export function handleWsConnection(
-        ws: WebSocket,
-        req: IncomingMessage,
-        sessions: SessionManager,
-        docker: DockerManager,
+	ws: WebSocket,
+	req: IncomingMessage,
+	sessions: SessionManager,
+	docker: DockerManager,
 ): void {
-        // Synchronous safety net registered BEFORE any await or sync ws.close().
-        // Node's EventEmitter routes an 'error' emission with no listener to
-        // process.emit('uncaughtException') → the whole server process dies,
-        // dropping every other attached session. The `ws` package emits
-        // 'error' on transport-level failures — RSTd TCP, malformed frames,
-        // invalid UTF-8 — any of which can land during the handshake/close
-        // dance or during the two awaits below (sessions.assertOwnership,
-        // docker.attach). A second ws.on('error', …) is added after attach()
-        // succeeds to also tear the exec down; `on` is additive, so both run.
-        // See issue #91 for the DoS reproduction path.
-        ws.on("error", (err) => {
-                console.error(`[ws] socket error: ${err.message}`);
-                // Don't trust the transport to always emit 'close' after
-                // 'error'. Some failure modes (RSTd TCP mid-handshake, upgrade
-                // parse error before the WS protocol is fully up) leave the
-                // underlying socket half-open until Node's GC notices. Close
-                // explicitly with 1011 "internal error"; ws.close() is a no-op
-                // on a socket already CLOSING/CLOSED, so this is safe for
-                // post-attach errors where the inner 'close' listener would
-                // also run.
-                ws.close(1011, "socket error");
-        });
+	// Synchronous safety net registered BEFORE any await or sync ws.close().
+	// Node's EventEmitter routes an 'error' emission with no listener to
+	// process.emit('uncaughtException') → the whole server process dies,
+	// dropping every other attached session. The `ws` package emits
+	// 'error' on transport-level failures — RSTd TCP, malformed frames,
+	// invalid UTF-8 — any of which can land during the handshake/close
+	// dance or during the two awaits below (sessions.assertOwnership,
+	// docker.attach). A second ws.on('error', …) is added after attach()
+	// succeeds to also tear the exec down; `on` is additive, so both run.
+	// See issue #91 for the DoS reproduction path.
+	ws.on("error", (err) => {
+		console.error(`[ws] socket error: ${err.message}`);
+		// Don't trust the transport to always emit 'close' after
+		// 'error'. Some failure modes (RSTd TCP mid-handshake, upgrade
+		// parse error before the WS protocol is fully up) leave the
+		// underlying socket half-open until Node's GC notices. Close
+		// explicitly with 1011 "internal error"; ws.close() is a no-op
+		// on a socket already CLOSING/CLOSED, so this is safe for
+		// post-attach errors where the inner 'close' listener would
+		// also run.
+		ws.close(1011, "socket error");
+	});
 
-        // Auth must run before path/tab inspection: distinct pre-close
-        // error reasons ("Invalid path" / "Missing tab" / …) leaked a
-        // probe oracle to unauthenticated callers (issue #82). Once we
-        // know the caller is a user, the specific errors below are fine
-        // — they're useful for diagnosing client bugs.
-        const url = req.url ?? "";
-        const payload = verifyWsToken(req.headers["sec-websocket-protocol"], url);
-        if (!payload) {
-                sendError(ws, "Unauthorized");
-                ws.close(1008, "Unauthorized");
-                return;
-        }
-        const userId = payload.sub;
+	// Auth must run before path/tab inspection: distinct pre-close
+	// error reasons ("Invalid path" / "Missing tab" / …) leaked a
+	// probe oracle to unauthenticated callers (issue #82). Once we
+	// know the caller is a user, the specific errors below are fine
+	// — they're useful for diagnosing client bugs.
+	const url = req.url ?? "";
+	const payload = verifyWsToken(req.headers["sec-websocket-protocol"], url);
+	if (!payload) {
+		sendError(ws, "Unauthorized");
+		ws.close(1008, "Unauthorized");
+		return;
+	}
+	const userId = payload.sub;
 
-        const match = url.match(/\/ws\/sessions\/([^/?#]+)/);
-        if (!match) {
-                sendError(ws, "Invalid WebSocket path");
-                ws.close(1008, "Invalid path");
-                return;
-        }
-        const sessionId = match[1]!;
+	const match = url.match(/\/ws\/sessions\/([^/?#]+)/);
+	if (!match) {
+		sendError(ws, "Invalid WebSocket path");
+		ws.close(1008, "Invalid path");
+		return;
+	}
+	const sessionId = match[1]!;
 
-        // Required ?tab=<tabId>. The container no longer creates a default tab
-        // at boot, so every WS attach must name its target explicitly. Strict
-        // charset: tmux session names + our own prefix; no shell metas
-        // (docker exec takes argv, not a shell line, but a defensive allowlist
-        // keeps surprising tmux targets like "main:1" out of the path).
-        const tabQueryMatch = url.match(/[?&]tab=([^&#]+)/);
-        const rawTab = tabQueryMatch ? decodeURIComponent(tabQueryMatch[1]!) : null;
-        if (rawTab === null) {
-                sendError(ws, "Missing tab id");
-                ws.close(1008, "Missing tab");
-                return;
-        }
-        if (!/^[a-zA-Z0-9._-]{1,64}$/.test(rawTab)) {
-                sendError(ws, "Invalid tab id");
-                ws.close(1008, "Invalid tab");
-                return;
-        }
-        const tabId = rawTab;
+	// Required ?tab=<tabId>. The container no longer creates a default tab
+	// at boot, so every WS attach must name its target explicitly. Strict
+	// charset: tmux session names + our own prefix; no shell metas
+	// (docker exec takes argv, not a shell line, but a defensive allowlist
+	// keeps surprising tmux targets like "main:1" out of the path).
+	const tabQueryMatch = url.match(/[?&]tab=([^&#]+)/);
+	const rawTab = tabQueryMatch ? decodeURIComponent(tabQueryMatch[1]!) : null;
+	if (rawTab === null) {
+		sendError(ws, "Missing tab id");
+		ws.close(1008, "Missing tab");
+		return;
+	}
+	if (!/^[a-zA-Z0-9._-]{1,64}$/.test(rawTab)) {
+		sendError(ws, "Invalid tab id");
+		ws.close(1008, "Invalid tab");
+		return;
+	}
+	const tabId = rawTab;
 
-        // Async auth + attach flow
-        (async () => {
-                // Authorise
-                const session = await sessions.assertOwnership(sessionId, userId);
+	// Async auth + attach flow
+	(async () => {
+		// Authorise
+		const session = await sessions.assertOwnership(sessionId, userId);
 
-                if (session.status === "terminated") {
-                        sendError(ws, "Session is terminated");
-                        ws.close(1008, "Session terminated");
-                        return;
-                }
+		if (session.status === "terminated") {
+			sendError(ws, "Session is terminated");
+			ws.close(1008, "Session terminated");
+			return;
+		}
 
-                // Attach to Docker container
-                const attachId = `${sessionId}:${uuidv4().slice(0, 8)}`;
-                const outputListener = (data: string) => {
-                        sendMsg(ws, { type: "output", data });
-                };
+		// Attach to Docker container
+		const attachId = `${sessionId}:${uuidv4().slice(0, 8)}`;
+		const outputListener = (data: string) => {
+			sendMsg(ws, { type: "output", data });
+		};
 
-                // attach() hands back `flushTail` — until we call it, the listener
-                // installed inside attach() piles incoming live bytes into a local
-                // array instead of forwarding them. This lets us guarantee the
-                // on-the-wire order is [replay][live], even on a noisy session
-                // where bytes stream in between attach() returning and this
-                // function sending the replay frame. See attach() for the full
-                // rationale. `sendMsg` is synchronous, so there is no await
-                // between the replay frame and flushTail() — a stream 'data'
-                // event cannot interleave.
-                const { replay, flushTail } = await docker.attach(
-                        sessionId, attachId, session.cols, session.rows, outputListener, tabId,
-                );
+		// attach() hands back `flushTail` — until we call it, the listener
+		// installed inside attach() piles incoming live bytes into a local
+		// array instead of forwarding them. This lets us guarantee the
+		// on-the-wire order is [replay][live], even on a noisy session
+		// where bytes stream in between attach() returning and this
+		// function sending the replay frame. See attach() for the full
+		// rationale. `sendMsg` is synchronous, so there is no await
+		// between the replay frame and flushTail() — a stream 'data'
+		// event cannot interleave.
+		const { replay, flushTail } = await docker.attach(
+			sessionId,
+			attachId,
+			session.cols,
+			session.rows,
+			outputListener,
+			tabId,
+		);
 
-                sendMsg(ws, { type: "status", status: "running" });
-                if (replay) {
-                        sendMsg(ws, { type: "output", data: replay });
-                }
-                flushTail();
+		sendMsg(ws, { type: "status", status: "running" });
+		if (replay) {
+			sendMsg(ws, { type: "output", data: replay });
+		}
+		flushTail();
 
-                console.log(`[ws] user=${userId} attached to session=${sessionId} tab=${tabId} (exec=${attachId})`);
+		console.log(
+			`[ws] user=${userId} attached to session=${sessionId} tab=${tabId} (exec=${attachId})`,
+		);
 
-                // Message handler
-                ws.on("message", (raw) => {
-                        let msg: WsClientMessage;
-                        try {
-                                msg = JSON.parse(raw.toString()) as WsClientMessage;
-                        } catch {
-                                sendError(ws, "Invalid JSON");
-                                return;
-                        }
+		// Message handler
+		ws.on("message", (raw) => {
+			let msg: WsClientMessage;
+			try {
+				msg = JSON.parse(raw.toString()) as WsClientMessage;
+			} catch {
+				sendError(ws, "Invalid JSON");
+				return;
+			}
 
-                        switch (msg.type) {
-                                case "input":
-                                        docker.write(attachId, msg.data);
-                                        break;
-                                case "resize":
-                                        if (msg.cols > 0 && msg.rows > 0) {
-                                                docker.resize(attachId, msg.cols, msg.rows).catch(() => { });
-                                        }
-                                        break;
-                                case "ping":
-                                        sendMsg(ws, { type: "pong" });
-                                        break;
-                        }
-                });
+			switch (msg.type) {
+				case "input":
+					docker.write(attachId, msg.data);
+					break;
+				case "resize":
+					if (msg.cols > 0 && msg.rows > 0) {
+						docker.resize(attachId, msg.cols, msg.rows).catch(() => {});
+					}
+					break;
+				case "ping":
+					sendMsg(ws, { type: "pong" });
+					break;
+			}
+		});
 
-                ws.on("close", () => {
-                        console.log(`[ws] user=${userId} detached from session=${sessionId}`);
-                        docker.detach(attachId);
-                });
+		ws.on("close", () => {
+			console.log(`[ws] user=${userId} detached from session=${sessionId}`);
+			docker.detach(attachId);
+		});
 
-                ws.on("error", (err) => {
-                        console.error(`[ws] error on session=${sessionId}:`, err.message);
-                        docker.detach(attachId);
-                });
-        })().catch((err) => {
-                if (err instanceof NotFoundError) {
-                        sendError(ws, "Session not found");
-                        ws.close(1008, "Not found");
-                } else if (err instanceof ForbiddenError) {
-                        sendError(ws, "Access denied");
-                        ws.close(1008, "Forbidden");
-                } else {
-                        console.error(`[ws] attach failed for session=${sessionId}:`, (err as Error).message);
-                        sendError(ws, `Failed to attach: ${(err as Error).message}`);
-                        ws.close(1011, "Attach failed");
-                }
-        });
+		ws.on("error", (err) => {
+			console.error(`[ws] error on session=${sessionId}:`, err.message);
+			docker.detach(attachId);
+		});
+	})().catch((err) => {
+		if (err instanceof NotFoundError) {
+			sendError(ws, "Session not found");
+			ws.close(1008, "Not found");
+		} else if (err instanceof ForbiddenError) {
+			sendError(ws, "Access denied");
+			ws.close(1008, "Forbidden");
+		} else {
+			console.error(`[ws] attach failed for session=${sessionId}:`, (err as Error).message);
+			sendError(ws, `Failed to attach: ${(err as Error).message}`);
+			ws.close(1011, "Attach failed");
+		}
+	});
 }
 
 function sendMsg(ws: WebSocket, msg: WsServerMessage): void {
-        if (ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify(msg));
-        }
+	if (ws.readyState === WebSocket.OPEN) {
+		ws.send(JSON.stringify(msg));
+	}
 }
 
 function sendError(ws: WebSocket, message: string): void {
-        sendMsg(ws, { type: "error", message });
+	sendMsg(ws, { type: "error", message });
 }


### PR DESCRIPTION
## Why

CLAUDE.md mandates tabs for indentation, but several backend files (`auth.ts`, `dockerManager.ts`, `index.ts`, `routes.ts`, `sessionManager.ts`, etc.) used 8-space indentation. CI had no enforcement, so the inconsistency had drifted. Recent code reviews have also flagged style-shaped issues (asymmetric guards, misleading `console.debug`) that a linter would catch automatically — the review bot shouldn't be doing what a linter can.

This PR closes the enforcement gap with [Biome](https://biomejs.dev/) — single binary, one config, lint + format together, no Prettier/ESLint orchestration.

## Config

`backend/biome.json`:
- formatter: `indentStyle=tab`, `lineWidth=100`
- linter `recommended` plus tightened style rules: `useImportType`, `useNodejsImportProtocol`, `useTemplate`
- relaxations matching the codebase's intent:
  - `noNonNullAssertion` **off** — regex-capture sites use `match[1]!` deliberately
  - `noExplicitAny` **warn** in src/ but **off** in `*.test.ts` (mocks rely on `as any`)
- `organizeImports` on

## Scripts + CI

- `npm run lint` → `biome check src/`
- `npm run lint:fix` / `npm run format` for autofix
- New `Lint (Biome)` step in `.github/workflows/ci.yml`, before typecheck — fails fast on style/import-order regressions

## Diff

The bulk of the diff is `biome check --write --unsafe` applied across `src/`:

- 18 files reformatted to tabs
- imports organised + `import type` migrations
- `"http"` → `"node:http"` etc.
- one manual concat→template fix in `sessionManager.ts`

The lint-rule changes are mostly mechanical and small per file; the visible churn is tab normalisation. After this lands, future PRs touch only the lines they actually change.

## Tested

- `npm run lint` clean
- `npm run build` (tsc) clean
- `npm test` — 149 passing (no behaviour change)