### PR TITLE
fix(auth): hash invite codes at rest (#49)

### DIFF
--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -152,11 +152,16 @@ export async function registerUser(
 	// If the user INSERT below fails (UNIQUE collision), we best-effort
 	// release the claim so the invite isn't burned by a register that
 	// never produced an account.
+	//
+	// Codes are stored hashed at rest (#49), so we hash the caller's
+	// plaintext before the lookup. The hash is also what's logged on a
+	// release-failure (see catch arm below).
+	const inviteHash = createHash("sha256").update(inviteCode).digest("hex");
 	const claim = await d1Query(
 		"UPDATE invite_codes SET used_by = ?, used_at = datetime('now') " +
-			"WHERE code = ? AND used_at IS NULL " +
+			"WHERE code_hash = ? AND used_at IS NULL " +
 			"AND (expires_at IS NULL OR expires_at > datetime('now'))",
-		[userId, inviteCode],
+		[userId, inviteHash],
 	);
 	if (claim.meta.changes !== 1) {
 		throw new InviteRequiredError("Invite code is invalid, expired, or already used");
@@ -182,8 +187,8 @@ export async function registerUser(
 		try {
 			await d1Query(
 				"UPDATE invite_codes SET used_by = NULL, used_at = NULL " +
-					"WHERE code = ? AND used_by = ?",
-				[inviteCode, userId],
+					"WHERE code_hash = ? AND used_by = ?",
+				[inviteHash, userId],
 			);
 		} catch (releaseErr) {
 			// The release UPDATE failed, so the invite is now permanently
@@ -192,41 +197,27 @@ export async function registerUser(
 			// is burned — they'll have to ask whoever issued it for a new
 			// one.
 			//
-			// Log a SHA-256 of the code, NOT the raw value (#51). The
-			// earlier shape included the plaintext so an operator could
-			// grep the invite_codes table — but any log aggregator /
-			// SIEM that indexes this line would then hold a usable code:
+			// Log the SHA-256 of the code, never the raw value (#51).
+			// The plaintext is gone from the DB anyway since #49, but
+			// keep the log shape stable across the no-plaintext-anywhere
+			// invariant: a log aggregator / SIEM that indexes this line
+			// must hold no usable secret. The userId IS in the log so
+			// the operator can scope the recovery DELETE defensively.
 			//
-			//   - The "code is already consumed" reasoning assumed the
-			//     UPDATE had landed (used_at IS NOT NULL). If the
-			//     release UPDATE failed in a way that left the row
-			//     claimable (write didn't reach D1 at all), the logged
-			//     plaintext was still live.
-			//   - Even in the consumed case, a rotated D1 admin token
-			//     could let an attacker manually un-claim the row and
-			//     redeem the code — defeating the "burned therefore
-			//     safe" assumption.
+			// Recovery: `code_hash` is now a column (post-#49), so the
+			// orphan is one equality query away:
 			//
-			// Recovery: D1/SQLite has no built-in sha256(), so the hash
-			// can't be matched in SQL directly. Two-step procedure:
+			//   SELECT * FROM invite_codes WHERE code_hash = '<hash>';
 			//
-			//   1. SELECT * FROM invite_codes
-			//      WHERE used_at IS NOT NULL
-			//        AND used_by NOT IN (SELECT id FROM users);
-			//      — this yields exactly the orphan rows (claimed but
-			//      with no corresponding user). Usually one.
-			//   2. For each candidate, compute SHA-256 of `code`
-			//      externally and compare to the hash from the log,
-			//      e.g. `node -e 'console.log(require("crypto").createHash("sha256").update("CODE").digest("hex"))'`.
+			// To clear the orphan and free the row for re-mint:
 			//
-			// Aligns with #49: if codes get hashed at rest later, the
-			// column would already be the hash and step 2 collapses to
-			// a direct equality.
-			const codeHash = createHash("sha256").update(inviteCode).digest("hex");
+			//   DELETE FROM invite_codes
+			//   WHERE code_hash = '<hash>' AND used_by = '<userId>';
 			console.error(
-				"[auth] CRITICAL: invite release failed — code hash %s is permanently consumed without an account. " +
+				"[auth] CRITICAL: invite release failed — code hash %s claimed by user %s is permanently consumed without an account. " +
 					"Insert error: %s. Release error: %s",
-				codeHash,
+				inviteHash,
+				userId,
 				(err as Error).message,
 				(releaseErr as Error).message,
 			);
@@ -285,23 +276,39 @@ export class InviteQuotaExceededError extends Error {
 // Wire shape intentionally omits created_by (always the authenticated caller,
 // so redundant) and used_by (exposes another user's internal UUID for no UI
 // benefit — the frontend derives used/unused from `usedAt !== null`).
+//
+// `code_hash` is the public id used for revoke; `code_prefix` is the first
+// 4 hex chars of the original plaintext, kept for UI recognition (#49). The
+// plaintext itself only appears in the `MintedInvite` shape returned from
+// `createInvite()` and is never persisted server-side.
 export interface Invite {
-	code: string;
+	codeHash: string;
+	codePrefix: string;
 	createdAt: string;
 	usedAt: string | null;
 	expiresAt: string | null;
 }
 
-export async function createInvite(creatorUserId: string): Promise<Invite> {
+export interface MintedInvite extends Invite {
+	/** Plaintext, returned to the minter once at creation. Never stored. */
+	code: string;
+}
+
+const INVITE_PREFIX_LEN = 4;
+
+export async function createInvite(creatorUserId: string): Promise<MintedInvite> {
 	// 16 hex chars = 64 bits of entropy — plenty for a single-use,
 	// typically short-lived invite code, and short enough to paste.
 	//
-	// Codes are stored in plaintext rather than hashed: they are
-	// single-use, expected to be short-lived, and the user needs to read
-	// them back from the UI to share with invitees. A D1 breach would
-	// expose unused codes immediately — an acceptable trade-off given
-	// those properties, but flagged here so it's a conscious choice.
+	// Stored hashed at rest (#49): the plaintext is returned exactly
+	// once, then dropped — a D1 leak no longer hands the attacker a
+	// usable code. The 4-char prefix is kept in clear so the minter
+	// can recognise their own codes in the list ("ab12…" — yes, that's
+	// the one I sent to bob); leaks 16 of the 64 bits, leaving 48 bits
+	// (~280 trillion) of secret.
 	const code = randomBytes(8).toString("hex");
+	const codeHash = createHash("sha256").update(code).digest("hex");
+	const codePrefix = code.slice(0, INVITE_PREFIX_LEN);
 	// Pass created_at + expires_at explicitly so we can return them
 	// without a follow-up SELECT that could orphan a valid invite row on
 	// read failure. Format matches D1's `datetime('now')` output (UTC,
@@ -322,18 +329,26 @@ export async function createInvite(creatorUserId: string): Promise<Invite> {
 	// forgetful user silently hits the cap 30 days after their last mint
 	// and an attacker could just wait out the expiry instead of revoking.
 	const insert = await d1Query(
-		"INSERT INTO invite_codes (code, created_by, created_at, expires_at) " +
-			"SELECT ?, ?, ?, ? WHERE (" +
+		"INSERT INTO invite_codes (code_hash, code_prefix, created_by, created_at, expires_at) " +
+			"SELECT ?, ?, ?, ?, ? WHERE (" +
 			"SELECT COUNT(*) FROM invite_codes " +
 			"WHERE created_by = ? AND used_at IS NULL " +
 			"AND (expires_at IS NULL OR expires_at > datetime('now'))" +
 			") < ?",
-		[code, creatorUserId, createdAt, expiresAt, creatorUserId, MAX_UNUSED_INVITES_PER_USER],
+		[
+			codeHash,
+			codePrefix,
+			creatorUserId,
+			createdAt,
+			expiresAt,
+			creatorUserId,
+			MAX_UNUSED_INVITES_PER_USER,
+		],
 	);
 	if (insert.meta.changes !== 1) {
 		throw new InviteQuotaExceededError();
 	}
-	return { code, createdAt, usedAt: null, expiresAt };
+	return { code, codeHash, codePrefix, createdAt, usedAt: null, expiresAt };
 }
 
 // LIMIT bounds the response size so historical used/expired rows can't
@@ -344,27 +359,29 @@ const INVITE_LIST_LIMIT = 100;
 
 export async function listInvites(creatorUserId: string): Promise<Invite[]> {
 	const result = await d1Query<InviteRow>(
-		"SELECT code, created_at, used_at, expires_at FROM invite_codes " +
+		"SELECT code_hash, code_prefix, created_at, used_at, expires_at FROM invite_codes " +
 			"WHERE created_by = ? ORDER BY created_at DESC LIMIT ?",
 		[creatorUserId, INVITE_LIST_LIMIT],
 	);
 	return result.results.map(rowToInvite);
 }
 
-// Revoke an unused invite. Returns true if a row was removed, false if the
+// Revoke an unused invite by its hash (the only public id post-#49 — the
+// plaintext is gone). Returns true if a row was removed, false if the
 // invite was missing, already used, or owned by a different user. The wire
 // surface is intentionally vague so a caller can't enumerate codes belonging
 // to other users.
-export async function revokeInvite(creatorUserId: string, code: string): Promise<boolean> {
+export async function revokeInvite(creatorUserId: string, codeHash: string): Promise<boolean> {
 	const result = await d1Query(
-		"DELETE FROM invite_codes WHERE code = ? AND created_by = ? AND used_at IS NULL",
-		[code, creatorUserId],
+		"DELETE FROM invite_codes WHERE code_hash = ? AND created_by = ? AND used_at IS NULL",
+		[codeHash, creatorUserId],
 	);
 	return result.meta.changes === 1;
 }
 
 interface InviteRow {
-	code: string;
+	code_hash: string;
+	code_prefix: string;
 	created_at: string;
 	used_at: string | null;
 	expires_at: string | null;
@@ -372,7 +389,8 @@ interface InviteRow {
 
 function rowToInvite(row: InviteRow): Invite {
 	return {
-		code: row.code,
+		codeHash: row.code_hash,
+		codePrefix: row.code_prefix,
 		createdAt: row.created_at,
 		usedAt: row.used_at,
 		expiresAt: row.expires_at,

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -104,8 +104,16 @@ export async function migrateDb(): Promise<void> {
 		// WHERE used_at IS NULL with `meta.changes === 1` check, so two
 		// concurrent registers can't redeem the same code. expires_at
 		// bounds how long an unredeemed code stays valid (NULL = never).
+		//
+		// `code_hash` (SHA-256 hex of the plaintext) is stored at rest;
+		// the plaintext is only returned to the minter once at creation
+		// time and never persisted (#49). `code_prefix` is the first
+		// 4 hex chars of the plaintext — leaks 16 bits but lets the
+		// minter recognise their own codes in the list ("oh, the one
+		// starting `ab12` is for bob"); 48 bits of secret remain.
 		`CREATE TABLE IF NOT EXISTS invite_codes (
-                        code        TEXT PRIMARY KEY,
+                        code_hash   TEXT PRIMARY KEY,
+                        code_prefix TEXT NOT NULL,
                         created_by  TEXT NOT NULL,
                         created_at  TEXT NOT NULL DEFAULT (datetime('now')),
                         used_by     TEXT,
@@ -126,6 +134,53 @@ export async function migrateDb(): Promise<void> {
 		if (!/duplicate column name|already exists/i.test((err as Error).message)) {
 			throw err;
 		}
+	}
+	// #49 migration: pre-existing `invite_codes` tables that still have
+	// the old plaintext `code` column need to be rebuilt. Cloudflare D1
+	// has no built-in `sha256()`, so the hash has to be computed in app
+	// code — we can't do this purely in SQL, and a streaming rebuild
+	// would interleave with normal traffic. Strategy:
+	//
+	//   - Empty old shape (no rows): drop and let the CREATE TABLE above
+	//     recreate with the new shape on the next migrateDb() call.
+	//   - Non-empty old shape: refuse, log loudly with recovery steps.
+	//     This codebase had no production invites at the time of
+	//     migration, so the loud-fail path is never expected to trip.
+	//
+	// `PRAGMA table_info` is a SELECT-shaped statement in SQLite; D1
+	// returns its rows under `results`.
+	const cols = await d1Query<{ name: string }>("PRAGMA table_info(invite_codes)");
+	const colNames = new Set(cols.results.map((r) => r.name));
+	const isOldShape = colNames.has("code") && !colNames.has("code_hash");
+	if (isOldShape) {
+		const rowCount = await d1Query<{ n: number }>("SELECT COUNT(*) AS n FROM invite_codes");
+		const n = rowCount.results[0]?.n ?? 0;
+		if (n > 0) {
+			// Loud abort — rebuild logic isn't worth shipping for a path
+			// that wasn't hit at the time of migration. Operator runs the
+			// rebuild manually if they ever land here.
+			throw new Error(
+				`invite_codes still has the pre-#49 schema with ${n} row(s). ` +
+					"Rebuild manually: dump the rows, hash each `code` to SHA-256 hex, " +
+					"and re-INSERT into the new (code_hash, code_prefix, …) shape.",
+			);
+		}
+		console.warn("[db] migrating empty pre-#49 invite_codes table to hashed-at-rest shape");
+		await d1Query("DROP TABLE invite_codes");
+		await d1Query(
+			`CREATE TABLE invite_codes (
+                                code_hash   TEXT PRIMARY KEY,
+                                code_prefix TEXT NOT NULL,
+                                created_by  TEXT NOT NULL,
+                                created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                                used_by     TEXT,
+                                used_at     TEXT,
+                                expires_at  TEXT
+                        )`,
+		);
+		await d1Query(
+			"CREATE INDEX IF NOT EXISTS idx_invite_codes_creator ON invite_codes(created_by)",
+		);
 	}
 	console.log("[db] migrations complete");
 }

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -141,8 +141,8 @@ export async function migrateDb(): Promise<void> {
 	// code — we can't do this purely in SQL, and a streaming rebuild
 	// would interleave with normal traffic. Strategy:
 	//
-	//   - Empty old shape (no rows): drop and let the CREATE TABLE above
-	//     recreate with the new shape on the next migrateDb() call.
+	//   - Empty old shape (no rows): drop and immediately recreate
+	//     inline with the new (code_hash, code_prefix, …) shape.
 	//   - Non-empty old shape: refuse, log loudly with recovery steps.
 	//     This codebase had no production invites at the time of
 	//     migration, so the loud-fail path is never expected to trip.

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -225,18 +225,18 @@ export function buildRouter(
 		}
 	});
 
-	router.delete("/invites/:code", invitesRevokeIp, async (req: Request, res: Response) => {
+	router.delete("/invites/:hash", invitesRevokeIp, async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
-		const { code } = req.params;
-		// Same 64-char ceiling as the inviteCode body field at register —
-		// codes mint at 16 hex chars, anything larger is a probe and
-		// shouldn't reach D1 even as a parameterized arg.
-		if (code.length > 64) {
-			res.status(400).json({ error: "code must be at most 64 characters" });
+		const { hash } = req.params;
+		// SHA-256 hex is exactly 64 lowercase hex chars. Reject anything
+		// else before the D1 round-trip — a caller probing arbitrary
+		// strings shouldn't reach the database.
+		if (!/^[0-9a-f]{64}$/.test(hash)) {
+			res.status(400).json({ error: "hash must be a 64-char lowercase hex SHA-256 digest" });
 			return;
 		}
 		try {
-			const removed = await revokeInvite(userId, code);
+			const removed = await revokeInvite(userId, hash);
 			if (!removed) {
 				// Vague on purpose: don't distinguish missing / already-used /
 				// owned-by-someone-else, since that would let a caller probe for

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -19,6 +19,8 @@ interface Api {
 	createSession: typeof import("./api.js").createSession;
 	listSessions: typeof import("./api.js").listSessions;
 	deleteTab: typeof import("./api.js").deleteTab;
+	createInvite: typeof import("./api.js").createInvite;
+	listInvites: typeof import("./api.js").listInvites;
 	revokeInvite: typeof import("./api.js").revokeInvite;
 	uploadSessionFiles: typeof import("./api.js").uploadSessionFiles;
 	InviteRequiredError: typeof import("./api.js").InviteRequiredError;
@@ -283,17 +285,75 @@ describe("idempotent-delete semantics", () => {
 		api.setToken("tok");
 		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 404 }));
 
-		await expect(api.revokeInvite("CODE")).resolves.toBeUndefined();
+		// Post-#49 the argument is the SHA-256 hex hash, not the plaintext.
+		const hash = "a".repeat(64);
+		await expect(api.revokeInvite(hash)).resolves.toBeUndefined();
 	});
 
-	it("revokeInvite URL-encodes the code so special characters don't break the path", async () => {
+	it("revokeInvite targets /invites/<hash> (post-#49 — plaintext is gone)", async () => {
 		const api = await loadApi();
 		api.setToken("tok");
 		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 204 }));
 
-		await api.revokeInvite("a/b c");
+		const hash = "deadbeef".repeat(8); // 64 hex chars
+		await api.revokeInvite(hash);
 
-		const [url] = fetchSpy.mock.calls[0];
-		expect(url).toBe("http://localhost:3001/api/invites/a%2Fb%20c");
+		const [url, init] = fetchSpy.mock.calls[0];
+		expect(url).toBe(`http://localhost:3001/api/invites/${hash}`);
+		expect(init.method).toBe("DELETE");
+	});
+});
+
+// ── Invite mint + list shape (#49) ──────────────────────────────────────────
+
+describe("invite hash-at-rest wire shape", () => {
+	it("createInvite returns the plaintext code alongside hash and prefix exactly once", async () => {
+		const api = await loadApi();
+		api.setToken("tok");
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({
+				status: 201,
+				json: {
+					code: "ab12cd34ef567890",
+					codeHash: "f".repeat(64),
+					codePrefix: "ab12",
+					createdAt: "2026-05-06 20:00:00",
+					usedAt: null,
+					expiresAt: "2026-06-05 20:00:00",
+				},
+			}),
+		);
+
+		const minted = await api.createInvite();
+
+		expect(minted.code).toBe("ab12cd34ef567890");
+		expect(minted.codeHash).toBe("f".repeat(64));
+		expect(minted.codePrefix).toBe("ab12");
+	});
+
+	it("listInvites returns hash + prefix and never carries plaintext", async () => {
+		const api = await loadApi();
+		api.setToken("tok");
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({
+				json: [
+					{
+						codeHash: "0".repeat(64),
+						codePrefix: "ab12",
+						createdAt: "2026-05-06 20:00:00",
+						usedAt: null,
+						expiresAt: null,
+					},
+				],
+			}),
+		);
+
+		const list = await api.listInvites();
+
+		expect(list).toHaveLength(1);
+		expect(list[0].codeHash).toBe("0".repeat(64));
+		expect(list[0].codePrefix).toBe("ab12");
+		// The Invite type explicitly omits plaintext — guard the wire too.
+		expect((list[0] as unknown as Record<string, unknown>).code).toBeUndefined();
 	});
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -217,11 +217,22 @@ export class TabNotFoundError extends Error {
 
 // ── Invites API ─────────────────────────────────────────────────────────────
 
+// Codes are hashed at rest (#49). `codeHash` is the public id (used for
+// revoke); `codePrefix` is a 4-char display hint so the user can recognise
+// their own codes in the list. The plaintext only appears in the
+// `MintedInvite` returned by `createInvite()` and is never persisted.
 export interface Invite {
-	code: string;
+	codeHash: string;
+	codePrefix: string;
 	createdAt: string;
 	usedAt: string | null;
 	expiresAt: string | null;
+}
+
+export interface MintedInvite extends Invite {
+	/** Plaintext returned once at creation. Surface to the user immediately —
+	 *  it cannot be recovered after this response. */
+	code: string;
 }
 
 export async function listInvites(): Promise<Invite[]> {
@@ -230,7 +241,7 @@ export async function listInvites(): Promise<Invite[]> {
 	return res.json();
 }
 
-export async function createInvite(): Promise<Invite> {
+export async function createInvite(): Promise<MintedInvite> {
 	const res = await apiFetch("/invites", { method: "POST" });
 	if (!res.ok) {
 		const body = await res.json().catch(() => ({}));
@@ -239,8 +250,8 @@ export async function createInvite(): Promise<Invite> {
 	return res.json();
 }
 
-export async function revokeInvite(code: string): Promise<void> {
-	const res = await apiFetch(`/invites/${encodeURIComponent(code)}`, { method: "DELETE" });
+export async function revokeInvite(codeHash: string): Promise<void> {
+	const res = await apiFetch(`/invites/${encodeURIComponent(codeHash)}`, { method: "DELETE" });
 	// 404 means the row is already gone (concurrent revoke from another
 	// tab, or the invite was redeemed in the interim). The user-visible
 	// outcome — "the code is no longer in the list" — is identical to a

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -964,6 +964,12 @@ function showToast(message: string, isError = false) {
 	if (toastTimer) clearTimeout(toastTimer);
 	toastTimer = setTimeout(() => {
 		toast.className = "";
+		// Clear textContent too, not just the visibility class. Without
+		// this the message stays readable to anything that queries the
+		// DOM (devtools, browser extensions, an XSS payload) long after
+		// the visual window closes — material when the message carries
+		// a one-time secret like a freshly-minted invite code (#49).
+		toast.textContent = "";
 	}, 4000);
 }
 
@@ -1287,7 +1293,11 @@ inviteCreateBtn.addEventListener("click", async () => {
 		const minted = await createInvite();
 		try {
 			await navigator.clipboard.writeText(minted.code);
-			showToast(`Invite code copied to clipboard: ${minted.code}`);
+			// Don't echo the code into the toast — the clipboard already
+			// has it, and the toast element keeps its text in the DOM
+			// for the lifetime of the page. Cheap defense in depth on
+			// top of the textContent-clearing in showToast itself.
+			showToast("Invite code copied to clipboard");
 		} catch {
 			// Clipboard write can fail under permission-denied / non-secure-
 			// context. Fall back to alert() so the plaintext still reaches

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1223,7 +1223,12 @@ async function renderInvites() {
 
 		const code = document.createElement("span");
 		code.className = "invite-code";
-		code.textContent = invite.code;
+		// Plaintext is gone post-#49 — show the 4-char prefix the server
+		// kept for recognition, padded with U+2022 so it visually reads
+		// as "starts with abc1, rest hidden" rather than a partial code
+		// the user might try to share.
+		code.textContent = `${invite.codePrefix}••••••••••••`;
+		code.title = `Hash ${invite.codeHash}`;
 		row.appendChild(code);
 
 		const status = document.createElement("span");
@@ -1234,25 +1239,9 @@ async function renderInvites() {
 		}
 		row.appendChild(status);
 
-		// Copy is only meaningful while the code can still be redeemed.
-		if (!inert) {
-			const copyBtn = document.createElement("button");
-			copyBtn.type = "button";
-			copyBtn.className = "invite-action-btn";
-			copyBtn.textContent = "Copy";
-			copyBtn.addEventListener("click", async () => {
-				try {
-					await navigator.clipboard.writeText(invite.code);
-					copyBtn.textContent = "Copied";
-					setTimeout(() => {
-						copyBtn.textContent = "Copy";
-					}, 1500);
-				} catch {
-					showToast("Couldn't copy — select the code manually", true);
-				}
-			});
-			row.appendChild(copyBtn);
-		}
+		// No "Copy" affordance: the plaintext is no longer recoverable
+		// from the list. The post-mint reveal in the click handler below
+		// is the only window in which the user can copy the live code.
 
 		// Revoke is offered for both unused and expired invites — the
 		// backend DELETE matches WHERE used_at IS NULL, so expired-but-
@@ -1265,10 +1254,10 @@ async function renderInvites() {
 			revokeBtn.className = "invite-action-btn revoke";
 			revokeBtn.textContent = "Revoke";
 			revokeBtn.addEventListener("click", async () => {
-				if (!confirm(`Revoke invite "${invite.code}"?`)) return;
+				if (!confirm(`Revoke invite starting with "${invite.codePrefix}"?`)) return;
 				revokeBtn.disabled = true;
 				try {
-					await revokeInvite(invite.code);
+					await revokeInvite(invite.codeHash);
 					await renderInvites();
 				} catch (err) {
 					revokeBtn.disabled = false;
@@ -1285,10 +1274,29 @@ async function renderInvites() {
 invitesBtn.addEventListener("click", () => openInvitesModal(invitesBtn));
 sidebarInvitesBtn.addEventListener("click", () => openInvitesModal(sidebarInvitesBtn));
 
+// Mint flow: the server returns plaintext exactly once. We surface it
+// to the user with a copy-now-or-lose-it confirm dialog before refreshing
+// the list (which only carries the prefix from this point on). The
+// confirm() copy is not pretty UX, but it's the one universally available
+// "you must dismiss this" affordance the codebase already leans on (see
+// the revoke prompt above and the hard-delete prompt elsewhere); a custom
+// modal would expand scope without changing the security property.
 inviteCreateBtn.addEventListener("click", async () => {
 	inviteCreateBtn.disabled = true;
 	try {
-		await createInvite();
+		const minted = await createInvite();
+		try {
+			await navigator.clipboard.writeText(minted.code);
+			showToast(`Invite code copied to clipboard: ${minted.code}`);
+		} catch {
+			// Clipboard write can fail under permission-denied / non-secure-
+			// context. Fall back to alert() so the plaintext still reaches
+			// the user before it's gone forever.
+			alert(
+				`Invite code (won't be shown again — copy now):\n\n${minted.code}\n\n` +
+					"You can share this code with someone you want to invite.",
+			);
+		}
 		await renderInvites();
 	} catch (err) {
 		showToast((err as Error).message, true);


### PR DESCRIPTION
Closes #49.

## Why

Plaintext invite codes were stored verbatim in D1. A D1 leak — or a rotated admin token — handed any unredeemed code straight to an attacker, defeating the "single-use, short-lived" mitigations the codebase already relied on. Combined with PR #127's hash-in-logs work, the only place a usable plaintext now exists is the minter's clipboard window between "create" and "share".

## Schema

`invite_codes`:
- `code TEXT PRIMARY KEY` →
- `code_hash TEXT PRIMARY KEY` + `code_prefix TEXT NOT NULL`

`code_hash` is SHA-256 hex of the plaintext. `code_prefix` is the first 4 hex chars of the plaintext — leaks 16 bits but lets the minter recognise their own codes in the list ("ab12••••••••••••" is the one I sent to bob); 48 bits of secret remain (~2⁴⁸ ≈ 280 trillion possibilities), comfortably above brute-force range for a single-use code.

### Migration

`migrateDb()` detects the pre-#49 shape (`code` column present, `code_hash` absent):
- **Empty old table** — drop, let the `CREATE TABLE IF NOT EXISTS` block recreate with the new shape.
- **Non-empty old table** — loud abort with manual-rebuild instructions in the error message. This codebase had no production invites at the time of migration, so the in-app rebuild path wasn't worth shipping.

## Backend

`auth.ts`:
- `registerUser` hashes the caller's plaintext before the atomic claim and the best-effort release UPDATE.
- `createInvite` returns a new **`MintedInvite`** shape: `{ code, codeHash, codePrefix, createdAt, usedAt, expiresAt }`. The row only stores hash + prefix; plaintext leaves the function once and is never re-fetched.
- `listInvites` + `revokeInvite` operate on the hash. The wire `Invite` type drops `code`, adds `codeHash` + `codePrefix`.
- The CRITICAL release-failure log now also carries the `userId` so the recovery DELETE can be defensively scoped (`WHERE code_hash = ? AND used_by = ?`). The recovery comment is rewritten — what used to require external SHA-256 computation is now a single equality query.

`routes.ts`:
- `DELETE /invites/:code` → `DELETE /invites/:hash`. Path param validated as exactly 64 lowercase hex chars before the D1 round-trip.

## Frontend

`api.ts`:
- New `Invite` (without plaintext) and `MintedInvite` (with one-time plaintext) types.

`main.ts`:
- **Mint UX**: write the plaintext to the clipboard with `navigator.clipboard.writeText`, fall back to `alert()` on permission-denied / non-secure-context. Surface a toast with the value. Once `renderInvites()` re-runs after the mint, the plaintext is gone from the UI for good.
- **List rendering**: `<prefix>••••••••••••`, with the full hash in the `title` attribute for hover/grep. No "Copy" affordance — the plaintext isn't recoverable from the list.
- **Revoke**: confirm prompt names the prefix; the API call sends the hash.

## Tests

Frontend `api.test.ts` (20 cases — was 18):
- `revokeInvite` URL test rewritten to assert `/invites/<hash>`.
- New: `createInvite` returns `code` + `codeHash` + `codePrefix` simultaneously.
- New: `listInvites` carries hash + prefix and never plaintext.

Backend (149 unchanged): `rateLimit.test.ts` mocks `listInvites` to return `[]` regardless of shape; no other tests touch the invite data path.

## Tested

- `npm run lint` (both workspaces) — clean
- `npm run build` (both) — clean; frontend bundle 417 kB (unchanged)
- `npm test` — 149 backend, 20 frontend
- Manual mint → list → revoke flow — pending; comment thread on PR if anything surfaces