### PR TITLE
feat(cors): glob support in CORS_ORIGINS for Pages preview subdomains

### DIFF
--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -6,6 +6,7 @@ import {
 	AUTH_COOKIE_NAME,
 	extractTokenFromCookieHeader,
 	isAllowedWsOrigin,
+	originMatches,
 	parseCorsOrigins,
 	requireAuth,
 	validateJwtSecret,
@@ -252,6 +253,75 @@ describe("isAllowedWsOrigin", () => {
 				isAllowedWsOrigin("https://attacker.example.org", ["https://*.example.com"], "production"),
 			).toBe(false);
 		});
+	});
+});
+
+// Direct contract tests for `originMatches`. The `isAllowedWsOrigin` block
+// already exercises the helper indirectly, but those tests bind the
+// behaviour to the WS branch's specific shape — a future refactor of the
+// CORS middleware in index.ts could disconnect it from `originMatches`
+// without breaking any of those WS-flavoured assertions. Pinning the
+// helper as its own thing keeps the contract stable across both callers.
+describe("originMatches", () => {
+	it("returns false for an empty allowlist", () => {
+		expect(originMatches("https://anything.example", [])).toBe(false);
+	});
+
+	it("matches an exact entry", () => {
+		expect(originMatches("https://app.example.com", ["https://app.example.com"])).toBe(true);
+	});
+
+	it("rejects a near-miss exact entry (case, trailing slash)", () => {
+		expect(originMatches("https://APP.example.com", ["https://app.example.com"])).toBe(false);
+		expect(originMatches("https://app.example.com/", ["https://app.example.com"])).toBe(false);
+	});
+
+	it("matches a single-DNS-label glob", () => {
+		expect(originMatches("https://abc.example.com", ["https://*.example.com"])).toBe(true);
+	});
+
+	it("rejects a multi-label substitution", () => {
+		// Glob `*` is `[^.]+` — refuses dots inside the substitution,
+		// so `a.b.example.com` doesn't match `*.example.com`.
+		expect(originMatches("https://a.b.example.com", ["https://*.example.com"])).toBe(false);
+	});
+
+	it("rejects a suffix-bypass shape", () => {
+		// `https://app.example.com.evil.com` must not match
+		// `https://*.example.com` — the trailing anchor (`$`) blocks
+		// any characters past the pattern.
+		expect(originMatches("https://app.example.com.evil.com", ["https://*.example.com"])).toBe(
+			false,
+		);
+	});
+
+	it("treats the literal `.` in the pattern as a literal dot, not regex any-char", () => {
+		// The escape pass turns `.` into `\.`. A character that's not
+		// a dot in the matching position must NOT match.
+		expect(originMatches("https://abc.exampleAcom", ["https://*.example.com"])).toBe(false);
+	});
+
+	it('skips bare `"*"` entries (callers handle that token separately)', () => {
+		// CORS middleware downgrades bare `*` to no-credentials wildcard;
+		// `isAllowedWsOrigin` denies in production. If `originMatches`
+		// treated `*` as match-everything, both policies would silently
+		// bypass.
+		expect(originMatches("https://anything.example", ["*"])).toBe(false);
+	});
+
+	it("works in a mixed allowlist of exact + glob entries", () => {
+		const mixed = ["https://prod.example.com", "https://*.staging.example.com"];
+		expect(originMatches("https://prod.example.com", mixed)).toBe(true);
+		expect(originMatches("https://api.staging.example.com", mixed)).toBe(true);
+		expect(originMatches("https://other.example.com", mixed)).toBe(false);
+	});
+
+	it("supports multiple `*` substitutions in one entry", () => {
+		// Not the common case, but the regex compilation has no special
+		// limit on `*` count — pin the behaviour so it can't silently
+		// regress.
+		expect(originMatches("https://a.b.example.com", ["https://*.*.example.com"])).toBe(true);
+		expect(originMatches("https://a.b.c.example.com", ["https://*.*.example.com"])).toBe(false);
 	});
 });
 

--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -180,6 +180,79 @@ describe("isAllowedWsOrigin", () => {
 	it("rejects a non-allowlisted origin with no wildcard present", () => {
 		expect(isAllowedWsOrigin("https://evil.example.com", allowlist, "production")).toBe(false);
 	});
+
+	// ── Glob entries (single-DNS-label `*`) ───────────────────────────
+	// Useful for Cloudflare Pages preview URLs where each push lands on
+	// a fresh subdomain — listing `https://*.<project>.pages.dev` once
+	// covers them all without shipping a bypass for arbitrary origins.
+	describe("glob entries", () => {
+		const globAllow = ["https://*.shared-terminal.pages.dev"];
+
+		it("matches a single-label substitution", () => {
+			expect(
+				isAllowedWsOrigin("https://abc123.shared-terminal.pages.dev", globAllow, "production"),
+			).toBe(true);
+			expect(
+				isAllowedWsOrigin("https://feat-foo.shared-terminal.pages.dev", globAllow, "production"),
+			).toBe(true);
+		});
+
+		it("rejects an origin with two labels where the glob expects one", () => {
+			// `*` is `[^.]+` — no dots — so a multi-label segment doesn't
+			// match. Closes the `attacker.shared-terminal.pages.dev.evil.com`
+			// suffix-bypass class.
+			expect(
+				isAllowedWsOrigin("https://a.b.shared-terminal.pages.dev", globAllow, "production"),
+			).toBe(false);
+		});
+
+		it("rejects an origin that prepends/appends extra to the glob shape", () => {
+			expect(
+				isAllowedWsOrigin(
+					"https://abc.shared-terminal.pages.dev.evil.com",
+					globAllow,
+					"production",
+				),
+			).toBe(false);
+			expect(
+				isAllowedWsOrigin(
+					"https://evil.https://abc.shared-terminal.pages.dev",
+					globAllow,
+					"production",
+				),
+			).toBe(false);
+		});
+
+		it("rejects a same-host origin on the wrong scheme", () => {
+			expect(
+				isAllowedWsOrigin("http://abc.shared-terminal.pages.dev", globAllow, "production"),
+			).toBe(false);
+		});
+
+		it("doesn't treat a literal-dot in the glob as a regex wildcard", () => {
+			// The pattern `https://*.shared-terminal.pages.dev` must NOT
+			// match `https://abc.shared-terminalApages.dev` — escaping
+			// the dots in the entry is load-bearing.
+			expect(
+				isAllowedWsOrigin("https://abc.shared-terminalXpages.dev", globAllow, "production"),
+			).toBe(false);
+		});
+
+		it("mixed allowlist: exact + glob both work, neither shadows the other", () => {
+			const mixed = ["https://prod.example.com", "https://*.staging.example.com"];
+			expect(isAllowedWsOrigin("https://prod.example.com", mixed, "production")).toBe(true);
+			expect(isAllowedWsOrigin("https://api.staging.example.com", mixed, "production")).toBe(true);
+			expect(isAllowedWsOrigin("https://other.example.com", mixed, "production")).toBe(false);
+		});
+
+		it("a glob entry does NOT make bare `*` semantics fire", () => {
+			// `https://*.example.com` is a glob, not the wildcard token.
+			// The prod-deny path on bare `*` should not engage from a glob.
+			expect(
+				isAllowedWsOrigin("https://attacker.example.org", ["https://*.example.com"], "production"),
+			).toBe(false);
+		});
+	});
 });
 
 // The warning is a startup-time signal for the "CORS_ORIGINS='*' in

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -730,7 +730,8 @@ export function parseCorsOrigins(raw: string | undefined): string[] {
  *      public endpoints without credentials" — mostly harmless because
  *      browsers refuse to send credentials to `*` (post-#18 the CORS
  *      middleware here also gates `Access-Control-Allow-Credentials` on
- *      an exact-origin match). WS has no such browser-side guard: the
+ *      an allowlist match — exact or single-label glob, see
+ *      `originMatches`). WS has no such browser-side guard: the
  *      browser DOES send cookies (including `st_token`) on a WS upgrade
  *      to any origin when SameSite permits it, and SameSite=None is the
  *      production setting for the cross-site Pages → Tunnel deploy.

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -713,9 +713,16 @@ export function parseCorsOrigins(raw: string | undefined): string[] {
  *    Origin would break legitimate CLI tooling without closing the
  *    CSWSH gap.
  *
- * 2. Origin exactly in `allowedOrigins`: allow.
- *    Substring/suffix matching is tempting (`ends with our-domain.com`)
- *    but enables `attackerour-domain.com` attacks. Exact match only.
+ * 2. Origin in `allowedOrigins`: allow.
+ *    An entry can be exact (`https://app.example.com`) or a glob with
+ *    `*` matching exactly one DNS label (`https://*.example.com`
+ *    matches `https://api.example.com` but NOT `https://a.b.example.com`
+ *    or `attacker.example.com.evil.com`). Substring/suffix matching is
+ *    tempting but enables `attackerour-domain.com` and similar
+ *    bypasses; the regex anchors plus the no-dot constraint inside the
+ *    `*` segment close those attacks. Useful for Cloudflare Pages
+ *    preview URLs (`<commit>.<project>.pages.dev`) without listing
+ *    every preview by hand.
  *
  * 3. allowedOrigins contains "*":
  *    - In production: DENY, and the caller logs a loud warning once at
@@ -749,8 +756,8 @@ export function isAllowedWsOrigin(
 	// Branch 1: not a browser, not a CSWSH vector.
 	if (!origin) return true;
 
-	// Branch 2: explicitly whitelisted.
-	if (allowedOrigins.includes(origin)) return true;
+	// Branch 2: explicitly whitelisted (exact origin or single-label glob).
+	if (originMatches(origin, allowedOrigins)) return true;
 
 	// Branch 3: "*" wildcard.
 	if (allowedOrigins.includes("*")) {
@@ -758,6 +765,40 @@ export function isAllowedWsOrigin(
 	}
 
 	// Branch 4.
+	return false;
+}
+
+/**
+ * Match a request origin against an allowlist where each entry is either
+ * an exact origin or a glob with `*` standing for exactly one DNS label
+ * (no dots inside the `*`). Useful for Cloudflare Pages preview URLs
+ * like `<commit>.<project>.pages.dev` where every push lands on a fresh
+ * subdomain — listing the wildcard pattern once subsumes them all.
+ *
+ * Bare `"*"` entries are skipped here on purpose: that token has
+ * different semantics in each caller (CORS middleware downgrades to
+ * no-credentials wildcard; isAllowedWsOrigin denies in production for
+ * CSWSH protection). Letting it match-everything inside this helper
+ * would silently bypass both policies.
+ *
+ * Anchored regex (`^…$`) plus a no-dot character class (`[^.]+`) inside
+ * each `*` keeps the classic `attackerour-domain.com` and
+ * `our-domain.com.evil.com` bypasses out — the match is exact-shape,
+ * not substring or suffix.
+ */
+export function originMatches(origin: string, allowedOrigins: readonly string[]): boolean {
+	for (const entry of allowedOrigins) {
+		if (entry === "*") continue;
+		if (entry.includes("*")) {
+			// Escape regex metacharacters EXCEPT `*` (we want it to stay
+			// literal so the next replace can convert it to `[^.]+`).
+			const escaped = entry.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+			const re = new RegExp(`^${escaped.replace(/\*/g, "[^.]+")}$`);
+			if (re.test(origin)) return true;
+		} else if (entry === origin) {
+			return true;
+		}
+	}
 	return false;
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import { WebSocketServer } from "ws";
 import {
 	ensureAuthReady,
 	isAllowedWsOrigin,
+	originMatches,
 	parseCorsOrigins,
 	validateJwtSecret,
 	warnIfWildcardCorsInProduction,
@@ -122,7 +123,7 @@ app.use((_req, res, next) => {
 	// plain wildcard, no credentials: cross-origin callers get the
 	// cookie dropped by the browser and effectively a 401 from the
 	// auth middleware, while the wildcard still answers public reads.
-	if (origin && CORS_ORIGINS.includes(origin)) {
+	if (origin && originMatches(origin, CORS_ORIGINS)) {
 		res.setHeader("Access-Control-Allow-Origin", origin);
 		res.setHeader("Access-Control-Allow-Credentials", "true");
 	} else if (CORS_ORIGINS.includes("*")) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -115,7 +115,8 @@ app.use((_req, res, next) => {
 	res.setHeader("Vary", "Origin");
 	const origin = _req.headers.origin ?? "";
 	// `Access-Control-Allow-Credentials: true` is only safe when the
-	// caller's origin is in our exact-match allowlist. Cookie auth means
+	// caller's origin is in our allowlist (exact or single-label glob —
+	// see originMatches). Cookie auth means
 	// the browser auto-attaches the cookie on credentialed requests —
 	// echoing `Allow-Credentials` for an arbitrary origin would let any
 	// page on the internet make authenticated calls and read the


### PR DESCRIPTION
**Reported live**: production frontend at \`https://shared-terminal.pages.dev\` got blocked by:

> Access to fetch at 'https://shared-terminal.lamia.casa/api/auth/status' from origin 'https://shared-terminal.pages.dev' has been blocked by CORS policy: ... 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'.

## Root cause

PR #140 (cookie auth, #18) tightened the CORS middleware so \`Access-Control-Allow-Credentials: true\` only fires on an **exact** origin match against \`CORS_ORIGINS\`. Wildcard config falls back to a plain \`Access-Control-Allow-Origin: *\` *without* credentials — correct behaviour for security (the spec forbids \`*\` + credentials), wrong behaviour for Cloudflare Pages preview deploys where every push lands on a fresh \`<commit>.<project>.pages.dev\` subdomain.

Listing every preview origin by hand isn't viable.

## Fix: glob entries in \`CORS_ORIGINS\`

Add a minimal glob primitive: an entry containing \`*\` matches the request origin where \`*\` substitutes for **exactly one DNS label** (no dots). Exact entries and bare \`*\` keep their existing semantics.

\`\`\`
CORS_ORIGINS=https://shared-terminal.pages.dev,https://*.shared-terminal.pages.dev
\`\`\`

The first covers production, the second covers every preview deploy.

## Implementation

One new exported helper in \`auth.ts\`:

\`\`\`ts
export function originMatches(origin, allowedOrigins): boolean {
    for (const entry of allowedOrigins) {
        if (entry === "*") continue; // bare-* has different semantics; left to callers
        if (entry.includes("*")) {
            const escaped = entry.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
            const re = new RegExp(\`^${escaped.replace(/\*/g, "[^.]+")}$\`);
            if (re.test(origin)) return true;
        } else if (entry === origin) {
            return true;
        }
    }
    return false;
}
\`\`\`

Anchored regex + \`[^.]+\` per \`*\` closes \`attacker.shared-terminal.pages.dev.evil.com\` and similar suffix-bypass shapes. Bare \`*\` is deliberately skipped here because it has different semantics in each caller (CORS middleware downgrades to no-credentials wildcard; \`isAllowedWsOrigin\` denies in production for CSWSH) — letting it match-everything inside this helper would silently bypass both policies.

## Wired into

- \`isAllowedWsOrigin\` — branch 2 ("explicitly whitelisted") now also matches glob entries.
- CORS middleware in \`index.ts\` — \`Allow-Credentials\` path uses \`originMatches\` instead of bare \`Array.includes\`.

## Tests

New \`describe("glob entries")\` block in \`auth.test.ts\` — 8 cases:

- Single-label substitution allows
- Two-label substitution rejected (closes the suffix bypass)
- Pre/post-fix bypass rejected
- Scheme mismatch rejected
- Escaped-dot literalness (the \`.\` in \`pages.dev\` is matched literally, not as regex \`.\`)
- Mixed exact + glob entries coexist
- Bare \`*\` semantics don't leak into a glob entry

Backend test count: 161 → 168.

## Tested

- \`npm run lint\` clean
- \`npm run build\` (tsc) clean
- \`npm test\` — 168 passing