### PR TITLE
chore(frontend): add Biome lint+format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Lint (Biome)
+        run: npm run lint
+
       # `npm run build` is `tsc && vite build`. VITE_API_URL is consumed by
       # vite.config.ts to rewrite the CSP meta tag; falls back to localhost
       # if unset, but setting it here exercises the replacement path.

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -21,7 +21,7 @@
 			"style": {
 				"noNonNullAssertion": "off",
 				"useImportType": "error",
-				"useNodejsImportProtocol": "error",
+				"useNodejsImportProtocol": "off",
 				"useTemplate": "error"
 			},
 			"suspicious": {

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,0 +1,57 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": true,
+		"includes": ["src/**/*.ts", "src/**/*.tsx"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"lineWidth": 100
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"noNonNullAssertion": "off",
+				"useImportType": "error",
+				"useNodejsImportProtocol": "error",
+				"useTemplate": "error"
+			},
+			"suspicious": {
+				"noExplicitAny": "warn"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
+	"overrides": [
+		{
+			"includes": ["**/*.test.ts"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noExplicitAny": "off"
+					}
+				}
+			}
+		}
+	]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,8 +13,172 @@
         "@xterm/xterm": "^5.5.0"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
         "typescript": "^5.4.5",
         "vite": "^8.0.9"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+      "integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.14",
+        "@biomejs/cli-darwin-x64": "2.4.14",
+        "@biomejs/cli-linux-arm64": "2.4.14",
+        "@biomejs/cli-linux-arm64-musl": "2.4.14",
+        "@biomejs/cli-linux-x64": "2.4.14",
+        "@biomejs/cli-linux-x64-musl": "2.4.14",
+        "@biomejs/cli-win32-arm64": "2.4.14",
+        "@biomejs/cli-win32-x64": "2.4.14"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.14.tgz",
+      "integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.14.tgz",
+      "integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.14.tgz",
+      "integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.14.tgz",
+      "integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.14.tgz",
+      "integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.14.tgz",
+      "integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.14.tgz",
+      "integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.14.tgz",
+      "integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "biome check src/",
+    "lint:fix": "biome check src/ --write",
+    "format": "biome format src/ --write"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",
@@ -14,6 +17,7 @@
     "@xterm/xterm": "^5.5.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.14",
     "typescript": "^5.4.5",
     "vite": "^8.0.9"
   }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -11,18 +11,22 @@ const API_BASE = `${BACKEND_URL}/api`;
 
 let _token: string | null = localStorage.getItem("st_token");
 
-export function getToken(): string | null { return _token; }
-
-export function setToken(token: string | null): void {
-        _token = token;
-        if (token) {
-                localStorage.setItem("st_token", token);
-        } else {
-                localStorage.removeItem("st_token");
-        }
+export function getToken(): string | null {
+	return _token;
 }
 
-export function isLoggedIn(): boolean { return !!_token; }
+export function setToken(token: string | null): void {
+	_token = token;
+	if (token) {
+		localStorage.setItem("st_token", token);
+	} else {
+		localStorage.removeItem("st_token");
+	}
+}
+
+export function isLoggedIn(): boolean {
+	return !!_token;
+}
 
 /** Fired by `apiFetch` once per 401-burst after clearing the stale token —
  * main.ts listens to perform UI teardown. See apiFetch for the emit guard. */
@@ -31,216 +35,222 @@ export const SESSION_EXPIRED_EVENT = "st:session-expired";
 // ── Auth API ────────────────────────────────────────────────────────────────
 
 export async function checkAuthStatus(): Promise<{ needsSetup: boolean }> {
-        const res = await apiFetch("/auth/status");
-        return res.json();
+	const res = await apiFetch("/auth/status");
+	return res.json();
 }
 
 export class InviteRequiredError extends Error {
-        constructor(message: string) {
-                super(message);
-                this.name = "InviteRequiredError";
-        }
+	constructor(message: string) {
+		super(message);
+		this.name = "InviteRequiredError";
+	}
 }
 
 export async function register(
-        username: string,
-        password: string,
-        inviteCode?: string,
+	username: string,
+	password: string,
+	inviteCode?: string,
 ): Promise<{ userId: string; token: string }> {
-        const res = await apiFetch("/auth/register", {
-                method: "POST",
-                body: JSON.stringify({ username, password, inviteCode }),
-        });
-        if (!res.ok) {
-                const body = await res.json().catch(() => ({}));
-                if (res.status === 403) {
-                        throw new InviteRequiredError(body.error ?? "Invite code required");
-                }
-                throw new Error(body.error ?? "Registration failed");
-        }
-        const data = await res.json();
-        setToken(data.token);
-        return data;
+	const res = await apiFetch("/auth/register", {
+		method: "POST",
+		body: JSON.stringify({ username, password, inviteCode }),
+	});
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		if (res.status === 403) {
+			throw new InviteRequiredError(body.error ?? "Invite code required");
+		}
+		throw new Error(body.error ?? "Registration failed");
+	}
+	const data = await res.json();
+	setToken(data.token);
+	return data;
 }
 
-export async function login(username: string, password: string): Promise<{ userId: string; token: string }> {
-        const res = await apiFetch("/auth/login", {
-                method: "POST",
-                body: JSON.stringify({ username, password }),
-        });
-        if (!res.ok) {
-                const body = await res.json();
-                throw new Error(body.error ?? "Login failed");
-        }
-        const data = await res.json();
-        setToken(data.token);
-        return data;
+export async function login(
+	username: string,
+	password: string,
+): Promise<{ userId: string; token: string }> {
+	const res = await apiFetch("/auth/login", {
+		method: "POST",
+		body: JSON.stringify({ username, password }),
+	});
+	if (!res.ok) {
+		const body = await res.json();
+		throw new Error(body.error ?? "Login failed");
+	}
+	const data = await res.json();
+	setToken(data.token);
+	return data;
 }
 
 export function logout(): void {
-        setToken(null);
+	setToken(null);
 }
 
 // ── Session types ───────────────────────────────────────────────────────────
 
 export interface SessionInfo {
-        sessionId: string;
-        name: string;
-        status: "running" | "stopped" | "terminated";
-        containerId: string | null;
-        containerName: string;
-        createdAt: string;
-        lastConnectedAt: string | null;
-        cols: number;
-        rows: number;
-        envVars: Record<string, string>;
+	sessionId: string;
+	name: string;
+	status: "running" | "stopped" | "terminated";
+	containerId: string | null;
+	containerName: string;
+	createdAt: string;
+	lastConnectedAt: string | null;
+	cols: number;
+	rows: number;
+	envVars: Record<string, string>;
 }
 
 // ── Session API ─────────────────────────────────────────────────────────────
 
 export async function createSession(
-        name: string,
-        envVars?: Record<string, string>,
+	name: string,
+	envVars?: Record<string, string>,
 ): Promise<SessionInfo> {
-        const res = await apiFetch("/sessions", {
-                method: "POST",
-                body: JSON.stringify({ name, envVars }),
-        });
-        if (!res.ok) {
-                const body = await res.json();
-                throw new Error(body.error ?? "Failed to create session");
-        }
-        return res.json();
+	const res = await apiFetch("/sessions", {
+		method: "POST",
+		body: JSON.stringify({ name, envVars }),
+	});
+	if (!res.ok) {
+		const body = await res.json();
+		throw new Error(body.error ?? "Failed to create session");
+	}
+	return res.json();
 }
 
 export async function listSessions(includeTerminated = false): Promise<SessionInfo[]> {
-        const path = includeTerminated ? "/sessions?all=true" : "/sessions";
-        const res = await apiFetch(path);
-        if (!res.ok) throw new Error("Failed to list sessions");
-        return res.json();
+	const path = includeTerminated ? "/sessions?all=true" : "/sessions";
+	const res = await apiFetch(path);
+	if (!res.ok) throw new Error("Failed to list sessions");
+	return res.json();
 }
 
 export async function getSession(id: string): Promise<SessionInfo> {
-        const res = await apiFetch(`/sessions/${id}`);
-        if (!res.ok) throw new Error("Session not found");
-        return res.json();
+	const res = await apiFetch(`/sessions/${id}`);
+	if (!res.ok) throw new Error("Session not found");
+	return res.json();
 }
 
 /** Soft delete stops the container and keeps the workspace; `hard` also wipes files + row. */
 export async function deleteSession(id: string, hard = false): Promise<void> {
-        const qs = hard ? "?hard=true" : "";
-        const res = await apiFetch(`/sessions/${id}${qs}`, { method: "DELETE" });
-        if (!res.ok && res.status !== 204) {
-                throw new Error("Failed to delete session");
-        }
+	const qs = hard ? "?hard=true" : "";
+	const res = await apiFetch(`/sessions/${id}${qs}`, { method: "DELETE" });
+	if (!res.ok && res.status !== 204) {
+		throw new Error("Failed to delete session");
+	}
 }
 
 export async function stopSession(id: string): Promise<SessionInfo> {
-        const res = await apiFetch(`/sessions/${id}/stop`, { method: "POST" });
-        if (!res.ok) throw new Error("Failed to stop session");
-        return res.json();
+	const res = await apiFetch(`/sessions/${id}/stop`, { method: "POST" });
+	if (!res.ok) throw new Error("Failed to stop session");
+	return res.json();
 }
 
 export async function startSession(id: string): Promise<SessionInfo> {
-        const res = await apiFetch(`/sessions/${id}/start`, { method: "POST" });
-        if (!res.ok) throw new Error("Failed to start session");
-        return res.json();
+	const res = await apiFetch(`/sessions/${id}/start`, { method: "POST" });
+	if (!res.ok) throw new Error("Failed to start session");
+	return res.json();
 }
 
-export async function updateEnvVars(id: string, envVars: Record<string, string>): Promise<SessionInfo> {
-        const res = await apiFetch(`/sessions/${id}/env`, {
-                method: "PATCH",
-                body: JSON.stringify({ envVars }),
-        });
-        if (!res.ok) throw new Error("Failed to update env vars");
-        return res.json();
+export async function updateEnvVars(
+	id: string,
+	envVars: Record<string, string>,
+): Promise<SessionInfo> {
+	const res = await apiFetch(`/sessions/${id}/env`, {
+		method: "PATCH",
+		body: JSON.stringify({ envVars }),
+	});
+	if (!res.ok) throw new Error("Failed to update env vars");
+	return res.json();
 }
 
 // ── Tabs API ────────────────────────────────────────────────────────────────
 
 export interface Tab {
-        tabId: string;
-        label: string;
-        createdAt: number;
+	tabId: string;
+	label: string;
+	createdAt: number;
 }
 
 export async function listTabs(sessionId: string): Promise<Tab[]> {
-        const res = await apiFetch(`/sessions/${sessionId}/tabs`);
-        if (!res.ok) throw new Error("Failed to list tabs");
-        return res.json();
+	const res = await apiFetch(`/sessions/${sessionId}/tabs`);
+	if (!res.ok) throw new Error("Failed to list tabs");
+	return res.json();
 }
 
 export async function createTab(sessionId: string, label?: string): Promise<Tab> {
-        // JSON.stringify drops undefined props, so this serialises to `{}` when
-        // no label is supplied — backend `req.body ?? {}` handles either form.
-        const res = await apiFetch(`/sessions/${sessionId}/tabs`, {
-                method: "POST",
-                body: JSON.stringify({ label }),
-        });
-        if (!res.ok) {
-                const body = await res.json().catch(() => ({}));
-                throw new Error(body.error ?? "Failed to create tab");
-        }
-        return res.json();
+	// JSON.stringify drops undefined props, so this serialises to `{}` when
+	// no label is supplied — backend `req.body ?? {}` handles either form.
+	const res = await apiFetch(`/sessions/${sessionId}/tabs`, {
+		method: "POST",
+		body: JSON.stringify({ label }),
+	});
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? "Failed to create tab");
+	}
+	return res.json();
 }
 
 /** Throws `TabNotFoundError` (HTTP 404) when the tab is already gone in the backend (e.g. tmux
  *  server died and dropped its sessions); callers should treat this as success and drop the
  *  stale chip from the UI. */
 export async function deleteTab(sessionId: string, tabId: string): Promise<void> {
-        const res = await apiFetch(`/sessions/${sessionId}/tabs/${tabId}`, { method: "DELETE" });
-        if (res.status === 404) {
-                throw new TabNotFoundError();
-        }
-        if (!res.ok) {
-                const body = await res.json().catch(() => ({}));
-                throw new Error(body.error ?? "Failed to close tab");
-        }
+	const res = await apiFetch(`/sessions/${sessionId}/tabs/${tabId}`, { method: "DELETE" });
+	if (res.status === 404) {
+		throw new TabNotFoundError();
+	}
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? "Failed to close tab");
+	}
 }
 
 export class TabNotFoundError extends Error {
-        constructor() {
-                super("Tab no longer exists in the session");
-                this.name = "TabNotFoundError";
-        }
+	constructor() {
+		super("Tab no longer exists in the session");
+		this.name = "TabNotFoundError";
+	}
 }
 
 // ── Invites API ─────────────────────────────────────────────────────────────
 
 export interface Invite {
-        code: string;
-        createdAt: string;
-        usedAt: string | null;
-        expiresAt: string | null;
+	code: string;
+	createdAt: string;
+	usedAt: string | null;
+	expiresAt: string | null;
 }
 
 export async function listInvites(): Promise<Invite[]> {
-        const res = await apiFetch("/invites");
-        if (!res.ok) throw new Error("Failed to list invites");
-        return res.json();
+	const res = await apiFetch("/invites");
+	if (!res.ok) throw new Error("Failed to list invites");
+	return res.json();
 }
 
 export async function createInvite(): Promise<Invite> {
-        const res = await apiFetch("/invites", { method: "POST" });
-        if (!res.ok) {
-                const body = await res.json().catch(() => ({}));
-                throw new Error(body.error ?? "Failed to create invite");
-        }
-        return res.json();
+	const res = await apiFetch("/invites", { method: "POST" });
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? "Failed to create invite");
+	}
+	return res.json();
 }
 
 export async function revokeInvite(code: string): Promise<void> {
-        const res = await apiFetch(`/invites/${encodeURIComponent(code)}`, { method: "DELETE" });
-        // 404 means the row is already gone (concurrent revoke from another
-        // tab, or the invite was redeemed in the interim). The user-visible
-        // outcome — "the code is no longer in the list" — is identical to a
-        // 204, so swallow it. Without this, two tabs racing on the same code
-        // would show one success and one spurious "not found" toast.
-        if (res.status === 404) return;
-        if (!res.ok) {
-                const body = await res.json().catch(() => ({}));
-                throw new Error(body.error ?? "Failed to revoke invite");
-        }
+	const res = await apiFetch(`/invites/${encodeURIComponent(code)}`, { method: "DELETE" });
+	// 404 means the row is already gone (concurrent revoke from another
+	// tab, or the invite was redeemed in the interim). The user-visible
+	// outcome — "the code is no longer in the list" — is identical to a
+	// 204, so swallow it. Without this, two tabs racing on the same code
+	// would show one success and one spurious "not found" toast.
+	if (res.status === 404) return;
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? "Failed to revoke invite");
+	}
 }
 
 // ── File uploads ────────────────────────────────────────────────────────────
@@ -251,60 +261,60 @@ export async function revokeInvite(code: string): Promise<void> {
  * the user can pass to Claude CLI.
  */
 export async function uploadSessionFiles(
-        sessionId: string,
-        files: File[],
+	sessionId: string,
+	files: File[],
 ): Promise<{ paths: string[] }> {
-        const fd = new FormData();
-        for (const f of files) fd.append("files", f, f.name);
-        const res = await apiFetch(`/sessions/${sessionId}/files`, {
-                method: "POST",
-                body: fd,
-        });
-        if (!res.ok) {
-                const body = await res.json().catch(() => ({}));
-                throw new Error(body.error ?? `Upload failed (${res.status})`);
-        }
-        return res.json() as Promise<{ paths: string[] }>;
+	const fd = new FormData();
+	for (const f of files) fd.append("files", f, f.name);
+	const res = await apiFetch(`/sessions/${sessionId}/files`, {
+		method: "POST",
+		body: fd,
+	});
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error ?? `Upload failed (${res.status})`);
+	}
+	return res.json() as Promise<{ paths: string[] }>;
 }
 
 // ── Fetch wrapper ───────────────────────────────────────────────────────────
 
 async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
-        // FormData carries its own multipart boundary — letting us set
-        // Content-Type would clobber that and the server would fail to
-        // parse the upload. Skip the JSON default in that case.
-        const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData;
-        const headers: Record<string, string> = {
-                ...(isFormData ? {} : { "Content-Type": "application/json" }),
-                ...(init?.headers as Record<string, string> ?? {}),
-        };
-        // Captured before the fetch so a concurrent setToken(null) between
-        // here and the response doesn't change how we classify the 401 below.
-        // `sentAuth` pins "this request carried an Authorization header" —
-        // only authed 401s are treated as "token is stale"; an unauthed 401
-        // (e.g. wrong password on /auth/login) must not clear token state.
-        const sentAuth = !!_token;
-        if (_token) {
-                headers["Authorization"] = `Bearer ${_token}`;
-        }
-        const res = await fetch(`${API_BASE}${path}`, { ...init, headers });
+	// FormData carries its own multipart boundary — letting us set
+	// Content-Type would clobber that and the server would fail to
+	// parse the upload. Skip the JSON default in that case.
+	const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData;
+	const headers: Record<string, string> = {
+		...(isFormData ? {} : { "Content-Type": "application/json" }),
+		...((init?.headers as Record<string, string>) ?? {}),
+	};
+	// Captured before the fetch so a concurrent setToken(null) between
+	// here and the response doesn't change how we classify the 401 below.
+	// `sentAuth` pins "this request carried an Authorization header" —
+	// only authed 401s are treated as "token is stale"; an unauthed 401
+	// (e.g. wrong password on /auth/login) must not clear token state.
+	const sentAuth = !!_token;
+	if (_token) {
+		headers.Authorization = `Bearer ${_token}`;
+	}
+	const res = await fetch(`${API_BASE}${path}`, { ...init, headers });
 
-        // Centralised stale-token handling (#95). Without this, the 15 s
-        // session poll toasts an error every 15 s forever once the JWT
-        // expires, because nothing else clears _token on 401.
-        //
-        // - sentAuth (captured pre-fetch) distinguishes authed 401s from
-        //   unauthed ones like a wrong-password /auth/login on a session
-        //   that already has a token — we mustn't clear auth state on that.
-        // - 401 is specifically "token stale"; 403 is policy and must not
-        //   trigger a logout.
-        // - _token !== null dedups concurrent 401 bursts (session poll +
-        //   a user-triggered call racing): the first setToken(null) through
-        //   silences the rest so the event fires exactly once per burst.
-        if (sentAuth && res.status === 401 && _token !== null) {
-                setToken(null);
-                window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
-        }
+	// Centralised stale-token handling (#95). Without this, the 15 s
+	// session poll toasts an error every 15 s forever once the JWT
+	// expires, because nothing else clears _token on 401.
+	//
+	// - sentAuth (captured pre-fetch) distinguishes authed 401s from
+	//   unauthed ones like a wrong-password /auth/login on a session
+	//   that already has a token — we mustn't clear auth state on that.
+	// - 401 is specifically "token stale"; 403 is policy and must not
+	//   trigger a logout.
+	// - _token !== null dedups concurrent 401 bursts (session poll +
+	//   a user-triggered call racing): the first setToken(null) through
+	//   silences the rest so the event fires exactly once per burst.
+	if (sentAuth && res.status === 401 && _token !== null) {
+		setToken(null);
+		window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
+	}
 
-        return res;
+	return res;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,15 +11,31 @@
 import "./main.css";
 
 import {
-        isLoggedIn, login, register, logout, checkAuthStatus,
-        listSessions, createSession, deleteSession, stopSession, startSession,
-        listTabs, createTab, deleteTab, TabNotFoundError,
-        listInvites, createInvite, revokeInvite, InviteRequiredError,
-        uploadSessionFiles,
-        SESSION_EXPIRED_EVENT,
-        type SessionInfo, type Tab, type Invite,
+	checkAuthStatus,
+	createInvite,
+	createSession,
+	createTab,
+	deleteSession,
+	deleteTab,
+	type Invite,
+	InviteRequiredError,
+	isLoggedIn,
+	listInvites,
+	listSessions,
+	listTabs,
+	login,
+	logout,
+	register,
+	revokeInvite,
+	SESSION_EXPIRED_EVENT,
+	type SessionInfo,
+	startSession,
+	stopSession,
+	type Tab,
+	TabNotFoundError,
+	uploadSessionFiles,
 } from "./api.js";
-import { openTerminalSession, type TerminalSession, type SessionStatus } from "./terminal.js";
+import { openTerminalSession, type SessionStatus, type TerminalSession } from "./terminal.js";
 
 // ── DOM refs ────────────────────────────────────────────────────────────────
 
@@ -73,7 +89,6 @@ const pasteClipboardBtn = document.getElementById("paste-clipboard-btn") as HTML
 const pasteSendBtn = document.getElementById("paste-send-btn") as HTMLButtonElement;
 const toast = document.getElementById("toast")!;
 
-
 // ── Viewport height ─────────────────────────────────────────────────────────
 // iOS Safari's soft keyboard overlays the layout viewport without resizing
 // it, so `100dvh` on <body> leaves the terminal partially behind the
@@ -81,9 +96,9 @@ const toast = document.getElementById("toast")!;
 // and as the URL bar shows/hides — we mirror its height into --app-vh so the
 // xterm host container refits to the space actually visible to the user.
 function syncViewportHeight() {
-        const vv = window.visualViewport;
-        const h = vv ? vv.height : window.innerHeight;
-        document.documentElement.style.setProperty("--app-vh", `${h}px`);
+	const vv = window.visualViewport;
+	const h = vv ? vv.height : window.innerHeight;
+	document.documentElement.style.setProperty("--app-vh", `${h}px`);
 }
 syncViewportHeight();
 window.visualViewport?.addEventListener("resize", syncViewportHeight);
@@ -97,9 +112,9 @@ const FONT_SIZE_STEPS = [11, 12, 13, 14, 15, 16, 18];
 const DEFAULT_FONT_SIZE = 14;
 const FONT_SIZE_KEY = "shared-terminal:font-size";
 function readFontSize(): number {
-        const raw = localStorage.getItem(FONT_SIZE_KEY);
-        const n = raw ? Number.parseInt(raw, 10) : DEFAULT_FONT_SIZE;
-        return FONT_SIZE_STEPS.includes(n) ? n : DEFAULT_FONT_SIZE;
+	const raw = localStorage.getItem(FONT_SIZE_KEY);
+	const n = raw ? Number.parseInt(raw, 10) : DEFAULT_FONT_SIZE;
+	return FONT_SIZE_STEPS.includes(n) ? n : DEFAULT_FONT_SIZE;
 }
 let currentFontSize = readFontSize();
 
@@ -110,7 +125,10 @@ let activeSessionId: string | null = null;
 let isRegisterMode = false;
 
 // Active session's tabs only; switching sessions tears these down.
-interface ActiveTerminal { pane: HTMLDivElement; term: TerminalSession }
+interface ActiveTerminal {
+	pane: HTMLDivElement;
+	term: TerminalSession;
+}
 let currentTabs: Tab[] = [];
 let currentActiveTabId: string | null = null;
 const currentTerminals = new Map<string, ActiveTerminal>();
@@ -119,24 +137,23 @@ const currentTerminals = new Map<string, ActiveTerminal>();
 const closingTabs = new Set<string>();
 
 function disposeAllCurrentTerminals() {
-        for (const { term, pane } of currentTerminals.values()) {
-                term.dispose();
-                pane.remove();
-        }
-        currentTerminals.clear();
-        currentTabs = [];
-        currentActiveTabId = null;
-        closingTabs.clear();
-        terminalTabs.innerHTML = "";
-        terminalTabs.style.display = "none";
-        terminalContainer.style.display = "none";
-        // Clearing the tabs invalidates the chrome-toggle label — refresh
-        // even though updateToolbar() (which would also do this) typically
-        // runs immediately after. The defensive call costs almost nothing
-        // and stops a stale "Tab N" lingering in the header on logout.
-        updateChromeToggle();
+	for (const { term, pane } of currentTerminals.values()) {
+		term.dispose();
+		pane.remove();
+	}
+	currentTerminals.clear();
+	currentTabs = [];
+	currentActiveTabId = null;
+	closingTabs.clear();
+	terminalTabs.innerHTML = "";
+	terminalTabs.style.display = "none";
+	terminalContainer.style.display = "none";
+	// Clearing the tabs invalidates the chrome-toggle label — refresh
+	// even though updateToolbar() (which would also do this) typically
+	// runs immediately after. The defensive call costs almost nothing
+	// and stops a stale "Tab N" lingering in the header on logout.
+	updateChromeToggle();
 }
-
 
 // ── Auth flow ───────────────────────────────────────────────────────────────
 
@@ -146,131 +163,134 @@ function disposeAllCurrentTerminals() {
 let isBootstrapRegister = false;
 
 async function initAuth() {
-        if (isLoggedIn()) {
-                showApp();
-                return;
-        }
+	if (isLoggedIn()) {
+		showApp();
+		return;
+	}
 
-        try {
-                const { needsSetup } = await checkAuthStatus();
-                if (needsSetup) {
-                        isRegisterMode = true;
-                        isBootstrapRegister = true;
-                        updateAuthUI();
-                }
-        } catch {
-                // Backend probably not running — show login anyway
-        }
+	try {
+		const { needsSetup } = await checkAuthStatus();
+		if (needsSetup) {
+			isRegisterMode = true;
+			isBootstrapRegister = true;
+			updateAuthUI();
+		}
+	} catch {
+		// Backend probably not running — show login anyway
+	}
 
-        showAuth();
+	showAuth();
 }
 
 function showAuth() {
-        authView.style.display = "flex";
-        appView.style.display = "none";
-        authUsername.focus();
+	authView.style.display = "flex";
+	appView.style.display = "none";
+	authUsername.focus();
 }
 
 function showApp() {
-        authView.style.display = "none";
-        appView.style.display = "flex";
-        userDisplay.textContent = "●";
-        // Keep the sidebar-footer marker in lockstep with the header one so
-        // a future swap of "●" for the actual username only needs editing
-        // a single line.
-        sidebarUserDisplay.textContent = userDisplay.textContent;
-        refreshSessions();
+	authView.style.display = "none";
+	appView.style.display = "flex";
+	userDisplay.textContent = "●";
+	// Keep the sidebar-footer marker in lockstep with the header one so
+	// a future swap of "●" for the actual username only needs editing
+	// a single line.
+	sidebarUserDisplay.textContent = userDisplay.textContent;
+	refreshSessions();
 }
 
-
 function updateAuthUI() {
-        if (isRegisterMode) {
-                authTitle.textContent = "Create Account";
-                authSubmitBtn.textContent = "Register";
-                authToggle.innerHTML = 'Already have an account? <a href="#" id="auth-toggle-link">Login</a>';
-                // Invite code is required for every register except the bootstrap
-                // first user — show the field accordingly.
-                authInviteCode.classList.toggle("hidden", isBootstrapRegister);
-        } else {
-                authTitle.textContent = "Login";
-                authSubmitBtn.textContent = "Login";
-                authToggle.innerHTML = 'No account? <a href="#" id="auth-toggle-link">Register</a>';
-                authInviteCode.classList.add("hidden");
-        }
-        // Re-bind toggle link
-        document.getElementById("auth-toggle-link")?.addEventListener("click", async (e) => {
-                e.preventDefault();
-                isRegisterMode = !isRegisterMode;
-                authError.textContent = "";
-                // Re-fetch the canonical bootstrap state when entering register
-                // mode. Otherwise isBootstrapRegister is whatever it was at page
-                // load — toggling login → register would silently keep the flag
-                // (and the hidden invite field) even if the bootstrap window
-                // closed in the interim. Single GET, only on the toggle click.
-                if (isRegisterMode) {
-                        try {
-                                const { needsSetup } = await checkAuthStatus();
-                                isBootstrapRegister = needsSetup;
-                        } catch { /* status check failed — keep prior flag value */ }
-                }
-                updateAuthUI();
-        });
+	if (isRegisterMode) {
+		authTitle.textContent = "Create Account";
+		authSubmitBtn.textContent = "Register";
+		authToggle.innerHTML = 'Already have an account? <a href="#" id="auth-toggle-link">Login</a>';
+		// Invite code is required for every register except the bootstrap
+		// first user — show the field accordingly.
+		authInviteCode.classList.toggle("hidden", isBootstrapRegister);
+	} else {
+		authTitle.textContent = "Login";
+		authSubmitBtn.textContent = "Login";
+		authToggle.innerHTML = 'No account? <a href="#" id="auth-toggle-link">Register</a>';
+		authInviteCode.classList.add("hidden");
+	}
+	// Re-bind toggle link
+	document.getElementById("auth-toggle-link")?.addEventListener("click", async (e) => {
+		e.preventDefault();
+		isRegisterMode = !isRegisterMode;
+		authError.textContent = "";
+		// Re-fetch the canonical bootstrap state when entering register
+		// mode. Otherwise isBootstrapRegister is whatever it was at page
+		// load — toggling login → register would silently keep the flag
+		// (and the hidden invite field) even if the bootstrap window
+		// closed in the interim. Single GET, only on the toggle click.
+		if (isRegisterMode) {
+			try {
+				const { needsSetup } = await checkAuthStatus();
+				isBootstrapRegister = needsSetup;
+			} catch {
+				/* status check failed — keep prior flag value */
+			}
+		}
+		updateAuthUI();
+	});
 }
 
 authForm.addEventListener("submit", async (e) => {
-        e.preventDefault();
-        authError.textContent = "";
-        const username = authUsername.value.trim();
-        const password = authPassword.value;
-        const inviteCode = authInviteCode.value.trim();
+	e.preventDefault();
+	authError.textContent = "";
+	const username = authUsername.value.trim();
+	const password = authPassword.value;
+	const inviteCode = authInviteCode.value.trim();
 
-        if (!username || !password) {
-                authError.textContent = "Username and password required";
-                return;
-        }
-        if (isRegisterMode && !isBootstrapRegister && !inviteCode) {
-                authError.textContent = "Invite code required";
-                return;
-        }
+	if (!username || !password) {
+		authError.textContent = "Username and password required";
+		return;
+	}
+	if (isRegisterMode && !isBootstrapRegister && !inviteCode) {
+		authError.textContent = "Invite code required";
+		return;
+	}
 
-        try {
-                if (isRegisterMode) {
-                        await register(username, password, inviteCode || undefined);
-                } else {
-                        await login(username, password);
-                }
-                showApp();
-        } catch (err) {
-                // The bootstrap window can close between page load and submit
-                // (a concurrent register sneaks in, or the page sat open after
-                // someone else set up the first account). The backend signals
-                // this with 403 InviteRequired — clear the flag and reveal the
-                // invite-code field so the user can retry without reloading.
-                if (err instanceof InviteRequiredError && isBootstrapRegister) {
-                        isBootstrapRegister = false;
-                        updateAuthUI();
-                        authError.textContent = "An account already exists — enter an invite code to register.";
-                        return;
-                }
-                // Non-403 failures during bootstrap (transient 500, network blip)
-                // would otherwise leave isBootstrapRegister=true forever — the
-                // invite field stays hidden and every retry re-fires the no-invite
-                // path, which the backend may now reject if a concurrent register
-                // already grabbed the bootstrap slot. Re-fetch the canonical state
-                // so the next submit either retries cleanly or shows the invite
-                // field. checkAuthStatus is cheap and only runs on the rare
-                // bootstrap-error path.
-                if (isRegisterMode && isBootstrapRegister) {
-                        try {
-                                const { needsSetup } = await checkAuthStatus();
-                                if (!needsSetup) {
-                                        isBootstrapRegister = false;
-                                        updateAuthUI();
-                                }
-                        } catch { /* status check itself failed — keep the flag, surface the original error */ }
-                }
-                authError.textContent = (err as Error).message;
-        }
+	try {
+		if (isRegisterMode) {
+			await register(username, password, inviteCode || undefined);
+		} else {
+			await login(username, password);
+		}
+		showApp();
+	} catch (err) {
+		// The bootstrap window can close between page load and submit
+		// (a concurrent register sneaks in, or the page sat open after
+		// someone else set up the first account). The backend signals
+		// this with 403 InviteRequired — clear the flag and reveal the
+		// invite-code field so the user can retry without reloading.
+		if (err instanceof InviteRequiredError && isBootstrapRegister) {
+			isBootstrapRegister = false;
+			updateAuthUI();
+			authError.textContent = "An account already exists — enter an invite code to register.";
+			return;
+		}
+		// Non-403 failures during bootstrap (transient 500, network blip)
+		// would otherwise leave isBootstrapRegister=true forever — the
+		// invite field stays hidden and every retry re-fires the no-invite
+		// path, which the backend may now reject if a concurrent register
+		// already grabbed the bootstrap slot. Re-fetch the canonical state
+		// so the next submit either retries cleanly or shows the invite
+		// field. checkAuthStatus is cheap and only runs on the rare
+		// bootstrap-error path.
+		if (isRegisterMode && isBootstrapRegister) {
+			try {
+				const { needsSetup } = await checkAuthStatus();
+				if (!needsSetup) {
+					isBootstrapRegister = false;
+					updateAuthUI();
+				}
+			} catch {
+				/* status check itself failed — keep the flag, surface the original error */
+			}
+		}
+		authError.textContent = (err as Error).message;
+	}
 });
 
 // Shared teardown for both the explicit logout button and the auto-triggered
@@ -280,16 +300,16 @@ authForm.addEventListener("submit", async (e) => {
 // case (multiple 401s briefly racing before _token is cleared) is safe even
 // though apiFetch's `_token !== null` guard already deduplicates.
 function handleLogout(toastMessage?: string): void {
-        logout();
-        disposeAllCurrentTerminals();
-        activeSessionId = null;
-        sessions = [];
-        showAuth();
-        if (toastMessage) showToast(toastMessage, true);
+	logout();
+	disposeAllCurrentTerminals();
+	activeSessionId = null;
+	sessions = [];
+	showAuth();
+	if (toastMessage) showToast(toastMessage, true);
 }
 
 logoutBtn.addEventListener("click", () => {
-        handleLogout();
+	handleLogout();
 });
 
 // Logout from the sidebar footer just delegates — handleLogout() tears
@@ -298,8 +318,6 @@ logoutBtn.addEventListener("click", () => {
 // restore focus to (the desktop invitesBtn is `display:none` on mobile,
 // so a delegated `invitesBtn.click()` would silently lose focus on close).
 sidebarLogoutBtn.addEventListener("click", () => logoutBtn.click());
-
-
 
 // Listen for the api-layer signal that our JWT is no longer accepted (#95).
 // Without this, a `refreshSessions()` tick 15 s after expiry produces a
@@ -312,621 +330,628 @@ sidebarLogoutBtn.addEventListener("click", () => logoutBtn.click());
 // the event fires at most once per 401 burst, so we don't need extra
 // debouncing here.
 window.addEventListener(SESSION_EXPIRED_EVENT, () => {
-        handleLogout("Your session has expired — please sign in again");
+	handleLogout("Your session has expired — please sign in again");
 });
 
 // ── Session management ──────────────────────────────────────────────────────
 
 async function refreshSessions() {
-        // Read the checkbox state fresh every time so there's no stale
-        // module-variable to get out of sync with the DOM.
-        const includeTerminated = showTerminatedToggle.checked;
-        try {
-                sessions = await listSessions(includeTerminated);
-                console.debug(
-                        `[sessions] fetched ${sessions.length} session(s) (includeTerminated=${includeTerminated})`,
-                        sessions.map((s) => ({ id: s.sessionId.slice(0, 8), name: s.name, status: s.status })),
-                );
-                renderSessionList();
-        } catch (err) {
-                showToast((err as Error).message, true);
-        }
+	// Read the checkbox state fresh every time so there's no stale
+	// module-variable to get out of sync with the DOM.
+	const includeTerminated = showTerminatedToggle.checked;
+	try {
+		sessions = await listSessions(includeTerminated);
+		console.debug(
+			`[sessions] fetched ${sessions.length} session(s) (includeTerminated=${includeTerminated})`,
+			sessions.map((s) => ({ id: s.sessionId.slice(0, 8), name: s.name, status: s.status })),
+		);
+		renderSessionList();
+	} catch (err) {
+		showToast((err as Error).message, true);
+	}
 }
 
 function renderSessionList() {
-        sessionList.innerHTML = "";
-        for (const s of sessions) {
-                const item = document.createElement("div");
-                const terminatedCls = s.status === "terminated" ? " terminated" : "";
-                item.className = `session-item${s.sessionId === activeSessionId ? " active" : ""}${terminatedCls}`;
+	sessionList.innerHTML = "";
+	for (const s of sessions) {
+		const item = document.createElement("div");
+		const terminatedCls = s.status === "terminated" ? " terminated" : "";
+		item.className = `session-item${s.sessionId === activeSessionId ? " active" : ""}${terminatedCls}`;
 
-                const dot = document.createElement("span");
-                dot.className = `session-dot ${s.status}`;
-                item.appendChild(dot);
+		const dot = document.createElement("span");
+		dot.className = `session-dot ${s.status}`;
+		item.appendChild(dot);
 
-                const name = document.createElement("span");
-                name.className = "session-name";
-                name.textContent = s.name;
-                item.appendChild(name);
+		const name = document.createElement("span");
+		name.className = "session-name";
+		name.textContent = s.name;
+		item.appendChild(name);
 
-                // Action buttons
-                const actions = document.createElement("span");
-                actions.className = "session-actions";
+		// Action buttons
+		const actions = document.createElement("span");
+		actions.className = "session-actions";
 
-                if (s.status === "stopped") {
-                        const playBtn = document.createElement("button");
-                        playBtn.className = "session-action-btn start";
-                        playBtn.textContent = "▶";
-                        playBtn.title = "Start";
-                        playBtn.addEventListener("click", async (e) => {
-                                e.stopPropagation();
-                                try {
-                                        await startSession(s.sessionId);
-                                        await refreshSessions();
-                                } catch (err) { showToast((err as Error).message, true); }
-                        });
-                        actions.appendChild(playBtn);
-                } else if (s.status === "running") {
-                        const stopBtn = document.createElement("button");
-                        stopBtn.className = "session-action-btn stop";
-                        stopBtn.textContent = "⏸";
-                        stopBtn.title = "Stop";
-                        stopBtn.addEventListener("click", async (e) => {
-                                e.stopPropagation();
-                                try {
-                                        await stopSession(s.sessionId);
-                                        await refreshSessions();
-                                } catch (err) { showToast((err as Error).message, true); }
-                        });
-                        actions.appendChild(stopBtn);
-                } else if (s.status === "terminated") {
-                        // Restore — spawns a fresh container reusing the original
-                        // container name + workspace bind mount. Files are preserved.
-                        const restoreBtn = document.createElement("button");
-                        restoreBtn.className = "session-action-btn start";
-                        restoreBtn.textContent = "↻";
-                        restoreBtn.title = "Restore (respawn container with existing workspace files)";
-                        restoreBtn.addEventListener("click", async (e) => {
-                                e.stopPropagation();
-                                try {
-                                        showToast(`Restoring "${s.name}"…`);
-                                        await startSession(s.sessionId);
-                                        await refreshSessions();
-                                        showToast(`Session "${s.name}" restored`);
-                                } catch (err) { showToast((err as Error).message, true); }
-                        });
-                        actions.appendChild(restoreBtn);
-                }
+		if (s.status === "stopped") {
+			const playBtn = document.createElement("button");
+			playBtn.className = "session-action-btn start";
+			playBtn.textContent = "▶";
+			playBtn.title = "Start";
+			playBtn.addEventListener("click", async (e) => {
+				e.stopPropagation();
+				try {
+					await startSession(s.sessionId);
+					await refreshSessions();
+				} catch (err) {
+					showToast((err as Error).message, true);
+				}
+			});
+			actions.appendChild(playBtn);
+		} else if (s.status === "running") {
+			const stopBtn = document.createElement("button");
+			stopBtn.className = "session-action-btn stop";
+			stopBtn.textContent = "⏸";
+			stopBtn.title = "Stop";
+			stopBtn.addEventListener("click", async (e) => {
+				e.stopPropagation();
+				try {
+					await stopSession(s.sessionId);
+					await refreshSessions();
+				} catch (err) {
+					showToast((err as Error).message, true);
+				}
+			});
+			actions.appendChild(stopBtn);
+		} else if (s.status === "terminated") {
+			// Restore — spawns a fresh container reusing the original
+			// container name + workspace bind mount. Files are preserved.
+			const restoreBtn = document.createElement("button");
+			restoreBtn.className = "session-action-btn start";
+			restoreBtn.textContent = "↻";
+			restoreBtn.title = "Restore (respawn container with existing workspace files)";
+			restoreBtn.addEventListener("click", async (e) => {
+				e.stopPropagation();
+				try {
+					showToast(`Restoring "${s.name}"…`);
+					await startSession(s.sessionId);
+					await refreshSessions();
+					showToast(`Session "${s.name}" restored`);
+				} catch (err) {
+					showToast((err as Error).message, true);
+				}
+			});
+			actions.appendChild(restoreBtn);
+		}
 
-                const killBtn = document.createElement("button");
-                killBtn.className = "session-kill";
-                killBtn.textContent = "✕";
-                // Shift-click enables hard delete — also wipes workspace files and
-                // removes the session record entirely. Plain click is a soft delete,
-                // which keeps the workspace files so the session can be restored.
-                killBtn.title = s.status === "terminated"
-                        ? "Delete permanently (wipes workspace files)"
-                        : "Terminate (Shift-click to also wipe workspace files)";
-                killBtn.addEventListener("click", async (e) => {
-                        e.stopPropagation();
-                        const mouseEvent = e as MouseEvent;
-                        // If the session is already terminated, the only meaningful action
-                        // is hard delete — otherwise there's nothing to do.
-                        const hard = s.status === "terminated" || mouseEvent.shiftKey;
+		const killBtn = document.createElement("button");
+		killBtn.className = "session-kill";
+		killBtn.textContent = "✕";
+		// Shift-click enables hard delete — also wipes workspace files and
+		// removes the session record entirely. Plain click is a soft delete,
+		// which keeps the workspace files so the session can be restored.
+		killBtn.title =
+			s.status === "terminated"
+				? "Delete permanently (wipes workspace files)"
+				: "Terminate (Shift-click to also wipe workspace files)";
+		killBtn.addEventListener("click", async (e) => {
+			e.stopPropagation();
+			const mouseEvent = e as MouseEvent;
+			// If the session is already terminated, the only meaningful action
+			// is hard delete — otherwise there's nothing to do.
+			const hard = s.status === "terminated" || mouseEvent.shiftKey;
 
-                        const prompt = hard
-                                ? `Permanently delete "${s.name}"?\n\nThis stops and removes the container, wipes workspace files from disk, and removes the session record. This cannot be undone.`
-                                : `Terminate "${s.name}"?\n\nContainer will be stopped and removed. Workspace files are preserved — you can restore the session later.`;
-                        if (!confirm(prompt)) return;
+			const prompt = hard
+				? `Permanently delete "${s.name}"?\n\nThis stops and removes the container, wipes workspace files from disk, and removes the session record. This cannot be undone.`
+				: `Terminate "${s.name}"?\n\nContainer will be stopped and removed. Workspace files are preserved — you can restore the session later.`;
+			if (!confirm(prompt)) return;
 
-                        try {
-                                await deleteSession(s.sessionId, hard);
-                                if (activeSessionId === s.sessionId) {
-                                        disposeAllCurrentTerminals();
-                                        activeSessionId = null;
-                                        updateToolbar();
-                                }
-                                await refreshSessions();
-                        } catch (err) { showToast((err as Error).message, true); }
-                });
-                actions.appendChild(killBtn);
-                item.appendChild(actions);
+			try {
+				await deleteSession(s.sessionId, hard);
+				if (activeSessionId === s.sessionId) {
+					disposeAllCurrentTerminals();
+					activeSessionId = null;
+					updateToolbar();
+				}
+				await refreshSessions();
+			} catch (err) {
+				showToast((err as Error).message, true);
+			}
+		});
+		actions.appendChild(killBtn);
+		item.appendChild(actions);
 
-                // Click to open session
-                item.addEventListener("click", () => {
-                        if (s.status === "running") {
-                                void openSession(s.sessionId);
-                        } else if (s.status === "stopped") {
-                                showToast("Start the session first", true);
-                        }
-                });
+		// Click to open session
+		item.addEventListener("click", () => {
+			if (s.status === "running") {
+				void openSession(s.sessionId);
+			} else if (s.status === "stopped") {
+				showToast("Start the session first", true);
+			}
+		});
 
-                sessionList.appendChild(item);
-        }
+		sessionList.appendChild(item);
+	}
 }
 
 async function openSession(sessionId: string) {
-        if (activeSessionId === sessionId) return;
+	if (activeSessionId === sessionId) return;
 
-        // Tabs stay alive across tab-switch, but are torn down on session-switch.
-        disposeAllCurrentTerminals();
+	// Tabs stay alive across tab-switch, but are torn down on session-switch.
+	disposeAllCurrentTerminals();
 
-        activeSessionId = sessionId;
-        renderSessionList();
-        updateToolbar();
+	activeSessionId = sessionId;
+	renderSessionList();
+	updateToolbar();
 
-        // Capturing `sessionId` guards against a rapid second openSession call
-        // clobbering this one — each `await` re-checks identity.
-        try {
-                const tabs = await listTabs(sessionId);
-                if (activeSessionId !== sessionId) return;
-                // Sort by creation order so +-added tabs stay on the right
-                // (listTabs returns alphabetical from tmux list-sessions).
-                currentTabs = tabs.sort((a, b) => a.createdAt - b.createdAt);
-        } catch (err) {
-                // Drop back to empty state so the toolbar/container don't linger
-                // visible with no tabs.
-                if (activeSessionId === sessionId) {
-                        activeSessionId = null;
-                        currentTabs = [];
-                        renderSessionList();
-                        updateToolbar();
-                }
-                showToast((err as Error).message, true);
-                return;
-        }
+	// Capturing `sessionId` guards against a rapid second openSession call
+	// clobbering this one — each `await` re-checks identity.
+	try {
+		const tabs = await listTabs(sessionId);
+		if (activeSessionId !== sessionId) return;
+		// Sort by creation order so +-added tabs stay on the right
+		// (listTabs returns alphabetical from tmux list-sessions).
+		currentTabs = tabs.sort((a, b) => a.createdAt - b.createdAt);
+	} catch (err) {
+		// Drop back to empty state so the toolbar/container don't linger
+		// visible with no tabs.
+		if (activeSessionId === sessionId) {
+			activeSessionId = null;
+			currentTabs = [];
+			renderSessionList();
+			updateToolbar();
+		}
+		showToast((err as Error).message, true);
+		return;
+	}
 
-        // Freshly-spawned session legitimately has zero tabs — the container no
-        // longer creates one at boot. Render just the + so the user can open
-        // their first tab, and keep the terminal pane hidden.
-        if (currentTabs.length === 0) {
-                renderTabBar();
-                // On mobile the chrome drawer (where the + button lives) is
-                // collapsed by default — auto-expand it for the empty session
-                // so the user can actually find the + without hunting for it.
-                if (isMobile()) setChromeOpen(true);
-                return;
-        }
+	// Freshly-spawned session legitimately has zero tabs — the container no
+	// longer creates one at boot. Render just the + so the user can open
+	// their first tab, and keep the terminal pane hidden.
+	if (currentTabs.length === 0) {
+		renderTabBar();
+		// On mobile the chrome drawer (where the + button lives) is
+		// collapsed by default — auto-expand it for the empty session
+		// so the user can actually find the + without hunting for it.
+		if (isMobile()) setChromeOpen(true);
+		return;
+	}
 
-        // Tapping a session in the sidebar drawer is the user's "go to that
-        // tmux" gesture; collapse the chrome drawer too so the freshly-attached
-        // terminal gets the full viewport. Mirrors the chip-click and addTab
-        // success paths — without this, switching session-to-session on mobile
-        // leaves whichever drawer state was last set by the previous session
-        // covering the top of the viewport.
-        if (isMobile()) setChromeOpen(false);
+	// Tapping a session in the sidebar drawer is the user's "go to that
+	// tmux" gesture; collapse the chrome drawer too so the freshly-attached
+	// terminal gets the full viewport. Mirrors the chip-click and addTab
+	// success paths — without this, switching session-to-session on mobile
+	// leaves whichever drawer state was last set by the previous session
+	// covering the top of the viewport.
+	if (isMobile()) setChromeOpen(false);
 
-        // openTab can throw synchronously (openTerminalSession init failure) —
-        // openSession is called with `void`, so an unhandled throw here would
-        // become an unhandled rejection with no toast and the UI left mid-switch.
-        try {
-                openTab(currentTabs[0]!.tabId);
-
-        } catch (err) {
-                if (activeSessionId === sessionId) {
-                        activeSessionId = null;
-                        currentTabs = [];
-                        renderSessionList();
-                        updateToolbar();
-                }
-                showToast((err as Error).message, true);
-        }
+	// openTab can throw synchronously (openTerminalSession init failure) —
+	// openSession is called with `void`, so an unhandled throw here would
+	// become an unhandled rejection with no toast and the UI left mid-switch.
+	try {
+		openTab(currentTabs[0]!.tabId);
+	} catch (err) {
+		if (activeSessionId === sessionId) {
+			activeSessionId = null;
+			currentTabs = [];
+			renderSessionList();
+			updateToolbar();
+		}
+		showToast((err as Error).message, true);
+	}
 }
 
 function updateToolbar() {
-        const s = sessions.find((x) => x.sessionId === activeSessionId);
-        if (!s) {
-                terminalToolbar.style.display = "none";
-                terminalTabs.style.display = "none";
-                terminalContainer.style.display = "none";
-                emptyState.style.display = "flex";
-                updateChromeToggle();
-                return;
-        }
-        terminalToolbar.style.display = "flex";
-        // #terminal-tabs and #terminal-container are flipped to visible only
-        // by renderTabBar/openTab — avoids an empty-bar flash before listTabs
-        // resolves.
-        emptyState.style.display = "none";
-        terminalSessionName.textContent = s.name;
-        terminalStatusBadge.textContent = s.status;
-        terminalStatusBadge.className = s.status;
-        // Refresh the mobile header context pill — its label tracks the
-        // active session/tab, and visibility flips on/off here.
-        updateChromeToggle();
+	const s = sessions.find((x) => x.sessionId === activeSessionId);
+	if (!s) {
+		terminalToolbar.style.display = "none";
+		terminalTabs.style.display = "none";
+		terminalContainer.style.display = "none";
+		emptyState.style.display = "flex";
+		updateChromeToggle();
+		return;
+	}
+	terminalToolbar.style.display = "flex";
+	// #terminal-tabs and #terminal-container are flipped to visible only
+	// by renderTabBar/openTab — avoids an empty-bar flash before listTabs
+	// resolves.
+	emptyState.style.display = "none";
+	terminalSessionName.textContent = s.name;
+	terminalStatusBadge.textContent = s.status;
+	terminalStatusBadge.className = s.status;
+	// Refresh the mobile header context pill — its label tracks the
+	// active session/tab, and visibility flips on/off here.
+	updateChromeToggle();
 }
-
 
 // ── Tabs within the active session ──────────────────────────────────────────
 
 function renderTabBar() {
-        terminalTabs.innerHTML = "";
-        if (!activeSessionId) {
-                terminalTabs.style.display = "none";
-                return;
-        }
-        // Render even at currentTabs.length === 0 so the + button is reachable
-        // — a brand-new session starts with no tabs and the user opens the
-        // first one from here.
-        terminalTabs.style.display = "flex";
+	terminalTabs.innerHTML = "";
+	if (!activeSessionId) {
+		terminalTabs.style.display = "none";
+		return;
+	}
+	// Render even at currentTabs.length === 0 so the + button is reachable
+	// — a brand-new session starts with no tabs and the user opens the
+	// first one from here.
+	terminalTabs.style.display = "flex";
 
-        for (const tab of currentTabs) {
-                const chip = document.createElement("div");
-                chip.className = `tab-chip${tab.tabId === currentActiveTabId ? " active" : ""}`;
-                chip.dataset.tabId = tab.tabId;
-                chip.title = tab.label;
+	for (const tab of currentTabs) {
+		const chip = document.createElement("div");
+		chip.className = `tab-chip${tab.tabId === currentActiveTabId ? " active" : ""}`;
+		chip.dataset.tabId = tab.tabId;
+		chip.title = tab.label;
 
-                const label = document.createElement("span");
-                label.className = "tab-chip-label";
-                label.textContent = tab.label;
-                chip.appendChild(label);
+		const label = document.createElement("span");
+		label.className = "tab-chip-label";
+		label.textContent = tab.label;
+		chip.appendChild(label);
 
-                const close = document.createElement("button");
-                close.className = "tab-close";
-                close.textContent = "×";
-                close.title = "Close tab";
-                close.disabled = closingTabs.has(tab.tabId);
-                close.addEventListener("click", (e) => {
-                        e.stopPropagation();
-                        void closeTab(tab.tabId, close);
-                });
-                chip.appendChild(close);
+		const close = document.createElement("button");
+		close.className = "tab-close";
+		close.textContent = "×";
+		close.title = "Close tab";
+		close.disabled = closingTabs.has(tab.tabId);
+		close.addEventListener("click", (e) => {
+			e.stopPropagation();
+			void closeTab(tab.tabId, close);
+		});
+		chip.appendChild(close);
 
-                chip.addEventListener("click", () => {
-                        // Click handlers eat synchronous throws — surface them as
-                        // a toast instead of letting the UI silently revert.
-                        try {
-                                openTab(tab.tabId);
-                        } catch (err) {
-                                showToast((err as Error).message, true);
-                        }
-                });
-                terminalTabs.appendChild(chip);
-        }
+		chip.addEventListener("click", () => {
+			// Click handlers eat synchronous throws — surface them as
+			// a toast instead of letting the UI silently revert.
+			try {
+				openTab(tab.tabId);
+			} catch (err) {
+				showToast((err as Error).message, true);
+			}
+		});
+		terminalTabs.appendChild(chip);
+	}
 
-        const addBtn = document.createElement("button");
-        addBtn.id = "tab-add";
-        addBtn.type = "button";
-        addBtn.textContent = "+";
-        addBtn.title = "Open a new tab (runs services independently; close to SIGHUP them)";
-        addBtn.addEventListener("click", () => void addTab(addBtn));
-        terminalTabs.appendChild(addBtn);
-        // The chrome-toggle label tracks whichever tab is active — refresh
-        // every time the bar is rebuilt so renames/closes/switches stay in
-        // sync without having to thread updateChromeToggle() through every
-        // caller of openTab/addTab/closeTab.
-        updateChromeToggle();
+	const addBtn = document.createElement("button");
+	addBtn.id = "tab-add";
+	addBtn.type = "button";
+	addBtn.textContent = "+";
+	addBtn.title = "Open a new tab (runs services independently; close to SIGHUP them)";
+	addBtn.addEventListener("click", () => void addTab(addBtn));
+	terminalTabs.appendChild(addBtn);
+	// The chrome-toggle label tracks whichever tab is active — refresh
+	// every time the bar is rebuilt so renames/closes/switches stay in
+	// sync without having to thread updateChromeToggle() through every
+	// caller of openTab/addTab/closeTab.
+	updateChromeToggle();
 }
 
-
 function openTab(tabId: string) {
-        if (!activeSessionId) return;
-        if (tabId === currentActiveTabId) return;
-        if (!currentTabs.some((t) => t.tabId === tabId)) return;
+	if (!activeSessionId) return;
+	if (tabId === currentActiveTabId) return;
+	if (!currentTabs.some((t) => t.tabId === tabId)) return;
 
-        // Only spin up a terminal for a running session — matches the sidebar.
-        // Treat a missing sessions[] entry as not-running too; if the list is
-        // stale or the session was deleted externally, attaching would just
-        // fail via the WS and leave a blank pane mounted as the active tab.
-        const s = sessions.find((x) => x.sessionId === activeSessionId);
-        if (!s || s.status !== "running") {
-                showToast("Session isn't running — start it first", true);
-                return;
-        }
+	// Only spin up a terminal for a running session — matches the sidebar.
+	// Treat a missing sessions[] entry as not-running too; if the list is
+	// stale or the session was deleted externally, attaching would just
+	// fail via the WS and leave a blank pane mounted as the active tab.
+	const s = sessions.find((x) => x.sessionId === activeSessionId);
+	if (!s || s.status !== "running") {
+		showToast("Session isn't running — start it first", true);
+		return;
+	}
 
-        // Capture the previously-active tab before stripping .active so we can
-        // restore the UI if openTerminalSession throws below — otherwise the
-        // prev pane stays invisible AND the `tabId === currentActiveTabId`
-        // guard above prevents the user from re-clicking its chip.
-        const prevActiveTabId = currentActiveTabId;
-        if (currentActiveTabId) {
-                currentTerminals.get(currentActiveTabId)?.pane.classList.remove("active");
-        }
+	// Capture the previously-active tab before stripping .active so we can
+	// restore the UI if openTerminalSession throws below — otherwise the
+	// prev pane stays invisible AND the `tabId === currentActiveTabId`
+	// guard above prevents the user from re-clicking its chip.
+	const prevActiveTabId = currentActiveTabId;
+	if (currentActiveTabId) {
+		currentTerminals.get(currentActiveTabId)?.pane.classList.remove("active");
+	}
 
-        // Lazily spin up the xterm+WS; re-opens of the same tab just toggle
-        // .active without reconnecting.
-        let entry = currentTerminals.get(tabId);
-        if (!entry) {
-                const pane = document.createElement("div");
-                pane.className = "tab-pane";
-                pane.dataset.tabId = tabId;
-                terminalContainer.appendChild(pane);
+	// Lazily spin up the xterm+WS; re-opens of the same tab just toggle
+	// .active without reconnecting.
+	let entry = currentTerminals.get(tabId);
+	if (!entry) {
+		const pane = document.createElement("div");
+		pane.className = "tab-pane";
+		pane.dataset.tabId = tabId;
+		terminalContainer.appendChild(pane);
 
-                // Capture the sessionId for this terminal — if the user switches
-                // sessions while this WS is closing, `onStatus("disconnected")`
-                // mustn't write to whatever session happens to be active *now*.
-                const ownSessionId = activeSessionId;
-                try {
-                        const term = openTerminalSession({
-                                container: pane,
-                                sessionId: ownSessionId,
-                                tabId,
-                                onStatus: (status: SessionStatus) => {
-                                        if (activeSessionId !== ownSessionId) return;
+		// Capture the sessionId for this terminal — if the user switches
+		// sessions while this WS is closing, `onStatus("disconnected")`
+		// mustn't write to whatever session happens to be active *now*.
+		const ownSessionId = activeSessionId;
+		try {
+			const term = openTerminalSession({
+				container: pane,
+				sessionId: ownSessionId,
+				tabId,
+				onStatus: (status: SessionStatus) => {
+					if (activeSessionId !== ownSessionId) return;
 
-                                        if (status === "disconnected") {
-                                                // "disconnected" is a frontend-only synthetic state
-                                                // fired by ws.onclose — the backend never sends it.
-                                                // Writing it into s.status casts an out-of-type value
-                                                // into SessionInfo.status (typed only as
-                                                // "running"|"stopped"|"terminated") and used to brick
-                                                // the session on any transient WS drop (Cloudflare
-                                                // Tunnel idle timeout ≈100 s, JWT refresh, network
-                                                // blip):
-                                                //   - the sidebar click handler matches neither
-                                                //     "running" nor "stopped" → clicking the session
-                                                //     became a silent no-op. Users reported this as
-                                                //     "my tab went invalid when I came back to the
-                                                //     session" — it's the session, not the tab.
-                                                //   - openTab's `status !== "running"` guard refused
-                                                //     to attach on a perfectly healthy backend.
-                                                //
-                                                // Leave s.status alone; pull the authoritative status
-                                                // with refreshSessions() so the sidebar reflects
-                                                // whatever the backend actually says. Also tear down
-                                                // the dead terminal for this tab so a later click on
-                                                // its chip recreates a fresh WebSocket instead of
-                                                // re-activating a frozen pane. The tab itself stays
-                                                // in currentTabs (still a valid tmux session on the
-                                                // backend) so it remains reachable from the tab bar.
-                                                const entry = currentTerminals.get(tabId);
-                                                if (entry) {
-                                                        // queueMicrotask so we don't dispose xterm
-                                                        // synchronously inside its own ws.onclose
-                                                        // callback chain.
-                                                        queueMicrotask(() => {
-                                                                const latest = currentTerminals.get(tabId);
-                                                                if (!latest || latest !== entry) return;
-                                                                latest.term.dispose();
-                                                                latest.pane.remove();
-                                                                currentTerminals.delete(tabId);
-                                                                if (currentActiveTabId === tabId) {
-                                                                        currentActiveTabId = null;
-                                                                        terminalContainer.style.display = "none";
-                                                                        // refreshSessions() below will eventually round-trip
-                                                                        // and call updateToolbar(), but until that resolves
-                                                                        // the toolbar still shows the session name + status
-                                                                        // badge with no terminal beneath it. Match the rest
-                                                                        // of the codebase (closeTab, openSession's error
-                                                                        // paths) by syncing the toolbar to the new state
-                                                                        // synchronously — if the session was meanwhile
-                                                                        // dropped from sessions[] (rare, but possible if
-                                                                        // refreshSessions raced ahead), the empty-state
-                                                                        // panel takes over instead of an orphan toolbar.
-                                                                        updateToolbar();
-                                                                }
-                                                                renderTabBar();
-                                                        });
-                                                }
-                                                void refreshSessions();
-                                                return;
-                                        }
+					if (status === "disconnected") {
+						// "disconnected" is a frontend-only synthetic state
+						// fired by ws.onclose — the backend never sends it.
+						// Writing it into s.status casts an out-of-type value
+						// into SessionInfo.status (typed only as
+						// "running"|"stopped"|"terminated") and used to brick
+						// the session on any transient WS drop (Cloudflare
+						// Tunnel idle timeout ≈100 s, JWT refresh, network
+						// blip):
+						//   - the sidebar click handler matches neither
+						//     "running" nor "stopped" → clicking the session
+						//     became a silent no-op. Users reported this as
+						//     "my tab went invalid when I came back to the
+						//     session" — it's the session, not the tab.
+						//   - openTab's `status !== "running"` guard refused
+						//     to attach on a perfectly healthy backend.
+						//
+						// Leave s.status alone; pull the authoritative status
+						// with refreshSessions() so the sidebar reflects
+						// whatever the backend actually says. Also tear down
+						// the dead terminal for this tab so a later click on
+						// its chip recreates a fresh WebSocket instead of
+						// re-activating a frozen pane. The tab itself stays
+						// in currentTabs (still a valid tmux session on the
+						// backend) so it remains reachable from the tab bar.
+						const entry = currentTerminals.get(tabId);
+						if (entry) {
+							// queueMicrotask so we don't dispose xterm
+							// synchronously inside its own ws.onclose
+							// callback chain.
+							queueMicrotask(() => {
+								const latest = currentTerminals.get(tabId);
+								if (!latest || latest !== entry) return;
+								latest.term.dispose();
+								latest.pane.remove();
+								currentTerminals.delete(tabId);
+								if (currentActiveTabId === tabId) {
+									currentActiveTabId = null;
+									terminalContainer.style.display = "none";
+									// refreshSessions() below will eventually round-trip
+									// and call updateToolbar(), but until that resolves
+									// the toolbar still shows the session name + status
+									// badge with no terminal beneath it. Match the rest
+									// of the codebase (closeTab, openSession's error
+									// paths) by syncing the toolbar to the new state
+									// synchronously — if the session was meanwhile
+									// dropped from sessions[] (rare, but possible if
+									// refreshSessions raced ahead), the empty-state
+									// panel takes over instead of an orphan toolbar.
+									updateToolbar();
+								}
+								renderTabBar();
+							});
+						}
+						void refreshSessions();
+						return;
+					}
 
-                                        // Backend-sourced status ("running" on attach). Only the
-                                        // active tab drives the shared session badge — a background
-                                        // tab's signal must not override the foreground view.
-                                        if (tabId !== currentActiveTabId) return;
-                                        const s = sessions.find((x) => x.sessionId === ownSessionId);
-                                        if (s) s.status = status;
-                                        updateToolbar();
-                                        renderSessionList();
-                                },
-                                onError: (msg: string) => {
-                                        // Same identity guard as onStatus: background tabs
-                                        // and post-session-switch WS errors must not surface
-                                        // toasts attributed to whatever session is current now.
-                                        if (activeSessionId !== ownSessionId) return;
-                                        showToast(msg, true);
-                                },
-                        });
-                        entry = { pane, term };
-                        currentTerminals.set(tabId, entry);
-                } catch (err) {
-                        pane.remove();
-                        if (prevActiveTabId) {
-                                currentTerminals.get(prevActiveTabId)?.pane.classList.add("active");
-                        }
-                        throw err;
-                }
-        }
+					// Backend-sourced status ("running" on attach). Only the
+					// active tab drives the shared session badge — a background
+					// tab's signal must not override the foreground view.
+					if (tabId !== currentActiveTabId) return;
+					const s = sessions.find((x) => x.sessionId === ownSessionId);
+					if (s) s.status = status;
+					updateToolbar();
+					renderSessionList();
+				},
+				onError: (msg: string) => {
+					// Same identity guard as onStatus: background tabs
+					// and post-session-switch WS errors must not surface
+					// toasts attributed to whatever session is current now.
+					if (activeSessionId !== ownSessionId) return;
+					showToast(msg, true);
+				},
+			});
+			entry = { pane, term };
+			currentTerminals.set(tabId, entry);
+		} catch (err) {
+			pane.remove();
+			if (prevActiveTabId) {
+				currentTerminals.get(prevActiveTabId)?.pane.classList.add("active");
+			}
+			throw err;
+		}
+	}
 
-        entry.pane.classList.add("active");
-        terminalContainer.style.display = "block";
-        currentActiveTabId = tabId;
-        renderTabBar();
+	entry.pane.classList.add("active");
+	terminalContainer.style.display = "block";
+	currentActiveTabId = tabId;
+	renderTabBar();
 }
 
 async function addTab(triggeredBy?: HTMLButtonElement) {
-        if (!activeSessionId) return;
-        const sessionId = activeSessionId;
-        const sessionName = sessions.find((x) => x.sessionId === sessionId)?.name ?? sessionId.slice(0, 8);
-        // Pre-check: don't create a backend tab we can't attach to. Matches
-        // openTab's own guard so this short-circuits before the POST. Treat
-        // "session missing from local list" as not-running too, matching both
-        // openTab and the post-check below.
-        const statusBefore = sessions.find((x) => x.sessionId === sessionId)?.status;
-        if (!statusBefore || statusBefore !== "running") {
-                showToast("Session isn't running — start it first", true);
-                return;
-        }
-        if (triggeredBy) triggeredBy.disabled = true;
-        try {
-                // Default label: smallest "Tab N" not already in use. Using
-                // `currentTabs.length + 1` would collide after a middle tab
-                // was closed (e.g. [Tab 1, Tab 3] + add → another "Tab 3").
-                const tab = await createTab(sessionId, nextDefaultLabel());
-                if (activeSessionId !== sessionId) {
-                        // User switched away before the POST resolved. The backend tab
-                        // exists but was never shown; clean it up so it doesn't resurface
-                        // on the next listTabs for that session. Fire-and-forget, but if
-                        // the cleanup fails surface a toast — include the owning session
-                        // name so the user knows WHICH session has the orphan, not just
-                        // whichever session happens to be active now.
-                        void deleteTab(sessionId, tab.tabId).catch((err) => {
-                                console.warn(`[tabs] orphan cleanup failed for ${tab.tabId}:`, err);
-                                showToast(`Orphan tab left on "${sessionName}": ${(err as Error).message}`, true);
-                        });
-                        return;
-                }
-                // Post-check: session may have stopped during the POST round-trip.
-                // openTab returns early (silent toast + return) on non-running
-                // sessions, which would otherwise leave us with currentTabs and
-                // a backend tab both pointing at an unattachable tmux session.
-                const statusAfter = sessions.find((x) => x.sessionId === sessionId)?.status;
-                if (!statusAfter || statusAfter !== "running") {
-                        void deleteTab(sessionId, tab.tabId).catch((err) => {
-                                console.warn(`[tabs] post-stop cleanup failed for ${tab.tabId}:`, err);
-                                showToast(`Orphan tab left on "${sessionName}": ${(err as Error).message}`, true);
-                        });
-                        showToast("Session stopped — tab discarded", true);
-                        return;
-                }
-                currentTabs.push(tab);
-                try {
-                        openTab(tab.tabId);
-                        // The tab-bar click listener auto-closes the chrome drawer
-                        // on chip clicks, but the + button is filtered out of that
-                        // path (it's not a chip yet at click time). Mirror the
-                        // behaviour here so adding a tab on mobile drops the user
-                        // straight into the new tmux pane instead of leaving the
-                        // drawer covering the top of the viewport.
-                        if (isMobile()) setChromeOpen(false);
-                } catch (err) {
-
-                        // Roll back the push so the chip doesn't linger pointing at a
-                        // tab with no currentTerminals entry, and clean up the backend
-                        // tab fire-and-forget since it was never actually shown.
-                        currentTabs = currentTabs.filter((t) => t.tabId !== tab.tabId);
-                        void deleteTab(sessionId, tab.tabId).catch((cleanupErr) => {
-                                console.warn(`[tabs] rollback cleanup failed for ${tab.tabId}:`, cleanupErr);
-                                showToast(`Orphan tab left on "${sessionName}": ${(cleanupErr as Error).message}`, true);
-                        });
-                        renderTabBar();
-                        throw err;
-                }
-        } catch (err) {
-                showToast((err as Error).message, true);
-        } finally {
-                // The inner-catch renderTabBar() rebuilds the + button, so the
-                // original triggeredBy may be detached by the time we get here.
-                if (triggeredBy?.isConnected) triggeredBy.disabled = false;
-        }
+	if (!activeSessionId) return;
+	const sessionId = activeSessionId;
+	const sessionName =
+		sessions.find((x) => x.sessionId === sessionId)?.name ?? sessionId.slice(0, 8);
+	// Pre-check: don't create a backend tab we can't attach to. Matches
+	// openTab's own guard so this short-circuits before the POST. Treat
+	// "session missing from local list" as not-running too, matching both
+	// openTab and the post-check below.
+	const statusBefore = sessions.find((x) => x.sessionId === sessionId)?.status;
+	if (!statusBefore || statusBefore !== "running") {
+		showToast("Session isn't running — start it first", true);
+		return;
+	}
+	if (triggeredBy) triggeredBy.disabled = true;
+	try {
+		// Default label: smallest "Tab N" not already in use. Using
+		// `currentTabs.length + 1` would collide after a middle tab
+		// was closed (e.g. [Tab 1, Tab 3] + add → another "Tab 3").
+		const tab = await createTab(sessionId, nextDefaultLabel());
+		if (activeSessionId !== sessionId) {
+			// User switched away before the POST resolved. The backend tab
+			// exists but was never shown; clean it up so it doesn't resurface
+			// on the next listTabs for that session. Fire-and-forget, but if
+			// the cleanup fails surface a toast — include the owning session
+			// name so the user knows WHICH session has the orphan, not just
+			// whichever session happens to be active now.
+			void deleteTab(sessionId, tab.tabId).catch((err) => {
+				console.warn(`[tabs] orphan cleanup failed for ${tab.tabId}:`, err);
+				showToast(`Orphan tab left on "${sessionName}": ${(err as Error).message}`, true);
+			});
+			return;
+		}
+		// Post-check: session may have stopped during the POST round-trip.
+		// openTab returns early (silent toast + return) on non-running
+		// sessions, which would otherwise leave us with currentTabs and
+		// a backend tab both pointing at an unattachable tmux session.
+		const statusAfter = sessions.find((x) => x.sessionId === sessionId)?.status;
+		if (!statusAfter || statusAfter !== "running") {
+			void deleteTab(sessionId, tab.tabId).catch((err) => {
+				console.warn(`[tabs] post-stop cleanup failed for ${tab.tabId}:`, err);
+				showToast(`Orphan tab left on "${sessionName}": ${(err as Error).message}`, true);
+			});
+			showToast("Session stopped — tab discarded", true);
+			return;
+		}
+		currentTabs.push(tab);
+		try {
+			openTab(tab.tabId);
+			// The tab-bar click listener auto-closes the chrome drawer
+			// on chip clicks, but the + button is filtered out of that
+			// path (it's not a chip yet at click time). Mirror the
+			// behaviour here so adding a tab on mobile drops the user
+			// straight into the new tmux pane instead of leaving the
+			// drawer covering the top of the viewport.
+			if (isMobile()) setChromeOpen(false);
+		} catch (err) {
+			// Roll back the push so the chip doesn't linger pointing at a
+			// tab with no currentTerminals entry, and clean up the backend
+			// tab fire-and-forget since it was never actually shown.
+			currentTabs = currentTabs.filter((t) => t.tabId !== tab.tabId);
+			void deleteTab(sessionId, tab.tabId).catch((cleanupErr) => {
+				console.warn(`[tabs] rollback cleanup failed for ${tab.tabId}:`, cleanupErr);
+				showToast(`Orphan tab left on "${sessionName}": ${(cleanupErr as Error).message}`, true);
+			});
+			renderTabBar();
+			throw err;
+		}
+	} catch (err) {
+		showToast((err as Error).message, true);
+	} finally {
+		// The inner-catch renderTabBar() rebuilds the + button, so the
+		// original triggeredBy may be detached by the time we get here.
+		if (triggeredBy?.isConnected) triggeredBy.disabled = false;
+	}
 }
 
 function nextDefaultLabel(): string {
-        const used = new Set(currentTabs.map((t) => t.label));
-        let n = 1;
-        while (used.has(`Tab ${n}`)) n++;
-        return `Tab ${n}`;
+	const used = new Set(currentTabs.map((t) => t.label));
+	let n = 1;
+	while (used.has(`Tab ${n}`)) n++;
+	return `Tab ${n}`;
 }
 
 async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
-        if (!activeSessionId) return;
-        const sessionId = activeSessionId;
-        if (closingTabs.has(tabId)) return; // duplicate invocation for same tab
-        const tabLabel = currentTabs.find((t) => t.tabId === tabId)?.label ?? tabId;
-        if (!confirm(`Close tab "${tabLabel}"?\n\nAny processes running in this tab will be terminated (SIGHUP).`)) {
-                return;
-        }
-        closingTabs.add(tabId);
-        // Re-render so sibling chips' × reflects the in-flight close (their
-        // disabled state mirrors the same guard).
-        renderTabBar();
-        if (triggeredBy) triggeredBy.disabled = true;
+	if (!activeSessionId) return;
+	const sessionId = activeSessionId;
+	if (closingTabs.has(tabId)) return; // duplicate invocation for same tab
+	const tabLabel = currentTabs.find((t) => t.tabId === tabId)?.label ?? tabId;
+	if (
+		!confirm(
+			`Close tab "${tabLabel}"?\n\nAny processes running in this tab will be terminated (SIGHUP).`,
+		)
+	) {
+		return;
+	}
+	closingTabs.add(tabId);
+	// Re-render so sibling chips' × reflects the in-flight close (their
+	// disabled state mirrors the same guard).
+	renderTabBar();
+	if (triggeredBy) triggeredBy.disabled = true;
 
-        try {
-                await deleteTab(sessionId, tabId);
-        } catch (err) {
-                // 404 means the backend already lost the tab (e.g. tmux server died).
-                // Drop the stale chip from the UI rather than leaving the user stuck
-                // with an unremovable phantom tab.
-                if (err instanceof TabNotFoundError) {
-                        // fall through to the success path below
-                } else {
-                        closingTabs.delete(tabId);
-                        renderTabBar();
-                        showToast((err as Error).message, true);
-                        if (triggeredBy?.isConnected) triggeredBy.disabled = false;
-                        return;
-                }
-        }
-        closingTabs.delete(tabId);
-        // Stale-session guard: renderTabBar() below rebuilds chips anyway, so
-        // the old `triggeredBy` becomes detached — no need to re-enable it.
-        if (activeSessionId !== sessionId) return;
+	try {
+		await deleteTab(sessionId, tabId);
+	} catch (err) {
+		// 404 means the backend already lost the tab (e.g. tmux server died).
+		// Drop the stale chip from the UI rather than leaving the user stuck
+		// with an unremovable phantom tab.
+		if (err instanceof TabNotFoundError) {
+			// fall through to the success path below
+		} else {
+			closingTabs.delete(tabId);
+			renderTabBar();
+			showToast((err as Error).message, true);
+			if (triggeredBy?.isConnected) triggeredBy.disabled = false;
+			return;
+		}
+	}
+	closingTabs.delete(tabId);
+	// Stale-session guard: renderTabBar() below rebuilds chips anyway, so
+	// the old `triggeredBy` becomes detached — no need to re-enable it.
+	if (activeSessionId !== sessionId) return;
 
-        const closedIndex = currentTabs.findIndex((t) => t.tabId === tabId);
-        const entry = currentTerminals.get(tabId);
-        if (entry) {
-                entry.term.dispose();
-                entry.pane.remove();
-                currentTerminals.delete(tabId);
-        }
-        currentTabs = currentTabs.filter((t) => t.tabId !== tabId);
+	const closedIndex = currentTabs.findIndex((t) => t.tabId === tabId);
+	const entry = currentTerminals.get(tabId);
+	if (entry) {
+		entry.term.dispose();
+		entry.pane.remove();
+		currentTerminals.delete(tabId);
+	}
+	currentTabs = currentTabs.filter((t) => t.tabId !== tabId);
 
-        // Closing the last tab on mobile leaves the chrome drawer collapsed
-        // (default state), and the CSS hides #terminal-tabs entirely while
-        // collapsed — so the + button rebuilt by renderTabBar() below isn't
-        // reachable until the user discovers the header pill. Mirror the
-        // openSession empty-tabs branch and auto-expand here too, so the
-        // first new tab is always one tap away.
-        if (isMobile() && currentTabs.length === 0) setChromeOpen(true);
+	// Closing the last tab on mobile leaves the chrome drawer collapsed
+	// (default state), and the CSS hides #terminal-tabs entirely while
+	// collapsed — so the + button rebuilt by renderTabBar() below isn't
+	// reachable until the user discovers the header pill. Mirror the
+	// openSession empty-tabs branch and auto-expand here too, so the
+	// first new tab is always one tap away.
+	if (isMobile() && currentTabs.length === 0) setChromeOpen(true);
 
-        if (currentActiveTabId === tabId) {
-
-                currentActiveTabId = null;
-                // Nearest surviving neighbour: what was at the same index is now
-                // the next sibling; clamp to the new last tab when we closed the
-                // rightmost one. If the tab wasn't in currentTabs at findIndex
-                // time (state drifted from under us), fall back to index 0.
-                const s = sessions.find((x) => x.sessionId === activeSessionId);
-                if (currentTabs.length > 0 && s?.status === "running") {
-                        const idx = closedIndex < 0
-                                ? 0
-                                : Math.min(closedIndex, currentTabs.length - 1);
-                        const next = currentTabs[idx];
-                        if (next) {
-                                // closeTab runs as `void`, so a sync throw from openTab
-                                // (openTerminalSession init failure) would be swallowed.
-                                // openTab's own prevActiveTabId restore is a no-op here
-                                // since the prev tab was just removed — recover directly.
-                                try {
-                                        openTab(next.tabId);
-                                        return;
-                                } catch (err) {
-                                        // Spell out the connection — the user sees a blank
-                                        // panel otherwise with no hint why.
-                                        showToast(`Couldn't switch to "${next.label}": ${(err as Error).message}`, true);
-                                        terminalContainer.style.display = "none";
-                                        renderTabBar();
-                                        return;
-                                }
-                        }
-                }
-                // No running sibling to switch to — hide the container so we
-                // don't leave an empty block sitting where the terminal was.
-                terminalContainer.style.display = "none";
-        }
-        renderTabBar();
+	if (currentActiveTabId === tabId) {
+		currentActiveTabId = null;
+		// Nearest surviving neighbour: what was at the same index is now
+		// the next sibling; clamp to the new last tab when we closed the
+		// rightmost one. If the tab wasn't in currentTabs at findIndex
+		// time (state drifted from under us), fall back to index 0.
+		const s = sessions.find((x) => x.sessionId === activeSessionId);
+		if (currentTabs.length > 0 && s?.status === "running") {
+			const idx = closedIndex < 0 ? 0 : Math.min(closedIndex, currentTabs.length - 1);
+			const next = currentTabs[idx];
+			if (next) {
+				// closeTab runs as `void`, so a sync throw from openTab
+				// (openTerminalSession init failure) would be swallowed.
+				// openTab's own prevActiveTabId restore is a no-op here
+				// since the prev tab was just removed — recover directly.
+				try {
+					openTab(next.tabId);
+					return;
+				} catch (err) {
+					// Spell out the connection — the user sees a blank
+					// panel otherwise with no hint why.
+					showToast(`Couldn't switch to "${next.label}": ${(err as Error).message}`, true);
+					terminalContainer.style.display = "none";
+					renderTabBar();
+					return;
+				}
+			}
+		}
+		// No running sibling to switch to — hide the container so we
+		// don't leave an empty block sitting where the terminal was.
+		terminalContainer.style.display = "none";
+	}
+	renderTabBar();
 }
 
 // ── New session ─────────────────────────────────────────────────────────────
 
 newSessionForm.addEventListener("submit", async (e) => {
-        e.preventDefault();
-        const name = newSessionInput.value.trim();
-        if (!name) return;
-        newSessionInput.value = "";
-        try {
-                showToast("Creating session…");
-                const session = await createSession(name);
-                sessions.unshift(session);
-                renderSessionList();
-                void openSession(session.sessionId);
-                showToast(`Session "${name}" created`);
-        } catch (err) {
-                showToast((err as Error).message, true);
-        }
+	e.preventDefault();
+	const name = newSessionInput.value.trim();
+	if (!name) return;
+	newSessionInput.value = "";
+	try {
+		showToast("Creating session…");
+		const session = await createSession(name);
+		sessions.unshift(session);
+		renderSessionList();
+		void openSession(session.sessionId);
+		showToast(`Session "${name}" created`);
+	} catch (err) {
+		showToast((err as Error).message, true);
+	}
 });
 
 // ── Toast ───────────────────────────────────────────────────────────────────
@@ -934,19 +959,19 @@ newSessionForm.addEventListener("submit", async (e) => {
 let toastTimer: ReturnType<typeof setTimeout> | null = null;
 
 function showToast(message: string, isError = false) {
-        toast.textContent = message;
-        toast.className = `visible${isError ? " error" : ""}`;
-        if (toastTimer) clearTimeout(toastTimer);
-        toastTimer = setTimeout(() => {
-                toast.className = "";
-        }, 4000);
+	toast.textContent = message;
+	toast.className = `visible${isError ? " error" : ""}`;
+	if (toastTimer) clearTimeout(toastTimer);
+	toastTimer = setTimeout(() => {
+		toast.className = "";
+	}, 4000);
 }
 
 // ── Show terminated toggle ──────────────────────────────────────────────────
 
 showTerminatedToggle.addEventListener("change", () => {
-        console.debug(`[sessions] show-terminated toggled → ${showTerminatedToggle.checked}`);
-        refreshSessions();
+	console.debug(`[sessions] show-terminated toggled → ${showTerminatedToggle.checked}`);
+	refreshSessions();
 });
 
 // ── Sidebar toggle ──────────────────────────────────────────────────────────
@@ -959,30 +984,30 @@ const mobileMql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX}px)`);
 const isMobile = () => mobileMql.matches;
 
 function setSidebarOpen(open: boolean) {
-        const wasOpen = mainEl.classList.contains("sidebar-open");
-        mainEl.classList.toggle("sidebar-open", open);
-        sidebarToggleBtn.setAttribute("aria-expanded", String(open));
+	const wasOpen = mainEl.classList.contains("sidebar-open");
+	mainEl.classList.toggle("sidebar-open", open);
+	sidebarToggleBtn.setAttribute("aria-expanded", String(open));
 
-        // Focus management is only meaningful on mobile, where the sidebar
-        // is a modal-style drawer — keyboard users opening it expect focus
-        // to land inside, and closing it should return focus to the toggle
-        // (only when focus was inside the drawer; otherwise the user has
-        // already moved on and we'd be stealing their focus).
-        if (!isMobile()) return;
-        if (open && !wasOpen) {
-                const firstFocusable = sidebarEl.querySelector<HTMLElement>(
-                        'input, button, a, [tabindex]:not([tabindex="-1"])',
-                );
-                firstFocusable?.focus();
-        } else if (!open && wasOpen) {
-                if (sidebarEl.contains(document.activeElement)) {
-                        sidebarToggleBtn.focus();
-                }
-        }
+	// Focus management is only meaningful on mobile, where the sidebar
+	// is a modal-style drawer — keyboard users opening it expect focus
+	// to land inside, and closing it should return focus to the toggle
+	// (only when focus was inside the drawer; otherwise the user has
+	// already moved on and we'd be stealing their focus).
+	if (!isMobile()) return;
+	if (open && !wasOpen) {
+		const firstFocusable = sidebarEl.querySelector<HTMLElement>(
+			'input, button, a, [tabindex]:not([tabindex="-1"])',
+		);
+		firstFocusable?.focus();
+	} else if (!open && wasOpen) {
+		if (sidebarEl.contains(document.activeElement)) {
+			sidebarToggleBtn.focus();
+		}
+	}
 }
 
 sidebarToggleBtn.addEventListener("click", () => {
-        setSidebarOpen(!mainEl.classList.contains("sidebar-open"));
+	setSidebarOpen(!mainEl.classList.contains("sidebar-open"));
 });
 
 sidebarBackdrop.addEventListener("click", () => setSidebarOpen(false));
@@ -994,22 +1019,27 @@ sidebarBackdrop.addEventListener("click", () => setSidebarOpen(false));
 // dialog, not every overlay at once. Without this guard, an Escape press
 // while paste/invites and the sidebar are both open would close both.
 document.addEventListener("keydown", (e) => {
-        if (e.key !== "Escape") return;
-        if (!isMobile()) return;
-        if (invitesModal.classList.contains("open") || pasteModal.classList.contains("open") || actionsMenu.classList.contains("open")) return;
-        if (!mainEl.classList.contains("sidebar-open")) return;
-        setSidebarOpen(false);
+	if (e.key !== "Escape") return;
+	if (!isMobile()) return;
+	if (
+		invitesModal.classList.contains("open") ||
+		pasteModal.classList.contains("open") ||
+		actionsMenu.classList.contains("open")
+	)
+		return;
+	if (!mainEl.classList.contains("sidebar-open")) return;
+	setSidebarOpen(false);
 });
 
 // On mobile, picking a session should dismiss the drawer so the user can
 // see the terminal — desktop keeps it pinned.
 sessionList.addEventListener("click", (e) => {
-        if (!isMobile()) return;
-        // Ignore clicks on action buttons (start/stop/delete) — those don't
-        // switch the active session, so dismissing the drawer is jarring.
-        const target = e.target as HTMLElement;
-        if (target.closest(".session-actions")) return;
-        if (target.closest(".session-item")) setSidebarOpen(false);
+	if (!isMobile()) return;
+	// Ignore clicks on action buttons (start/stop/delete) — those don't
+	// switch the active session, so dismissing the drawer is jarring.
+	const target = e.target as HTMLElement;
+	if (target.closest(".session-actions")) return;
+	if (target.closest(".session-item")) setSidebarOpen(false);
 });
 
 // Crossing the breakpoint resets to the default state for that mode —
@@ -1018,11 +1048,11 @@ sessionList.addEventListener("click", (e) => {
 // "show drawer"), and a mobile user who widens the window would find the
 // sidebar column pinned at 0 with no visible trigger to recover.
 mobileMql.addEventListener("change", () => {
-        setSidebarOpen(!isMobile());
-        // Re-derive the chrome drawer state too — desktop always wants it open
-        // (since the toolbar/tabs are part of the layout there), and mobile
-        // wants it closed unless the user is mid-onboarding (no tabs yet).
-        setChromeOpen(chromeDefaultOpen());
+	setSidebarOpen(!isMobile());
+	// Re-derive the chrome drawer state too — desktop always wants it open
+	// (since the toolbar/tabs are part of the layout there), and mobile
+	// wants it closed unless the user is mid-onboarding (no tabs yet).
+	setChromeOpen(chromeDefaultOpen());
 });
 
 // Default state: open on desktop, closed on mobile. The HTML+CSS start in
@@ -1039,18 +1069,18 @@ mainEl.setAttribute("data-sidebar-ready", "");
 // pattern: tap to expand, tap a tab to collapse again.
 
 function chromeDefaultOpen(): boolean {
-        // Desktop: always open — the layout includes the toolbar/tabs row.
-        if (!isMobile()) return true;
-        // Mobile + active session with no tabs: expand so the user can see
-        // the "+" button and create their first tab. Without this they'd
-        // land on a blank screen with no obvious way forward.
-        if (activeSessionId !== null && currentTabs.length === 0) return true;
-        return false;
+	// Desktop: always open — the layout includes the toolbar/tabs row.
+	if (!isMobile()) return true;
+	// Mobile + active session with no tabs: expand so the user can see
+	// the "+" button and create their first tab. Without this they'd
+	// land on a blank screen with no obvious way forward.
+	if (activeSessionId !== null && currentTabs.length === 0) return true;
+	return false;
 }
 
 function setChromeOpen(open: boolean) {
-        mainEl.classList.toggle("chrome-open", open);
-        chromeToggleBtn.setAttribute("aria-expanded", String(open));
+	mainEl.classList.toggle("chrome-open", open);
+	chromeToggleBtn.setAttribute("aria-expanded", String(open));
 }
 
 // Keep the header chrome-toggle's label in sync with the active session
@@ -1060,28 +1090,26 @@ function setChromeOpen(open: boolean) {
 // nothing to paste into or attach to when no session is active, so hide
 // both together.
 function updateChromeToggle() {
-        const s = sessions.find((x) => x.sessionId === activeSessionId);
-        // Hide the toggle entirely when there's no session — there's nothing
-        // for it to toggle, and the empty-state message in the terminal area
-        // already explains what to do next.
-        if (!s) {
-                chromeToggleBtn.hidden = true;
-                actionsBtn.hidden = true;
-                return;
-        }
-        chromeToggleBtn.hidden = false;
-        actionsBtn.hidden = false;
-        const activeTab = currentTabs.find((t) => t.tabId === currentActiveTabId);
-        // Format: "session › tab". Falls back to just the session name when
-        // no tab is active yet (fresh session, between switches). Using a
-        // thin space + chevron keeps it scannable on a 430-pt-wide screen.
-        chromeToggleLabel.textContent = activeTab
-                ? `${s.name} › ${activeTab.label}`
-                : s.name;
+	const s = sessions.find((x) => x.sessionId === activeSessionId);
+	// Hide the toggle entirely when there's no session — there's nothing
+	// for it to toggle, and the empty-state message in the terminal area
+	// already explains what to do next.
+	if (!s) {
+		chromeToggleBtn.hidden = true;
+		actionsBtn.hidden = true;
+		return;
+	}
+	chromeToggleBtn.hidden = false;
+	actionsBtn.hidden = false;
+	const activeTab = currentTabs.find((t) => t.tabId === currentActiveTabId);
+	// Format: "session › tab". Falls back to just the session name when
+	// no tab is active yet (fresh session, between switches). Using a
+	// thin space + chevron keeps it scannable on a 430-pt-wide screen.
+	chromeToggleLabel.textContent = activeTab ? `${s.name} › ${activeTab.label}` : s.name;
 }
 
 chromeToggleBtn.addEventListener("click", () => {
-        setChromeOpen(!mainEl.classList.contains("chrome-open"));
+	setChromeOpen(!mainEl.classList.contains("chrome-open"));
 });
 
 // On mobile, picking a tab from the chrome drawer is the user's signal
@@ -1091,14 +1119,14 @@ chromeToggleBtn.addEventListener("click", () => {
 // button are NOT collapse triggers: those are tweaks the user often
 // repeats in succession, and forcing a re-expand each time is annoying.
 terminalTabs.addEventListener("click", (e) => {
-        if (!isMobile()) return;
-        const target = e.target as HTMLElement;
-        // Ignore the × close button and the + add button — they're explicit
-        // affordances inside the chrome drawer that the user expects to stay
-        // accessible. Only collapse on a chip click (tab switch).
-        if (target.closest(".tab-close")) return;
-        if (target.closest("#tab-add")) return;
-        if (target.closest(".tab-chip")) setChromeOpen(false);
+	if (!isMobile()) return;
+	const target = e.target as HTMLElement;
+	// Ignore the × close button and the + add button — they're explicit
+	// affordances inside the chrome drawer that the user expects to stay
+	// accessible. Only collapse on a chip click (tab switch).
+	if (target.closest(".tab-close")) return;
+	if (target.closest("#tab-add")) return;
+	if (target.closest(".tab-chip")) setChromeOpen(false);
 });
 
 // Default chrome state — apply once, then defer to the per-action
@@ -1106,22 +1134,21 @@ terminalTabs.addEventListener("click", (e) => {
 setChromeOpen(chromeDefaultOpen());
 updateChromeToggle();
 
-
 // ── Font size cycle button ──────────────────────────────────────────────────
 
 function nextFontSize(current: number): number {
-        const i = FONT_SIZE_STEPS.indexOf(current);
-        if (i === -1) return DEFAULT_FONT_SIZE;
-        return FONT_SIZE_STEPS[(i + 1) % FONT_SIZE_STEPS.length]!;
+	const i = FONT_SIZE_STEPS.indexOf(current);
+	if (i === -1) return DEFAULT_FONT_SIZE;
+	return FONT_SIZE_STEPS[(i + 1) % FONT_SIZE_STEPS.length]!;
 }
 
 fontSizeBtn.addEventListener("click", () => {
-        currentFontSize = nextFontSize(currentFontSize);
-        localStorage.setItem(FONT_SIZE_KEY, String(currentFontSize));
-        fontSizeBtn.textContent = `Aa ${currentFontSize}`;
-        for (const { term } of currentTerminals.values()) {
-                term.setFontSize(currentFontSize);
-        }
+	currentFontSize = nextFontSize(currentFontSize);
+	localStorage.setItem(FONT_SIZE_KEY, String(currentFontSize));
+	fontSizeBtn.textContent = `Aa ${currentFontSize}`;
+	for (const { term } of currentTerminals.values()) {
+		term.setFontSize(currentFontSize);
+	}
 });
 // Reflect the persisted size in the label on load so users see e.g. "Aa 16"
 // rather than a generic "Aa" after they've picked their size once.
@@ -1137,154 +1164,156 @@ fontSizeBtn.textContent = `Aa ${currentFontSize}`;
 let invitesOpener: HTMLButtonElement | null = null;
 
 function openInvitesModal(opener: HTMLButtonElement) {
-        invitesOpener = opener;
-        invitesModal.classList.add("open");
-        invitesModal.setAttribute("aria-hidden", "false");
-        // Move focus into the dialog so a keyboard user activating the Invites
-        // button via Enter doesn't have their first Tab walk through the page
-        // behind the backdrop. Restored to invitesOpener on close.
-        inviteCreateBtn.focus();
-        void renderInvites();
+	invitesOpener = opener;
+	invitesModal.classList.add("open");
+	invitesModal.setAttribute("aria-hidden", "false");
+	// Move focus into the dialog so a keyboard user activating the Invites
+	// button via Enter doesn't have their first Tab walk through the page
+	// behind the backdrop. Restored to invitesOpener on close.
+	inviteCreateBtn.focus();
+	void renderInvites();
 }
 
 function closeInvitesModal() {
-        invitesModal.classList.remove("open");
-        invitesModal.setAttribute("aria-hidden", "true");
-        // Fall back to invitesBtn if the opener is missing (legacy path or
-        // a future caller that forgot to set it). On mobile invitesBtn is
-        // hidden, so a missing opener would still drop focus — but that's
-        // a regression to flag in code review, not something to silently
-        // paper over here.
-        (invitesOpener ?? invitesBtn).focus();
-        invitesOpener = null;
+	invitesModal.classList.remove("open");
+	invitesModal.setAttribute("aria-hidden", "true");
+	// Fall back to invitesBtn if the opener is missing (legacy path or
+	// a future caller that forgot to set it). On mobile invitesBtn is
+	// hidden, so a missing opener would still drop focus — but that's
+	// a regression to flag in code review, not something to silently
+	// paper over here.
+	(invitesOpener ?? invitesBtn).focus();
+	invitesOpener = null;
 }
 
-
 async function renderInvites() {
-        inviteList.textContent = "Loading…";
-        let invites: Invite[];
-        try {
-                invites = await listInvites();
-        } catch (err) {
-                inviteList.textContent = "";
-                showToast((err as Error).message, true);
-                return;
-        }
+	inviteList.textContent = "Loading…";
+	let invites: Invite[];
+	try {
+		invites = await listInvites();
+	} catch (err) {
+		inviteList.textContent = "";
+		showToast((err as Error).message, true);
+		return;
+	}
 
-        inviteList.textContent = "";
-        if (invites.length === 0) {
-                const empty = document.createElement("div");
-                empty.className = "invite-empty";
-                empty.textContent = "No invites yet — generate one above.";
-                inviteList.appendChild(empty);
-                return;
-        }
+	inviteList.textContent = "";
+	if (invites.length === 0) {
+		const empty = document.createElement("div");
+		empty.className = "invite-empty";
+		empty.textContent = "No invites yet — generate one above.";
+		inviteList.appendChild(empty);
+		return;
+	}
 
-        for (const invite of invites) {
-                const used = invite.usedAt !== null;
-                // expires_at is server-stored as "YYYY-MM-DD HH:MM:SS" UTC. Swap
-                // the space for "T" before appending "Z" so the result is valid
-                // ISO 8601 — Safari rejects the space-separated form and returns
-                // Invalid Date, which would silently misclassify expired invites
-                // as Unused.
-                const expired = !used && invite.expiresAt !== null
-                        && new Date(`${invite.expiresAt.replace(" ", "T")}Z`).getTime() <= Date.now();
-                const inert = used || expired;
-                const row = document.createElement("div");
-                row.className = `invite-row${inert ? " used" : ""}`;
+	for (const invite of invites) {
+		const used = invite.usedAt !== null;
+		// expires_at is server-stored as "YYYY-MM-DD HH:MM:SS" UTC. Swap
+		// the space for "T" before appending "Z" so the result is valid
+		// ISO 8601 — Safari rejects the space-separated form and returns
+		// Invalid Date, which would silently misclassify expired invites
+		// as Unused.
+		const expired =
+			!used &&
+			invite.expiresAt !== null &&
+			new Date(`${invite.expiresAt.replace(" ", "T")}Z`).getTime() <= Date.now();
+		const inert = used || expired;
+		const row = document.createElement("div");
+		row.className = `invite-row${inert ? " used" : ""}`;
 
-                const code = document.createElement("span");
-                code.className = "invite-code";
-                code.textContent = invite.code;
-                row.appendChild(code);
+		const code = document.createElement("span");
+		code.className = "invite-code";
+		code.textContent = invite.code;
+		row.appendChild(code);
 
-                const status = document.createElement("span");
-                status.className = `invite-status ${inert ? "used" : "unused"}`;
-                status.textContent = used ? "Used" : expired ? "Expired" : "Unused";
-                if (!used && !expired && invite.expiresAt) {
-                        status.title = `Expires ${invite.expiresAt} UTC`;
-                }
-                row.appendChild(status);
+		const status = document.createElement("span");
+		status.className = `invite-status ${inert ? "used" : "unused"}`;
+		status.textContent = used ? "Used" : expired ? "Expired" : "Unused";
+		if (!used && !expired && invite.expiresAt) {
+			status.title = `Expires ${invite.expiresAt} UTC`;
+		}
+		row.appendChild(status);
 
-                // Copy is only meaningful while the code can still be redeemed.
-                if (!inert) {
-                        const copyBtn = document.createElement("button");
-                        copyBtn.type = "button";
-                        copyBtn.className = "invite-action-btn";
-                        copyBtn.textContent = "Copy";
-                        copyBtn.addEventListener("click", async () => {
-                                try {
-                                        await navigator.clipboard.writeText(invite.code);
-                                        copyBtn.textContent = "Copied";
-                                        setTimeout(() => { copyBtn.textContent = "Copy"; }, 1500);
-                                } catch {
-                                        showToast("Couldn't copy — select the code manually", true);
-                                }
-                        });
-                        row.appendChild(copyBtn);
-                }
+		// Copy is only meaningful while the code can still be redeemed.
+		if (!inert) {
+			const copyBtn = document.createElement("button");
+			copyBtn.type = "button";
+			copyBtn.className = "invite-action-btn";
+			copyBtn.textContent = "Copy";
+			copyBtn.addEventListener("click", async () => {
+				try {
+					await navigator.clipboard.writeText(invite.code);
+					copyBtn.textContent = "Copied";
+					setTimeout(() => {
+						copyBtn.textContent = "Copy";
+					}, 1500);
+				} catch {
+					showToast("Couldn't copy — select the code manually", true);
+				}
+			});
+			row.appendChild(copyBtn);
+		}
 
-                // Revoke is offered for both unused and expired invites — the
-                // backend DELETE matches WHERE used_at IS NULL, so expired-but-
-                // unused codes can be cleared from the list. Quota slots are
-                // already auto-freed by the expiry filter on the COUNT subquery,
-                // so this is purely UI hygiene.
-                if (!used) {
-                        const revokeBtn = document.createElement("button");
-                        revokeBtn.type = "button";
-                        revokeBtn.className = "invite-action-btn revoke";
-                        revokeBtn.textContent = "Revoke";
-                        revokeBtn.addEventListener("click", async () => {
-                                if (!confirm(`Revoke invite "${invite.code}"?`)) return;
-                                revokeBtn.disabled = true;
-                                try {
-                                        await revokeInvite(invite.code);
-                                        await renderInvites();
-                                } catch (err) {
-                                        revokeBtn.disabled = false;
-                                        showToast((err as Error).message, true);
-                                }
-                        });
-                        row.appendChild(revokeBtn);
-                }
+		// Revoke is offered for both unused and expired invites — the
+		// backend DELETE matches WHERE used_at IS NULL, so expired-but-
+		// unused codes can be cleared from the list. Quota slots are
+		// already auto-freed by the expiry filter on the COUNT subquery,
+		// so this is purely UI hygiene.
+		if (!used) {
+			const revokeBtn = document.createElement("button");
+			revokeBtn.type = "button";
+			revokeBtn.className = "invite-action-btn revoke";
+			revokeBtn.textContent = "Revoke";
+			revokeBtn.addEventListener("click", async () => {
+				if (!confirm(`Revoke invite "${invite.code}"?`)) return;
+				revokeBtn.disabled = true;
+				try {
+					await revokeInvite(invite.code);
+					await renderInvites();
+				} catch (err) {
+					revokeBtn.disabled = false;
+					showToast((err as Error).message, true);
+				}
+			});
+			row.appendChild(revokeBtn);
+		}
 
-                inviteList.appendChild(row);
-        }
+		inviteList.appendChild(row);
+	}
 }
 
 invitesBtn.addEventListener("click", () => openInvitesModal(invitesBtn));
 sidebarInvitesBtn.addEventListener("click", () => openInvitesModal(sidebarInvitesBtn));
 
-
 inviteCreateBtn.addEventListener("click", async () => {
-        inviteCreateBtn.disabled = true;
-        try {
-                await createInvite();
-                await renderInvites();
-        } catch (err) {
-                showToast((err as Error).message, true);
-        } finally {
-                inviteCreateBtn.disabled = false;
-        }
+	inviteCreateBtn.disabled = true;
+	try {
+		await createInvite();
+		await renderInvites();
+	} catch (err) {
+		showToast((err as Error).message, true);
+	} finally {
+		inviteCreateBtn.disabled = false;
+	}
 });
 
 // data-close-modal lives on both the backdrop and the × button — one
 // listener handles both rather than wiring two element refs.
 invitesModal.addEventListener("click", (e) => {
-        const target = e.target as HTMLElement;
-        if (target.hasAttribute("data-close-modal")) closeInvitesModal();
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeInvitesModal();
 });
 
 document.addEventListener("keydown", (e) => {
-        if (e.key !== "Escape") return;
-        if (invitesModal.classList.contains("open")) {
-                closeInvitesModal();
-        } else if (pasteModal.classList.contains("open")) {
-                closePasteModal();
-        } else if (actionsMenu.classList.contains("open")) {
-                closeActionsMenu();
-                actionsBtn.focus();
-        }
+	if (e.key !== "Escape") return;
+	if (invitesModal.classList.contains("open")) {
+		closeInvitesModal();
+	} else if (pasteModal.classList.contains("open")) {
+		closePasteModal();
+	} else if (actionsMenu.classList.contains("open")) {
+		closeActionsMenu();
+		actionsBtn.focus();
+	}
 });
 
 // ── Paste modal ─────────────────────────────────────────────────────────────
@@ -1308,52 +1337,52 @@ const MAX_PASTE_CHARS = 65_536;
 let pasteOpener: HTMLButtonElement | null = null;
 
 function getActiveTerminal(): TerminalSession | null {
-        if (!currentActiveTabId) return null;
-        return currentTerminals.get(currentActiveTabId)?.term ?? null;
+	if (!currentActiveTabId) return null;
+	return currentTerminals.get(currentActiveTabId)?.term ?? null;
 }
 
 function openPasteModal(opener: HTMLButtonElement) {
-        pasteOpener = opener;
-        pasteModal.classList.add("open");
-        pasteModal.setAttribute("aria-hidden", "false");
-        pasteTextarea.value = "";
-        pasteSendBtn.disabled = true;
-        // Focus the textarea so the soft keyboard pops and a long-press
-        // immediately offers Paste — saves the user one tap.
-        pasteTextarea.focus();
+	pasteOpener = opener;
+	pasteModal.classList.add("open");
+	pasteModal.setAttribute("aria-hidden", "false");
+	pasteTextarea.value = "";
+	pasteSendBtn.disabled = true;
+	// Focus the textarea so the soft keyboard pops and a long-press
+	// immediately offers Paste — saves the user one tap.
+	pasteTextarea.focus();
 }
 
 function closePasteModal() {
-        pasteModal.classList.remove("open");
-        pasteModal.setAttribute("aria-hidden", "true");
-        pasteTextarea.value = "";
-        pasteSendBtn.disabled = true;
-        // Release the runPasteFlow in-flight guard. The flow intentionally
-        // leaves it set on the modal-open path so a second tap can't kick
-        // off a parallel readClipboardText() while the modal is open;
-        // closure of the modal is the signal that the cycle is truly
-        // finished.
-        pasteInFlight = false;
-        // Restore focus to the opener — typically actionsBtn, which is
-        // visible whenever a session is active. If it's somehow gone the
-        // focus call is a harmless no-op.
-        pasteOpener?.focus();
-        pasteOpener = null;
+	pasteModal.classList.remove("open");
+	pasteModal.setAttribute("aria-hidden", "true");
+	pasteTextarea.value = "";
+	pasteSendBtn.disabled = true;
+	// Release the runPasteFlow in-flight guard. The flow intentionally
+	// leaves it set on the modal-open path so a second tap can't kick
+	// off a parallel readClipboardText() while the modal is open;
+	// closure of the modal is the signal that the cycle is truly
+	// finished.
+	pasteInFlight = false;
+	// Restore focus to the opener — typically actionsBtn, which is
+	// visible whenever a session is active. If it's somehow gone the
+	// focus call is a harmless no-op.
+	pasteOpener?.focus();
+	pasteOpener = null;
 }
 
 async function readClipboardText(): Promise<string | null> {
-        // navigator.clipboard.readText is the silent path. Returns null when
-        // the API is unavailable, rejected (permission denied / in-app
-        // webview), or throws synchronously on browsers that ship the API
-        // gated on a secure context they don't recognise.
-        if (!navigator.clipboard || typeof navigator.clipboard.readText !== "function") {
-                return null;
-        }
-        try {
-                return await navigator.clipboard.readText();
-        } catch {
-                return null;
-        }
+	// navigator.clipboard.readText is the silent path. Returns null when
+	// the API is unavailable, rejected (permission denied / in-app
+	// webview), or throws synchronously on browsers that ship the API
+	// gated on a secure context they don't recognise.
+	if (!navigator.clipboard || typeof navigator.clipboard.readText !== "function") {
+		return null;
+	}
+	try {
+		return await navigator.clipboard.readText();
+	} catch {
+		return null;
+	}
 }
 
 // Guards against two distinct races:
@@ -1372,104 +1401,104 @@ async function readClipboardText(): Promise<string | null> {
 let pasteInFlight = false;
 
 async function runPasteFlow(opener: HTMLButtonElement) {
-        if (pasteInFlight) return;
-        pasteInFlight = true;
-        let releaseGuard = true;
-        try {
-                const term = getActiveTerminal();
-                if (!term) {
-                        showToast("No active session", true);
-                        return;
-                }
-                const clip = await readClipboardText();
-                // Empty string is treated the same as null. iOS Safari can
-                // resolve readText() with "" when the user dismisses or
-                // never engages with the system "Paste" consent chip — even
-                // if the clipboard genuinely has content. Treating that as
-                // success would dead-end the user with a misleading
-                // "clipboard empty" toast; falling through to the modal
-                // gives them a long-press path that always works.
-                if (clip) {
-                        if (clip.length > MAX_PASTE_CHARS) {
-                                showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
-                                return;
-                        }
-                        term.paste(clip);
-                        showToast(`Pasted ${clip.length} character${clip.length === 1 ? "" : "s"}`);
-                        return;
-                }
-                // Clipboard API unavailable, denied, or returned empty —
-                // surface the manual fallback. Hand the guard ownership to
-                // closePasteModal so the second-tap protection covers the
-                // entire modal lifetime, not just the synchronous tail of
-                // this handler.
-                openPasteModal(opener);
-                releaseGuard = false;
-        } finally {
-                if (releaseGuard) pasteInFlight = false;
-        }
+	if (pasteInFlight) return;
+	pasteInFlight = true;
+	let releaseGuard = true;
+	try {
+		const term = getActiveTerminal();
+		if (!term) {
+			showToast("No active session", true);
+			return;
+		}
+		const clip = await readClipboardText();
+		// Empty string is treated the same as null. iOS Safari can
+		// resolve readText() with "" when the user dismisses or
+		// never engages with the system "Paste" consent chip — even
+		// if the clipboard genuinely has content. Treating that as
+		// success would dead-end the user with a misleading
+		// "clipboard empty" toast; falling through to the modal
+		// gives them a long-press path that always works.
+		if (clip) {
+			if (clip.length > MAX_PASTE_CHARS) {
+				showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
+				return;
+			}
+			term.paste(clip);
+			showToast(`Pasted ${clip.length} character${clip.length === 1 ? "" : "s"}`);
+			return;
+		}
+		// Clipboard API unavailable, denied, or returned empty —
+		// surface the manual fallback. Hand the guard ownership to
+		// closePasteModal so the second-tap protection covers the
+		// entire modal lifetime, not just the synchronous tail of
+		// this handler.
+		openPasteModal(opener);
+		releaseGuard = false;
+	} finally {
+		if (releaseGuard) pasteInFlight = false;
+	}
 }
 
 pasteClipboardBtn.addEventListener("click", async () => {
-        // Disable for the duration of the async readText() so a double-tap on
-        // a slow iOS consent chip doesn't queue a stale second resolve. Same
-        // intent as the runPasteFlow pasteInFlight guard, just expressed via
-        // the button's own disabled state since there's nowhere visual to
-        // look for in-flight feedback otherwise.
-        pasteClipboardBtn.disabled = true;
-        try {
-                const clip = await readClipboardText();
-                // Collapse null and "" — both mean "we couldn't get usable
-                // clipboard text". null = API unavailable/denied. "" = iOS
-                // resolved without engaging the consent chip, OR the
-                // clipboard genuinely is empty. Either way the textarea
-                // (long-press fallback) is the right next step. The toast
-                // covers both interpretations because we can't distinguish
-                // them: iOS doesn't tell us which "" we got.
-                if (!clip) {
-                        showToast("Clipboard is empty or couldn't be read — long-press to paste manually", true);
-                        return;
-                }
-                if (clip.length > MAX_PASTE_CHARS) {
-                        showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
-                        return;
-                }
-                pasteTextarea.value = clip;
-                pasteSendBtn.disabled = false;
-                pasteTextarea.focus();
-        } finally {
-                pasteClipboardBtn.disabled = false;
-        }
+	// Disable for the duration of the async readText() so a double-tap on
+	// a slow iOS consent chip doesn't queue a stale second resolve. Same
+	// intent as the runPasteFlow pasteInFlight guard, just expressed via
+	// the button's own disabled state since there's nowhere visual to
+	// look for in-flight feedback otherwise.
+	pasteClipboardBtn.disabled = true;
+	try {
+		const clip = await readClipboardText();
+		// Collapse null and "" — both mean "we couldn't get usable
+		// clipboard text". null = API unavailable/denied. "" = iOS
+		// resolved without engaging the consent chip, OR the
+		// clipboard genuinely is empty. Either way the textarea
+		// (long-press fallback) is the right next step. The toast
+		// covers both interpretations because we can't distinguish
+		// them: iOS doesn't tell us which "" we got.
+		if (!clip) {
+			showToast("Clipboard is empty or couldn't be read — long-press to paste manually", true);
+			return;
+		}
+		if (clip.length > MAX_PASTE_CHARS) {
+			showToast(`Clipboard too large (${clip.length} chars; max ${MAX_PASTE_CHARS})`, true);
+			return;
+		}
+		pasteTextarea.value = clip;
+		pasteSendBtn.disabled = false;
+		pasteTextarea.focus();
+	} finally {
+		pasteClipboardBtn.disabled = false;
+	}
 });
 
 pasteTextarea.addEventListener("input", () => {
-        pasteSendBtn.disabled = pasteTextarea.value.length === 0;
+	pasteSendBtn.disabled = pasteTextarea.value.length === 0;
 });
 
 pasteSendBtn.addEventListener("click", () => {
-        const text = pasteTextarea.value;
-        if (!text) return;
-        // Defence in depth — HTML maxlength gates user typing but not
-        // programmatic value sets, so a clipboard-fill of >65 KB could
-        // sneak past it before this point.
-        if (text.length > MAX_PASTE_CHARS) {
-                showToast(`Too large (${text.length} chars; max ${MAX_PASTE_CHARS})`, true);
-                return;
-        }
-        const term = getActiveTerminal();
-        if (!term) {
-                showToast("No active session", true);
-                closePasteModal();
-                return;
-        }
-        term.paste(text);
-        showToast(`Pasted ${text.length} character${text.length === 1 ? "" : "s"}`);
-        closePasteModal();
+	const text = pasteTextarea.value;
+	if (!text) return;
+	// Defence in depth — HTML maxlength gates user typing but not
+	// programmatic value sets, so a clipboard-fill of >65 KB could
+	// sneak past it before this point.
+	if (text.length > MAX_PASTE_CHARS) {
+		showToast(`Too large (${text.length} chars; max ${MAX_PASTE_CHARS})`, true);
+		return;
+	}
+	const term = getActiveTerminal();
+	if (!term) {
+		showToast("No active session", true);
+		closePasteModal();
+		return;
+	}
+	term.paste(text);
+	showToast(`Pasted ${text.length} character${text.length === 1 ? "" : "s"}`);
+	closePasteModal();
 });
 
 pasteModal.addEventListener("click", (e) => {
-        const target = e.target as HTMLElement;
-        if (target.hasAttribute("data-close-modal")) closePasteModal();
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closePasteModal();
 });
 
 // ── Actions (+) menu ────────────────────────────────────────────────────────
@@ -1478,142 +1507,140 @@ pasteModal.addEventListener("click", (e) => {
 // supporting more than one command from a single header button.
 
 function openActionsMenu() {
-        actionsMenu.classList.add("open");
-        actionsMenu.setAttribute("aria-hidden", "false");
-        actionsBtn.setAttribute("aria-expanded", "true");
-        actionsPasteBtn.focus();
+	actionsMenu.classList.add("open");
+	actionsMenu.setAttribute("aria-hidden", "false");
+	actionsBtn.setAttribute("aria-expanded", "true");
+	actionsPasteBtn.focus();
 }
 
 function closeActionsMenu() {
-        actionsMenu.classList.remove("open");
-        actionsMenu.setAttribute("aria-hidden", "true");
-        actionsBtn.setAttribute("aria-expanded", "false");
+	actionsMenu.classList.remove("open");
+	actionsMenu.setAttribute("aria-hidden", "true");
+	actionsBtn.setAttribute("aria-expanded", "false");
 }
 
 actionsBtn.addEventListener("click", () => {
-        if (actionsMenu.classList.contains("open")) {
-                closeActionsMenu();
-                actionsBtn.focus();
-        } else {
-                openActionsMenu();
-        }
+	if (actionsMenu.classList.contains("open")) {
+		closeActionsMenu();
+		actionsBtn.focus();
+	} else {
+		openActionsMenu();
+	}
 });
 
 actionsMenu.addEventListener("click", (e) => {
-        const target = e.target as HTMLElement;
-        if (target.hasAttribute("data-close-modal")) {
-                closeActionsMenu();
-                actionsBtn.focus();
-        }
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) {
+		closeActionsMenu();
+		actionsBtn.focus();
+	}
 });
 
 actionsPasteBtn.addEventListener("click", async () => {
-        closeActionsMenu();
-        // actionsBtn is the visible widget the user tapped first; route focus
-        // back to it when the paste modal eventually closes.
-        await runPasteFlow(actionsBtn);
+	closeActionsMenu();
+	// actionsBtn is the visible widget the user tapped first; route focus
+	// back to it when the paste modal eventually closes.
+	await runPasteFlow(actionsBtn);
 });
 
 actionsAttachBtn.addEventListener("click", () => {
-        closeActionsMenu();
-        // Reset the input so picking the same file twice in a row still
-        // fires `change` (browsers no-op when value is unchanged).
-        fileInput.value = "";
-        fileInput.click();
+	closeActionsMenu();
+	// Reset the input so picking the same file twice in a row still
+	// fires `change` (browsers no-op when value is unchanged).
+	fileInput.value = "";
+	fileInput.click();
 });
 
 // ── File attachment flow ────────────────────────────────────────────────────
 // Upload via multipart, then type the in-container paths into the active
 // terminal so the user can keep typing their prompt around them.
 
-const MAX_ATTACH_FILES = 8;        // mirrors backend multer cap
+const MAX_ATTACH_FILES = 8; // mirrors backend multer cap
 const MAX_ATTACH_BYTES = 25 * 1024 * 1024; // mirrors backend per-file cap
 
 let attachInFlight = false;
 
 fileInput.addEventListener("change", async () => {
-        const picked = Array.from(fileInput.files ?? []);
-        // Clear immediately so a re-pick of the same files still triggers change.
-        fileInput.value = "";
-        if (picked.length === 0) return;
-        if (attachInFlight) {
-                // Without the toast the picker silently closes and nothing
-                // happens — the prior "Uploading…" toast may have already
-                // scrolled away, so the user has no feedback.
-                showToast("Upload in progress, try again shortly", true);
-                return;
-        }
-        attachInFlight = true;
-        // Every `return` inside this try { } is covered by the finally below
-        // that resets attachInFlight — including the early validation
-        // returns. Don't move attachInFlight = false above the try or
-        // duplicate it on each early return; the finally is the single
-        // release point.
-        try {
-                if (!activeSessionId) {
-                        showToast("No active session", true);
-                        return;
-                }
-                // Snapshot the id before any await so a session-switch or
-                // logout that flips activeSessionId mid-upload doesn't end
-                // up POSTing to /sessions/null/files. Same pattern as
-                // addTab and openSession.
-                const sessionId = activeSessionId;
-                if (picked.length > MAX_ATTACH_FILES) {
-                        showToast(`Too many files (${picked.length}; max ${MAX_ATTACH_FILES})`, true);
-                        return;
-                }
-                const oversized = picked.find((f) => f.size > MAX_ATTACH_BYTES);
-                if (oversized) {
-                        const mb = (oversized.size / (1024 * 1024)).toFixed(1);
-                        showToast(`"${oversized.name}" is ${mb} MB — files must be ≤25 MB`, true);
-                        return;
-                }
-                showToast(`Uploading ${picked.length} file${picked.length === 1 ? "" : "s"}…`);
-                let result: { paths: string[] };
-                try {
-                        result = await uploadSessionFiles(sessionId, picked);
-                } catch (err) {
-                        showToast(`Upload failed: ${(err as Error).message}`, true);
-                        return;
-                }
-                // Re-check identity post-await: if the user switched away
-                // from this session while the upload was in flight, pasting
-                // its paths into whatever terminal they're now looking at
-                // would silently inject foreign-session paths into their
-                // current command. Mirrors the same guard pattern used in
-                // addTab/openSession/closeTab. The files still landed in
-                // session A's workspace; the user can switch back and
-                // reference them manually.
-                if (activeSessionId !== sessionId) {
-                        showToast(`Uploaded ${result.paths.length} to the previous session`);
-                        return;
-                }
-                const term = getActiveTerminal();
-                if (term && result.paths.length > 0) {
-                        // Quote any path containing whitespace — the sanitiser shouldn't
-                        // produce one, but the user pastes this directly into the shell.
-                        // Trailing space lets them keep typing immediately after.
-                        const inserted = result.paths
-                                .map((p) => (/\s/.test(p) ? `"${p}"` : p))
-                                .join(" ") + " ";
-                        term.paste(inserted);
-                        showToast(`Attached ${result.paths.length} file${result.paths.length === 1 ? "" : "s"}`);
-                } else {
-                        // Container isn't running, so there's nothing to type into. The
-                        // files still land in the workspace and survive a /start, so the
-                        // user can reference them later.
-                        showToast(`Uploaded ${result.paths.length}; start the session to use them`);
-                }
-        } finally {
-                attachInFlight = false;
-        }
+	const picked = Array.from(fileInput.files ?? []);
+	// Clear immediately so a re-pick of the same files still triggers change.
+	fileInput.value = "";
+	if (picked.length === 0) return;
+	if (attachInFlight) {
+		// Without the toast the picker silently closes and nothing
+		// happens — the prior "Uploading…" toast may have already
+		// scrolled away, so the user has no feedback.
+		showToast("Upload in progress, try again shortly", true);
+		return;
+	}
+	attachInFlight = true;
+	// Every `return` inside this try { } is covered by the finally below
+	// that resets attachInFlight — including the early validation
+	// returns. Don't move attachInFlight = false above the try or
+	// duplicate it on each early return; the finally is the single
+	// release point.
+	try {
+		if (!activeSessionId) {
+			showToast("No active session", true);
+			return;
+		}
+		// Snapshot the id before any await so a session-switch or
+		// logout that flips activeSessionId mid-upload doesn't end
+		// up POSTing to /sessions/null/files. Same pattern as
+		// addTab and openSession.
+		const sessionId = activeSessionId;
+		if (picked.length > MAX_ATTACH_FILES) {
+			showToast(`Too many files (${picked.length}; max ${MAX_ATTACH_FILES})`, true);
+			return;
+		}
+		const oversized = picked.find((f) => f.size > MAX_ATTACH_BYTES);
+		if (oversized) {
+			const mb = (oversized.size / (1024 * 1024)).toFixed(1);
+			showToast(`"${oversized.name}" is ${mb} MB — files must be ≤25 MB`, true);
+			return;
+		}
+		showToast(`Uploading ${picked.length} file${picked.length === 1 ? "" : "s"}…`);
+		let result: { paths: string[] };
+		try {
+			result = await uploadSessionFiles(sessionId, picked);
+		} catch (err) {
+			showToast(`Upload failed: ${(err as Error).message}`, true);
+			return;
+		}
+		// Re-check identity post-await: if the user switched away
+		// from this session while the upload was in flight, pasting
+		// its paths into whatever terminal they're now looking at
+		// would silently inject foreign-session paths into their
+		// current command. Mirrors the same guard pattern used in
+		// addTab/openSession/closeTab. The files still landed in
+		// session A's workspace; the user can switch back and
+		// reference them manually.
+		if (activeSessionId !== sessionId) {
+			showToast(`Uploaded ${result.paths.length} to the previous session`);
+			return;
+		}
+		const term = getActiveTerminal();
+		if (term && result.paths.length > 0) {
+			// Quote any path containing whitespace — the sanitiser shouldn't
+			// produce one, but the user pastes this directly into the shell.
+			// Trailing space lets them keep typing immediately after.
+			const inserted = `${result.paths.map((p) => (/\s/.test(p) ? `"${p}"` : p)).join(" ")} `;
+			term.paste(inserted);
+			showToast(`Attached ${result.paths.length} file${result.paths.length === 1 ? "" : "s"}`);
+		} else {
+			// Container isn't running, so there's nothing to type into. The
+			// files still land in the workspace and survive a /start, so the
+			// user can reference them later.
+			showToast(`Uploaded ${result.paths.length}; start the session to use them`);
+		}
+	} finally {
+		attachInFlight = false;
+	}
 });
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────
 
 setInterval(() => {
-        if (isLoggedIn()) refreshSessions();
+	if (isLoggedIn()) refreshSessions();
 }, 15_000);
 
 // ── Init ────────────────────────────────────────────────────────────────────

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -2,486 +2,501 @@
  * terminal.ts — xterm.js wrapper with WebSocket bridge to Docker exec.
  */
 
-import { Terminal, ILink, ILinkProvider, IDisposable } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { type IDisposable, type ILink, type ILinkProvider, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { getToken } from "./api.js";
 
 export type SessionStatus = "running" | "stopped" | "terminated" | "disconnected";
 
 export interface TerminalSession {
-        dispose(): void;
-        setFontSize(px: number): void;
-        paste(text: string): void;
+	dispose(): void;
+	setFontSize(px: number): void;
+	paste(text: string): void;
 }
 
 export type StatusCallback = (status: SessionStatus) => void;
 export type ErrorCallback = (message: string) => void;
 
 export function openTerminalSession(opts: {
-        container: HTMLElement;
-        sessionId: string;
-        tabId?: string;
-        fontSize?: number;
-        onStatus: StatusCallback;
-        onError: ErrorCallback;
+	container: HTMLElement;
+	sessionId: string;
+	tabId?: string;
+	fontSize?: number;
+	onStatus: StatusCallback;
+	onError: ErrorCallback;
 }): TerminalSession {
-        const { container, sessionId, tabId, fontSize, onStatus, onError } = opts;
+	const { container, sessionId, tabId, fontSize, onStatus, onError } = opts;
 
-        // ── xterm.js setup ──────────────────────────────────────────────────────
-        const term = new Terminal({
-                theme: {
-                        background: "#0d1117",
-                        foreground: "#e6edf3",
-                        cursor: "#58a6ff",
-                        selectionBackground: "#264f78",
-                },
-                fontFamily: '"Cascadia Code", "Fira Code", "JetBrains Mono", "Monaco", "Courier New", monospace',
-                fontSize: fontSize ?? 14,
-                lineHeight: 1.2,
-                cursorBlink: true,
-                cursorInactiveStyle: "outline",
-                convertEol: true,
-                allowProposedApi: true,
-                // Apps like Claude Code emit OSC 8 hyperlink escapes. xterm renders
-                // them (underline + pointer cursor) but needs an explicit handler
-                // to actually open them on click.
-                linkHandler: {
-                        activate(event, uri) {
-                                event.preventDefault();
-                                window.open(uri, "_blank", "noopener,noreferrer");
-                        },
-                        allowNonHttpProtocols: false,
-                },
-                scrollback: 5000,
-        });
+	// ── xterm.js setup ──────────────────────────────────────────────────────
+	const term = new Terminal({
+		theme: {
+			background: "#0d1117",
+			foreground: "#e6edf3",
+			cursor: "#58a6ff",
+			selectionBackground: "#264f78",
+		},
+		fontFamily:
+			'"Cascadia Code", "Fira Code", "JetBrains Mono", "Monaco", "Courier New", monospace',
+		fontSize: fontSize ?? 14,
+		lineHeight: 1.2,
+		cursorBlink: true,
+		cursorInactiveStyle: "outline",
+		convertEol: true,
+		allowProposedApi: true,
+		// Apps like Claude Code emit OSC 8 hyperlink escapes. xterm renders
+		// them (underline + pointer cursor) but needs an explicit handler
+		// to actually open them on click.
+		linkHandler: {
+			activate(event, uri) {
+				event.preventDefault();
+				window.open(uri, "_blank", "noopener,noreferrer");
+			},
+			allowNonHttpProtocols: false,
+		},
+		scrollback: 5000,
+	});
 
-        const fitAddon = new FitAddon();
-        term.loadAddon(fitAddon);
-        term.open(container);
+	const fitAddon = new FitAddon();
+	term.loadAddon(fitAddon);
+	term.open(container);
 
-        // Touch-action none so the OS doesn't eat vertical drags as page-scroll
-        // — our touch handler below routes them into terminal scroll instead.
-        container.style.touchAction = "none";
+	// Touch-action none so the OS doesn't eat vertical drags as page-scroll
+	// — our touch handler below routes them into terminal scroll instead.
+	container.style.touchAction = "none";
 
-        // ── WebGL renderer ──────────────────────────────────────────────────────
-        // WebGL avoids the DOM renderer's visibility-loss glitches (rows written
-        // while a tab is hidden drop out of the paint). Activate after open so
-        // the canvas exists. If the GPU driver revokes the context we dispose
-        // the addon and xterm silently falls back to the DOM renderer.
-        let webgl: WebglAddon | null = null;
-        try {
-                webgl = new WebglAddon();
-                webgl.onContextLoss(() => {
-                        webgl?.dispose();
-                        webgl = null;
-                });
-                term.loadAddon(webgl);
-        } catch (err) {
-                console.warn("[terminal] WebGL renderer unavailable, falling back to DOM:", err);
-                webgl = null;
-        }
+	// ── WebGL renderer ──────────────────────────────────────────────────────
+	// WebGL avoids the DOM renderer's visibility-loss glitches (rows written
+	// while a tab is hidden drop out of the paint). Activate after open so
+	// the canvas exists. If the GPU driver revokes the context we dispose
+	// the addon and xterm silently falls back to the DOM renderer.
+	let webgl: WebglAddon | null = null;
+	try {
+		webgl = new WebglAddon();
+		webgl.onContextLoss(() => {
+			webgl?.dispose();
+			webgl = null;
+		});
+		term.loadAddon(webgl);
+	} catch (err) {
+		console.warn("[terminal] WebGL renderer unavailable, falling back to DOM:", err);
+		webgl = null;
+	}
 
-        // webglcontextlost bubbles; webglcontextrestored does not — listen on the
-        // canvas obtained from the loss event's target.
-        let pendingRestoreCanvas: HTMLCanvasElement | null = null;
-        const onContextRestored = () => {
-                // Don't load a second addon while one is already live (prior loss handler nulls webgl).
-                if (webgl) return;
-                pendingRestoreCanvas = null;
-                // The let/const split is deliberate. `restoredAddon` (let, outer) is
-                // the catch-block's only handle for disposing a partially-initialised
-                // addon if `term.loadAddon(addon)` throws after construction —
-                // otherwise the just-allocated WebGL context would leak. `addon`
-                // (const, inner) is what the onContextLoss closure binds to: a
-                // const here keeps the closure immune to a future refactor that
-                // reassigns `restoredAddon` between construction and the closure
-                // firing, which would otherwise have the closure dispose the wrong
-                // addon. Both bindings point at the same object on the success path;
-                // they only diverge on the partial-failure path. Don't collapse them.
-                let restoredAddon: WebglAddon | undefined;
-                try {
-                        const addon = new WebglAddon();
-                        restoredAddon = addon;
-                        addon.onContextLoss(() => { addon.dispose(); webgl = null; });
-                        term.loadAddon(addon);
-                        webgl = addon;
-                        console.debug("[terminal] WebGL context restored, re-enabled GPU renderer");
-                } catch (err) {
-                        restoredAddon?.dispose();
-                        console.warn("[terminal] WebGL restore failed:", err);
-                }
-        };
-        const onContextLost = (ev: Event) => {
-                if (!(ev.target instanceof HTMLCanvasElement)) return;
-                pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
-                pendingRestoreCanvas = ev.target;
-                pendingRestoreCanvas.addEventListener("webglcontextrestored", onContextRestored, { once: true });
-        };
-        // Listener is registered unconditionally. The cost is one no-op
-        // attach when WebGL never initialised (no canvas under `container`
-        // ever fires webglcontextlost), but in exchange a future code path
-        // that hot-swaps the renderer — disposing the addon and replacing it
-        // without a full navigate-away — gets the loss/restore plumbing
-        // already wired for free, instead of having to re-register the
-        // listener from inside that swap. The dispose path was already
-        // unconditional, so the symmetry is now properly established.
-        container.addEventListener("webglcontextlost", onContextLost);
+	// webglcontextlost bubbles; webglcontextrestored does not — listen on the
+	// canvas obtained from the loss event's target.
+	let pendingRestoreCanvas: HTMLCanvasElement | null = null;
+	const onContextRestored = () => {
+		// Don't load a second addon while one is already live (prior loss handler nulls webgl).
+		if (webgl) return;
+		pendingRestoreCanvas = null;
+		// The let/const split is deliberate. `restoredAddon` (let, outer) is
+		// the catch-block's only handle for disposing a partially-initialised
+		// addon if `term.loadAddon(addon)` throws after construction —
+		// otherwise the just-allocated WebGL context would leak. `addon`
+		// (const, inner) is what the onContextLoss closure binds to: a
+		// const here keeps the closure immune to a future refactor that
+		// reassigns `restoredAddon` between construction and the closure
+		// firing, which would otherwise have the closure dispose the wrong
+		// addon. Both bindings point at the same object on the success path;
+		// they only diverge on the partial-failure path. Don't collapse them.
+		let restoredAddon: WebglAddon | undefined;
+		try {
+			const addon = new WebglAddon();
+			restoredAddon = addon;
+			addon.onContextLoss(() => {
+				addon.dispose();
+				webgl = null;
+			});
+			term.loadAddon(addon);
+			webgl = addon;
+			console.debug("[terminal] WebGL context restored, re-enabled GPU renderer");
+		} catch (err) {
+			restoredAddon?.dispose();
+			console.warn("[terminal] WebGL restore failed:", err);
+		}
+	};
+	const onContextLost = (ev: Event) => {
+		if (!(ev.target instanceof HTMLCanvasElement)) return;
+		pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
+		pendingRestoreCanvas = ev.target;
+		pendingRestoreCanvas.addEventListener("webglcontextrestored", onContextRestored, {
+			once: true,
+		});
+	};
+	// Listener is registered unconditionally. The cost is one no-op
+	// attach when WebGL never initialised (no canvas under `container`
+	// ever fires webglcontextlost), but in exchange a future code path
+	// that hot-swaps the renderer — disposing the addon and replacing it
+	// without a full navigate-away — gets the loss/restore plumbing
+	// already wired for free, instead of having to re-register the
+	// listener from inside that swap. The dispose path was already
+	// unconditional, so the symmetry is now properly established.
+	container.addEventListener("webglcontextlost", onContextLost);
 
-        fitAddon.fit();
+	fitAddon.fit();
 
-        // Cmd/Ctrl + C copies the current xterm selection to the clipboard.
-        // Without this, Cmd-C falls through to the terminal (Claude Code
-        // intercepts it as SIGINT) and nothing gets copied.
-        term.attachCustomKeyEventHandler((ev) => {
-                if (
-                        ev.type === "keydown" &&
-                        (ev.metaKey || ev.ctrlKey) &&
-                        !ev.altKey &&
-                        !ev.shiftKey &&
-                        ev.key.toLowerCase() === "c"
-                ) {
-                        const sel = term.getSelection();
-                        if (sel) {
-                                navigator.clipboard.writeText(sel).catch(() => { });
-                                return false;
-                        }
-                }
-                return true;
-        });
-        // Fallback for plain-text URLs (without OSC 8). Custom provider so URLs
-        // that soft-wrap across rows are still recognised as ONE link — hover
-        // underlines the full URL and clicking anywhere on it opens the
-        // complete URL. No-op when the app already emits OSC 8 (xterm's native
-        // hyperlink handling takes precedence per-cell).
-        const linkProviderDisposable = term.registerLinkProvider(
-                new MultilineUrlLinkProvider(term),
-        );
+	// Cmd/Ctrl + C copies the current xterm selection to the clipboard.
+	// Without this, Cmd-C falls through to the terminal (Claude Code
+	// intercepts it as SIGINT) and nothing gets copied.
+	term.attachCustomKeyEventHandler((ev) => {
+		if (
+			ev.type === "keydown" &&
+			(ev.metaKey || ev.ctrlKey) &&
+			!ev.altKey &&
+			!ev.shiftKey &&
+			ev.key.toLowerCase() === "c"
+		) {
+			const sel = term.getSelection();
+			if (sel) {
+				navigator.clipboard.writeText(sel).catch(() => {});
+				return false;
+			}
+		}
+		return true;
+	});
+	// Fallback for plain-text URLs (without OSC 8). Custom provider so URLs
+	// that soft-wrap across rows are still recognised as ONE link — hover
+	// underlines the full URL and clicking anywhere on it opens the
+	// complete URL. No-op when the app already emits OSC 8 (xterm's native
+	// hyperlink handling takes precedence per-cell).
+	const linkProviderDisposable = term.registerLinkProvider(new MultilineUrlLinkProvider(term));
 
-        // Mouse clicks should focus xterm immediately. Touch taps are handled
-        // in onTouchEnd below — we wait until touchend to distinguish a tap
-        // from a scroll gesture so a swipe doesn't pop the keyboard mid-drag.
-        const focusOnPointer = (ev: PointerEvent) => {
-                if (ev.pointerType !== "touch") term.focus();
-        };
-        container.addEventListener("pointerdown", focusOnPointer);
+	// Mouse clicks should focus xterm immediately. Touch taps are handled
+	// in onTouchEnd below — we wait until touchend to distinguish a tap
+	// from a scroll gesture so a swipe doesn't pop the keyboard mid-drag.
+	const focusOnPointer = (ev: PointerEvent) => {
+		if (ev.pointerType !== "touch") term.focus();
+	};
+	container.addEventListener("pointerdown", focusOnPointer);
 
-        // ── WebSocket connection ────────────────────────────────────────────────
-        // Prefer passing the JWT as a subprotocol (`auth.bearer.<jwt>`) so the
-        // token stays out of the URL, access logs, browser history and Referer
-        // headers. Some proxies/tunnels silently strip `Sec-WebSocket-Protocol`
-        // though, so we also include the token as a `?token=` query param as a
-        // fallback — the backend accepts either.
-        const token = getToken() ?? "";
-        const wsUrl = buildWsUrl(sessionId, token, tabId);
-        const ws = new WebSocket(wsUrl, [`auth.bearer.${token}`]);
-        let disposed = false;
+	// ── WebSocket connection ────────────────────────────────────────────────
+	// Prefer passing the JWT as a subprotocol (`auth.bearer.<jwt>`) so the
+	// token stays out of the URL, access logs, browser history and Referer
+	// headers. Some proxies/tunnels silently strip `Sec-WebSocket-Protocol`
+	// though, so we also include the token as a `?token=` query param as a
+	// fallback — the backend accepts either.
+	const token = getToken() ?? "";
+	const wsUrl = buildWsUrl(sessionId, token, tabId);
+	const ws = new WebSocket(wsUrl, [`auth.bearer.${token}`]);
+	let disposed = false;
 
-        ws.onopen = () => {
-                send({ type: "ping" });
-                startHeartbeat();
-        };
+	ws.onopen = () => {
+		send({ type: "ping" });
+		startHeartbeat();
+	};
 
-        ws.onmessage = (ev) => {
-                // disposed: post-close frames buffered by the browser or in flight
-                // from the server still fire here, and term.write() throws on a
-                // disposed xterm. Sibling of the onerror/onclose guards below (#93).
-                if (disposed) return;
-                type Msg =
-                        | { type: "output"; data: string }
-                        | { type: "status"; status: SessionStatus }
-                        | { type: "pong" }
-                        | { type: "error"; message: string };
+	ws.onmessage = (ev) => {
+		// disposed: post-close frames buffered by the browser or in flight
+		// from the server still fire here, and term.write() throws on a
+		// disposed xterm. Sibling of the onerror/onclose guards below (#93).
+		if (disposed) return;
+		type Msg =
+			| { type: "output"; data: string }
+			| { type: "status"; status: SessionStatus }
+			| { type: "pong" }
+			| { type: "error"; message: string };
 
-                let msg: Msg;
-                try {
-                        msg = JSON.parse(ev.data as string) as Msg;
-                } catch {
-                        return;
-                }
+		let msg: Msg;
+		try {
+			msg = JSON.parse(ev.data as string) as Msg;
+		} catch {
+			return;
+		}
 
-                switch (msg.type) {
-                        case "output":
-                                term.write(msg.data);
-                                break;
-                        case "status":
-                                onStatus(msg.status);
-                                break;
-                        case "error":
-                                onError(msg.message);
-                                break;
-                        case "pong":
-                                break;
-                }
-        };
+		switch (msg.type) {
+			case "output":
+				term.write(msg.data);
+				break;
+			case "status":
+				onStatus(msg.status);
+				break;
+			case "error":
+				onError(msg.message);
+				break;
+			case "pong":
+				break;
+		}
+	};
 
-        ws.onerror = () => {
-                if (disposed) return;
-                onError("WebSocket connection error");
-        };
+	ws.onerror = () => {
+		if (disposed) return;
+		onError("WebSocket connection error");
+	};
 
-        ws.onclose = (ev) => {
-                // disposed: stale async close from a prior navigate-away — ignore
-                if (disposed) return;
-                if (ev.code !== 1000) {
-                        onError(`Connection closed (${ev.code}): ${ev.reason || "unknown reason"}`);
-                }
-                onStatus("disconnected");
-        };
+	ws.onclose = (ev) => {
+		// disposed: stale async close from a prior navigate-away — ignore
+		if (disposed) return;
+		if (ev.code !== 1000) {
+			onError(`Connection closed (${ev.code}): ${ev.reason || "unknown reason"}`);
+		}
+		onStatus("disconnected");
+	};
 
-        // ── Input: xterm → WS ──────────────────────────────────────────────────
-        const inputDisposable = term.onData((data) => {
-                send({ type: "input", data });
-        });
+	// ── Input: xterm → WS ──────────────────────────────────────────────────
+	const inputDisposable = term.onData((data) => {
+		send({ type: "input", data });
+	});
 
-        // ── Touch scroll ────────────────────────────────────────────────────────
-        // On mobile there are no wheel events, and `mouse on` in tmux means
-        // finger drags aren't forwarded as anything useful. We translate the
-        // drag into terminal scroll:
-        //
-        //  - Main buffer (shell prompt, command output): scroll xterm's own
-        //    scrollback with `scrollLines`. Users expect to pull older lines
-        //    back into view; we don't involve tmux at all, so there's no weird
-        //    copy-mode dance.
-        //  - Alt buffer (vim, less, Claude Code, htop, …): synthesise
-        //    up/down arrow keys. Every TUI app responds to arrows, so the
-        //    user can navigate without needing mouse-wheel support in the app
-        //    or tmux copy-mode.
-        //
-        // Direction follows iOS/Android convention — content tracks the
-        // finger: drag up → view moves up → scroll toward newer (bottom).
-        let lastTouchY: number | null = null;
-        let touchIsScroll = false; // true once the gesture has moved ≥1 cell
-        const getCellHeight = () => (term.rows > 0 ? container.clientHeight / term.rows : 20);
+	// ── Touch scroll ────────────────────────────────────────────────────────
+	// On mobile there are no wheel events, and `mouse on` in tmux means
+	// finger drags aren't forwarded as anything useful. We translate the
+	// drag into terminal scroll:
+	//
+	//  - Main buffer (shell prompt, command output): scroll xterm's own
+	//    scrollback with `scrollLines`. Users expect to pull older lines
+	//    back into view; we don't involve tmux at all, so there's no weird
+	//    copy-mode dance.
+	//  - Alt buffer (vim, less, Claude Code, htop, …): synthesise
+	//    up/down arrow keys. Every TUI app responds to arrows, so the
+	//    user can navigate without needing mouse-wheel support in the app
+	//    or tmux copy-mode.
+	//
+	// Direction follows iOS/Android convention — content tracks the
+	// finger: drag up → view moves up → scroll toward newer (bottom).
+	let lastTouchY: number | null = null;
+	let touchIsScroll = false; // true once the gesture has moved ≥1 cell
+	const getCellHeight = () => (term.rows > 0 ? container.clientHeight / term.rows : 20);
 
-        const onTouchStart = (ev: TouchEvent) => {
-                if (ev.touches.length !== 1) { lastTouchY = null; touchIsScroll = false; return; }
-                lastTouchY = ev.touches[0]!.clientY;
-                touchIsScroll = false;
-        };
-        const onTouchMove = (ev: TouchEvent) => {
-                if (lastTouchY === null || ev.touches.length !== 1) {
-                        // Defence-in-depth: clear lastTouchY whenever we see a non-
-                        // single-touch frame. onTouchStart already clears it when a
-                        // second finger lands (touchstart fires for each new touch
-                        // point), so under normal browser behaviour this is a no-op.
-                        // But touch events are notoriously flaky on the long tail of
-                        // mobile browsers — Safari has shipped bugs where a touch's
-                        // touchstart was suppressed while it still appeared in
-                        // ev.touches on a later move. If anything ever skips that
-                        // path, lastTouchY would carry over from before the multi-
-                        // touch and produce a phantom scroll jump on the first
-                        // single-touch frame after the second finger lifts. Clearing
-                        // here makes that impossible regardless.
-                        if (ev.touches.length !== 1) lastTouchY = null;
-                        return;
-                }
-                const y = ev.touches[0]!.clientY;
-                const cellH = getCellHeight();
-                const deltaPx = lastTouchY - y;
-                const lines = Math.trunc(deltaPx / cellH);
+	const onTouchStart = (ev: TouchEvent) => {
+		if (ev.touches.length !== 1) {
+			lastTouchY = null;
+			touchIsScroll = false;
+			return;
+		}
+		lastTouchY = ev.touches[0]!.clientY;
+		touchIsScroll = false;
+	};
+	const onTouchMove = (ev: TouchEvent) => {
+		if (lastTouchY === null || ev.touches.length !== 1) {
+			// Defence-in-depth: clear lastTouchY whenever we see a non-
+			// single-touch frame. onTouchStart already clears it when a
+			// second finger lands (touchstart fires for each new touch
+			// point), so under normal browser behaviour this is a no-op.
+			// But touch events are notoriously flaky on the long tail of
+			// mobile browsers — Safari has shipped bugs where a touch's
+			// touchstart was suppressed while it still appeared in
+			// ev.touches on a later move. If anything ever skips that
+			// path, lastTouchY would carry over from before the multi-
+			// touch and produce a phantom scroll jump on the first
+			// single-touch frame after the second finger lifts. Clearing
+			// here makes that impossible regardless.
+			if (ev.touches.length !== 1) lastTouchY = null;
+			return;
+		}
+		const y = ev.touches[0]!.clientY;
+		const cellH = getCellHeight();
+		const deltaPx = lastTouchY - y;
+		const lines = Math.trunc(deltaPx / cellH);
 
-                // Suppress xterm's drag-selection handler on every frame the
-                // gesture qualifies as a scroll — either because it's already
-                // been classified as one (touchIsScroll) or because *this* frame
-                // crossed at least one cell (lines !== 0) and is about to flip
-                // the flag. A single call covers both paths:
-                //   - First qualifying frame: lines !== 0 trips the OR;
-                //     touchIsScroll flips below.
-                //   - Subsequent frames once classified: touchIsScroll trips
-                //     the OR, including sub-cell frames where lines === 0.
-                // Previously this was two separate ev.preventDefault() calls
-                // straddling the `if (lines === 0)` early return — correct
-                // (preventDefault is idempotent) but the duplication looked
-                // suspicious. touch-action:none is set in CSS, so calling
-                // preventDefault here doesn't trigger a passive-listener
-                // warning even on the first qualifying frame.
-                if (touchIsScroll || lines !== 0) ev.preventDefault();
-                if (lines === 0) return;
+		// Suppress xterm's drag-selection handler on every frame the
+		// gesture qualifies as a scroll — either because it's already
+		// been classified as one (touchIsScroll) or because *this* frame
+		// crossed at least one cell (lines !== 0) and is about to flip
+		// the flag. A single call covers both paths:
+		//   - First qualifying frame: lines !== 0 trips the OR;
+		//     touchIsScroll flips below.
+		//   - Subsequent frames once classified: touchIsScroll trips
+		//     the OR, including sub-cell frames where lines === 0.
+		// Previously this was two separate ev.preventDefault() calls
+		// straddling the `if (lines === 0)` early return — correct
+		// (preventDefault is idempotent) but the duplication looked
+		// suspicious. touch-action:none is set in CSS, so calling
+		// preventDefault here doesn't trigger a passive-listener
+		// warning even on the first qualifying frame.
+		if (touchIsScroll || lines !== 0) ev.preventDefault();
+		if (lines === 0) return;
 
-                touchIsScroll = true;
+		touchIsScroll = true;
 
-                if (term.buffer.active.type === "alternate") {
-                        // Cap the burst so a fast flick doesn't fire 100+ arrows
-                        // at the app in one frame.
-                        const n = Math.min(Math.abs(lines), 20);
-                        const key = lines > 0 ? "\x1b[B" : "\x1b[A";
-                        send({ type: "input", data: key.repeat(n) });
-                } else {
-                        term.scrollLines(lines);
-                }
-                lastTouchY -= lines * cellH;
-        };
-        const onTouchEnd = () => {
-                // If the finger never moved a full cell it was a tap: focus xterm
-                // so the OS keyboard appears for typing. Scroll gestures skip this
-                // so the keyboard doesn't flash open mid-swipe.
-                // Guard on lastTouchY !== null: a multi-touch start (pinch) clears
-                // lastTouchY and resets touchIsScroll, so when one finger lifts we
-                // must not treat it as a tap and pop the keyboard.
-                if (!touchIsScroll && lastTouchY !== null) term.focus();
-                lastTouchY = null;
-                touchIsScroll = false;
-        };
-        const onTouchCancel = () => { lastTouchY = null; touchIsScroll = false; };
+		if (term.buffer.active.type === "alternate") {
+			// Cap the burst so a fast flick doesn't fire 100+ arrows
+			// at the app in one frame.
+			const n = Math.min(Math.abs(lines), 20);
+			const key = lines > 0 ? "\x1b[B" : "\x1b[A";
+			send({ type: "input", data: key.repeat(n) });
+		} else {
+			term.scrollLines(lines);
+		}
+		lastTouchY -= lines * cellH;
+	};
+	const onTouchEnd = () => {
+		// If the finger never moved a full cell it was a tap: focus xterm
+		// so the OS keyboard appears for typing. Scroll gestures skip this
+		// so the keyboard doesn't flash open mid-swipe.
+		// Guard on lastTouchY !== null: a multi-touch start (pinch) clears
+		// lastTouchY and resets touchIsScroll, so when one finger lifts we
+		// must not treat it as a tap and pop the keyboard.
+		if (!touchIsScroll && lastTouchY !== null) term.focus();
+		lastTouchY = null;
+		touchIsScroll = false;
+	};
+	const onTouchCancel = () => {
+		lastTouchY = null;
+		touchIsScroll = false;
+	};
 
-        container.addEventListener("touchstart", onTouchStart, { passive: true });
-        // passive:false required so ev.preventDefault() can stop xterm's drag-selection
-        container.addEventListener("touchmove", onTouchMove, { passive: false });
-        container.addEventListener("touchend", onTouchEnd, { passive: true });
-        container.addEventListener("touchcancel", onTouchCancel, { passive: true });
+	container.addEventListener("touchstart", onTouchStart, { passive: true });
+	// passive:false required so ev.preventDefault() can stop xterm's drag-selection
+	container.addEventListener("touchmove", onTouchMove, { passive: false });
+	container.addEventListener("touchend", onTouchEnd, { passive: true });
+	container.addEventListener("touchcancel", onTouchCancel, { passive: true });
 
-        // ── Resize ──────────────────────────────────────────────────────────────
-        // ResizeObserver fires continuously during mobile viewport churn (URL
-        // bar show/hide, soft-keyboard open/close, rotation) and desktop
-        // window drags. Coalescing to one fit per frame avoids overlapping
-        // tmux redraws that leave half-painted cells on screen.
-        //
-        // LOCAL fit runs every animation frame so the visible terminal
-        // tracks the container smoothly (xterm handles the cell math client
-        // side). The REMOTE resize notification is trailing-debounced on a
-        // short idle window, because every `{type:"resize"}` WS message
-        // triggers a synchronous chain on the backend:
-        //
-        //   wsHandler → DockerManager.resize → recomputeSize →
-        //   exec.resize → tmux resize-window → pane repaint fan-out.
-        //
-        // A sustained window-edge drag on a 1080p display can cross cell
-        // boundaries ~50× per second; forwarding every crossing lets the
-        // Docker exec API queue up dozens of resizes that tmux processes
-        // after the fact, producing a cascade of repaints that each get
-        // invalidated by the next one. Debouncing collapses a drag into a
-        // single backend resize at the settled size.
-        //
-        // 100 ms is enough to absorb the noisy tail of a mouse-drag or
-        // soft-keyboard slide but short enough to feel "instant" when the
-        // user stops adjusting.
-        const RESIZE_DEBOUNCE_MS = 100;
-        let lastSentCols = term.cols;
-        let lastSentRows = term.rows;
-        let fitScheduled = false;
-        let resizeSendTimer: ReturnType<typeof setTimeout> | null = null;
-        const sendResizeDebounced = () => {
-                if (resizeSendTimer !== null) clearTimeout(resizeSendTimer);
-                resizeSendTimer = setTimeout(() => {
-                        resizeSendTimer = null;
-                        // Skip if disposed between schedule and fire — the socket is
-                        // already being torn down by the parent component.
-                        if (disposed) return;
-                        // Re-check dimensions at fire time; they may have bounced back
-                        // to the last-sent size during the debounce window (e.g. user
-                        // overshoots a drag and returns). No point spending a round
-                        // trip for a no-op.
-                        if (term.cols === lastSentCols && term.rows === lastSentRows) return;
-                        lastSentCols = term.cols;
-                        lastSentRows = term.rows;
-                        send({ type: "resize", cols: term.cols, rows: term.rows });
-                }, RESIZE_DEBOUNCE_MS);
-        };
-        const scheduleFit = () => {
-                if (fitScheduled) return;
-                fitScheduled = true;
-                requestAnimationFrame(() => {
-                        fitScheduled = false;
-                        try { fitAddon.fit(); } catch { /* container detached mid-resize */ }
-                        if (term.cols !== lastSentCols || term.rows !== lastSentRows) {
-                                sendResizeDebounced();
-                        }
-                });
-        };
-        const ro = new ResizeObserver(scheduleFit);
-        ro.observe(container);
+	// ── Resize ──────────────────────────────────────────────────────────────
+	// ResizeObserver fires continuously during mobile viewport churn (URL
+	// bar show/hide, soft-keyboard open/close, rotation) and desktop
+	// window drags. Coalescing to one fit per frame avoids overlapping
+	// tmux redraws that leave half-painted cells on screen.
+	//
+	// LOCAL fit runs every animation frame so the visible terminal
+	// tracks the container smoothly (xterm handles the cell math client
+	// side). The REMOTE resize notification is trailing-debounced on a
+	// short idle window, because every `{type:"resize"}` WS message
+	// triggers a synchronous chain on the backend:
+	//
+	//   wsHandler → DockerManager.resize → recomputeSize →
+	//   exec.resize → tmux resize-window → pane repaint fan-out.
+	//
+	// A sustained window-edge drag on a 1080p display can cross cell
+	// boundaries ~50× per second; forwarding every crossing lets the
+	// Docker exec API queue up dozens of resizes that tmux processes
+	// after the fact, producing a cascade of repaints that each get
+	// invalidated by the next one. Debouncing collapses a drag into a
+	// single backend resize at the settled size.
+	//
+	// 100 ms is enough to absorb the noisy tail of a mouse-drag or
+	// soft-keyboard slide but short enough to feel "instant" when the
+	// user stops adjusting.
+	const RESIZE_DEBOUNCE_MS = 100;
+	let lastSentCols = term.cols;
+	let lastSentRows = term.rows;
+	let fitScheduled = false;
+	let resizeSendTimer: ReturnType<typeof setTimeout> | null = null;
+	const sendResizeDebounced = () => {
+		if (resizeSendTimer !== null) clearTimeout(resizeSendTimer);
+		resizeSendTimer = setTimeout(() => {
+			resizeSendTimer = null;
+			// Skip if disposed between schedule and fire — the socket is
+			// already being torn down by the parent component.
+			if (disposed) return;
+			// Re-check dimensions at fire time; they may have bounced back
+			// to the last-sent size during the debounce window (e.g. user
+			// overshoots a drag and returns). No point spending a round
+			// trip for a no-op.
+			if (term.cols === lastSentCols && term.rows === lastSentRows) return;
+			lastSentCols = term.cols;
+			lastSentRows = term.rows;
+			send({ type: "resize", cols: term.cols, rows: term.rows });
+		}, RESIZE_DEBOUNCE_MS);
+	};
+	const scheduleFit = () => {
+		if (fitScheduled) return;
+		fitScheduled = true;
+		requestAnimationFrame(() => {
+			fitScheduled = false;
+			try {
+				fitAddon.fit();
+			} catch {
+				/* container detached mid-resize */
+			}
+			if (term.cols !== lastSentCols || term.rows !== lastSentRows) {
+				sendResizeDebounced();
+			}
+		});
+	};
+	const ro = new ResizeObserver(scheduleFit);
+	ro.observe(container);
 
-        // ── Visibility / focus refresh ──────────────────────────────────────────
-        // Backgrounded tabs get rAF throttled, so xterm's renderer stops
-        // flushing dirty cells while the user is away. Output still streams
-        // in and lands in the internal buffer, but the painted DOM/canvas
-        // can end up several screens stale by the time the tab returns.
-        //
-        // On return, re-fit (viewport may have resized while hidden), wipe
-        // the WebGL texture atlas (fonts render sharp again after DPR change
-        // or OS font-smoothing toggles), and force a full refresh so every
-        // row repaints.
-        const onVisibilityChange = () => {
-                if (document.hidden) return;
-                scheduleFit();
-                try {
-                        webgl?.clearTextureAtlas();
-                } catch {
-                        webgl?.dispose();
-                        webgl = null;
-                }
-                term.refresh(0, term.rows - 1);
-        };
-        const onWindowFocus = () => {
-                scheduleFit();
-                term.refresh(0, term.rows - 1);
-        };
-        document.addEventListener("visibilitychange", onVisibilityChange);
-        window.addEventListener("focus", onWindowFocus);
+	// ── Visibility / focus refresh ──────────────────────────────────────────
+	// Backgrounded tabs get rAF throttled, so xterm's renderer stops
+	// flushing dirty cells while the user is away. Output still streams
+	// in and lands in the internal buffer, but the painted DOM/canvas
+	// can end up several screens stale by the time the tab returns.
+	//
+	// On return, re-fit (viewport may have resized while hidden), wipe
+	// the WebGL texture atlas (fonts render sharp again after DPR change
+	// or OS font-smoothing toggles), and force a full refresh so every
+	// row repaints.
+	const onVisibilityChange = () => {
+		if (document.hidden) return;
+		scheduleFit();
+		try {
+			webgl?.clearTextureAtlas();
+		} catch {
+			webgl?.dispose();
+			webgl = null;
+		}
+		term.refresh(0, term.rows - 1);
+	};
+	const onWindowFocus = () => {
+		scheduleFit();
+		term.refresh(0, term.rows - 1);
+	};
+	document.addEventListener("visibilitychange", onVisibilityChange);
+	window.addEventListener("focus", onWindowFocus);
 
-        // ── Heartbeat ───────────────────────────────────────────────────────────
-        let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-        function startHeartbeat() {
-                heartbeatInterval = setInterval(() => {
-                        if (ws.readyState === WebSocket.OPEN) send({ type: "ping" });
-                }, 30_000);
-        }
+	// ── Heartbeat ───────────────────────────────────────────────────────────
+	let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+	function startHeartbeat() {
+		heartbeatInterval = setInterval(() => {
+			if (ws.readyState === WebSocket.OPEN) send({ type: "ping" });
+		}, 30_000);
+	}
 
-        // ── Helpers ─────────────────────────────────────────────────────────────
-        function send(msg: object) {
-                if (ws.readyState === WebSocket.OPEN) {
-                        ws.send(JSON.stringify(msg));
-                }
-        }
+	// ── Helpers ─────────────────────────────────────────────────────────────
+	function send(msg: object) {
+		if (ws.readyState === WebSocket.OPEN) {
+			ws.send(JSON.stringify(msg));
+		}
+	}
 
-        function setFontSize(px: number) {
-                term.options.fontSize = px;
-                scheduleFit();
-        }
+	function setFontSize(px: number) {
+		term.options.fontSize = px;
+		scheduleFit();
+	}
 
-        // term.paste() routes through the same onData handler that pipes browser
-        // → WS, and wraps the bytes in DECSET 2004 bracketed-paste sequences
-        // (\e[200~ … \e[201~) when the receiving app has bracketed paste on —
-        // bash, zsh, and Claude CLI all do — so multi-line content arrives as
-        // one paste event instead of being executed line-by-line.
-        function paste(text: string) {
-                term.paste(text);
-        }
+	// term.paste() routes through the same onData handler that pipes browser
+	// → WS, and wraps the bytes in DECSET 2004 bracketed-paste sequences
+	// (\e[200~ … \e[201~) when the receiving app has bracketed paste on —
+	// bash, zsh, and Claude CLI all do — so multi-line content arrives as
+	// one paste event instead of being executed line-by-line.
+	function paste(text: string) {
+		term.paste(text);
+	}
 
-        // ── Dispose ─────────────────────────────────────────────────────────────
-        function dispose() {
-                disposed = true;
-                if (heartbeatInterval !== null) clearInterval(heartbeatInterval);
-                // The resize send is debounced on a trailing 100 ms window; if the
-                // user navigates away inside that window the timer would fire after
-                // the socket closes. The `if (disposed) return` guard at the top of
-                // the callback already makes this harmless today — but it leaves
-                // the pending timer holding a closure reference to the (disposed)
-                // xterm + ws for up to 100 ms, and any future logic added to the
-                // callback ahead of that guard would run post-dispose. Cancelling
-                // here matches the heartbeatInterval path and removes the subtle
-                // refactor trap.
-                if (resizeSendTimer !== null) clearTimeout(resizeSendTimer);
-                ro.disconnect();
-                document.removeEventListener("visibilitychange", onVisibilityChange);
-                window.removeEventListener("focus", onWindowFocus);
-                container.removeEventListener("pointerdown", focusOnPointer);
-                container.removeEventListener("touchstart", onTouchStart);
-                container.removeEventListener("touchmove", onTouchMove);
-                container.removeEventListener("touchend", onTouchEnd);
-                container.removeEventListener("touchcancel", onTouchCancel);
-                inputDisposable.dispose();
-                linkProviderDisposable.dispose();
-                pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
-                container.removeEventListener("webglcontextlost", onContextLost);
-                webgl?.dispose();
-                ws.close(1000, "User navigated away");
-                term.dispose();
-        }
+	// ── Dispose ─────────────────────────────────────────────────────────────
+	function dispose() {
+		disposed = true;
+		if (heartbeatInterval !== null) clearInterval(heartbeatInterval);
+		// The resize send is debounced on a trailing 100 ms window; if the
+		// user navigates away inside that window the timer would fire after
+		// the socket closes. The `if (disposed) return` guard at the top of
+		// the callback already makes this harmless today — but it leaves
+		// the pending timer holding a closure reference to the (disposed)
+		// xterm + ws for up to 100 ms, and any future logic added to the
+		// callback ahead of that guard would run post-dispose. Cancelling
+		// here matches the heartbeatInterval path and removes the subtle
+		// refactor trap.
+		if (resizeSendTimer !== null) clearTimeout(resizeSendTimer);
+		ro.disconnect();
+		document.removeEventListener("visibilitychange", onVisibilityChange);
+		window.removeEventListener("focus", onWindowFocus);
+		container.removeEventListener("pointerdown", focusOnPointer);
+		container.removeEventListener("touchstart", onTouchStart);
+		container.removeEventListener("touchmove", onTouchMove);
+		container.removeEventListener("touchend", onTouchEnd);
+		container.removeEventListener("touchcancel", onTouchCancel);
+		inputDisposable.dispose();
+		linkProviderDisposable.dispose();
+		pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
+		container.removeEventListener("webglcontextlost", onContextLost);
+		webgl?.dispose();
+		ws.close(1000, "User navigated away");
+		term.dispose();
+	}
 
-        return { dispose, setFontSize, paste };
+	return { dispose, setFontSize, paste };
 }
 
 // ── Multiline URL link provider ─────────────────────────────────────────────
@@ -498,171 +513,168 @@ export function openTerminalSession(opts: {
 // than on every hover.
 
 interface CachedLink {
-        url: string;
-        // 1-based buffer coordinates (xterm's ILink range convention)
-        startX: number;
-        startY: number;
-        endX: number;
-        endY: number;
+	url: string;
+	// 1-based buffer coordinates (xterm's ILink range convention)
+	startX: number;
+	startY: number;
+	endX: number;
+	endY: number;
 }
 
 class MultilineUrlLinkProvider implements ILinkProvider {
-        private cache: CachedLink[] = [];
-        private dirty = true;
-        private onWrite: IDisposable;
+	private cache: CachedLink[] = [];
+	private dirty = true;
+	private onWrite: IDisposable;
 
-        constructor(private term: Terminal) {
-                this.onWrite = term.onWriteParsed(() => {
-                        this.dirty = true;
-                });
-        }
+	constructor(private term: Terminal) {
+		this.onWrite = term.onWriteParsed(() => {
+			this.dirty = true;
+		});
+	}
 
-        provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void): void {
-                if (this.dirty) this.rebuild();
-                const y = bufferLineNumber;
-                const links: ILink[] = [];
-                for (const c of this.cache) {
-                        if (c.startY <= y && c.endY >= y) {
-                                // Return the FULL multi-row range, not a per-row slice. xterm
-                                // iterates start.y → end.y internally when drawing the hover
-                                // underline, so one link with the full span lights up every
-                                // row the URL occupies. Returning per-row slices here is what
-                                // caused "hover only underlines the first line" — each slice
-                                // was a distinct link confined to its own row.
-                                links.push({
-                                        range: {
-                                                start: { x: c.startX, y: c.startY },
-                                                end: { x: c.endX, y: c.endY },
-                                        },
-                                        text: c.url,
-                                        decorations: { underline: true, pointerCursor: true },
-                                        activate: (event, text) => {
-                                                event.preventDefault();
-                                                window.open(text, "_blank", "noopener,noreferrer");
-                                        },
-                                });
-                        }
-                }
-                callback(links.length ? links : undefined);
-        }
+	provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void): void {
+		if (this.dirty) this.rebuild();
+		const y = bufferLineNumber;
+		const links: ILink[] = [];
+		for (const c of this.cache) {
+			if (c.startY <= y && c.endY >= y) {
+				// Return the FULL multi-row range, not a per-row slice. xterm
+				// iterates start.y → end.y internally when drawing the hover
+				// underline, so one link with the full span lights up every
+				// row the URL occupies. Returning per-row slices here is what
+				// caused "hover only underlines the first line" — each slice
+				// was a distinct link confined to its own row.
+				links.push({
+					range: {
+						start: { x: c.startX, y: c.startY },
+						end: { x: c.endX, y: c.endY },
+					},
+					text: c.url,
+					decorations: { underline: true, pointerCursor: true },
+					activate: (event, text) => {
+						event.preventDefault();
+						window.open(text, "_blank", "noopener,noreferrer");
+					},
+				});
+			}
+		}
+		callback(links.length ? links : undefined);
+	}
 
+	dispose(): void {
+		this.onWrite.dispose();
+	}
 
-        dispose(): void {
-                this.onWrite.dispose();
-        }
+	private rebuild(): void {
+		this.cache = [];
+		const buf = this.term.buffer.active;
 
-        private rebuild(): void {
-                this.cache = [];
-                const buf = this.term.buffer.active;
+		// "Terminators" that can't appear inside a URL. Includes
+		// whitespace, common quote/bracket chars, and the Unicode Box
+		// Drawing block — the `─-╿` range covers U+2500–U+257F (│ ─
+		// ╭ ╮ etc. that ink/React TUIs draw around their panels). The
+		// dash inside the brackets is a regex range operator, NOT a
+		// literal hyphen-or-three-chars; flagging this so a future
+		// reviewer doesn't "fix" what looks like a typo. This lets
+		// us treat a row's URL "zone" as the contiguous run of
+		// URL-safe chars between the left and right borders/padding
+		// of the row.
+		const NON_URL = /[\s<>"'`{}()[\]─-╿|]/; //   ─-╿ = box-drawing range
+		const URL_RE = /https?:\/\/[^\s<>"'`{}()[\]─-╿|]+/g; // ─-╿ = box-drawing range
 
-                // "Terminators" that can't appear inside a URL. Includes
-                // whitespace, common quote/bracket chars, and the Unicode Box
-                // Drawing block — the `─-╿` range covers U+2500–U+257F (│ ─
-                // ╭ ╮ etc. that ink/React TUIs draw around their panels). The
-                // dash inside the brackets is a regex range operator, NOT a
-                // literal hyphen-or-three-chars; flagging this so a future
-                // reviewer doesn't "fix" what looks like a typo. This lets
-                // us treat a row's URL "zone" as the contiguous run of
-                // URL-safe chars between the left and right borders/padding
-                // of the row.
-                const NON_URL = /[\s<>"'`{}()[\]─-╿|]/; //   ─-╿ = box-drawing range
-                const URL_RE = /https?:\/\/[^\s<>"'`{}()[\]─-╿|]+/g; // ─-╿ = box-drawing range
+		// Phase 1 — for every row in the buffer, strip leading/trailing
+		// non-URL chars (borders, padding) and record where the interior
+		// URL zone starts and ends. Inner whitespace in the zone is kept
+		// (the URL regex will terminate at it).
+		interface Row {
+			content: string; // interior zone, inclusive of both ends
+			startCol: number; // 0-based col in the row where `content` begins
+			endCol: number; // 0-based col where `content` ends (inclusive)
+		}
+		const rows: Row[] = [];
+		for (let r = 0; r < buf.length; r++) {
+			const line = buf.getLine(r);
+			const raw = line?.translateToString(false) ?? "";
+			let first = 0;
+			let last = raw.length - 1;
+			while (first <= last && NON_URL.test(raw[first])) first++;
+			while (last >= first && NON_URL.test(raw[last])) last--;
+			if (first > last) {
+				rows.push({ content: "", startCol: -1, endCol: -1 });
+			} else {
+				rows.push({ content: raw.slice(first, last + 1), startCol: first, endCol: last });
+			}
+		}
 
-                // Phase 1 — for every row in the buffer, strip leading/trailing
-                // non-URL chars (borders, padding) and record where the interior
-                // URL zone starts and ends. Inner whitespace in the zone is kept
-                // (the URL regex will terminate at it).
-                interface Row {
-                        content: string;  // interior zone, inclusive of both ends
-                        startCol: number; // 0-based col in the row where `content` begins
-                        endCol: number;   // 0-based col where `content` ends (inclusive)
-                }
-                const rows: Row[] = [];
-                for (let r = 0; r < buf.length; r++) {
-                        const line = buf.getLine(r);
-                        const raw = line?.translateToString(false) ?? "";
-                        let first = 0;
-                        let last = raw.length - 1;
-                        while (first <= last && NON_URL.test(raw[first])) first++;
-                        while (last >= first && NON_URL.test(raw[last])) last--;
-                        if (first > last) {
-                                rows.push({ content: "", startCol: -1, endCol: -1 });
-                        } else {
-                                rows.push({ content: raw.slice(first, last + 1), startCol: first, endCol: last });
-                        }
-                }
+		// Phase 2 — find URL starts and follow them across row boundaries
+		// when the URL clearly continues. A "continuation" row is one
+		// whose entire interior zone is a single whitespace-free run
+		// (i.e. all URL-safe chars). Any whitespace anywhere in the next
+		// row's zone means the URL has ended.
+		for (let r = 0; r < rows.length; r++) {
+			const row = rows[r];
+			if (row.startCol < 0) continue;
+			for (const m of row.content.matchAll(URL_RE)) {
+				if (m.index === undefined) continue;
+				let url = m[0];
+				const matchStartInZone = m.index;
+				const matchEndInZone = matchStartInZone + url.length; // exclusive
+				let endRow = r;
+				let endColInRow = row.startCol + matchEndInZone - 1;
 
-                // Phase 2 — find URL starts and follow them across row boundaries
-                // when the URL clearly continues. A "continuation" row is one
-                // whose entire interior zone is a single whitespace-free run
-                // (i.e. all URL-safe chars). Any whitespace anywhere in the next
-                // row's zone means the URL has ended.
-                for (let r = 0; r < rows.length; r++) {
-                        const row = rows[r];
-                        if (row.startCol < 0) continue;
-                        for (const m of row.content.matchAll(URL_RE)) {
-                                if (m.index === undefined) continue;
-                                let url = m[0];
-                                const matchStartInZone = m.index;
-                                const matchEndInZone = matchStartInZone + url.length; // exclusive
-                                let endRow = r;
-                                let endColInRow = row.startCol + matchEndInZone - 1;
+				// Only try to extend if the URL reaches the very end of the
+				// row's interior — otherwise the URL already terminated with
+				// whitespace or punctuation on this same row.
+				if (matchEndInZone === row.content.length) {
+					for (let next = r + 1; next < rows.length; next++) {
+						const nr = rows[next];
+						if (nr.startCol < 0) break; // empty row ends the URL
+						if (/\s/.test(nr.content)) break; // sentence text, not URL
+						url += nr.content;
+						endRow = next;
+						endColInRow = nr.endCol;
+					}
+				}
 
-                                // Only try to extend if the URL reaches the very end of the
-                                // row's interior — otherwise the URL already terminated with
-                                // whitespace or punctuation on this same row.
-                                if (matchEndInZone === row.content.length) {
-                                        for (let next = r + 1; next < rows.length; next++) {
-                                                const nr = rows[next];
-                                                if (nr.startCol < 0) break; // empty row ends the URL
-                                                if (/\s/.test(nr.content)) break; // sentence text, not URL
-                                                url += nr.content;
-                                                endRow = next;
-                                                endColInRow = nr.endCol;
-                                        }
-                                }
+				// Strip trailing sentence punctuation that's usually not URL.
+				const trailingPunct = url.match(/[.,;:!?)]+$/)?.[0] ?? "";
+				if (trailingPunct) {
+					url = url.slice(0, -trailingPunct.length);
+					endColInRow -= trailingPunct.length;
+				}
+				if (!url) continue;
 
-                                // Strip trailing sentence punctuation that's usually not URL.
-                                const trailingPunct = url.match(/[.,;:!?)]+$/)?.[0] ?? "";
-                                if (trailingPunct) {
-                                        url = url.slice(0, -trailingPunct.length);
-                                        endColInRow -= trailingPunct.length;
-                                }
-                                if (!url) continue;
+				this.cache.push({
+					url,
+					// +1 because xterm's IBufferRange is 1-based in both x and y.
+					startX: row.startCol + matchStartInZone + 1,
+					startY: r + 1,
+					endX: endColInRow + 1,
+					endY: endRow + 1,
+				});
+			}
+		}
 
-                                this.cache.push({
-                                        url,
-                                        // +1 because xterm's IBufferRange is 1-based in both x and y.
-                                        startX: row.startCol + matchStartInZone + 1,
-                                        startY: r + 1,
-                                        endX: endColInRow + 1,
-                                        endY: endRow + 1,
-                                });
-                        }
-                }
-
-                this.dirty = false;
-        }
-
-
+		this.dirty = false;
+	}
 }
 
 // ── URL builder ─────────────────────────────────────────────────────────────
 
 function buildWsUrl(sessionId: string, token: string, tabId?: string): string {
-        // Use VITE_API_URL to derive the WebSocket URL
-        const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
-        const url = new URL(apiUrl);
-        const wsProto = url.protocol === "https:" ? "wss:" : "ws:";
-        const base = `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
-        const params = new URLSearchParams();
-        if (token) params.set("token", token);
-        // tabId is server-issued and re-validated on the backend before any
-        // `tmux attach -t` — see backend/src/wsHandler.ts (rawTab regex
-        // /^[a-zA-Z0-9._-]{1,64}$/). Excluding `:` is the load-bearing part:
-        // tmux target syntax needs a colon to parse `session:window.pane`, so
-        // `.` alone can't escalate a tabId into a different tmux target.
-        if (tabId) params.set("tab", tabId);
-        const qs = params.toString();
-        return qs ? `${base}?${qs}` : base;
+	// Use VITE_API_URL to derive the WebSocket URL
+	const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
+	const url = new URL(apiUrl);
+	const wsProto = url.protocol === "https:" ? "wss:" : "ws:";
+	const base = `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
+	const params = new URLSearchParams();
+	if (token) params.set("token", token);
+	// tabId is server-issued and re-validated on the backend before any
+	// `tmux attach -t` — see backend/src/wsHandler.ts (rawTab regex
+	// /^[a-zA-Z0-9._-]{1,64}$/). Excluding `:` is the load-bearing part:
+	// tmux target syntax needs a colon to parse `session:window.pane`, so
+	// `.` alone can't escalate a tabId into a different tmux target.
+	if (tabId) params.set("tab", tabId);
+	const qs = params.toString();
+	return qs ? `${base}?${qs}` : base;
 }


### PR DESCRIPTION
## Why

Mirrors the backend Biome rollout (#134) in the frontend workspace. Same motivation: CLAUDE.md mandates tabs, all three frontend files (`api.ts`, `main.ts`, `terminal.ts`) used 8-space indentation, and CI had no enforcement.

## Config

`frontend/biome.json` is identical in shape to `backend/biome.json`:

- formatter: `indentStyle=tab`, `lineWidth=100`
- linter `recommended` plus the same three style rules at `"error"`: `useImportType`, `useNodejsImportProtocol`, `useTemplate`
- `noNonNullAssertion` off; `noExplicitAny` warn in src/ and off in `*.test.ts`
- `organizeImports` on

## Scripts + CI

- `npm run lint` / `lint:fix` / `format`
- New `Lint (Biome)` step in the `frontend` CI job, before `Typecheck + build`

## Diff

`biome check --write --unsafe` applied to src/:

- 3 files reformatted from 8-space to tabs
- one `import` → `import type` migration
- one `useTemplate` fix
- imports organised

The visible churn is tab normalisation; logic is unchanged.

## Tested

- `npm run lint` clean
- `tsc --noEmit` clean
- `vite build` clean (417 kB bundle, identical output structure)