### PR TITLE
chore(ci): pin claude-review.yml actions to commit SHAs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,8 +19,10 @@ name: Claude PR Review
 #   tools (Read, Grep, Glob). Nothing that can write, push, or reach
 #   network, so a prompt-injection attack can't pivot beyond influencing
 #   the single review comment.
-# - Action is pinned to major version `@v1`. Consider pinning to a commit SHA
-#   for stricter supply-chain hygiene.
+# - All `uses:` references are pinned to a full commit SHA with the
+#   resolved tag in a trailing comment, matching ci.yml. A compromised
+#   tag (e.g. someone force-moves `v1`) can't pull a new SHA into a run
+#   here without a code change that's visible in PR diff.
 
 on:
   pull_request:
@@ -40,13 +42,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Claude review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@62238ddb33772a079b0a6d8665a1ff3043583067 # v1.0.114
         with:
           # Claude Max / Pro subscription (OAuth). For pay-as-you-go API billing instead,
           # comment the line below and use: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
`ci.yml` already pinned every `uses:` to a full commit SHA with the resolved tag in a trailing comment. `claude-review.yml` had two stragglers on floating tags — the header comment in that file even called this out as a known gap.

## Pins

- `actions/checkout@v6` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
  - Same SHA already in use in `ci.yml`.
- `anthropics/claude-code-action@v1` → `62238ddb33772a079b0a6d8665a1ff3043583067 # v1.0.114`
  - `v1` is an annotated tag; resolved via `gh api repos/anthropics/claude-code-action/git/tags/<sha>` to the commit object it points at.

After this, a force-moved tag can't ship a new SHA into a run without a code change visible in PR diff — matching the property `ci.yml` already had.

The header comment in `claude-review.yml` is updated to describe the new state instead of flagging the old gap.

## Tested

Workflow files only — no application code touched. CI runs against the unchanged ci.yml job set on this PR.