### PR TITLE
feat(auth): move JWT to httpOnly cookie (#18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,9 @@ Multiple browser tabs attaching to the same session share the same tmux exec (ea
 
 ### Auth
 
-- REST: `Authorization: Bearer <jwt>` via `requireAuth` middleware. First visit shows `needsSetup: true` from `/api/auth/status` and the frontend drives user creation.
-- WebSocket: token is passed via the `Sec-WebSocket-Protocol` header as `auth.bearer.<jwt>` (preferred — keeps it out of URLs/access logs), with a `?token=<jwt>` query-param fallback for proxies that strip the subprotocol header. `selectWsAuthProtocol` echoes the chosen subprotocol back in the handshake (RFC 6455 requires this).
+- JWT is delivered as an httpOnly cookie named `st_token` set by `setAuthCookie` in `auth.ts`. `Secure` is on in production, `SameSite=None` in production (cross-site Pages → Tunnel) / `SameSite=Strict` in dev. CSRF for state-changing JSON routes is handled by the CORS preflight + `Content-Type: application/json` requirement; the CORS middleware in `index.ts` only echoes `Access-Control-Allow-Credentials: true` for an exact-origin match against `CORS_ORIGINS`. JS cannot read the token (closing the XSS exfiltration path).
+- REST: `requireAuth` middleware reads `req.cookies.st_token` (cookie-parser populated) with a raw-`Cookie`-header fallback for tests bypassing middleware. First visit shows `needsSetup: true` from `/api/auth/status`, which also returns `authenticated` so the frontend can route between login and app on first load without a separate round-trip.
+- WebSocket: `verifyWsToken` reads the cookie from the upgrade request's `Cookie` header — browsers send cookies on the WS handshake to the cookie's domain automatically. CSWSH protection is independent: `isAllowedWsOrigin` rejects unlisted origins before `wss.handleUpgrade` runs. There is no subprotocol or query-string auth fallback.
 - `sessions.assertOwnership(sessionId, userId)` is the single choke point for authorization on REST and WebSocket paths.
 
 ### Notes on D1

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.7",
         "dockerode": "^4.0.4",
         "express": "^4.19.2",
         "express-rate-limit": "^8.3.2",
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@types/bcryptjs": "^2.4.6",
+        "@types/cookie-parser": "^1.4.10",
         "@types/dockerode": "^3.3.31",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.7",
@@ -1159,6 +1161,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/docker-modem": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
@@ -1852,6 +1864,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.7",
     "dockerode": "^4.0.4",
     "express": "^4.19.2",
     "express-rate-limit": "^8.3.2",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
     "@types/bcryptjs": "^2.4.6",
+    "@types/cookie-parser": "^1.4.10",
     "@types/dockerode": "^3.3.31",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.7",

--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -1,8 +1,13 @@
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	__resetJwtSecretForTests,
+	AUTH_COOKIE_NAME,
+	extractTokenFromCookieHeader,
 	isAllowedWsOrigin,
 	parseCorsOrigins,
+	requireAuth,
 	validateJwtSecret,
 	warnIfWildcardCorsInProduction,
 } from "./auth.js";
@@ -265,5 +270,174 @@ describe("parseCorsOrigins", () => {
 		// also round-trip.
 		expect(parseCorsOrigins("*")).toEqual(["*"]);
 		expect(parseCorsOrigins("*, https://b")).toEqual(["*", "https://b"]);
+	});
+});
+
+// ── Cookie auth primitives (#18) ───────────────────────────────────────────
+
+describe("extractTokenFromCookieHeader", () => {
+	it("returns null on missing or malformed inputs", () => {
+		expect(extractTokenFromCookieHeader(undefined)).toBeNull();
+		expect(extractTokenFromCookieHeader("")).toBeNull();
+		// No `=` at all → ignore the part.
+		expect(extractTokenFromCookieHeader("badheader")).toBeNull();
+		// Cookie with our name but empty value → null, not "".
+		expect(extractTokenFromCookieHeader(`${AUTH_COOKIE_NAME}=`)).toBeNull();
+	});
+
+	it("picks our cookie out of a multi-cookie header regardless of position", () => {
+		expect(
+			extractTokenFromCookieHeader(`other=value; ${AUTH_COOKIE_NAME}=tok-123; trailing=stuff`),
+		).toBe("tok-123");
+		expect(extractTokenFromCookieHeader(`${AUTH_COOKIE_NAME}=tok-first; other=ignored`)).toBe(
+			"tok-first",
+		);
+	});
+
+	it("trims surrounding whitespace on both name and value", () => {
+		expect(extractTokenFromCookieHeader(`  ${AUTH_COOKIE_NAME} = tok-spacey  `)).toBe("tok-spacey");
+	});
+
+	it("URL-decodes percent-encoded values", () => {
+		// `=` shows up in the JWT padding for some payloads; servers
+		// percent-encode cookie values when setting them. Make sure we
+		// undo that on read.
+		const encoded = encodeURIComponent("tok+with/special=chars");
+		expect(extractTokenFromCookieHeader(`${AUTH_COOKIE_NAME}=${encoded}`)).toBe(
+			"tok+with/special=chars",
+		);
+	});
+
+	it("returns the raw value when decodeURIComponent throws on a malformed sequence", () => {
+		// `%E0%A4%A` is a truncated UTF-8 sequence that decodeURIComponent
+		// rejects with URIError. We'd rather hand the verifier a string
+		// it'll reject downstream than 500 the request here.
+		expect(extractTokenFromCookieHeader(`${AUTH_COOKIE_NAME}=tok%E0%A4%A`)).toBe("tok%E0%A4%A");
+	});
+
+	it("ignores cookies with other names", () => {
+		expect(extractTokenFromCookieHeader("session=foo; csrf=bar")).toBeNull();
+	});
+
+	it("flattens an array Cookie header (not standard but tolerated)", () => {
+		// Some frameworks coerce duplicate Cookie headers into a string[].
+		// Joining mirrors what the browser actually transmits — a single
+		// string with `; ` between entries.
+		expect(extractTokenFromCookieHeader(["other=value", `${AUTH_COOKIE_NAME}=tok-arr`])).toBe(
+			"tok-arr",
+		);
+	});
+});
+
+describe("requireAuth", () => {
+	const TEST_SECRET = "test-secret-do-not-use-in-prod";
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		process.env.JWT_SECRET = TEST_SECRET;
+		__resetJwtSecretForTests();
+		validateJwtSecret();
+	});
+
+	afterEach(() => {
+		for (const k of Object.keys(process.env)) delete process.env[k];
+		Object.assign(process.env, originalEnv);
+		__resetJwtSecretForTests();
+	});
+
+	type CookieReq = Request & { cookies?: Record<string, string> };
+
+	function makeReq(opts: { cookies?: Record<string, string>; cookieHeader?: string }): CookieReq {
+		return {
+			cookies: opts.cookies,
+			headers: { cookie: opts.cookieHeader },
+		} as unknown as CookieReq;
+	}
+
+	function makeRes(): {
+		res: Response;
+		status: ReturnType<typeof vi.fn>;
+		json: ReturnType<typeof vi.fn>;
+	} {
+		const json = vi.fn();
+		const status = vi.fn(() => ({ json }) as unknown as Response);
+		return {
+			res: { status } as unknown as Response,
+			status,
+			json,
+		};
+	}
+
+	it("401s when no cookie is present anywhere", () => {
+		const req = makeReq({});
+		const { res, status, json } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		requireAuth(req, res, next);
+
+		expect(status).toHaveBeenCalledWith(401);
+		expect(json).toHaveBeenCalledWith({ error: "Missing or invalid auth cookie" });
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("401s when the cookie carries a malformed JWT", () => {
+		const req = makeReq({ cookies: { [AUTH_COOKIE_NAME]: "not-a-jwt" } });
+		const { res, status, json } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		requireAuth(req, res, next);
+
+		expect(status).toHaveBeenCalledWith(401);
+		expect(json).toHaveBeenCalledWith({ error: "Missing or invalid auth cookie" });
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("populates userId/username from a valid cookie via cookie-parser path", () => {
+		const token = jwt.sign({ sub: "u-1", username: "alice" }, TEST_SECRET);
+		const req = makeReq({ cookies: { [AUTH_COOKIE_NAME]: token } });
+		const { res } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		requireAuth(req, res, next);
+
+		const reqWithIdent = req as unknown as { userId: string; username: string };
+		expect(reqWithIdent.userId).toBe("u-1");
+		expect(reqWithIdent.username).toBe("alice");
+		expect(next).toHaveBeenCalled();
+	});
+
+	it("falls back to the raw Cookie header when req.cookies is absent", () => {
+		// Simulates a path that bypassed cookie-parser. The fallback exists
+		// strictly for defence in depth — if the middleware is wired
+		// correctly the bypass never fires, but a future test stubbing
+		// the express stack should still authenticate.
+		const token = jwt.sign({ sub: "u-2", username: "bob" }, TEST_SECRET);
+		const req = makeReq({ cookieHeader: `other=x; ${AUTH_COOKIE_NAME}=${token}` });
+		const { res } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		requireAuth(req, res, next);
+
+		const reqWithIdent = req as unknown as { userId: string; username: string };
+		expect(reqWithIdent.userId).toBe("u-2");
+		expect(next).toHaveBeenCalled();
+	});
+
+	it("prefers req.cookies over the raw Cookie header (cookie-parser is authoritative)", () => {
+		// If both somehow exist, the parsed map wins so behaviour matches
+		// the rest of the app, which trusts cookie-parser.
+		const tokenA = jwt.sign({ sub: "from-cookies", username: "a" }, TEST_SECRET);
+		const tokenB = jwt.sign({ sub: "from-header", username: "b" }, TEST_SECRET);
+		const req = makeReq({
+			cookies: { [AUTH_COOKIE_NAME]: tokenA },
+			cookieHeader: `${AUTH_COOKIE_NAME}=${tokenB}`,
+		});
+		const { res } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		requireAuth(req, res, next);
+
+		expect((req as unknown as { userId: string }).userId).toBe("from-cookies");
+		expect(next).toHaveBeenCalled();
 	});
 });

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -498,105 +498,124 @@ function signToken(userId: string, username: string): string {
 	return jwt.sign(payload, jwtSecret(), options);
 }
 
+// ── Cookie auth (#18) ──────────────────────────────────────────────────────
+
+export const AUTH_COOKIE_NAME = "st_token";
+
+/**
+ * Set the JWT as an httpOnly Secure SameSite=Strict cookie. `Secure` is
+ * conditional on production so the dev server (http://localhost) can set
+ * the cookie at all — Chrome/Firefox refuse Secure cookies on plain HTTP.
+ *
+ * `maxAge` derived from the JWT's own `exp` claim so the cookie expires
+ * exactly when the token does — no "cookie says logged in but every
+ * request comes back 401" window if JWT_EXPIRES_IN is changed.
+ */
+export function setAuthCookie(res: Response, token: string): void {
+	const decoded = jwt.decode(token) as { exp?: number } | null;
+	const expSec = decoded?.exp;
+	const maxAge = expSec ? Math.max(0, expSec * 1000 - Date.now()) : 0;
+	res.cookie(AUTH_COOKIE_NAME, token, {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === "production",
+		sameSite: "strict",
+		path: "/",
+		maxAge,
+	});
+}
+
+export function clearAuthCookie(res: Response): void {
+	// Clearing has to mirror the same cookie attributes (path, sameSite,
+	// secure) the browser used to scope the cookie, otherwise it picks a
+	// different stored cookie and the live one survives.
+	res.clearCookie(AUTH_COOKIE_NAME, {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === "production",
+		sameSite: "strict",
+		path: "/",
+	});
+}
+
+/** Verify a raw JWT string. Returns the payload, or null on any failure. */
+export function verifyJwt(token: string | undefined): JwtPayload | null {
+	if (!token) return null;
+	try {
+		return jwt.verify(token, jwtSecret()) as JwtPayload;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Pick the JWT out of a `Cookie` request header, returning the raw token or
+ * null if the cookie isn't present. Tolerates the various encodings real
+ * clients send: missing header, multiple cookies, leading/trailing whitespace,
+ * URL-encoded values. Used by both the WS upgrade path and (via cookie-parser
+ * in production) the REST middleware for a defence-in-depth fallback when the
+ * middleware is somehow bypassed.
+ */
+export function extractTokenFromCookieHeader(
+	cookieHeader: string | string[] | undefined,
+): string | null {
+	if (!cookieHeader) return null;
+	const raw = Array.isArray(cookieHeader) ? cookieHeader.join("; ") : cookieHeader;
+	for (const part of raw.split(";")) {
+		const eq = part.indexOf("=");
+		if (eq <= 0) continue;
+		const name = part.slice(0, eq).trim();
+		if (name !== AUTH_COOKIE_NAME) continue;
+		const value = part.slice(eq + 1).trim();
+		if (!value) return null;
+		// Cookie values may be URL-encoded. decodeURIComponent throws on a
+		// malformed sequence — treat as missing rather than 500.
+		try {
+			return decodeURIComponent(value);
+		} catch {
+			return value;
+		}
+	}
+	return null;
+}
+
 // ── Express middleware ──────────────────────────────────────────────────────
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
-	const header = req.headers.authorization;
-	if (!header?.startsWith("Bearer ")) {
-		res.status(401).json({ error: "Missing or invalid Authorization header" });
+	// `cookie-parser` is wired in index.ts and populates req.cookies. The
+	// header-fallback below only runs if the middleware is somehow absent
+	// (e.g. a future test bypassing express). It's not load-bearing —
+	// strictly defence-in-depth.
+	const cookies = (req as Request & { cookies?: Record<string, string> }).cookies;
+	const token = cookies?.[AUTH_COOKIE_NAME] ?? extractTokenFromCookieHeader(req.headers.cookie);
+	const payload = verifyJwt(token);
+	if (!payload) {
+		res.status(401).json({ error: "Missing or invalid auth cookie" });
 		return;
 	}
-
-	const token = header.slice(7);
-	try {
-		const payload = jwt.verify(token, jwtSecret()) as JwtPayload;
-		(req as AuthedRequest).userId = payload.sub;
-		(req as AuthedRequest).username = payload.username;
-		next();
-	} catch {
-		res.status(401).json({ error: "Invalid or expired token" });
-	}
+	(req as AuthedRequest).userId = payload.sub;
+	(req as AuthedRequest).username = payload.username;
+	next();
 }
 
 // ── WebSocket auth ──────────────────────────────────────────────────────────
 
-const WS_AUTH_PROTOCOL_PREFIX = "auth.bearer.";
-
 /**
- * Extract the bearer token from either:
- *   1. The `Sec-WebSocket-Protocol` header as `auth.bearer.<jwt>` (preferred —
- *      keeps the token out of URLs, access logs and Referer headers), or
- *   2. The `?token=<jwt>` query string (fallback for proxies / tunnels that
- *      strip the `Sec-WebSocket-Protocol` header).
- *
- * Then verify it and return the decoded payload, or null on any failure.
+ * Verify the JWT carried by an incoming WS upgrade. Reads from the request's
+ * `Cookie` header — browsers send cookies on the WS handshake to the cookie's
+ * domain regardless of the page's origin (CSWSH protection lives separately
+ * via the `Origin` allowlist).
  */
-export function verifyWsToken(
-	protocolHeader: string | string[] | undefined,
-	requestUrl: string | undefined,
-): JwtPayload | null {
-	const fromProtocol = extractTokenFromProtocol(protocolHeader);
-	const fromUrl = fromProtocol ? null : extractTokenFromUrl(requestUrl);
-	const token = fromProtocol ?? fromUrl;
-
+export function verifyWsToken(cookieHeader: string | string[] | undefined): JwtPayload | null {
+	const token = extractTokenFromCookieHeader(cookieHeader);
 	if (!token) {
-		// Help operators tell which channel(s) were tried. The subprotocol path
-		// is preferred; the query-string path only kicks in as a fallback for
-		// proxies that strip Sec-WebSocket-Protocol.
-		if (!protocolHeader && !requestUrl) {
-			logger.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no request URL");
-		} else if (!protocolHeader) {
-			logger.error("[verifyWsToken] no Sec-WebSocket-Protocol header and no ?token= query param");
-		} else {
-			const header = Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader;
-			logger.error(
-				"[verifyWsToken] no usable auth.bearer.* subprotocol (got: %s) and no ?token= query param",
-				header,
-			);
-		}
+		logger.error("[verifyWsToken] no auth cookie on upgrade request");
 		return null;
 	}
-
-	try {
-		return jwt.verify(token, jwtSecret()) as JwtPayload;
-	} catch (err) {
-		logger.error(
-			`[verifyWsToken] jwt verify failed: ${(err as Error).name}: ${(err as Error).message}`,
-		);
+	const payload = verifyJwt(token);
+	if (!payload) {
+		logger.error("[verifyWsToken] auth cookie failed JWT verification");
 		return null;
 	}
-}
-
-function extractTokenFromProtocol(protocolHeader: string | string[] | undefined): string | null {
-	if (!protocolHeader) return null;
-	const header = Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader;
-	const protocols = header.split(",").map((s) => s.trim());
-	const authProto = protocols.find((p) => p.startsWith(WS_AUTH_PROTOCOL_PREFIX));
-	if (!authProto) return null;
-	const token = authProto.slice(WS_AUTH_PROTOCOL_PREFIX.length);
-	return token || null;
-}
-
-function extractTokenFromUrl(requestUrl: string | undefined): string | null {
-	if (!requestUrl) return null;
-	try {
-		const parsed = new URL(requestUrl, "http://localhost");
-		const token = parsed.searchParams.get("token");
-		return token || null;
-	} catch {
-		return null;
-	}
-}
-
-/**
- * Pick the `auth.bearer.<jwt>` subprotocol from an offered set so the server
- * can echo it back in the handshake response (required by RFC 6455).
- */
-export function selectWsAuthProtocol(protocols: Set<string>): string | false {
-	for (const p of protocols) {
-		if (p.startsWith(WS_AUTH_PROTOCOL_PREFIX)) return p;
-	}
-	return false;
+	return payload;
 }
 
 /**

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -751,10 +751,13 @@ export function warnIfWildcardCorsInProduction(
 	if (nodeEnv !== "production") return;
 	if (!allowedOrigins.includes("*")) return;
 	out.warn(
-		"[server] CORS_ORIGINS contains '*' in production. The HTTP layer " +
-			"still honours this, but the WebSocket upgrade handler refuses it " +
-			"(CSWSH protection). Set CORS_ORIGINS to an explicit origin list " +
-			"to re-enable WebSocket connections from production clients.",
+		"[server] CORS_ORIGINS contains '*' in production. " +
+			"Cookie auth (#18) requires an exact-origin match to send " +
+			"Access-Control-Allow-Credentials, so authenticated REST calls " +
+			"from cross-origin browsers will silently 401 — the cookie is " +
+			"dropped by the browser. The WebSocket upgrade handler also " +
+			"refuses wildcard origins (CSWSH protection). Set CORS_ORIGINS " +
+			"to an explicit origin list to re-enable both.",
 	);
 }
 

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -615,6 +615,13 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
  * `Cookie` header — browsers send cookies on the WS handshake to the cookie's
  * domain regardless of the page's origin (CSWSH protection lives separately
  * via the `Origin` allowlist).
+ *
+ * Log the specific JWT error name+message on failure: WS-auth misses are
+ * uncommon and almost always signal something specific (expired token,
+ * wrong-secret deploy, malformed cookie). Dropping the detail to a generic
+ * "verification failed" makes 2-AM triage harder than it needs to be. The
+ * REST `requireAuth` path stays quiet because it's exposed to unauthenticated
+ * probing and the same logging there would be a flood.
  */
 export function verifyWsToken(cookieHeader: string | string[] | undefined): JwtPayload | null {
 	const token = extractTokenFromCookieHeader(cookieHeader);
@@ -622,12 +629,14 @@ export function verifyWsToken(cookieHeader: string | string[] | undefined): JwtP
 		logger.error("[verifyWsToken] no auth cookie on upgrade request");
 		return null;
 	}
-	const payload = verifyJwt(token);
-	if (!payload) {
-		logger.error("[verifyWsToken] auth cookie failed JWT verification");
+	try {
+		return jwt.verify(token, jwtSecret()) as JwtPayload;
+	} catch (err) {
+		logger.error(
+			`[verifyWsToken] jwt verify failed: ${(err as Error).name}: ${(err as Error).message}`,
+		);
 		return null;
 	}
-	return payload;
 }
 
 /**

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -524,6 +524,11 @@ const cookieSameSite = (): "strict" | "none" => (isProduction() ? "none" : "stri
  * if JWT_EXPIRES_IN is changed.
  */
 export function setAuthCookie(res: Response, token: string): void {
+	// jwt.decode does NOT verify the signature — safe only because every
+	// caller hands us a token freshly produced by signToken(). If a future
+	// caller passes an externally-supplied token here, switch to
+	// jwt.verify (or compute maxAge from JWT_EXPIRES_IN directly), since
+	// an attacker could otherwise lift the cookie's lifetime to anything.
 	const decoded = jwt.decode(token) as { exp?: number } | null;
 	const expSec = decoded?.exp;
 	const maxAge = expSec ? Math.max(0, expSec * 1000 - Date.now()) : 0;
@@ -548,12 +553,25 @@ export function clearAuthCookie(res: Response): void {
 	});
 }
 
-/** Verify a raw JWT string. Returns the payload, or null on any failure. */
+/**
+ * Verify a raw JWT string. Returns the payload, or null on any JWT-level
+ * failure (missing token, expired, bad signature, malformed). Configuration
+ * panics from `jwtSecret()` are *not* swallowed: a deploy that forgot to
+ * call `validateJwtSecret()` would otherwise present as "every user is
+ * silently rejected" with no log trail. Re-throwing surfaces the misconfig
+ * loudly via the global error handler.
+ */
 export function verifyJwt(token: string | undefined): JwtPayload | null {
 	if (!token) return null;
 	try {
 		return jwt.verify(token, jwtSecret()) as JwtPayload;
-	} catch {
+	} catch (err) {
+		// jwtSecret() throws a fixed-prefix message when called before
+		// validateJwtSecret(). Anything else is a JWT-level failure
+		// (TokenExpiredError, JsonWebTokenError, etc.) — treat as null.
+		if ((err as Error).message?.startsWith("jwtSecret() called before")) {
+			throw err;
+		}
 		return null;
 	}
 }
@@ -703,10 +721,14 @@ export function parseCorsOrigins(raw: string | undefined): string[] {
  *    - In production: DENY, and the caller logs a loud warning once at
  *      startup. The HTTP CORS layer treats "*" as "anyone can hit
  *      public endpoints without credentials" — mostly harmless because
- *      browsers refuse to send credentials to `*`. WS has no such
- *      browser-side guard: the browser DOES send the auth.bearer.* sub-
- *      protocol on a WS to any origin. "*" for WS in production means
- *      "any page on the web can CSWSH our authenticated users".
+ *      browsers refuse to send credentials to `*` (post-#18 the CORS
+ *      middleware here also gates `Access-Control-Allow-Credentials` on
+ *      an exact-origin match). WS has no such browser-side guard: the
+ *      browser DOES send cookies (including `st_token`) on a WS upgrade
+ *      to any origin when SameSite permits it, and SameSite=None is the
+ *      production setting for the cross-site Pages → Tunnel deploy.
+ *      "*" for WS in production therefore means "any page on the web
+ *      can CSWSH our authenticated users".
  *    - Outside production: allow. Local dev frequently runs on
  *      multiple/ephemeral ports, and the CSWSH prerequisite (attacker
  *      site in the victim's browser) is ~never the local-dev threat

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -502,14 +502,26 @@ function signToken(userId: string, username: string): string {
 
 export const AUTH_COOKIE_NAME = "st_token";
 
+// SameSite/Secure pair driven by NODE_ENV. Cross-site delivery (frontend
+// on `*.pages.dev`, backend on a tunnel with a custom domain — different
+// eTLD+1) requires `SameSite=None`, which the spec forces to come with
+// `Secure`. Dev (http://localhost) keeps `Strict` because same-site is
+// guaranteed there and `Secure` would refuse to set on plain HTTP.
+//
+// CSRF guarantees with `SameSite=None`:
+//   - State-changing routes are POST/DELETE/PATCH with
+//     `Content-Type: application/json`, so the browser preflights them.
+//     CORS rejects unlisted origins → the actual request never fires.
+//   - WebSocket upgrades go through `isAllowedWsOrigin` (CSWSH) which
+//     enforces the same allowlist independently of SameSite.
+const isProduction = (): boolean => process.env.NODE_ENV === "production";
+const cookieSameSite = (): "strict" | "none" => (isProduction() ? "none" : "strict");
+
 /**
- * Set the JWT as an httpOnly Secure SameSite=Strict cookie. `Secure` is
- * conditional on production so the dev server (http://localhost) can set
- * the cookie at all — Chrome/Firefox refuse Secure cookies on plain HTTP.
- *
- * `maxAge` derived from the JWT's own `exp` claim so the cookie expires
- * exactly when the token does — no "cookie says logged in but every
- * request comes back 401" window if JWT_EXPIRES_IN is changed.
+ * Set the JWT as an httpOnly cookie. `maxAge` is derived from the JWT's
+ * own `exp` claim so the cookie expires exactly when the token does —
+ * no "cookie says logged in but every request comes back 401" window
+ * if JWT_EXPIRES_IN is changed.
  */
 export function setAuthCookie(res: Response, token: string): void {
 	const decoded = jwt.decode(token) as { exp?: number } | null;
@@ -517,8 +529,8 @@ export function setAuthCookie(res: Response, token: string): void {
 	const maxAge = expSec ? Math.max(0, expSec * 1000 - Date.now()) : 0;
 	res.cookie(AUTH_COOKIE_NAME, token, {
 		httpOnly: true,
-		secure: process.env.NODE_ENV === "production",
-		sameSite: "strict",
+		secure: isProduction(),
+		sameSite: cookieSameSite(),
 		path: "/",
 		maxAge,
 	});
@@ -530,8 +542,8 @@ export function clearAuthCookie(res: Response): void {
 	// different stored cookie and the live one survives.
 	res.clearCookie(AUTH_COOKIE_NAME, {
 		httpOnly: true,
-		secure: process.env.NODE_ENV === "production",
-		sameSite: "strict",
+		secure: isProduction(),
+		sameSite: cookieSameSite(),
 		path: "/",
 	});
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,13 +6,13 @@
  */
 
 import http from "node:http";
+import cookieParser from "cookie-parser";
 import express from "express";
 import { WebSocketServer } from "ws";
 import {
 	ensureAuthReady,
 	isAllowedWsOrigin,
 	parseCorsOrigins,
-	selectWsAuthProtocol,
 	validateJwtSecret,
 	warnIfWildcardCorsInProduction,
 } from "./auth.js";
@@ -87,15 +87,33 @@ if (trustProxyValue !== undefined) {
 	logger.info("[server] trust proxy = unset (req.ip will be the socket address)");
 }
 app.use(express.json());
+// Populates `req.cookies` from the Cookie header. requireAuth reads the
+// JWT from `req.cookies.st_token` (#18). No `secret` is passed because we
+// don't use signed cookies — the JWT itself is the integrity-protected
+// payload, and signing the cookie wrapping it would be redundant.
+app.use(cookieParser());
 
-// CORS — allow frontend from Cloudflare Pages (or any configured origin)
+// CORS — allow frontend from Cloudflare Pages (or any configured origin).
+//
+// Cookie-based auth (#18) requires:
+//   - `Access-Control-Allow-Credentials: true`, so the browser is willing
+//     to send the cookie cross-origin.
+//   - A specific `Access-Control-Allow-Origin` echoing the request's
+//     origin — `*` is illegal alongside credentials and the browser
+//     refuses the response. We never echo `*` here.
+//
+// `Authorization` is no longer in `Allow-Headers` because the frontend
+// never sends one — auth travels in the cookie and there's no read path
+// for the frontend that needs to inspect or set it.
 app.use((_req, res, next) => {
 	const origin = _req.headers.origin ?? "";
-	if (CORS_ORIGINS.includes("*") || CORS_ORIGINS.includes(origin)) {
-		res.setHeader("Access-Control-Allow-Origin", origin || "*");
+	if (origin && (CORS_ORIGINS.includes("*") || CORS_ORIGINS.includes(origin))) {
+		res.setHeader("Access-Control-Allow-Origin", origin);
+		res.setHeader("Access-Control-Allow-Credentials", "true");
+		res.setHeader("Vary", "Origin");
 	}
 	res.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,PATCH,OPTIONS");
-	res.setHeader("Access-Control-Allow-Headers", "Content-Type,Authorization");
+	res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 	if (_req.method === "OPTIONS") {
 		res.sendStatus(204);
 		return;
@@ -109,10 +127,10 @@ app.get("/health", (_req, res) => res.json({ ok: true }));
 // ── HTTP + WebSocket server ───────────────────────────────────────────────────
 
 const server = http.createServer(app);
-const wss = new WebSocketServer({
-	noServer: true,
-	handleProtocols: (protocols) => selectWsAuthProtocol(protocols),
-});
+// Auth lands via the request's Cookie header (#18) — no protocol selection
+// is needed for auth purposes, so handleProtocols is dropped along with
+// the `auth.bearer.<jwt>` subprotocol convention.
+const wss = new WebSocketServer({ noServer: true });
 
 server.on("upgrade", (req, socket, head) => {
 	const url = req.url ?? "";

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -106,11 +106,16 @@ app.use(cookieParser());
 // never sends one — auth travels in the cookie and there's no read path
 // for the frontend that needs to inspect or set it.
 app.use((_req, res, next) => {
+	// `Vary: Origin` set unconditionally so an intermediate cache can't
+	// serve a same-origin (no-CORS) cached response to a cross-origin
+	// client, which would arrive without `Access-Control-Allow-Origin`
+	// and trip the browser's same-origin block. No CDN sits in front of
+	// the tunnel today; this is hardening for the moment one is added.
+	res.setHeader("Vary", "Origin");
 	const origin = _req.headers.origin ?? "";
 	if (origin && (CORS_ORIGINS.includes("*") || CORS_ORIGINS.includes(origin))) {
 		res.setHeader("Access-Control-Allow-Origin", origin);
 		res.setHeader("Access-Control-Allow-Credentials", "true");
-		res.setHeader("Vary", "Origin");
 	}
 	res.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,PATCH,OPTIONS");
 	res.setHeader("Access-Control-Allow-Headers", "Content-Type");

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -113,9 +113,20 @@ app.use((_req, res, next) => {
 	// the tunnel today; this is hardening for the moment one is added.
 	res.setHeader("Vary", "Origin");
 	const origin = _req.headers.origin ?? "";
-	if (origin && (CORS_ORIGINS.includes("*") || CORS_ORIGINS.includes(origin))) {
+	// `Access-Control-Allow-Credentials: true` is only safe when the
+	// caller's origin is in our exact-match allowlist. Cookie auth means
+	// the browser auto-attaches the cookie on credentialed requests —
+	// echoing `Allow-Credentials` for an arbitrary origin would let any
+	// page on the internet make authenticated calls and read the
+	// responses. Wildcard config (`CORS_ORIGINS=*`) falls back to a
+	// plain wildcard, no credentials: cross-origin callers get the
+	// cookie dropped by the browser and effectively a 401 from the
+	// auth middleware, while the wildcard still answers public reads.
+	if (origin && CORS_ORIGINS.includes(origin)) {
 		res.setHeader("Access-Control-Allow-Origin", origin);
 		res.setHeader("Access-Control-Allow-Credentials", "true");
+	} else if (CORS_ORIGINS.includes("*")) {
+		res.setHeader("Access-Control-Allow-Origin", "*");
 	}
 	res.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,PATCH,OPTIONS");
 	res.setHeader("Access-Control-Allow-Headers", "Content-Type");

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -15,6 +15,17 @@ const authStubs = vi.hoisted(() => ({
 	hasAnyUsers: vi.fn(async () => true),
 	listInvites: vi.fn(async (_u?: string) => [] as unknown[]),
 	requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+	// Cookie-auth helpers (#18). Tests don't read the cookie back, so a
+	// no-op for set/clear and a permissive shape-only verify is enough.
+	AUTH_COOKIE_NAME: "st_token",
+	setAuthCookie: vi.fn(() => {
+		/* no-op */
+	}),
+	clearAuthCookie: vi.fn(() => {
+		/* no-op */
+	}),
+	extractTokenFromCookieHeader: vi.fn(() => null),
+	verifyJwt: vi.fn(() => null),
 	// The route handler checks `err instanceof InvalidCredentialsError` where
 	// `InvalidCredentialsError` is imported from `./auth.js`. Because we
 	// `vi.mock` the whole module, both the handler's import and the stub's

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -386,15 +386,17 @@ describe("auth route rate limiting", () => {
 		invitesList?: { ipMax: number; ipWindowMs: number };
 		invitesRevoke?: { ipMax: number; ipWindowMs: number };
 		fileUpload?: { ipMax: number; ipWindowMs: number };
+		logout?: { ipMax: number; ipWindowMs: number };
 	}): Promise<void> {
-		// Invite + upload limiters were added later; default each to a
-		// permissive setting so tests that only exercise login/register
+		// Invite + upload + logout limiters were added later; default each
+		// to a permissive setting so tests that only exercise login/register
 		// don't trip them.
 		const fullCfg = {
 			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
 			invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
 			invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
 			fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+			logout: { ipMax: 1000, ipWindowMs: 60_000 },
 			...cfg,
 		};
 		const router = buildRouter(fakeSessions, fakeDocker, fullCfg);

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -62,6 +62,18 @@ export interface RateLimitConfig {
 		ipMax: number;
 		ipWindowMs: number;
 	};
+	// Caps how often a single IP can POST /auth/logout. Logout is
+	// unauthenticated by design (a stale cookie has to be clearable), so
+	// post-#18 with SameSite=None a malicious page could fire a simple
+	// cross-site form POST in a loop and repeatedly log a victim out.
+	// User-inconvenience attack only — no data exposed — but trivially
+	// preventable. Dedicated bucket so the abuse path can't drain the
+	// login budget too: sharing with `loginIp` would let an attacker
+	// who hammers logout starve the victim's ability to log back in.
+	logout: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
 }
 
 // Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
@@ -97,6 +109,14 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 		ipMax: 30,
 		ipWindowMs: 5 * 60 * 1000,
 	},
+	// 30 logouts per 15 min per IP. Legitimate use is at most "click
+	// logout once, maybe twice if the network blipped" — well under
+	// the cap. The cap is high enough that a session-expired race
+	// (multiple tabs all firing logout at once) won't trip it.
+	logout: {
+		ipMax: 30,
+		ipWindowMs: 15 * 60 * 1000,
+	},
 };
 
 // ── IP-based limiters (express-rate-limit) ─────────────────────────────────
@@ -108,6 +128,7 @@ export interface AuthRateLimiters {
 	invitesListIp: RateLimitRequestHandler;
 	invitesRevokeIp: RateLimitRequestHandler;
 	fileUploadIp: RateLimitRequestHandler;
+	logoutIp: RateLimitRequestHandler;
 }
 
 export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
@@ -166,7 +187,22 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many file uploads from this IP, try again later", scope: "ip" },
 	});
-	return { loginIp, registerIp, invitesCreateIp, invitesListIp, invitesRevokeIp, fileUploadIp };
+	const logoutIp = rateLimit({
+		windowMs: cfg.logout.ipWindowMs,
+		limit: cfg.logout.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: { error: "Too many logout attempts from this IP, try again later", scope: "ip" },
+	});
+	return {
+		loginIp,
+		registerIp,
+		invitesCreateIp,
+		invitesListIp,
+		invitesRevokeIp,
+		fileUploadIp,
+		logoutIp,
+	};
 }
 
 // ── Per-username limiter ────────────────────────────────────────────────────

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -9,6 +9,7 @@ import { Router } from "express";
 import multer from "multer";
 import type { AuthedRequest } from "./auth.js";
 import {
+	AUTH_COOKIE_NAME,
 	clearAuthCookie,
 	createInvite,
 	extractTokenFromCookieHeader,
@@ -70,7 +71,7 @@ export function buildRouter(
 			cookies?: Record<string, string | undefined>;
 		};
 		const token =
-			reqWithCookies.cookies?.st_token ??
+			reqWithCookies.cookies?.[AUTH_COOKIE_NAME] ??
 			extractTokenFromCookieHeader(req.headers.cookie) ??
 			undefined;
 		const authenticated = verifyJwt(token) !== null;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -49,8 +49,15 @@ export function buildRouter(
 
 	// ── Auth routes (public) ────────────────────────────────────────────────
 
-	const { loginIp, registerIp, invitesCreateIp, invitesListIp, invitesRevokeIp, fileUploadIp } =
-		createAuthRateLimiters(rateLimitConfig);
+	const {
+		loginIp,
+		registerIp,
+		invitesCreateIp,
+		invitesListIp,
+		invitesRevokeIp,
+		fileUploadIp,
+		logoutIp,
+	} = createAuthRateLimiters(rateLimitConfig);
 	const usernameLimiter = new UsernameRateLimiter(
 		rateLimitConfig.login.usernameMax,
 		rateLimitConfig.login.usernameWindowMs,
@@ -223,7 +230,7 @@ export function buildRouter(
 	// by clearing the victim's cookie. State-changing routes that DO
 	// matter for CSRF (POST/DELETE/PATCH with JSON bodies) are
 	// preflight-gated by the CORS middleware in index.ts.
-	router.post("/auth/logout", (_req: Request, res: Response) => {
+	router.post("/auth/logout", logoutIp, (_req: Request, res: Response) => {
 		clearAuthCookie(res);
 		res.status(204).send();
 	});

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -214,8 +214,15 @@ export function buildRouter(
 	// Logout is intentionally NOT auth-gated: the action is "discard the
 	// cookie", which is harmless to the server even on a missing/invalid
 	// session — and gating it would mean that an already-expired token
-	// couldn't even be cleaned up locally. SameSite=Strict on the cookie
-	// itself blocks any cross-site forced logout.
+	// couldn't even be cleaned up locally.
+	//
+	// In production the auth cookie is SameSite=None (required for the
+	// cross-site Pages → Tunnel deployment), so a cross-site form POST
+	// to this endpoint *can* reach the server. The consequence is user
+	// inconvenience only — no data is exposed, no session can be hijacked
+	// by clearing the victim's cookie. State-changing routes that DO
+	// matter for CSRF (POST/DELETE/PATCH with JSON bodies) are
+	// preflight-gated by the CORS middleware in index.ts.
 	router.post("/auth/logout", (_req: Request, res: Response) => {
 		clearAuthCookie(res);
 		res.status(204).send();

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -9,7 +9,9 @@ import { Router } from "express";
 import multer from "multer";
 import type { AuthedRequest } from "./auth.js";
 import {
+	clearAuthCookie,
 	createInvite,
+	extractTokenFromCookieHeader,
 	hasAnyUsers,
 	InvalidCredentialsError,
 	InviteQuotaExceededError,
@@ -19,7 +21,9 @@ import {
 	registerUser,
 	requireAuth,
 	revokeInvite,
+	setAuthCookie,
 	UsernameTakenError,
+	verifyJwt,
 } from "./auth.js";
 import type { DockerManager } from "./dockerManager.js";
 import { UploadQuotaExceededError } from "./dockerManager.js";
@@ -54,8 +58,23 @@ export function buildRouter(
 	// land in the limiter map or D1.
 	const USERNAME_MAX_LEN = 64;
 
-	router.get("/auth/status", async (_req: Request, res: Response) => {
-		res.json({ needsSetup: !(await hasAnyUsers()) });
+	router.get("/auth/status", async (req: Request, res: Response) => {
+		// `authenticated` lets the frontend decide between "show login" and
+		// "show app" on first load, since the cookie is httpOnly and JS
+		// can't observe it directly. Read from req.cookies (populated by
+		// cookie-parser); fall back to the raw header for tests / paths
+		// that bypass middleware. Verification failures land as
+		// `authenticated: false`, never as a 4xx — this endpoint is
+		// public-by-design.
+		const reqWithCookies = req as Request & {
+			cookies?: Record<string, string | undefined>;
+		};
+		const token =
+			reqWithCookies.cookies?.st_token ??
+			extractTokenFromCookieHeader(req.headers.cookie) ??
+			undefined;
+		const authenticated = verifyJwt(token) !== null;
+		res.json({ needsSetup: !(await hasAnyUsers()), authenticated });
 	});
 
 	router.post("/auth/register", registerIp, async (req: Request, res: Response) => {
@@ -102,7 +121,11 @@ export function buildRouter(
 		}
 		try {
 			const result = await registerUser(username, password, trimmedInviteCode);
-			res.status(201).json(result);
+			// JWT goes out as an httpOnly cookie (#18); the response body
+			// keeps the userId for clients that want to address the new
+			// account, but never the raw token.
+			setAuthCookie(res, result.token);
+			res.status(201).json({ userId: result.userId });
 		} catch (err) {
 			if (err instanceof InviteRequiredError) {
 				// 403 — caller authenticated nothing yet, but the action is
@@ -175,7 +198,8 @@ export function buildRouter(
 				return;
 			}
 			usernameLimiter.reset(username);
-			res.json(result);
+			setAuthCookie(res, result.token);
+			res.json({ userId: result.userId });
 		} finally {
 			// Always release the in-flight slot — success, invalid creds,
 			// or infra error alike. `reset()` above wipes the failure
@@ -184,6 +208,16 @@ export function buildRouter(
 			// endAttempt.
 			usernameLimiter.endAttempt(username);
 		}
+	});
+
+	// Logout is intentionally NOT auth-gated: the action is "discard the
+	// cookie", which is harmless to the server even on a missing/invalid
+	// session — and gating it would mean that an already-expired token
+	// couldn't even be cleaned up locally. SameSite=Strict on the cookie
+	// itself blocks any cross-site forced logout.
+	router.post("/auth/logout", (_req: Request, res: Response) => {
+		clearAuthCookie(res);
+		res.status(204).send();
 	});
 
 	// ── Authenticated route prefixes ────────────────────────────────────────

--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -46,7 +46,9 @@ function makeReq(
 	const headers: Record<string, string | undefined> = {};
 	if (withToken) {
 		const token = jwt.sign({ sub: "user-1" }, TEST_SECRET);
-		headers["sec-websocket-protocol"] = `auth.bearer.${token}`;
+		// Cookie-based auth (#18): browsers send the auth cookie on the
+		// WS upgrade automatically; tests inject the same shape.
+		headers.cookie = `st_token=${token}`;
 	}
 	return { url, headers };
 }

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -78,7 +78,7 @@ export function handleWsConnection(
 	// know the caller is a user, the specific errors below are fine
 	// — they're useful for diagnosing client bugs.
 	const url = req.url ?? "";
-	const payload = verifyWsToken(req.headers["sec-websocket-protocol"], url);
+	const payload = verifyWsToken(req.headers.cookie);
 	if (!payload) {
 		sendError(ws, "Unauthorized");
 		ws.close(1008, "Unauthorized");

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -2,20 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Test harness ────────────────────────────────────────────────────────────
 //
-// api.ts caches the token in module state and reads `localStorage` *once* at
-// import time. Most tests can manipulate state via `setToken`, but anything
-// that depends on the load-time read (the `_token` initialiser at the top of
-// api.ts) needs `vi.resetModules()` + a fresh import. The helper below makes
-// that explicit so individual tests don't have to reach for vi.resetModules
-// themselves.
+// Auth state lives in module-level memory now (#18). Tests that need to start
+// from a known state load a fresh module via vi.resetModules() + dynamic
+// import — `loadApi()` handles both.
 
 interface Api {
-	getToken: typeof import("./api.js").getToken;
-	setToken: typeof import("./api.js").setToken;
 	isLoggedIn: typeof import("./api.js").isLoggedIn;
-	logout: typeof import("./api.js").logout;
+	checkAuthStatus: typeof import("./api.js").checkAuthStatus;
 	register: typeof import("./api.js").register;
 	login: typeof import("./api.js").login;
+	logout: typeof import("./api.js").logout;
 	createSession: typeof import("./api.js").createSession;
 	listSessions: typeof import("./api.js").listSessions;
 	deleteTab: typeof import("./api.js").deleteTab;
@@ -46,7 +42,6 @@ function mockFetchResponse(init: { status?: number; ok?: boolean; json?: unknown
 let fetchSpy: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
-	localStorage.clear();
 	fetchSpy = vi.fn();
 	globalThis.fetch = fetchSpy as unknown as typeof fetch;
 });
@@ -55,72 +50,93 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-// ── Token management ───────────────────────────────────────────────────────
+// ── Login state mirror ─────────────────────────────────────────────────────
 
-describe("token management", () => {
-	it("setToken persists to localStorage; getToken / isLoggedIn reflect the cached value", async () => {
+describe("login state", () => {
+	it("isLoggedIn defaults to false on a fresh load (cookie not yet observed)", async () => {
 		const api = await loadApi();
-		expect(api.getToken()).toBeNull();
 		expect(api.isLoggedIn()).toBe(false);
-
-		api.setToken("abc.def.ghi");
-		expect(api.getToken()).toBe("abc.def.ghi");
-		expect(api.isLoggedIn()).toBe(true);
-		expect(localStorage.getItem("st_token")).toBe("abc.def.ghi");
 	});
 
-	it("setToken(null) clears localStorage; logout is sugar for it", async () => {
+	it("checkAuthStatus mirrors the server's `authenticated` field into module state", async () => {
 		const api = await loadApi();
-		api.setToken("abc");
-		api.logout();
-		expect(api.getToken()).toBeNull();
-		expect(api.isLoggedIn()).toBe(false);
-		expect(localStorage.getItem("st_token")).toBeNull();
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({ json: { needsSetup: false, authenticated: true } }),
+		);
+
+		const status = await api.checkAuthStatus();
+		expect(status.authenticated).toBe(true);
+		expect(api.isLoggedIn()).toBe(true);
 	});
 
-	it("module load picks up an existing token from localStorage", async () => {
-		// The load-time read in `let _token = localStorage.getItem(...)` is the
-		// only way returning users stay logged in across tab reopens. Pin it.
-		localStorage.setItem("st_token", "from-disk");
+	it("checkAuthStatus authenticated=false leaves isLoggedIn() false", async () => {
 		const api = await loadApi();
-		expect(api.getToken()).toBe("from-disk");
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({ json: { needsSetup: false, authenticated: false } }),
+		);
+
+		await api.checkAuthStatus();
+		expect(api.isLoggedIn()).toBe(false);
+	});
+
+	it("login flips isLoggedIn to true on success", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+
+		await api.login("alice", "secret");
 		expect(api.isLoggedIn()).toBe(true);
+	});
+
+	it("logout POSTs /auth/logout and flips isLoggedIn to false even if the call fails", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		await api.login("alice", "secret");
+		expect(api.isLoggedIn()).toBe(true);
+
+		// Even an outright network rejection must not leave the UI thinking
+		// it's still logged in — fail-closed.
+		fetchSpy.mockRejectedValueOnce(new Error("offline"));
+		await api.logout();
+		expect(api.isLoggedIn()).toBe(false);
+
+		// Confirm the logout endpoint was hit (last call before the test ends).
+		const calls = fetchSpy.mock.calls;
+		const last = calls[calls.length - 1];
+		expect(last[0]).toBe("http://localhost:3001/api/auth/logout");
+		expect(last[1].method).toBe("POST");
 	});
 });
 
 // ── apiFetch wrapper ───────────────────────────────────────────────────────
-//
-// apiFetch is private but we exercise it indirectly via every public route.
-// Pinned behaviours: Authorization header gating, Content-Type vs FormData
-// and the 401 stale-token logout.
 
-describe("apiFetch — Authorization + Content-Type", () => {
-	it("omits Authorization when no token is set", async () => {
+describe("apiFetch — credentials and headers (#18)", () => {
+	it("sends `credentials: include` on every request so the auth cookie travels cross-origin", async () => {
 		const api = await loadApi();
 		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: [] }));
 
 		await api.listSessions();
 
 		const [, init] = fetchSpy.mock.calls[0];
+		expect(init.credentials).toBe("include");
+	});
+
+	it("never sends an Authorization header (cookie-based auth, post-#18)", async () => {
+		const api = await loadApi();
+		// Simulate a logged-in session.
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		await api.login("alice", "secret");
+
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: [] }));
+		await api.listSessions();
+
+		const [, init] = fetchSpy.mock.calls[1];
 		const headers = init.headers as Record<string, string>;
 		expect(headers.Authorization).toBeUndefined();
 		expect(headers["Content-Type"]).toBe("application/json");
 	});
 
-	it("sets `Authorization: Bearer <token>` when a token is present", async () => {
-		const api = await loadApi();
-		api.setToken("tok-123");
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: [] }));
-
-		await api.listSessions();
-
-		const [, init] = fetchSpy.mock.calls[0];
-		expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok-123");
-	});
-
 	it("does NOT set Content-Type when the body is FormData (boundary clobber)", async () => {
 		const api = await loadApi();
-		api.setToken("tok");
 		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { paths: [] } }));
 
 		const file = new File(["hi"], "a.txt", { type: "text/plain" });
@@ -129,8 +145,7 @@ describe("apiFetch — Authorization + Content-Type", () => {
 		const [, init] = fetchSpy.mock.calls[0];
 		const headers = init.headers as Record<string, string>;
 		expect(headers["Content-Type"]).toBeUndefined();
-		// Authorization still gets through — only Content-Type is suppressed.
-		expect(headers.Authorization).toBe("Bearer tok");
+		expect(init.credentials).toBe("include");
 		expect(init.body).toBeInstanceOf(FormData);
 	});
 
@@ -146,12 +161,14 @@ describe("apiFetch — Authorization + Content-Type", () => {
 	});
 });
 
-// ── 401 stale-token handling ───────────────────────────────────────────────
+// ── 401 stale-session handling ─────────────────────────────────────────────
 
-describe("apiFetch — 401 stale-token semantics (issue #95)", () => {
-	it("authed 401 clears the token AND dispatches SESSION_EXPIRED_EVENT exactly once", async () => {
+describe("apiFetch — 401 stale-session semantics (issue #95)", () => {
+	it("authed 401 flips isLoggedIn to false AND dispatches SESSION_EXPIRED_EVENT exactly once", async () => {
 		const api = await loadApi();
-		api.setToken("stale");
+		// Establish a logged-in state so the 401 is classified as "stale".
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		await api.login("alice", "secret");
 
 		const handler = vi.fn();
 		window.addEventListener(api.SESSION_EXPIRED_EVENT, handler);
@@ -161,17 +178,19 @@ describe("apiFetch — 401 stale-token semantics (issue #95)", () => {
 			/* listSessions throws on !ok; we only care about side-effects here */
 		});
 
-		expect(api.getToken()).toBeNull();
+		expect(api.isLoggedIn()).toBe(false);
 		expect(handler).toHaveBeenCalledTimes(1);
 
 		window.removeEventListener(api.SESSION_EXPIRED_EVENT, handler);
 	});
 
-	it("unauthed 401 (e.g. wrong-password /auth/login) does NOT clear token state", async () => {
+	it("unauthed 401 (e.g. wrong-password /auth/login) does NOT dispatch the event", async () => {
 		const api = await loadApi();
-		// Simulate the case where the user is logged out but tries to log in
-		// with a bad password — the 401 from /auth/login is policy, not stale.
-		expect(api.getToken()).toBeNull();
+		// Logged-out state — login attempt with bad creds returns 401.
+		expect(api.isLoggedIn()).toBe(false);
+
+		const handler = vi.fn();
+		window.addEventListener(api.SESSION_EXPIRED_EVENT, handler);
 		fetchSpy.mockResolvedValueOnce(
 			mockFetchResponse({ status: 401, json: { error: "bad creds" } }),
 		);
@@ -180,19 +199,20 @@ describe("apiFetch — 401 stale-token semantics (issue #95)", () => {
 			/* login throws on !ok */
 		});
 
-		// _token must remain null (not actively set, but also not "cleared by
-		// the 401 path" — these tests are belt-and-braces).
-		expect(api.getToken()).toBeNull();
+		expect(api.isLoggedIn()).toBe(false);
+		expect(handler).not.toHaveBeenCalled();
+		window.removeEventListener(api.SESSION_EXPIRED_EVENT, handler);
 	});
 
-	it("dedups concurrent 401 bursts so only one event fires per stale-token window", async () => {
+	it("dedups concurrent 401 bursts so only one event fires per stale-session window", async () => {
 		const api = await loadApi();
-		api.setToken("stale");
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		await api.login("alice", "secret");
 
 		const handler = vi.fn();
 		window.addEventListener(api.SESSION_EXPIRED_EVENT, handler);
-		// Two concurrent authed 401s — the dedup gate is `_token !== null`,
-		// so the first response clears _token and the second sees null.
+		// Two concurrent authed 401s — the dedup gate is `_loggedIn`,
+		// so the first response flips it false and the second sees false.
 		fetchSpy
 			.mockResolvedValueOnce(mockFetchResponse({ status: 401 }))
 			.mockResolvedValueOnce(mockFetchResponse({ status: 401 }));
@@ -210,9 +230,11 @@ describe("apiFetch — 401 stale-token semantics (issue #95)", () => {
 		window.removeEventListener(api.SESSION_EXPIRED_EVENT, handler);
 	});
 
-	it("403 does NOT clear the token (policy, not stale)", async () => {
+	it("403 does NOT flip isLoggedIn (policy, not stale)", async () => {
 		const api = await loadApi();
-		api.setToken("good");
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		await api.login("alice", "secret");
+
 		fetchSpy.mockResolvedValueOnce(
 			mockFetchResponse({ status: 403, json: { error: "forbidden" } }),
 		);
@@ -221,22 +243,20 @@ describe("apiFetch — 401 stale-token semantics (issue #95)", () => {
 			/* createSession throws on !ok */
 		});
 
-		expect(api.getToken()).toBe("good");
+		expect(api.isLoggedIn()).toBe(true);
 	});
 });
 
 // ── Auth + invite-required path ───────────────────────────────────────────
 
 describe("auth API", () => {
-	it("register success stores the returned token and resolves to the body", async () => {
+	it("register success returns the userId and flips isLoggedIn", async () => {
 		const api = await loadApi();
-		fetchSpy.mockResolvedValueOnce(
-			mockFetchResponse({ status: 201, json: { userId: "u1", token: "t1" } }),
-		);
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 201, json: { userId: "u1" } }));
 
 		const data = await api.register("alice", "secret");
-		expect(data).toEqual({ userId: "u1", token: "t1" });
-		expect(api.getToken()).toBe("t1");
+		expect(data).toEqual({ userId: "u1" });
+		expect(api.isLoggedIn()).toBe(true);
 	});
 
 	it("register 403 throws InviteRequiredError carrying the server message", async () => {
@@ -247,8 +267,7 @@ describe("auth API", () => {
 
 		await expect(api.register("u", "p")).rejects.toThrow(api.InviteRequiredError);
 		await expect(api.register("u", "p")).rejects.toThrow("Invite code required");
-		// Token stays null on the failed register.
-		expect(api.getToken()).toBeNull();
+		expect(api.isLoggedIn()).toBe(false);
 	});
 
 	it("register on other errors throws a generic Error with the body message", async () => {
@@ -258,14 +277,15 @@ describe("auth API", () => {
 		);
 
 		await expect(api.register("u", "p")).rejects.toThrow("Username taken");
+		expect(api.isLoggedIn()).toBe(false);
 	});
 
-	it("login success stores the returned token", async () => {
+	it("login success returns the userId", async () => {
 		const api = await loadApi();
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", token: "tok" } }));
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
 
-		await api.login("u", "p");
-		expect(api.getToken()).toBe("tok");
+		const data = await api.login("u", "p");
+		expect(data).toEqual({ userId: "u1" });
 	});
 });
 
@@ -274,7 +294,6 @@ describe("auth API", () => {
 describe("idempotent-delete semantics", () => {
 	it("deleteTab on a 404 throws TabNotFoundError so callers can drop the chip", async () => {
 		const api = await loadApi();
-		api.setToken("tok");
 		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 404 }));
 
 		await expect(api.deleteTab("session-1", "tab-1")).rejects.toThrow(api.TabNotFoundError);
@@ -282,7 +301,6 @@ describe("idempotent-delete semantics", () => {
 
 	it("revokeInvite on a 404 resolves silently (concurrent revoke / redemption)", async () => {
 		const api = await loadApi();
-		api.setToken("tok");
 		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 404 }));
 
 		// Post-#49 the argument is the SHA-256 hex hash, not the plaintext.
@@ -292,7 +310,6 @@ describe("idempotent-delete semantics", () => {
 
 	it("revokeInvite targets /invites/<hash> (post-#49 — plaintext is gone)", async () => {
 		const api = await loadApi();
-		api.setToken("tok");
 		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 204 }));
 
 		const hash = "deadbeef".repeat(8); // 64 hex chars
@@ -309,7 +326,6 @@ describe("idempotent-delete semantics", () => {
 describe("invite hash-at-rest wire shape", () => {
 	it("createInvite returns the plaintext code alongside hash and prefix exactly once", async () => {
 		const api = await loadApi();
-		api.setToken("tok");
 		fetchSpy.mockResolvedValueOnce(
 			mockFetchResponse({
 				status: 201,
@@ -333,7 +349,6 @@ describe("invite hash-at-rest wire shape", () => {
 
 	it("listInvites returns hash + prefix and never carries plaintext", async () => {
 		const api = await loadApi();
-		api.setToken("tok");
 		fetchSpy.mockResolvedValueOnce(
 			mockFetchResponse({
 				json: [
@@ -353,7 +368,6 @@ describe("invite hash-at-rest wire shape", () => {
 		expect(list).toHaveLength(1);
 		expect(list[0].codeHash).toBe("0".repeat(64));
 		expect(list[0].codePrefix).toBe("ab12");
-		// The Invite type explicitly omits plaintext — guard the wire too.
 		expect((list[0] as unknown as Record<string, unknown>).code).toBeUndefined();
 	});
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -85,10 +85,13 @@ export async function login(username: string, password: string): Promise<{ userI
 }
 
 export async function logout(): Promise<void> {
-	// POST so SameSite=Strict applies (a cross-site GET would still be
-	// blocked, but POST is the canonical "this is a state change"
-	// signal). The endpoint is unauthenticated server-side — we don't
-	// want a stale cookie to lock the user out of clearing it.
+	// POST is the canonical HTTP verb for state-changing operations.
+	// The CSRF guard in production is the CORS + Content-Type preflight,
+	// not SameSite — the cookie is SameSite=None there to permit
+	// cross-site delivery on the Pages → Tunnel deploy. The endpoint is
+	// unauthenticated server-side because we don't want a stale cookie
+	// to lock the user out of clearing it; the only consequence of a
+	// forced cross-site logout is user inconvenience.
 	//
 	// Swallow network errors so a logout-while-offline still tears down
 	// local state. The server's view becomes consistent on the next

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,36 +7,39 @@
 const BACKEND_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
 const API_BASE = `${BACKEND_URL}/api`;
 
-// ── Token management ────────────────────────────────────────────────────────
+// ── Auth state (#18) ────────────────────────────────────────────────────────
+//
+// The JWT lives in an httpOnly cookie that JS cannot read. The boolean below
+// is just an in-memory mirror of "do we currently have a valid session" so
+// the UI can route between the login screen and the app without doing a
+// round-trip on every navigation. It's hydrated on boot from /auth/status
+// (which the server populates from req.cookies), and updated on
+// login/register/logout/401.
 
-let _token: string | null = localStorage.getItem("st_token");
-
-export function getToken(): string | null {
-	return _token;
-}
-
-export function setToken(token: string | null): void {
-	_token = token;
-	if (token) {
-		localStorage.setItem("st_token", token);
-	} else {
-		localStorage.removeItem("st_token");
-	}
-}
+let _loggedIn = false;
 
 export function isLoggedIn(): boolean {
-	return !!_token;
+	return _loggedIn;
 }
 
-/** Fired by `apiFetch` once per 401-burst after clearing the stale token —
+/** Fired by `apiFetch` once per 401-burst after flipping `_loggedIn` to false —
  * main.ts listens to perform UI teardown. See apiFetch for the emit guard. */
 export const SESSION_EXPIRED_EVENT = "st:session-expired";
 
 // ── Auth API ────────────────────────────────────────────────────────────────
 
-export async function checkAuthStatus(): Promise<{ needsSetup: boolean }> {
+export interface AuthStatus {
+	needsSetup: boolean;
+	authenticated: boolean;
+}
+
+export async function checkAuthStatus(): Promise<AuthStatus> {
 	const res = await apiFetch("/auth/status");
-	return res.json();
+	const data = (await res.json()) as AuthStatus;
+	// The server is the source of truth for cookie presence. Mirror it
+	// into module state so isLoggedIn() can answer instantly thereafter.
+	_loggedIn = data.authenticated;
+	return data;
 }
 
 export class InviteRequiredError extends Error {
@@ -50,7 +53,7 @@ export async function register(
 	username: string,
 	password: string,
 	inviteCode?: string,
-): Promise<{ userId: string; token: string }> {
+): Promise<{ userId: string }> {
 	const res = await apiFetch("/auth/register", {
 		method: "POST",
 		body: JSON.stringify({ username, password, inviteCode }),
@@ -62,15 +65,12 @@ export async function register(
 		}
 		throw new Error(body.error ?? "Registration failed");
 	}
-	const data = await res.json();
-	setToken(data.token);
+	const data = (await res.json()) as { userId: string };
+	_loggedIn = true;
 	return data;
 }
 
-export async function login(
-	username: string,
-	password: string,
-): Promise<{ userId: string; token: string }> {
+export async function login(username: string, password: string): Promise<{ userId: string }> {
 	const res = await apiFetch("/auth/login", {
 		method: "POST",
 		body: JSON.stringify({ username, password }),
@@ -79,13 +79,26 @@ export async function login(
 		const body = await res.json();
 		throw new Error(body.error ?? "Login failed");
 	}
-	const data = await res.json();
-	setToken(data.token);
+	const data = (await res.json()) as { userId: string };
+	_loggedIn = true;
 	return data;
 }
 
-export function logout(): void {
-	setToken(null);
+export async function logout(): Promise<void> {
+	// POST so SameSite=Strict applies (a cross-site GET would still be
+	// blocked, but POST is the canonical "this is a state change"
+	// signal). The endpoint is unauthenticated server-side — we don't
+	// want a stale cookie to lock the user out of clearing it.
+	//
+	// Swallow network errors so a logout-while-offline still tears down
+	// local state. The server's view becomes consistent on the next
+	// /auth/status round-trip after the user comes back online.
+	try {
+		await apiFetch("/auth/logout", { method: "POST" });
+	} catch {
+		/* network down — local teardown is what the user actually wants */
+	}
+	_loggedIn = false;
 }
 
 // ── Session types ───────────────────────────────────────────────────────────
@@ -299,31 +312,36 @@ async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
 		...(isFormData ? {} : { "Content-Type": "application/json" }),
 		...((init?.headers as Record<string, string>) ?? {}),
 	};
-	// Captured before the fetch so a concurrent setToken(null) between
-	// here and the response doesn't change how we classify the 401 below.
-	// `sentAuth` pins "this request carried an Authorization header" —
-	// only authed 401s are treated as "token is stale"; an unauthed 401
-	// (e.g. wrong password on /auth/login) must not clear token state.
-	const sentAuth = !!_token;
-	if (_token) {
-		headers.Authorization = `Bearer ${_token}`;
-	}
-	const res = await fetch(`${API_BASE}${path}`, { ...init, headers });
+	// Captured before the fetch so a concurrent flip of `_loggedIn`
+	// between here and the response doesn't change how we classify the
+	// 401 below. `sentAuth` is "we believed we were logged in when this
+	// request started"; only those 401s are treated as "session expired".
+	// A 401 from /auth/login on bad credentials, with `_loggedIn === false`
+	// before the call, must NOT trigger the SESSION_EXPIRED_EVENT.
+	const sentAuth = _loggedIn;
+	// `credentials: "include"` is mandatory for cookie-based auth across
+	// origins (frontend on Pages, backend on Tunnel). Without it the
+	// browser silently drops the auth cookie.
+	const res = await fetch(`${API_BASE}${path}`, {
+		...init,
+		headers,
+		credentials: "include",
+	});
 
-	// Centralised stale-token handling (#95). Without this, the 15 s
+	// Centralised stale-cookie handling (#95). Without this, the 15 s
 	// session poll toasts an error every 15 s forever once the JWT
-	// expires, because nothing else clears _token on 401.
+	// expires, because nothing else flips `_loggedIn` on 401.
 	//
-	// - sentAuth (captured pre-fetch) distinguishes authed 401s from
-	//   unauthed ones like a wrong-password /auth/login on a session
-	//   that already has a token — we mustn't clear auth state on that.
-	// - 401 is specifically "token stale"; 403 is policy and must not
+	// - sentAuth distinguishes authed 401s from unauthed ones like a
+	//   wrong-password /auth/login on a logged-out session — we mustn't
+	//   pretend a session existed when one didn't.
+	// - 401 is specifically "session stale"; 403 is policy and must not
 	//   trigger a logout.
-	// - _token !== null dedups concurrent 401 bursts (session poll +
-	//   a user-triggered call racing): the first setToken(null) through
-	//   silences the rest so the event fires exactly once per burst.
-	if (sentAuth && res.status === 401 && _token !== null) {
-		setToken(null);
+	// - `_loggedIn` check dedups concurrent 401 bursts (session poll +
+	//   a user-triggered call racing): the first one through flips it
+	//   false and the rest see false, so the event fires exactly once.
+	if (sentAuth && res.status === 401 && _loggedIn) {
+		_loggedIn = false;
 		window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
 	}
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -163,13 +163,16 @@ function disposeAllCurrentTerminals() {
 let isBootstrapRegister = false;
 
 async function initAuth() {
-	if (isLoggedIn()) {
-		showApp();
-		return;
-	}
-
+	// Cookie-based auth (#18): the only way to know if we're already
+	// authenticated is to ask the server, since the cookie is httpOnly.
+	// /auth/status fields both questions in one round-trip — `authenticated`
+	// for "show app vs. login" and `needsSetup` for "show invite field".
 	try {
-		const { needsSetup } = await checkAuthStatus();
+		const { needsSetup, authenticated } = await checkAuthStatus();
+		if (authenticated) {
+			showApp();
+			return;
+		}
 		if (needsSetup) {
 			isRegisterMode = true;
 			isBootstrapRegister = true;
@@ -294,13 +297,18 @@ authForm.addEventListener("submit", async (e) => {
 });
 
 // Shared teardown for both the explicit logout button and the auto-triggered
-// session-expired path below. Idempotent: `logout()` clears the already-null
-// token on a second call, disposeAllCurrentTerminals() handles an empty
-// terminal map, and showAuth() just re-applies display styles. So the burst
-// case (multiple 401s briefly racing before _token is cleared) is safe even
-// though apiFetch's `_token !== null` guard already deduplicates.
+// session-expired path below. Idempotent: `logout()` is safe to call from a
+// logged-out state (it just POSTs /auth/logout and the server returns 204
+// either way), disposeAllCurrentTerminals() handles an empty terminal map,
+// and showAuth() just re-applies display styles. So the burst case (multiple
+// 401s briefly racing) is safe even though apiFetch's `_loggedIn` guard
+// already deduplicates.
+//
+// Fire and forget on the network call — the UI teardown shouldn't block on
+// the round-trip, and the server's POST /auth/logout response carries no
+// information we'd act on.
 function handleLogout(toastMessage?: string): void {
-	logout();
+	void logout();
 	disposeAllCurrentTerminals();
 	activeSessionId = null;
 	sessions = [];

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -327,15 +327,15 @@ logoutBtn.addEventListener("click", () => {
 // so a delegated `invitesBtn.click()` would silently lose focus on close).
 sidebarLogoutBtn.addEventListener("click", () => logoutBtn.click());
 
-// Listen for the api-layer signal that our JWT is no longer accepted (#95).
-// Without this, a `refreshSessions()` tick 15 s after expiry produces a
-// 401 → red toast, the next tick does the same, and so on forever because
-// nothing was clearing `_token`. api.ts now clears the token at the 401 and
-// dispatches this event; we pair that with a UI transition back to the
-// login view and a single explanatory toast.
+// Listen for the api-layer signal that our session cookie is no longer
+// accepted (#95). Without this, a `refreshSessions()` tick 15 s after
+// expiry produces a 401 → red toast, the next tick does the same, and
+// so on forever because nothing was flipping `_loggedIn` to false. api.ts
+// now does that at the 401 and dispatches this event; we pair that with
+// a UI transition back to the login view and a single explanatory toast.
 //
-// One-shot per burst: apiFetch's internal `_token !== null` guard ensures
-// the event fires at most once per 401 burst, so we don't need extra
+// One-shot per burst: apiFetch's internal `_loggedIn` guard ensures the
+// event fires at most once per 401 burst, so we don't need extra
 // debouncing here.
 window.addEventListener(SESSION_EXPIRED_EVENT, () => {
 	handleLogout("Your session has expired — please sign in again");

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -6,7 +6,6 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { type IDisposable, type ILink, type ILinkProvider, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import { getToken } from "./api.js";
 
 export type SessionStatus = "running" | "stopped" | "terminated" | "disconnected";
 
@@ -172,14 +171,12 @@ export function openTerminalSession(opts: {
 	container.addEventListener("pointerdown", focusOnPointer);
 
 	// ── WebSocket connection ────────────────────────────────────────────────
-	// Prefer passing the JWT as a subprotocol (`auth.bearer.<jwt>`) so the
-	// token stays out of the URL, access logs, browser history and Referer
-	// headers. Some proxies/tunnels silently strip `Sec-WebSocket-Protocol`
-	// though, so we also include the token as a `?token=` query param as a
-	// fallback — the backend accepts either.
-	const token = getToken() ?? "";
-	const wsUrl = buildWsUrl(sessionId, token, tabId);
-	const ws = new WebSocket(wsUrl, [`auth.bearer.${token}`]);
+	// Auth lives in an httpOnly cookie (#18). Browsers send cookies on the
+	// WS upgrade to the cookie's domain automatically — no token needs to
+	// be threaded through here. Origin policy (CSWSH protection) is
+	// enforced server-side by isAllowedWsOrigin against CORS_ORIGINS.
+	const wsUrl = buildWsUrl(sessionId, tabId);
+	const ws = new WebSocket(wsUrl);
 	let disposed = false;
 
 	ws.onopen = () => {
@@ -661,20 +658,20 @@ class MultilineUrlLinkProvider implements ILinkProvider {
 
 // ── URL builder ─────────────────────────────────────────────────────────────
 
-function buildWsUrl(sessionId: string, token: string, tabId?: string): string {
+function buildWsUrl(sessionId: string, tabId?: string): string {
 	// Use VITE_API_URL to derive the WebSocket URL
 	const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
 	const url = new URL(apiUrl);
 	const wsProto = url.protocol === "https:" ? "wss:" : "ws:";
 	const base = `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
-	const params = new URLSearchParams();
-	if (token) params.set("token", token);
 	// tabId is server-issued and re-validated on the backend before any
 	// `tmux attach -t` — see backend/src/wsHandler.ts (rawTab regex
 	// /^[a-zA-Z0-9._-]{1,64}$/). Excluding `:` is the load-bearing part:
 	// tmux target syntax needs a colon to parse `session:window.pane`, so
 	// `.` alone can't escalate a tabId into a different tmux target.
-	if (tabId) params.set("tab", tabId);
-	const qs = params.toString();
-	return qs ? `${base}?${qs}` : base;
+	if (tabId) {
+		const params = new URLSearchParams({ tab: tabId });
+		return `${base}?${params.toString()}`;
+	}
+	return base;
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,6 +10,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
+    "noEmit": true,
     "types": ["vite/client"]
   },
   "include": ["src"]


### PR DESCRIPTION
Closes #18.

Token previously lived in `localStorage` and travelled in the `Authorization: Bearer …` header — a single XSS sink would have exfiltrated it. Switching to an httpOnly cookie removes that read path: JS can no longer observe the token at all.

## Backend

**`auth.ts`**
- New `setAuthCookie(res, token)` / `clearAuthCookie(res)` helpers — `httpOnly`, `Secure` in production, `SameSite=None` in production / `SameSite=Strict` in dev. The `None` choice is required for the cross-site Pages → Tunnel deployment (different eTLD+1); CSRF is then carried by the CORS preflight + `Content-Type: application/json` requirement on every state-changing JSON route. `maxAge` is derived from the JWT's own `exp` claim so cookie and token expire together.
- `verifyJwt(token)` is the single-source verify primitive used by both REST and WS paths.
- `requireAuth` reads from `req.cookies.st_token` with a header fallback for tests bypassing middleware. `Authorization` is no longer accepted.
- `verifyWsToken` reads the JWT from the WS upgrade request's `Cookie` header — browsers send cookies on the upgrade to the cookie's domain automatically. `auth.bearer.<jwt>` subprotocol and `?token=` query-string fallbacks are gone, along with `selectWsAuthProtocol` and related extractors.

**`routes.ts`**
- `/auth/status` adds `authenticated: boolean` so the frontend can decide between login and app screens on first load.
- `/auth/login` + `/auth/register` set the cookie and return only `{ userId }` in the body. Raw token never leaves the server.
- New `POST /auth/logout` clears the cookie. Intentionally not auth-gated so a client with an expired session can still tidy up; a forced cross-site logout via a simple form POST is possible (see code comment) but the consequence is user inconvenience only — no data exposed, no session hijacked.

**`index.ts`**
- `cookie-parser` middleware registered before the router.
- WebSocketServer drops `handleProtocols`.
- CORS middleware: `Access-Control-Allow-Credentials: true` is gated on an **exact-origin** match against the allowlist. Wildcard config falls back to a plain `Access-Control-Allow-Origin: *` without credentials — cross-origin callers without an explicit listing get the cookie dropped by the browser and effectively a 401 from the auth middleware. `Vary: Origin` is set unconditionally so a future intermediate cache can't serve a cached no-CORS response to a cross-origin client. `Authorization` removed from `Allow-Headers`.

## Frontend

**`api.ts`**
- `_token` / localStorage / `getToken` / `setToken` all gone. Auth state is now an in-memory `_loggedIn` boolean, hydrated on boot from `/auth/status` and updated on login / register / logout / 401.
- Every request sends `credentials: "include"` so the browser ships the cookie cross-origin (Pages → Tunnel). No Authorization header is set.
- 401 stale-session dedup keys off `_loggedIn`; same single-fire `SESSION_EXPIRED_EVENT` semantics.
- `logout()` is async — POSTs `/auth/logout` and swallows any network rejection so an offline logout still tears local state down.

**`terminal.ts`**
- `new WebSocket(wsUrl)` — no subprotocol, no `?token=`. Cookie travels on the upgrade automatically.
- `buildWsUrl` no longer takes a token.

**`main.ts`**
- `initAuth` calls `/auth/status` unconditionally to learn `authenticated`, rather than starting from a localStorage-derived guess.
- `handleLogout` fires the async `logout()` and continues without awaiting.

## Tests

- `wsHandler.test.ts`: WS auth injection switched from `Sec-WebSocket-Protocol: auth.bearer.…` to `Cookie: st_token=…`.
- `rateLimit.test.ts`: `vi.mock("./auth.js")` stub gains the new cookie-helper exports.
- `api.test.ts` (frontend): rewritten. Token-management cases dropped, replaced with `_loggedIn` mirroring tests, `credentials: "include"` assertion, `Authorization` absence assertion, async `logout()` with offline fallthrough, and the same 401 dedup semantics translated to the new state model. **22 cases passing (was 20)**.
- `frontend/tsconfig.json`: `"noEmit": true` — Vite handles the bundle and tsc was leaving stray `.js` siblings in `src/` that vitest then picked up as duplicate test files.

## Migration

Existing localStorage-tokened users get logged out exactly once on upgrade — `_loggedIn` defaults to `false` and only `/auth/status` can flip it to true, which requires the cookie. Acceptable for a personal product with a small known userbase.

## Tested

- backend: lint clean, tsc clean, **149 tests passing**
- frontend: lint clean, tsc clean, vite build clean, **22 tests passing**
- node smoke of the cookie-attribute math (Secure flag flip on NODE_ENV, maxAge from `exp`).