### PR TITLE
fix(frontend): three small UX issues (#54, #55, #56)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -750,6 +750,16 @@ function openTab(tabId: string) {
 					if (activeSessionId !== ownSessionId) return;
 					showToast(msg, true);
 				},
+				onRendererFallback: (msg: string) => {
+					// Show even for non-active tabs — a backgrounded tab
+					// that loses its WebGL context will surface the
+					// notice when it next becomes active or, in this
+					// flow, immediately. Toast is one-time per tab
+					// (gated inside terminal.ts) so a flapping driver
+					// can't spam it. Surfaced as a non-error toast
+					// because the terminal still works, just slower.
+					showToast(`${msg} Reload the tab to retry GPU rendering.`);
+				},
 			});
 			entry = { pane, term };
 			currentTerminals.set(tabId, entry);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1156,13 +1156,25 @@ function nextFontSize(current: number): number {
 	return FONT_SIZE_STEPS[(i + 1) % FONT_SIZE_STEPS.length]!;
 }
 
+// RAF-coalesce the per-tab apply (#56). Each click cycles
+// `currentFontSize` immediately so the button label stays in lock-step
+// with what the user clicked, but the per-tab `setFontSize` (which
+// triggers an xterm re-layout + refit per tab) defers to the next
+// animation frame and reads the latest value once. A burst of N clicks
+// inside one frame collapses to exactly one apply per terminal.
+let fontSizeRafScheduled = false;
 fontSizeBtn.addEventListener("click", () => {
 	currentFontSize = nextFontSize(currentFontSize);
 	localStorage.setItem(FONT_SIZE_KEY, String(currentFontSize));
 	fontSizeBtn.textContent = `Aa ${currentFontSize}`;
-	for (const { term } of currentTerminals.values()) {
-		term.setFontSize(currentFontSize);
-	}
+	if (fontSizeRafScheduled) return;
+	fontSizeRafScheduled = true;
+	requestAnimationFrame(() => {
+		fontSizeRafScheduled = false;
+		for (const { term } of currentTerminals.values()) {
+			term.setFontSize(currentFontSize);
+		}
+	});
 });
 // Reflect the persisted size in the label on load so users see e.g. "Aa 16"
 // rather than a generic "Aa" after they've picked their size once.

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1283,6 +1283,19 @@ async function renderInvites() {
 
 		inviteList.appendChild(row);
 	}
+
+	// Backend caps the response at INVITE_LIST_LIMIT=100 (#54). When we
+	// hit that boundary, the modal is silently truncated — surface a
+	// hint so a user with > 100 historical invites isn't misled into
+	// thinking that's everything. Real cursor pagination is overkill
+	// today; this footer is the cheap signal that something was elided.
+	const SERVER_INVITE_LIMIT = 100;
+	if (invites.length === SERVER_INVITE_LIMIT) {
+		const footer = document.createElement("div");
+		footer.className = "invite-empty";
+		footer.textContent = "Older invites not shown — only the most recent 100 are listed.";
+		inviteList.appendChild(footer);
+	}
 }
 
 invitesBtn.addEventListener("click", () => openInvitesModal(invitesBtn));

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -17,6 +17,10 @@ export interface TerminalSession {
 
 export type StatusCallback = (status: SessionStatus) => void;
 export type ErrorCallback = (message: string) => void;
+/** Notice fired the first time WebGL is unavailable on this tab — once
+ *  per terminal lifetime. Used by main.ts to surface a one-time toast
+ *  so the user knows why their session feels slower (#55). */
+export type RendererNoticeCallback = (message: string) => void;
 
 export function openTerminalSession(opts: {
 	container: HTMLElement;
@@ -25,8 +29,20 @@ export function openTerminalSession(opts: {
 	fontSize?: number;
 	onStatus: StatusCallback;
 	onError: ErrorCallback;
+	onRendererFallback?: RendererNoticeCallback;
 }): TerminalSession {
-	const { container, sessionId, tabId, fontSize, onStatus, onError } = opts;
+	const { container, sessionId, tabId, fontSize, onStatus, onError, onRendererFallback } = opts;
+	// Fires the fallback notice at most once per tab, regardless of how
+	// many times the WebGL context flaps (#55). A flapping driver
+	// shouldn't toast on every cycle.
+	let rendererFallbackNoticed = false;
+	const noticeFallback = (reason: string) => {
+		if (rendererFallbackNoticed) return;
+		rendererFallbackNoticed = true;
+		onRendererFallback?.(
+			`GPU rendering unavailable (${reason}) — falling back to slower DOM renderer.`,
+		);
+	};
 
 	// ── xterm.js setup ──────────────────────────────────────────────────────
 	const term = new Terminal({
@@ -76,11 +92,13 @@ export function openTerminalSession(opts: {
 		webgl.onContextLoss(() => {
 			webgl?.dispose();
 			webgl = null;
+			noticeFallback("context lost");
 		});
 		term.loadAddon(webgl);
 	} catch (err) {
 		console.warn("[terminal] WebGL renderer unavailable, falling back to DOM:", err);
 		webgl = null;
+		noticeFallback("addon init failed");
 	}
 
 	// webglcontextlost bubbles; webglcontextrestored does not — listen on the
@@ -107,6 +125,7 @@ export function openTerminalSession(opts: {
 			addon.onContextLoss(() => {
 				addon.dispose();
 				webgl = null;
+				noticeFallback("context lost");
 			});
 			term.loadAddon(addon);
 			webgl = addon;
@@ -114,6 +133,11 @@ export function openTerminalSession(opts: {
 		} catch (err) {
 			restoredAddon?.dispose();
 			console.warn("[terminal] WebGL restore failed:", err);
+			// Restore failed — we're locked into the DOM renderer for
+			// this tab. Surface the same one-time notice so the user
+			// understands the slowdown that started at context loss
+			// will persist.
+			noticeFallback("restore failed");
 		}
 	};
 	const onContextLost = (ev: Event) => {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -133,10 +133,13 @@ export function openTerminalSession(opts: {
 		} catch (err) {
 			restoredAddon?.dispose();
 			console.warn("[terminal] WebGL restore failed:", err);
-			// Restore failed — we're locked into the DOM renderer for
-			// this tab. Surface the same one-time notice so the user
-			// understands the slowdown that started at context loss
-			// will persist.
+			// In the common loss → restore → restore-fail sequence the
+			// "context lost" notice already fired and `noticeFallback`
+			// here is a no-op (the once-per-tab gate is already set).
+			// Kept so a future change that resets the flag between
+			// loss and restore — e.g. to allow re-notice after an
+			// interim successful restore — wouldn't silently skip
+			// surfacing this terminal-state failure.
 			noticeFallback("restore failed");
 		}
 	};


### PR DESCRIPTION
Bundles three frontend issues into one PR. Each landed as its own commit so the diff stays readable per-fix.

## #54 — invites footer when at the server cap

\`listInvites\` is capped server-side at 100. Below that the modal is exhaustive; AT 100 it's silently truncated. Adds a one-liner footer in \`renderInvites\` that fires only when \`invites.length === 100\`. Real cursor pagination becomes worth doing if anyone hits this and asks for it.

## #56 — RAF-coalesce font-size apply

Each font-size button click was firing \`setFontSize\` on every open tab synchronously plus a localStorage write — multi-tab sessions on lower-end phones felt chunky if the user mashed the cycle button. Label still updates immediately (visual feedback), but the per-tab apply defers to the next animation frame and reads \`currentFontSize\` once. A click burst inside one frame collapses to one apply per terminal.

## #55 — surface WebGL → DOM renderer fallback

The WebGL fallback was a silent \`console.warn\`. A user whose tab loses its WebGL context (GPU hiccup, mobile policy, driver suspension) sees the terminal feel sluggish and blames the network. \`openTerminalSession\` gains an optional \`onRendererFallback\` callback fired AT MOST ONCE per tab regardless of how many times the context flaps. Three call sites are wired:

- initial \`WebglAddon()\` construction failure
- \`onContextLoss\` (context revoked mid-session)
- restore failure (context tried to come back but addon re-init threw)

\`main.ts\` wires the callback to \`showToast\` (non-error toast, since the terminal still works — just slower) with a "reload the tab to retry" hint.

## Tested

- \`npm run lint\` clean
- \`npm run build\` (tsc + vite) clean
- \`npm test\` — 22 passing, no regressions
- Manual UI verification not done; happy to repro any of the three behaviours if needed.