### PR TITLE
fix(db): FK on sessions.user_id (#20)

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -61,15 +61,25 @@ export async function d1Query<T = Record<string, unknown>>(
 }
 
 /**
- * Execute multiple SQL statements (for migrations).
+ * Execute multiple SQL statements as a single batch (one HTTP round-trip)
+ * on Cloudflare D1's `/query` endpoint, which "supports multiple statements,
+ * joined by semicolons, which will be executed as a batch" (per the D1 REST
+ * API docs). The batch runs as one transaction — any single statement
+ * failing rolls all of them back and surfaces as a throw from `d1Query`.
+ *
+ * Migration-only and parameter-free by construction. Don't pass user input
+ * here without escaping; the SQL is concatenated verbatim. The return shape
+ * for a multi-statement batch is an array of one result per statement;
+ * callers don't read it (this returns void), so the lie inside `d1Query` —
+ * which only surfaces `result[0]` — doesn't matter for migration.
  */
 export async function d1Batch(statements: string[]): Promise<void> {
-	// D1 doesn't have a batch endpoint via HTTP, so run sequentially
-	for (const sql of statements) {
-		const trimmed = sql.trim();
-		if (!trimmed) continue;
-		await d1Query(trimmed);
-	}
+	const sql = statements
+		.map((s) => s.trim())
+		.filter(Boolean)
+		.join(";\n");
+	if (!sql) return;
+	await d1Query(sql);
 }
 
 /**
@@ -85,6 +95,15 @@ export async function migrateDb(): Promise<void> {
                         password_hash TEXT NOT NULL,
                         created_at  TEXT NOT NULL DEFAULT (datetime('now'))
                 )`,
+		// FK on user_id (#20): D1 enables foreign-key enforcement on every
+		// connection by default, so this is load-bearing once user
+		// deletion lands. ON DELETE CASCADE: deleting a user purges their
+		// sessions atomically, no orphan rows. Pre-existing tables
+		// (created before this migration) won't pick up the FK — SQLite
+		// has no ADD CONSTRAINT, only table rebuild — so existing
+		// deployments need a manual rebuild if they want enforcement on
+		// rows that already exist. Documented as a known limitation in
+		// the issue.
 		`CREATE TABLE IF NOT EXISTS sessions (
                         session_id      TEXT PRIMARY KEY,
                         user_id         TEXT NOT NULL,
@@ -96,7 +115,8 @@ export async function migrateDb(): Promise<void> {
                         rows            INTEGER NOT NULL DEFAULT 36,
                         env_vars        TEXT NOT NULL DEFAULT '{}',
                         created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-                        last_connected_at TEXT
+                        last_connected_at TEXT,
+                        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
                 )`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_user
                         ON sessions(user_id, status)`,

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -61,68 +61,20 @@ export async function d1Query<T = Record<string, unknown>>(
 }
 
 /**
- * Execute multiple SQL statements as one HTTP round-trip via D1's `batch`
- * parameter on `/query` — body is `{ batch: [{ sql, params }, ...] }`.
- * Per the D1 REST API reference, `/query` and `/raw` both accept this
- * shape; there is no separate `/batch` endpoint. Sequential execution;
- * no documented rollback guarantee at the REST layer (the transactional
- * promise belongs to the Workers `db.batch()` binding, not this endpoint).
- * Treat a failed statement as "the schema is now partial — fix it
- * manually" and throw on every per-statement failure so a silent
- * partial migration can't boot the server.
+ * Execute multiple SQL statements (for migrations).
  *
- * Migration-only and parameter-free by construction. `d1Query`'s
- * envelope-only check + `result[0]` surface would mask a mid-batch
- * failure, so the fetch is inlined here so we can walk every
- * statement's `success` flag. The length-check guard below also
- * catches a silent-no-op shape where D1 ignored the `batch` field
- * entirely (zero results returned for N statements sent) — without
- * it that path would log "migrations complete" and break at first
- * real request.
+ * Sequential one-statement-per-request. The D1 REST `/query` endpoint
+ * does have undocumented multi-statement shapes (semicolon-joined SQL,
+ * `{ batch: [...] }` body), but neither has been empirically verified
+ * here. Five DDL round-trips at cold start is negligible; trading
+ * proven reliability for that tiny optimisation regresses the only
+ * code path that runs at every boot. See PR #141 review history.
  */
 export async function d1Batch(statements: string[]): Promise<void> {
-	const trimmed = statements.map((s) => s.trim()).filter(Boolean);
-	if (trimmed.length === 0) return;
-
-	const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/d1/database/${DATABASE_ID}/query`;
-	const res = await fetch(url, {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${API_TOKEN}`,
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			batch: trimmed.map((sql) => ({ sql, params: [] })),
-		}),
-	});
-	if (!res.ok) {
-		const text = await res.text();
-		throw new Error(`D1 batch HTTP error (${res.status}): ${text}`);
-	}
-	const data = (await res.json()) as D1ApiResponse;
-	if (!data.success) {
-		throw new Error(`D1 batch envelope failed: ${data.errors.map((e) => e.message).join(", ")}`);
-	}
-	// Length guard: a 200 with zero results despite N statements sent is
-	// the silent-no-op shape — endpoint shape mismatched, server applied
-	// nothing. Make it loud here rather than at the first real request.
-	if (data.result.length !== trimmed.length) {
-		throw new Error(
-			`D1 batch: sent ${trimmed.length} statement(s) but got ${data.result.length} result(s); ` +
-				"schema is partial or unapplied — check D1 dashboard / API contract.",
-		);
-	}
-	// Per-statement check: D1 may set data.success=true while reporting a
-	// per-result failure for one of the statements.
-	for (const [i, r] of data.result.entries()) {
-		if (!r.success) {
-			// `D1QueryResult` doesn't currently surface a per-statement
-			// error message. If a future shape adds one, widen the type
-			// and inline it here.
-			throw new Error(
-				`D1 batch statement ${i} reported failure — see Cloudflare D1 dashboard for the per-statement error detail.`,
-			);
-		}
+	for (const sql of statements) {
+		const trimmed = sql.trim();
+		if (!trimmed) continue;
+		await d1Query(trimmed);
 	}
 }
 
@@ -139,6 +91,9 @@ export async function migrateDb(): Promise<void> {
                         password_hash TEXT NOT NULL,
                         created_at  TEXT NOT NULL DEFAULT (datetime('now'))
                 )`,
+		// `sessions` must follow `users` — the FK on user_id references
+		// users(id), and these statements run sequentially. Don't reorder
+		// without also handling deferred-FK semantics on D1.
 		// FK on user_id (#20): D1 enables foreign-key enforcement on every
 		// connection by default, so this is load-bearing once user
 		// deletion lands. ON DELETE CASCADE: deleting a user purges their

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -61,29 +61,25 @@ export async function d1Query<T = Record<string, unknown>>(
 }
 
 /**
- * Execute multiple SQL statements as a single semicolon-joined batch on
- * Cloudflare D1's `/query` endpoint (one HTTP round-trip, per the D1 REST
- * API docs). Migration-only and parameter-free by construction; the SQL
- * is concatenated verbatim, so don't pass user input without escaping.
+ * Execute multiple SQL statements as one HTTP round-trip via D1's
+ * documented `batch` parameter on `/query`: the body is `{ batch: [...] }`
+ * with one `{ sql, params }` object per statement. Sequential execution;
+ * no documented rollback guarantee at the REST layer (that's the Workers
+ * `db.batch()` binding's promise, not this endpoint's). Treat a failed
+ * statement as "the schema is now partial — fix it manually" and throw
+ * on every per-statement failure so a silent partial migration can't
+ * boot the server.
  *
- * D1's `/query` endpoint executes statements sequentially. Whether it
- * rolls back on a mid-batch failure is not documented for the REST
- * endpoint (the transactional guarantee is the Workers `db.batch()`
- * binding's, not `/query`'s). Treat a failed statement as "the schema
- * is now in an inconsistent state — fix it manually" and surface every
- * per-statement failure with a throw.
- *
- * `d1Query` only surfaces `result[0]`, so calling it with a multi-stmt
- * SQL would silently drop a failure at index > 0. Inline the fetch here
- * so we can check every statement's `success` flag instead of relying
- * on the envelope-level `data.success` alone.
+ * Migration-only and parameter-free by construction. The semicolon-
+ * joined `{ sql }` shape is undocumented for multi-statement execution
+ * and could plausibly run only the first; the `{ batch }` shape is
+ * the spec'd path. `d1Query`'s envelope-only check + `result[0]`
+ * surface would also have masked a mid-batch failure, so the fetch
+ * is inlined here to walk every statement's `success` flag.
  */
 export async function d1Batch(statements: string[]): Promise<void> {
-	const sql = statements
-		.map((s) => s.trim())
-		.filter(Boolean)
-		.join(";\n");
-	if (!sql) return;
+	const trimmed = statements.map((s) => s.trim()).filter(Boolean);
+	if (trimmed.length === 0) return;
 
 	const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/d1/database/${DATABASE_ID}/query`;
 	const res = await fetch(url, {
@@ -92,7 +88,9 @@ export async function d1Batch(statements: string[]): Promise<void> {
 			Authorization: `Bearer ${API_TOKEN}`,
 			"Content-Type": "application/json",
 		},
-		body: JSON.stringify({ sql }),
+		body: JSON.stringify({
+			batch: trimmed.map((sql) => ({ sql, params: [] })),
+		}),
 	});
 	if (!res.ok) {
 		const text = await res.text();
@@ -103,13 +101,16 @@ export async function d1Batch(statements: string[]): Promise<void> {
 		throw new Error(`D1 batch envelope failed: ${data.errors.map((e) => e.message).join(", ")}`);
 	}
 	// Per-statement check: D1 may set data.success=true while reporting a
-	// per-result failure for one of the statements. The envelope-only
-	// check d1Query does is enough for single-statement queries but not
-	// for a batch where the result array has N entries.
+	// per-result failure for one of the statements. Envelope-only check
+	// like d1Query does is enough for single-statement queries but masks
+	// a mid-batch failure here.
 	for (const [i, r] of data.result.entries()) {
 		if (!r.success) {
+			// `D1QueryResult` doesn't currently surface a per-statement
+			// error message. If a future shape adds one, widen the type
+			// and inline it here.
 			throw new Error(
-				`D1 batch statement ${i} reported failure (no message in per-statement payload — check the upstream SQL)`,
+				`D1 batch statement ${i} reported failure — see Cloudflare D1 dashboard for the per-statement error detail.`,
 			);
 		}
 	}

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -61,21 +61,24 @@ export async function d1Query<T = Record<string, unknown>>(
 }
 
 /**
- * Execute multiple SQL statements as one HTTP round-trip via D1's
- * documented `batch` parameter on `/query`: the body is `{ batch: [...] }`
- * with one `{ sql, params }` object per statement. Sequential execution;
- * no documented rollback guarantee at the REST layer (that's the Workers
- * `db.batch()` binding's promise, not this endpoint's). Treat a failed
- * statement as "the schema is now partial — fix it manually" and throw
- * on every per-statement failure so a silent partial migration can't
- * boot the server.
+ * Execute multiple SQL statements as one HTTP round-trip via D1's `batch`
+ * parameter on `/query` — body is `{ batch: [{ sql, params }, ...] }`.
+ * Per the D1 REST API reference, `/query` and `/raw` both accept this
+ * shape; there is no separate `/batch` endpoint. Sequential execution;
+ * no documented rollback guarantee at the REST layer (the transactional
+ * promise belongs to the Workers `db.batch()` binding, not this endpoint).
+ * Treat a failed statement as "the schema is now partial — fix it
+ * manually" and throw on every per-statement failure so a silent
+ * partial migration can't boot the server.
  *
- * Migration-only and parameter-free by construction. The semicolon-
- * joined `{ sql }` shape is undocumented for multi-statement execution
- * and could plausibly run only the first; the `{ batch }` shape is
- * the spec'd path. `d1Query`'s envelope-only check + `result[0]`
- * surface would also have masked a mid-batch failure, so the fetch
- * is inlined here to walk every statement's `success` flag.
+ * Migration-only and parameter-free by construction. `d1Query`'s
+ * envelope-only check + `result[0]` surface would mask a mid-batch
+ * failure, so the fetch is inlined here so we can walk every
+ * statement's `success` flag. The length-check guard below also
+ * catches a silent-no-op shape where D1 ignored the `batch` field
+ * entirely (zero results returned for N statements sent) — without
+ * it that path would log "migrations complete" and break at first
+ * real request.
  */
 export async function d1Batch(statements: string[]): Promise<void> {
 	const trimmed = statements.map((s) => s.trim()).filter(Boolean);
@@ -100,10 +103,17 @@ export async function d1Batch(statements: string[]): Promise<void> {
 	if (!data.success) {
 		throw new Error(`D1 batch envelope failed: ${data.errors.map((e) => e.message).join(", ")}`);
 	}
+	// Length guard: a 200 with zero results despite N statements sent is
+	// the silent-no-op shape — endpoint shape mismatched, server applied
+	// nothing. Make it loud here rather than at the first real request.
+	if (data.result.length !== trimmed.length) {
+		throw new Error(
+			`D1 batch: sent ${trimmed.length} statement(s) but got ${data.result.length} result(s); ` +
+				"schema is partial or unapplied — check D1 dashboard / API contract.",
+		);
+	}
 	// Per-statement check: D1 may set data.success=true while reporting a
-	// per-result failure for one of the statements. Envelope-only check
-	// like d1Query does is enough for single-statement queries but masks
-	// a mid-batch failure here.
+	// per-result failure for one of the statements.
 	for (const [i, r] of data.result.entries()) {
 		if (!r.success) {
 			// `D1QueryResult` doesn't currently surface a per-statement

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -61,17 +61,22 @@ export async function d1Query<T = Record<string, unknown>>(
 }
 
 /**
- * Execute multiple SQL statements as a single batch (one HTTP round-trip)
- * on Cloudflare D1's `/query` endpoint, which "supports multiple statements,
- * joined by semicolons, which will be executed as a batch" (per the D1 REST
- * API docs). The batch runs as one transaction — any single statement
- * failing rolls all of them back and surfaces as a throw from `d1Query`.
+ * Execute multiple SQL statements as a single semicolon-joined batch on
+ * Cloudflare D1's `/query` endpoint (one HTTP round-trip, per the D1 REST
+ * API docs). Migration-only and parameter-free by construction; the SQL
+ * is concatenated verbatim, so don't pass user input without escaping.
  *
- * Migration-only and parameter-free by construction. Don't pass user input
- * here without escaping; the SQL is concatenated verbatim. The return shape
- * for a multi-statement batch is an array of one result per statement;
- * callers don't read it (this returns void), so the lie inside `d1Query` —
- * which only surfaces `result[0]` — doesn't matter for migration.
+ * D1's `/query` endpoint executes statements sequentially. Whether it
+ * rolls back on a mid-batch failure is not documented for the REST
+ * endpoint (the transactional guarantee is the Workers `db.batch()`
+ * binding's, not `/query`'s). Treat a failed statement as "the schema
+ * is now in an inconsistent state — fix it manually" and surface every
+ * per-statement failure with a throw.
+ *
+ * `d1Query` only surfaces `result[0]`, so calling it with a multi-stmt
+ * SQL would silently drop a failure at index > 0. Inline the fetch here
+ * so we can check every statement's `success` flag instead of relying
+ * on the envelope-level `data.success` alone.
  */
 export async function d1Batch(statements: string[]): Promise<void> {
 	const sql = statements
@@ -79,7 +84,35 @@ export async function d1Batch(statements: string[]): Promise<void> {
 		.filter(Boolean)
 		.join(";\n");
 	if (!sql) return;
-	await d1Query(sql);
+
+	const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/d1/database/${DATABASE_ID}/query`;
+	const res = await fetch(url, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${API_TOKEN}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ sql }),
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`D1 batch HTTP error (${res.status}): ${text}`);
+	}
+	const data = (await res.json()) as D1ApiResponse;
+	if (!data.success) {
+		throw new Error(`D1 batch envelope failed: ${data.errors.map((e) => e.message).join(", ")}`);
+	}
+	// Per-statement check: D1 may set data.success=true while reporting a
+	// per-result failure for one of the statements. The envelope-only
+	// check d1Query does is enough for single-statement queries but not
+	// for a batch where the result array has N entries.
+	for (const [i, r] of data.result.entries()) {
+		if (!r.success) {
+			throw new Error(
+				`D1 batch statement ${i} reported failure (no message in per-statement payload — check the upstream SQL)`,
+			);
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
Closes #20.

Adds \`FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE\` to the \`CREATE TABLE sessions\` statement. D1 enables foreign-key enforcement on every connection by default, so this is load-bearing on fresh deploys: a future user-deletion path will atomically purge the user's sessions instead of leaving orphans.

**Caveat** (acknowledged in the issue): SQLite has no \`ADD CONSTRAINT\`, only table rebuild. Pre-existing tables created before this migration won't pick up the FK — existing deployments need a manual rebuild if they want enforcement on rows that already exist. Comment in the migration documents this.

Also adds an ordering comment between the \`users\` and \`sessions\` CREATE statements so a future contributor reordering the array doesn't break FK resolution at fresh-deploy time.

## #19 — withdrawn from this PR

The original scope tried to also rewrite \`d1Batch\` from N sequential round-trips to one POST. Multiple review rounds flagged that the multi-statement shape on D1's REST \`/query\` endpoint isn't empirically verified, and the cost of N=5 round-trips at cold start is negligible. Reverted to sequential \`d1Query\` loop — proven correct, every statement's envelope success checked individually. Issue #19 stays open; closing requires either a real D1 round-trip test or accepting that the current "1 RT per stmt" is fine.

## Tested

- \`npm run lint\` clean
- \`npm run build\` (tsc) clean
- \`npm test\` — 161 passing, no regressions