### PR TITLE
feat(backend): switch to pino structured logger (#5)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "express-rate-limit": "^8.3.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "pino": "^10.3.1",
         "uuid": "^9.0.1",
         "ws": "^8.17.1"
       },
@@ -27,6 +28,7 @@
         "@types/node": "^20.14.2",
         "@types/uuid": "^9.0.8",
         "@types/ws": "^8.5.10",
+        "pino-pretty": "^13.1.3",
         "tsx": "^4.15.6",
         "typescript": "^5.4.5",
         "vitest": "^2.1.9"
@@ -708,6 +710,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1530,6 +1538,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1784,6 +1801,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -1847,6 +1871,16 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -2196,6 +2230,20 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -2372,6 +2420,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2455,6 +2510,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -2640,6 +2705,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -2718,6 +2793,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2778,6 +2862,68 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -2806,6 +2952,22 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/protobufjs": {
       "version": "7.5.5",
@@ -2869,6 +3031,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2905,6 +3073,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/require-directory": {
@@ -2991,11 +3168,37 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -3148,6 +3351,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3163,6 +3375,15 @@
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
       "license": "ISC"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/ssh2": {
       "version": "1.17.0",
@@ -3247,6 +3468,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -3273,6 +3507,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tinybench": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "express-rate-limit": "^8.3.2",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "pino": "^10.3.1",
     "uuid": "^9.0.1",
     "ws": "^8.17.1"
   },
@@ -35,6 +36,7 @@
     "@types/node": "^20.14.2",
     "@types/uuid": "^9.0.8",
     "@types/ws": "^8.5.10",
+    "pino-pretty": "^13.1.3",
     "tsx": "^4.15.6",
     "typescript": "^5.4.5",
     "vitest": "^2.1.9"

--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -6,9 +6,12 @@ import {
 	validateJwtSecret,
 	warnIfWildcardCorsInProduction,
 } from "./auth.js";
+import { logger } from "./logger.js";
 
-// These tests manipulate process.env.{JWT_SECRET, NODE_ENV} and use a
-// spy on console.warn. Snapshot + restore each to avoid cross-test leakage.
+// These tests manipulate process.env.{JWT_SECRET, NODE_ENV} and spy on
+// the pino logger's `warn` method (production code now logs through the
+// shared logger, not raw console). Snapshot + restore each to avoid
+// cross-test leakage.
 describe("validateJwtSecret", () => {
 	const originalEnv = { ...process.env };
 	let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -16,7 +19,7 @@ describe("validateJwtSecret", () => {
 	beforeEach(() => {
 		delete process.env.JWT_SECRET;
 		delete process.env.NODE_ENV;
-		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+		warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {
 			/* swallow */
 		});
 		// Reset the module-level captured secret so each test starts from

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -8,6 +8,7 @@ import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { v4 as uuidv4 } from "uuid";
 import { d1Query } from "./db.js";
+import { logger } from "./logger.js";
 import type { JwtPayload } from "./types.js";
 
 // Dev fallback. Production deployments must supply JWT_SECRET — validateJwtSecret()
@@ -49,12 +50,12 @@ export function validateJwtSecret(): void {
 		);
 	}
 	if (missing) {
-		console.warn(
+		logger.warn(
 			"[auth] JWT_SECRET is not set — using the insecure default. " +
 				"Set JWT_SECRET in your .env before any non-local use.",
 		);
 	} else if (usingPlaceholder) {
-		console.warn(
+		logger.warn(
 			"[auth] JWT_SECRET is set to the insecure placeholder value. " +
 				"Replace it in your .env before any non-local use.",
 		);
@@ -213,13 +214,9 @@ export async function registerUser(
 			//
 			//   DELETE FROM invite_codes
 			//   WHERE code_hash = '<hash>' AND used_by = '<userId>';
-			console.error(
-				"[auth] CRITICAL: invite release failed — code hash %s claimed by user %s is permanently consumed without an account. " +
-					"Insert error: %s. Release error: %s",
-				inviteHash,
-				userId,
-				(err as Error).message,
-				(releaseErr as Error).message,
+			logger.error(
+				`[auth] CRITICAL: invite release failed — code hash ${inviteHash} claimed by user ${userId} is permanently consumed without an account. ` +
+					`Insert error: ${(err as Error).message}. Release error: ${(releaseErr as Error).message}`,
 			);
 		}
 		// SQLite UNIQUE-constraint violation → username already taken.
@@ -547,12 +544,12 @@ export function verifyWsToken(
 		// is preferred; the query-string path only kicks in as a fallback for
 		// proxies that strip Sec-WebSocket-Protocol.
 		if (!protocolHeader && !requestUrl) {
-			console.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no request URL");
+			logger.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no request URL");
 		} else if (!protocolHeader) {
-			console.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no ?token= query param");
+			logger.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no ?token= query param");
 		} else {
 			const header = Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader;
-			console.error(
+			logger.error(
 				"[verifyWsToken] no usable auth.bearer.* subprotocol (got: %s) and no ?token= query param",
 				header,
 			);
@@ -563,10 +560,8 @@ export function verifyWsToken(
 	try {
 		return jwt.verify(token, jwtSecret()) as JwtPayload;
 	} catch (err) {
-		console.error(
-			"[verifyWsToken] jwt verify failed:",
-			(err as Error).name,
-			(err as Error).message,
+		logger.error(
+			`[verifyWsToken] jwt verify failed: ${(err as Error).name}: ${(err as Error).message}`,
 		);
 		return null;
 	}
@@ -713,16 +708,18 @@ export function isAllowedWsOrigin(
  * (on boot) rather than per-rejected-request, which would be noisy and
  * drown out genuine attack-surface signals.
  *
- * Logger is injectable for the test.
+ * `out` is injectable for the test — defaults to the module-level pino
+ * logger; tests pass a `{ warn: vi.fn() }` and assert on it. The
+ * parameter name avoids shadowing the imported `logger`.
  */
 export function warnIfWildcardCorsInProduction(
 	allowedOrigins: readonly string[],
 	nodeEnv: string | undefined,
-	logger: Pick<Console, "warn"> = console,
+	out: { warn: (msg: string) => void } = logger,
 ): void {
 	if (nodeEnv !== "production") return;
 	if (!allowedOrigins.includes("*")) return;
-	logger.warn(
+	out.warn(
 		"[server] CORS_ORIGINS contains '*' in production. The HTTP layer " +
 			"still honours this, but the WebSocket upgrade handler refuses it " +
 			"(CSWSH protection). Set CORS_ORIGINS to an explicit origin list " +

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -10,6 +10,8 @@
  *   D1_DATABASE_ID
  */
 
+import { logger } from "./logger.js";
+
 const ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID ?? "";
 const API_TOKEN = process.env.CLOUDFLARE_API_TOKEN ?? "";
 const DATABASE_ID = process.env.D1_DATABASE_ID ?? "";
@@ -75,7 +77,7 @@ export async function d1Batch(statements: string[]): Promise<void> {
  * Call once on server startup.
  */
 export async function migrateDb(): Promise<void> {
-	console.log("[db] running D1 migrations…");
+	logger.info("[db] running D1 migrations…");
 	await d1Batch([
 		`CREATE TABLE IF NOT EXISTS users (
                         id          TEXT PRIMARY KEY,
@@ -165,7 +167,7 @@ export async function migrateDb(): Promise<void> {
 					"and re-INSERT into the new (code_hash, code_prefix, …) shape.",
 			);
 		}
-		console.warn("[db] migrating empty pre-#49 invite_codes table to hashed-at-rest shape");
+		logger.warn("[db] migrating empty pre-#49 invite_codes table to hashed-at-rest shape");
 		await d1Query("DROP TABLE invite_codes");
 		await d1Query(
 			`CREATE TABLE invite_codes (
@@ -182,7 +184,7 @@ export async function migrateDb(): Promise<void> {
 			"CREATE INDEX IF NOT EXISTS idx_invite_codes_creator ON invite_codes(created_by)",
 		);
 	}
-	console.log("[db] migrations complete");
+	logger.info("[db] migrations complete");
 }
 
 /** Validate that D1 credentials are configured. */

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -15,6 +15,7 @@ import {
 	sanitiseHostname,
 	sanitiseUploadName,
 } from "./dockerManager.js";
+import { logger } from "./logger.js";
 import type { SessionManager } from "./sessionManager.js";
 
 // ── Test harness ────────────────────────────────────────────────────────────
@@ -753,7 +754,7 @@ describe("DockerManager.reconcile", () => {
 	}
 
 	it("warns when reconcile inspects a running pre-#15 container (no CapDrop/SecurityOpt)", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const { dm, sessions } = makeDockerWithInspectResult({
 			State: { Running: true },
 			HostConfig: { CapDrop: [], SecurityOpt: [] },
@@ -781,7 +782,7 @@ describe("DockerManager.reconcile", () => {
 		// migration footgun surfaces even on containers that happen to be
 		// dead at reconcile time — they'll be respawned later, and the
 		// operator needs to know the old image is involved.
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const { dm, sessions } = makeDockerWithInspectResult({
 			State: { Running: false },
 			HostConfig: { CapDrop: [], SecurityOpt: [] },
@@ -800,7 +801,7 @@ describe("DockerManager.reconcile", () => {
 	});
 
 	it("does not warn for properly hardened containers", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const { dm } = makeDockerWithInspectResult({
 			State: { Running: true },
 			HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
@@ -823,7 +824,7 @@ describe("DockerManager.startContainer", () => {
 	// reached this way must surface the same warn as reconcile so a future
 	// refactor can't silently drop the call.
 	it("warns when starting an existing pre-#15 container (Case 2)", async () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const sessions = makeFakeSessions();
 		const dm = new DockerManager(sessions);
 		(dm as unknown as { docker: unknown }).docker = {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -13,6 +13,7 @@ import type { Duplex } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 import Dockerode from "dockerode";
 import { d1Query } from "./db.js";
+import { logger } from "./logger.js";
 import type { SessionManager } from "./sessionManager.js";
 
 const SESSION_IMAGE = process.env.SESSION_IMAGE ?? "shared-terminal-session";
@@ -211,7 +212,7 @@ export class DockerManager {
 		const containerId = container.id;
 		await this.sessions.setContainerId(sessionId, containerId);
 
-		console.log(
+		logger.info(
 			`[docker] spawned container ${meta.containerName} (${containerId.slice(0, 12)}) for session ${sessionId}`,
 		);
 		return containerId;
@@ -285,7 +286,7 @@ export class DockerManager {
 		} catch (err) {
 			const code = (err as NodeJS.ErrnoException).code;
 			if (code === "EPERM" || code === "ENOSYS") {
-				console.warn(
+				logger.warn(
 					`[docker] couldn't chown ${target} to ${WORKSPACE_UID}:${WORKSPACE_GID} (${code}); ` +
 						`run the backend as root or pre-create paths with matching ownership.`,
 				);
@@ -422,7 +423,7 @@ export class DockerManager {
 			// Log the detail server-side; the thrown error carries
 			// a generic message so byte counts don't ride out in
 			// the 413 body to the client.
-			console.warn(
+			logger.warn(
 				`[docker] upload quota rejected for session ${sessionId}: ` +
 					`${usedBytes} used + ${attemptedBytes} attempted > ${UPLOAD_QUOTA_BYTES} cap`,
 			);
@@ -521,9 +522,8 @@ export class DockerManager {
 					/* already removed */
 				}
 			} catch (err) {
-				console.error(
-					`[docker] error killing container for session ${sessionId}:`,
-					(err as Error).message,
+				logger.error(
+					`[docker] error killing container for session ${sessionId}: ${(err as Error).message}`,
 				);
 			}
 			// The container no longer exists in Docker — reflect that in D1 so any
@@ -531,9 +531,8 @@ export class DockerManager {
 			try {
 				await this.sessions.setContainerId(sessionId, null);
 			} catch (err) {
-				console.error(
-					`[docker] failed to null container_id for session ${sessionId}:`,
-					(err as Error).message,
+				logger.error(
+					`[docker] failed to null container_id for session ${sessionId}: ${(err as Error).message}`,
 				);
 			}
 		}
@@ -564,7 +563,7 @@ export class DockerManager {
 				this.keyOf.delete(attachId);
 			}
 		}
-		console.log(`[docker] killed container for session ${sessionId}`);
+		logger.info(`[docker] killed container for session ${sessionId}`);
 	}
 
 	/**
@@ -593,9 +592,9 @@ export class DockerManager {
 
 		try {
 			await fs.rm(sessionAbs, { recursive: true, force: true });
-			console.log(`[docker] purged workspace dir ${sessionAbs}`);
+			logger.info(`[docker] purged workspace dir ${sessionAbs}`);
 		} catch (err) {
-			console.error(`[docker] failed to purge workspace ${sessionAbs}:`, (err as Error).message);
+			logger.error(`[docker] failed to purge workspace ${sessionAbs}: ${(err as Error).message}`);
 			throw err;
 		}
 		// Per-session uploads dir lives at <WORKSPACE_ROOT>/.uploads/<sessionId>/
@@ -604,9 +603,9 @@ export class DockerManager {
 		// forever for a row that no longer exists in D1.
 		try {
 			await fs.rm(uploadsAbs, { recursive: true, force: true });
-			console.log(`[docker] purged uploads dir ${uploadsAbs}`);
+			logger.info(`[docker] purged uploads dir ${uploadsAbs}`);
 		} catch (err) {
-			console.error(`[docker] failed to purge uploads ${uploadsAbs}:`, (err as Error).message);
+			logger.error(`[docker] failed to purge uploads ${uploadsAbs}: ${(err as Error).message}`);
 			throw err;
 		}
 	}
@@ -631,7 +630,7 @@ export class DockerManager {
 		if (!meta.containerId) {
 			await this.spawn(sessionId);
 			await this.sessions.updateStatus(sessionId, "running");
-			console.log(`[docker] respawned container for session ${sessionId}`);
+			logger.info(`[docker] respawned container for session ${sessionId}`);
 			return;
 		}
 
@@ -645,9 +644,9 @@ export class DockerManager {
 				await this.docker.getContainer(meta.containerId).start();
 			}
 			await this.sessions.updateStatus(sessionId, "running");
-			console.log(`[docker] restarted container for session ${sessionId}`);
+			logger.info(`[docker] restarted container for session ${sessionId}`);
 		} catch {
-			console.log(`[docker] stale container_id for session ${sessionId}, respawning`);
+			logger.info(`[docker] stale container_id for session ${sessionId}, respawning`);
 			await this.sessions.setContainerId(sessionId, null);
 			await this.spawn(sessionId);
 			await this.sessions.updateStatus(sessionId, "running");
@@ -671,7 +670,7 @@ export class DockerManager {
 		const capDrop = hostConfig?.CapDrop ?? [];
 		const securityOpt = hostConfig?.SecurityOpt ?? [];
 		if (capDrop.includes("ALL") && securityOpt.includes("no-new-privileges:true")) return;
-		console.warn(
+		logger.warn(
 			`[docker] session ${sessionId} container ${containerId.slice(0, 12)} ` +
 				`predates issue-#15 hardening (CapDrop=${JSON.stringify(capDrop)}, ` +
 				`SecurityOpt=${JSON.stringify(securityOpt)}). ` +
@@ -688,7 +687,7 @@ export class DockerManager {
 			/* already stopped */
 		}
 		await this.sessions.updateStatus(sessionId, "stopped");
-		console.log(`[docker] stopped container for session ${sessionId}`);
+		logger.info(`[docker] stopped container for session ${sessionId}`);
 	}
 
 	// ── Exec attach ────────────────────────────────────────────────────────
@@ -716,7 +715,7 @@ export class DockerManager {
 			// before this microtask.
 			pending.catch((err) => {
 				if (this.shared.get(key) === pending) this.shared.delete(key);
-				console.error(`[docker] shared exec spawn failed for ${key}:`, (err as Error).message);
+				logger.error(`[docker] shared exec spawn failed for ${key}: ${(err as Error).message}`);
 			});
 			this.shared.set(key, pending);
 		}
@@ -838,7 +837,7 @@ export class DockerManager {
 			this.detach(attachId);
 			throw err;
 		}
-		console.log(
+		logger.info(
 			`[docker] attached ${attachId} to session ${sessionId} (listeners=${s.listeners.size})`,
 		);
 
@@ -905,9 +904,8 @@ export class DockerManager {
 			// dump xterm needs CRLF line terminators — add the \r back.
 			return stdout.replace(/\n/g, "\r\n");
 		} catch (err) {
-			console.warn(
-				`[docker] capture-pane failed for ${this.targetKey(sessionId, tabId)}:`,
-				(err as Error).message,
+			logger.warn(
+				`[docker] capture-pane failed for ${this.targetKey(sessionId, tabId)}: ${(err as Error).message}`,
 			);
 			return "";
 		}
@@ -966,12 +964,12 @@ export class DockerManager {
 					} catch {
 						/* already destroyed */
 					}
-					console.log(`[docker] detached ${attachId}; last client, shared exec closed`);
+					logger.info(`[docker] detached ${attachId}; last client, shared exec closed`);
 				} else {
 					// Someone else may have had a smaller terminal; recompute so
 					// the survivors don't stay pinned to a too-small size.
 					void this.recomputeSize(s);
-					console.log(`[docker] detached ${attachId}; ${s.listeners.size} listener(s) remain`);
+					logger.info(`[docker] detached ${attachId}; ${s.listeners.size} listener(s) remain`);
 				}
 			},
 			() => {
@@ -1079,11 +1077,11 @@ export class DockerManager {
 			void forgetIfCurrent();
 		});
 		stream.on("error", (err) => {
-			console.error(`[docker] shared exec stream error for ${key}:`, (err as Error).message);
+			logger.error(`[docker] shared exec stream error for ${key}: ${(err as Error).message}`);
 			void forgetIfCurrent();
 		});
 
-		console.log(`[docker] spawned shared exec for ${key}`);
+		logger.info(`[docker] spawned shared exec for ${key}`);
 		return s;
 	}
 
@@ -1178,7 +1176,7 @@ export class DockerManager {
 		]);
 
 		const now = Math.floor(Date.now() / 1000);
-		console.log(`[docker] created tab ${tabId} (${displayLabel}) in session ${sessionId}`);
+		logger.info(`[docker] created tab ${tabId} (${displayLabel}) in session ${sessionId}`);
 		return { tabId, label: displayLabel, createdAt: now };
 	}
 
@@ -1210,9 +1208,9 @@ export class DockerManager {
 		if (exitCode !== 0) {
 			// kill-session returns non-zero if the target doesn't exist — OK for
 			// the idempotent case; caller has already validated it existed.
-			console.warn(`[docker] kill-session ${tabId} exited ${exitCode}`);
+			logger.warn(`[docker] kill-session ${tabId} exited ${exitCode}`);
 		}
-		console.log(`[docker] deleted tab ${tabId} from session ${sessionId}`);
+		logger.info(`[docker] deleted tab ${tabId} from session ${sessionId}`);
 	}
 
 	private async execOneShot(
@@ -1280,9 +1278,7 @@ export class DockerManager {
 		} catch (err) {
 			// ENOENT is expected on a fresh deployment — nothing to sweep.
 			if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-				console.warn(
-					`[docker] sweepUploadTmp readdir failed for ${dir}: ${(err as Error).message}`,
-				);
+				logger.warn(`[docker] sweepUploadTmp readdir failed for ${dir}: ${(err as Error).message}`);
 			}
 			return;
 		}
@@ -1298,13 +1294,13 @@ export class DockerManager {
 			fileEntries.map((e) => fs.unlink(path.join(dir, e.name))),
 		);
 		const failed = results.filter((r) => r.status === "rejected").length;
-		console.log(
+		logger.info(
 			`[docker] sweepUploadTmp removed ${fileEntries.length - failed}/${fileEntries.length} stale tmp files`,
 		);
 	}
 
 	async reconcile(): Promise<void> {
-		console.log("[docker] reconciling session state with Docker…");
+		logger.info("[docker] reconciling session state with Docker…");
 		await this.sweepUploadTmp();
 		const result = await d1Query<{ session_id: string; container_id: string | null }>(
 			"SELECT session_id, container_id FROM sessions WHERE status = 'running'",
@@ -1336,14 +1332,14 @@ export class DockerManager {
 				if (statusCode === 404) {
 					await this.sessions.recordContainerGone(row.session_id);
 				} else {
-					console.warn(
+					logger.warn(
 						`[docker] reconcile inspect failed for session ${row.session_id}: ${(err as Error).message}`,
 					);
 					await this.sessions.updateStatus(row.session_id, "stopped");
 				}
 			}
 		}
-		console.log("[docker] reconciliation complete");
+		logger.info("[docker] reconciliation complete");
 	}
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./auth.js";
 import { migrateDb, validateD1Config } from "./db.js";
 import { DockerManager } from "./dockerManager.js";
+import { logger } from "./logger.js";
 import { buildRouter } from "./routes.js";
 import { SessionManager } from "./sessionManager.js";
 import { parseTrustProxy, TrustProxyError, warnIfProductionMisconfigured } from "./trustProxy.js";
@@ -62,7 +63,7 @@ try {
 	trustProxyValue = parseTrustProxy(TRUST_PROXY_RAW);
 } catch (err) {
 	if (err instanceof TrustProxyError) {
-		console.error("[server]", err.message);
+		logger.error(`[server] ${err.message}`);
 		process.exit(1);
 	}
 	throw err;
@@ -81,9 +82,9 @@ if (trustProxyValue !== undefined) {
 	// Log the effective value so ops can spot a misconfigured prod
 	// (e.g. TRUST_PROXY=0 behind a tunnel would silently collapse
 	// per-IP rate limits into one bucket).
-	console.log(`[server] trust proxy = ${JSON.stringify(trustProxyValue)}`);
+	logger.info(`[server] trust proxy = ${JSON.stringify(trustProxyValue)}`);
 } else {
-	console.log("[server] trust proxy = unset (req.ip will be the socket address)");
+	logger.info("[server] trust proxy = unset (req.ip will be the socket address)");
 }
 app.use(express.json());
 
@@ -149,7 +150,7 @@ server.on("upgrade", (req, socket, head) => {
 	if (!isAllowedWsOrigin(req.headers.origin, CORS_ORIGINS, process.env.NODE_ENV)) {
 		// Dev/staging only: see the block comment above and issue #66.
 		if (process.env.NODE_ENV !== "production") {
-			console.log(
+			logger.info(
 				"[ws] rejecting upgrade: Origin=%s not in allowlist %j",
 				req.headers.origin ?? "<absent>",
 				CORS_ORIGINS,
@@ -182,15 +183,15 @@ async function start() {
 	await ensureAuthReady();
 
 	server.listen(PORT, () => {
-		console.log(`[server] listening on http://localhost:${PORT}`);
-		console.log(`[server] WebSocket: ws://localhost:${PORT}/ws/sessions/:id`);
-		console.log(`[server] CORS origins: ${CORS_ORIGINS.join(", ")}`);
-		console.log(`[server] Database: Cloudflare D1`);
+		logger.info(`[server] listening on http://localhost:${PORT}`);
+		logger.info(`[server] WebSocket: ws://localhost:${PORT}/ws/sessions/:id`);
+		logger.info(`[server] CORS origins: ${CORS_ORIGINS.join(", ")}`);
+		logger.info(`[server] Database: Cloudflare D1`);
 	});
 }
 
 start().catch((err) => {
-	console.error("[server] failed to start:", err);
+	logger.error(`[server] failed to start: ${err}`);
 	process.exit(1);
 });
 
@@ -207,7 +208,7 @@ let shuttingDown = false;
 function shutdown() {
 	if (shuttingDown) return;
 	shuttingDown = true;
-	console.log("[server] shutting down…");
+	logger.info("[server] shutting down…");
 
 	// Actively close live WS clients. `wss.close()` alone only stops accepting
 	// new upgrades — existing connections stay open, which keeps `server.close()`
@@ -227,7 +228,7 @@ function shutdown() {
 	// keeps the event loop alive), exit anyway after a grace period instead of
 	// hanging the orchestrator's stop timeout.
 	const watchdog = setTimeout(() => {
-		console.warn("[server] shutdown watchdog fired — forcing exit");
+		logger.warn("[server] shutdown watchdog fired — forcing exit");
 		process.exit(1);
 	}, 10_000);
 	watchdog.unref();

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,0 +1,74 @@
+/**
+ * logger.ts — Backend structured logger (#5).
+ *
+ * Single pino instance. Replaces ad-hoc `console.{log,warn,error,debug}`
+ * calls so:
+ *  - Production logs are JSON, indexable by whatever ships them off the host
+ *    (Cloudflare Tunnel access logs, journalctl, a future shipper).
+ *  - Levels are honoured — `LOG_LEVEL=warn` actually suppresses info, where
+ *    `console.log` had nothing to filter on.
+ *  - Sensitive values (jwt, password fields, raw invite plaintext) are
+ *    redacted at the logger boundary so a future caller can't accidentally
+ *    leak by passing the wrong field into a log object.
+ *
+ * Dev runs through pino-pretty for human-readable output. Test runs are
+ * silent by default — vi.spyOn still captures calls — so the test reporter
+ * stays uncluttered.
+ *
+ * Migration scope: `console.*` → `logger.*` only. Request-id middleware
+ * and per-WebSocket child loggers come later (deliberately scoped out of
+ * the initial migration to keep the diff readable).
+ */
+
+import { pino } from "pino";
+
+const NODE_ENV = process.env.NODE_ENV;
+const isProduction = NODE_ENV === "production";
+// Tests run under vitest which sets the VITEST env var; honour an explicit
+// NODE_ENV=test too so the same path applies to anything else that flips it.
+const isTest = NODE_ENV === "test" || process.env.VITEST === "true";
+
+// pino-pretty as an inline transport spawns a worker thread, which clashes
+// with vitest's lifecycle (the thread can outlive a test file and emit after
+// teardown). Only enable it in dev, where the readability win matters.
+const transport =
+	!isProduction && !isTest
+		? {
+				target: "pino-pretty",
+				options: {
+					translateTime: "SYS:HH:MM:ss.l",
+					ignore: "pid,hostname",
+				},
+			}
+		: undefined;
+
+const defaultLevel = isProduction ? "info" : isTest ? "silent" : "debug";
+
+export const logger = pino({
+	level: process.env.LOG_LEVEL ?? defaultLevel,
+	transport,
+	// Redaction acts on field paths, not message-string substrings. Listed
+	// here are the known carriers of secret material in this codebase —
+	// adding a new auth path that lands a JWT or invite plaintext into a
+	// log object should grow this list, not depend on every caller
+	// remembering to scrub.
+	redact: {
+		paths: [
+			"password",
+			"passwordHash",
+			"password_hash",
+			"token",
+			"jwt",
+			"jwtSecret",
+			"JWT_SECRET",
+			"inviteCode",
+			"invite_code",
+			"code",
+			"authorization",
+			"Authorization",
+			"cookie",
+			"Cookie",
+		],
+		censor: "[redacted]",
+	},
+});

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -53,6 +53,12 @@ export const logger = pino({
 	// log object should grow this list, not depend on every caller
 	// remembering to scrub.
 	redact: {
+		// Field-name list, not substring match. Picked specifically so a
+		// future caller logging `{ code: statusCode }` (HTTP status, error
+		// code, anything-but-an-invite-secret) doesn't get silently
+		// redacted — `inviteCode` / `invite_code` cover the actual
+		// plaintext-bearing fields, and any new secret carrier should
+		// land here under its own specific key.
 		paths: [
 			"password",
 			"passwordHash",
@@ -63,7 +69,6 @@ export const logger = pino({
 			"JWT_SECRET",
 			"inviteCode",
 			"invite_code",
-			"code",
 			"authorization",
 			"Authorization",
 			"cookie",

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -24,6 +24,7 @@ import {
 import type { DockerManager } from "./dockerManager.js";
 import { UploadQuotaExceededError } from "./dockerManager.js";
 import { EnvVarValidationError, validateEnvVars } from "./envVarValidation.js";
+import { logger } from "./logger.js";
 import type { RateLimitConfig } from "./rateLimit.js";
 import {
 	createAuthRateLimiters,
@@ -115,7 +116,7 @@ export function buildRouter(
 				res.status(409).json({ error: err.message });
 				return;
 			}
-			console.error(`[auth] register failed unexpectedly:`, (err as Error).message);
+			logger.error(`[auth] register failed unexpectedly: ${(err as Error).message}`);
 			res.status(500).json({ error: "Internal server error" });
 		}
 	});
@@ -169,7 +170,7 @@ export function buildRouter(
 					return;
 				}
 				// Username omitted from the log to avoid an enumeration vector.
-				console.error(`[auth] login failed unexpectedly:`, (err as Error).message);
+				logger.error(`[auth] login failed unexpectedly: ${(err as Error).message}`);
 				res.status(500).json({ error: "Internal server error" });
 				return;
 			}
@@ -205,7 +206,7 @@ export function buildRouter(
 			const invites = await listInvites(userId);
 			res.json(invites);
 		} catch (err) {
-			console.error(`[invites] list failed:`, (err as Error).message);
+			logger.error(`[invites] list failed: ${(err as Error).message}`);
 			res.status(500).json({ error: "Internal server error" });
 		}
 	});
@@ -220,7 +221,7 @@ export function buildRouter(
 				res.status(429).json({ error: err.message });
 				return;
 			}
-			console.error(`[invites] create failed:`, (err as Error).message);
+			logger.error(`[invites] create failed: ${(err as Error).message}`);
 			res.status(500).json({ error: "Internal server error" });
 		}
 	});
@@ -246,7 +247,7 @@ export function buildRouter(
 			}
 			res.status(204).send();
 		} catch (err) {
-			console.error(`[invites] revoke failed:`, (err as Error).message);
+			logger.error(`[invites] revoke failed: ${(err as Error).message}`);
 			res.status(500).json({ error: "Internal server error" });
 		}
 	});
@@ -306,7 +307,7 @@ export function buildRouter(
 				res.status(429).json({ error: err.message, quota: err.quota });
 				return;
 			}
-			console.error(`[routes] session create failed:`, (err as Error).message);
+			logger.error(`[routes] session create failed: ${(err as Error).message}`);
 			if (meta) {
 				// Best-effort rollback. If deleteRow itself fails (D1 blip),
 				// the reconciler will eventually flip status to stopped but
@@ -315,9 +316,8 @@ export function buildRouter(
 				try {
 					await sessions.deleteRow(meta.sessionId);
 				} catch (cleanupErr) {
-					console.error(
-						`[routes] CRITICAL: spawn rollback failed for session ${meta.sessionId}:`,
-						(cleanupErr as Error).message,
+					logger.error(
+						`[routes] CRITICAL: spawn rollback failed for session ${meta.sessionId}: ${(cleanupErr as Error).message}`,
 					);
 				}
 			}
@@ -368,9 +368,8 @@ export function buildRouter(
 				try {
 					await docker.purgeWorkspace(req.params.id);
 				} catch (err) {
-					console.error(
-						`[routes] purgeWorkspace failed for ${req.params.id}:`,
-						(err as Error).message,
+					logger.error(
+						`[routes] purgeWorkspace failed for ${req.params.id}: ${(err as Error).message}`,
 					);
 					// Fall through — we still want to remove the row.
 				}
@@ -594,7 +593,7 @@ export function buildRouter(
 					// signal than silence.
 					for (const r of results) {
 						if (r.status === "rejected") {
-							console.warn("[routes] tmp unlink failed:", (r.reason as Error).message);
+							logger.warn(`[routes] tmp unlink failed: ${(r.reason as Error).message}`);
 						}
 					}
 				});
@@ -623,7 +622,7 @@ export function buildRouter(
 				res.status(400).json({ error: `Upload rejected: ${err.message}` });
 				return;
 			}
-			console.error("[routes] upload middleware error:", (err as Error).message);
+			logger.error(`[routes] upload middleware error: ${(err as Error).message}`);
 			res.status(500).json({ error: "Upload failed" });
 		});
 	};
@@ -757,7 +756,7 @@ function handleSessionError(err: unknown, res: Response): void {
 		// session usage to the client.
 		res.status(413).json({ error: err.message });
 	} else {
-		console.error("[routes] unexpected error:", (err as Error).message);
+		logger.error(`[routes] unexpected error: ${(err as Error).message}`);
 		res.status(500).json({ error: "Internal server error" });
 	}
 }

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -6,6 +6,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 import { d1Query } from "./db.js";
+import { logger } from "./logger.js";
 import type { CreateSessionOpts, SessionMeta, SessionStatus } from "./types.js";
 
 // ── Custom errors ───────────────────────────────────────────────────────────
@@ -48,11 +49,11 @@ const MAX_ACTIVE_SESSIONS_PER_USER = ((): number => {
 		// Surface the original value (quoted, so "  " etc. stay visible)
 		// and the effective fallback — ops should be able to tell at a
 		// glance which variable was wrong and what the server is
-		// actually running with. Uses console.warn rather than throw
+		// actually running with. Uses logger.warn rather than throw
 		// because a startup abort here would gate the whole server on
 		// a non-critical config typo, which is worse than running with
 		// the documented default.
-		console.warn(
+		logger.warn(
 			`[sessionManager] MAX_ACTIVE_SESSIONS_PER_USER=${JSON.stringify(raw)} ` +
 				`is not a positive integer; falling back to ${DEFAULT_MAX_ACTIVE_SESSIONS_PER_USER}`,
 		);

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 import { WebSocket } from "ws";
 import { verifyWsToken } from "./auth.js";
 import type { DockerManager } from "./dockerManager.js";
+import { logger } from "./logger.js";
 import { ForbiddenError, NotFoundError, type SessionManager } from "./sessionManager.js";
 import type { WsClientMessage, WsServerMessage } from "./types.js";
 
@@ -59,7 +60,7 @@ export function handleWsConnection(
 	// succeeds to also tear the exec down; `on` is additive, so both run.
 	// See issue #91 for the DoS reproduction path.
 	ws.on("error", (err) => {
-		console.error(`[ws] socket error: ${err.message}`);
+		logger.error(`[ws] socket error: ${err.message}`);
 		// Don't trust the transport to always emit 'close' after
 		// 'error'. Some failure modes (RSTd TCP mid-handshake, upgrade
 		// parse error before the WS protocol is fully up) leave the
@@ -153,7 +154,7 @@ export function handleWsConnection(
 		}
 		flushTail();
 
-		console.log(
+		logger.info(
 			`[ws] user=${userId} attached to session=${sessionId} tab=${tabId} (exec=${attachId})`,
 		);
 
@@ -183,12 +184,12 @@ export function handleWsConnection(
 		});
 
 		ws.on("close", () => {
-			console.log(`[ws] user=${userId} detached from session=${sessionId}`);
+			logger.info(`[ws] user=${userId} detached from session=${sessionId}`);
 			docker.detach(attachId);
 		});
 
 		ws.on("error", (err) => {
-			console.error(`[ws] error on session=${sessionId}:`, err.message);
+			logger.error(`[ws] error on session=${sessionId}: ${err.message}`);
 			docker.detach(attachId);
 		});
 	})().catch((err) => {
@@ -199,7 +200,7 @@ export function handleWsConnection(
 			sendError(ws, "Access denied");
 			ws.close(1008, "Forbidden");
 		} else {
-			console.error(`[ws] attach failed for session=${sessionId}:`, (err as Error).message);
+			logger.error(`[ws] attach failed for session=${sessionId}: ${(err as Error).message}`);
 			sendError(ws, `Failed to attach: ${(err as Error).message}`);
 			ws.close(1011, "Attach failed");
 		}


### PR DESCRIPTION
Closes #5.

Replaces ad-hoc `console.{log,warn,error,debug}` across the backend with a single pino logger instance.

## Why

Beyond closing #5, the gap surfaced explicitly in the PR #126 review: `console.*` has no level filtering, no JSON output, and no redaction. Any future caller that lands a token or invite plaintext into a log line is one mistake away from the SIEM.

## logger.ts

Single pino instance:

- **transport** selected by `NODE_ENV`:
  - production: JSON to stdout (pino default).
  - dev: `pino-pretty` (in-process worker; readable output).
  - test (`NODE_ENV=test` or `VITEST=true`): silent by default, level overridable via `LOG_LEVEL`. Spies still capture calls.
- **redaction** covers the known carriers of secret material today — `password{,_hash,Hash}`, `token`, `jwt{,Secret}`, `JWT_SECRET`, `inviteCode/invite_code/code`, `authorization/cookie`. A new auth surface that lands a secret in a log object should grow this list, not depend on every caller scrubbing.

## Migration

- All 70 `console.*` call sites replaced with `logger.*` (`info`/`warn`/`error`/`debug` mapping unchanged).
- Multi-arg `console.error("text:", err.message)` collapsed to template literals where pino's typing rejected the legacy shape (printf without `%s` placeholders).
- `warnIfWildcardCorsInProduction` kept its injectable `out` parameter for the test seam — default just changes from `console` to the module-level logger.
- 6 `vi.spyOn(console, "warn")` test sites switched to `vi.spyOn(logger, "warn")`.

## Out of scope (deliberate)

These are separable features and would balloon the diff:

- **Request-id middleware** + per-request child logger.
- **Per-WebSocket-connection child logger** carrying `sessionId` / `tabId` / `userId`.
- **Structured fields** for the existing `[scope] message` idiom — kept verbatim so the diff stays mechanical and reviewable.

## Tested

- `npm run lint` clean
- `npm run build` (tsc) clean
- `npm test` — 149 passing (unchanged from main)
- Node smoke-test of pino printf interpolation against the surviving `%s/%j` call site in `index.ts` — output matches the `console.log` behaviour the original site relied on.