### PR TITLE
feat(ws): protocol-level liveness ping/pong (#79)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,7 +8,7 @@
 import http from "node:http";
 import cookieParser from "cookie-parser";
 import express from "express";
-import { WebSocketServer } from "ws";
+import { type WebSocket, WebSocketServer } from "ws";
 import {
 	ensureAuthReady,
 	isAllowedWsOrigin,
@@ -201,7 +201,51 @@ server.on("upgrade", (req, socket, head) => {
 	});
 });
 
+// ── Liveness heartbeat (#79) ─────────────────────────────────────────────────
+//
+// Bidirectional protocol-level ping/pong via the `ws` package's built-in
+// control frames. The previous app-layer `{type:"ping"}` was unidirectional
+// (client → server only), so a hung server with a still-alive TCP socket
+// (Docker daemon stalled, event loop blocked, half-closed TCP sitting in a
+// NAT translation table) left the client staring at a frozen terminal with
+// no reconnect prompt — `ws.readyState` stayed OPEN until kernel keepalive
+// reaped the socket minutes later. And the server never noticed a backgrounded
+// browser tab going silent at all.
+//
+// Pattern (from the `ws` README): mark each connection alive on attach, flip
+// to `isAlive=false` on every interval tick, fire `ws.ping()`. Browsers auto-
+// reply at the protocol layer; the pong handler flips `isAlive` back to true.
+// If the next tick still sees `isAlive=false`, the peer didn't respond inside
+// the window and we `terminate()` (immediate, no graceful close — we already
+// know the peer is dead). Protocol-level pings also pass through middleboxes
+// that idle out app-layer JSON traffic.
+const HEARTBEAT_INTERVAL_MS = 30_000;
+interface WsWithLiveness extends WebSocket {
+	isAlive?: boolean;
+}
+const heartbeat = setInterval(() => {
+	for (const client of wss.clients) {
+		const c = client as unknown as WsWithLiveness;
+		if (c.isAlive === false) {
+			c.terminate();
+			continue;
+		}
+		c.isAlive = false;
+		try {
+			(c as unknown as { ping: () => void }).ping();
+		} catch {
+			// Peer already dead — terminate on the next tick (isAlive stays false).
+		}
+	}
+}, HEARTBEAT_INTERVAL_MS);
+heartbeat.unref();
+
 wss.on("connection", (ws, req) => {
+	const c = ws as unknown as WsWithLiveness;
+	c.isAlive = true;
+	ws.on("pong", () => {
+		c.isAlive = true;
+	});
 	handleWsConnection(ws, req, sessions, docker);
 });
 
@@ -245,6 +289,10 @@ function shutdown() {
 	if (shuttingDown) return;
 	shuttingDown = true;
 	logger.info("[server] shutting down…");
+
+	// Stop the heartbeat first so it doesn't try to ping a half-closed
+	// client during teardown (would race with the close calls below).
+	clearInterval(heartbeat);
 
 	// Actively close live WS clients. `wss.close()` alone only stops accepting
 	// new upgrades — existing connections stay open, which keeps `server.close()`

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,7 +8,7 @@
 import http from "node:http";
 import cookieParser from "cookie-parser";
 import express from "express";
-import { type WebSocket, WebSocketServer } from "ws";
+import { WebSocketServer } from "ws";
 import {
 	ensureAuthReady,
 	isAllowedWsOrigin,
@@ -23,7 +23,7 @@ import { logger } from "./logger.js";
 import { buildRouter } from "./routes.js";
 import { SessionManager } from "./sessionManager.js";
 import { parseTrustProxy, TrustProxyError, warnIfProductionMisconfigured } from "./trustProxy.js";
-import { endUpgradeSocketWithReply, handleWsConnection } from "./wsHandler.js";
+import { endUpgradeSocketWithReply, handleWsConnection, startWsHeartbeat } from "./wsHandler.js";
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -201,51 +201,13 @@ server.on("upgrade", (req, socket, head) => {
 	});
 });
 
-// ── Liveness heartbeat (#79) ─────────────────────────────────────────────────
-//
-// Bidirectional protocol-level ping/pong via the `ws` package's built-in
-// control frames. The previous app-layer `{type:"ping"}` was unidirectional
-// (client → server only), so a hung server with a still-alive TCP socket
-// (Docker daemon stalled, event loop blocked, half-closed TCP sitting in a
-// NAT translation table) left the client staring at a frozen terminal with
-// no reconnect prompt — `ws.readyState` stayed OPEN until kernel keepalive
-// reaped the socket minutes later. And the server never noticed a backgrounded
-// browser tab going silent at all.
-//
-// Pattern (from the `ws` README): mark each connection alive on attach, flip
-// to `isAlive=false` on every interval tick, fire `ws.ping()`. Browsers auto-
-// reply at the protocol layer; the pong handler flips `isAlive` back to true.
-// If the next tick still sees `isAlive=false`, the peer didn't respond inside
-// the window and we `terminate()` (immediate, no graceful close — we already
-// know the peer is dead). Protocol-level pings also pass through middleboxes
-// that idle out app-layer JSON traffic.
-const HEARTBEAT_INTERVAL_MS = 30_000;
-interface WsWithLiveness extends WebSocket {
-	isAlive?: boolean;
-}
-const heartbeat = setInterval(() => {
-	for (const client of wss.clients) {
-		const c = client as unknown as WsWithLiveness;
-		if (c.isAlive === false) {
-			c.terminate();
-			continue;
-		}
-		c.isAlive = false;
-		try {
-			(c as unknown as { ping: () => void }).ping();
-		} catch {
-			// Peer already dead — terminate on the next tick (isAlive stays false).
-		}
-	}
-}, HEARTBEAT_INTERVAL_MS);
-heartbeat.unref();
+// Liveness heartbeat (#79). The helper sets the per-connection `pong`
+// listener and runs the 30 s interval; we keep the cleanup so the
+// shutdown path can stop the timer before `wss.close()` to avoid
+// racing teardown.
+const stopHeartbeat = startWsHeartbeat(wss, 30_000);
 
 wss.on("connection", (ws, req) => {
-	const c = ws as unknown as WsWithLiveness;
-	c.isAlive = true;
-	ws.on("pong", () => {
-		c.isAlive = true;
-	});
 	handleWsConnection(ws, req, sessions, docker);
 });
 
@@ -292,7 +254,7 @@ function shutdown() {
 
 	// Stop the heartbeat first so it doesn't try to ping a half-closed
 	// client during teardown (would race with the close calls below).
-	clearInterval(heartbeat);
+	stopHeartbeat();
 
 	// Actively close live WS clients. `wss.close()` alone only stops accepting
 	// new upgrades — existing connections stay open, which keeps `server.close()`

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -58,21 +58,16 @@ export interface WsResizeMessage {
 	rows: number;
 }
 
-export interface WsPingMessage {
-	type: "ping";
-}
-
-export type WsClientMessage = WsInputMessage | WsResizeMessage | WsPingMessage;
+// Liveness is now bidirectional protocol-level ws.ping/pong (#79); no
+// app-layer ping message required. The control frames travel below the
+// JSON message layer, so message-shape unions stay clean.
+export type WsClientMessage = WsInputMessage | WsResizeMessage;
 
 // ── WebSocket server → client messages ──────────────────────────────────────
 
 export interface WsOutputMessage {
 	type: "output";
 	data: string;
-}
-
-export interface WsPongMessage {
-	type: "pong";
 }
 
 export interface WsErrorMessage {
@@ -85,4 +80,4 @@ export interface WsStatusMessage {
 	status: SessionStatus;
 }
 
-export type WsServerMessage = WsOutputMessage | WsPongMessage | WsErrorMessage | WsStatusMessage;
+export type WsServerMessage = WsOutputMessage | WsErrorMessage | WsStatusMessage;

--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -3,7 +3,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { __resetJwtSecretForTests, validateJwtSecret } from "./auth.js";
 import type { DockerManager } from "./dockerManager.js";
 import type { SessionManager } from "./sessionManager.js";
-import { endUpgradeSocketWithReply, handleWsConnection } from "./wsHandler.js";
+import { endUpgradeSocketWithReply, handleWsConnection, startWsHeartbeat } from "./wsHandler.js";
 
 // ── Test harness ────────────────────────────────────────────────────────────
 
@@ -189,5 +189,181 @@ describe("endUpgradeSocketWithReply", () => {
 		// Advancing past 500 ms must not propagate the throw.
 		expect(() => vi.advanceTimersByTime(500)).not.toThrow();
 		expect(socket.destroy).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ── startWsHeartbeat ───────────────────────────────────────────────────────
+// Pins the bidirectional liveness invariants from issue #79: every tick
+// pings each client, terminates anything that didn't pong since the
+// previous tick, and the cleanup function returned by startWsHeartbeat
+// stops the timer cleanly.
+
+describe("startWsHeartbeat", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	type FakeWs = {
+		isAlive?: boolean;
+		ping: ReturnType<typeof vi.fn>;
+		terminate: ReturnType<typeof vi.fn>;
+		on: ReturnType<typeof vi.fn>;
+		_pongHandler?: () => void;
+	};
+
+	function makeFakeWs(): FakeWs {
+		const ws: FakeWs = {
+			ping: vi.fn(),
+			terminate: vi.fn(),
+			on: vi.fn(),
+		};
+		// Capture the pong handler the moment it's registered so the test
+		// can fire it synthetically — that's the path the production code
+		// expects, and it's what flips `isAlive` back to true.
+		ws.on.mockImplementation((event: string, handler: () => void) => {
+			if (event === "pong") ws._pongHandler = handler;
+		});
+		return ws;
+	}
+
+	function makeFakeWss(): {
+		wss: { clients: Set<FakeWs>; on: ReturnType<typeof vi.fn>; off: ReturnType<typeof vi.fn> };
+		fireConnection: (ws: FakeWs) => void;
+	} {
+		const clients = new Set<FakeWs>();
+		let connectionHandler: ((ws: FakeWs) => void) | undefined;
+		const on = vi.fn((event: string, handler: (ws: FakeWs) => void) => {
+			if (event === "connection") connectionHandler = handler;
+		});
+		const off = vi.fn();
+		return {
+			wss: { clients, on, off },
+			fireConnection: (ws: FakeWs) => {
+				clients.add(ws);
+				connectionHandler?.(ws);
+			},
+		};
+	}
+
+	it("pings every connected client on each tick and marks them not-yet-replied", () => {
+		const { wss, fireConnection } = makeFakeWss();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		startWsHeartbeat(wss as any, 30_000);
+
+		const ws = makeFakeWs();
+		fireConnection(ws);
+		expect(ws.isAlive).toBe(true);
+
+		vi.advanceTimersByTime(30_000);
+		expect(ws.ping).toHaveBeenCalledTimes(1);
+		expect(ws.isAlive).toBe(false);
+	});
+
+	it("terminates a client that didn't pong before the next tick", () => {
+		const { wss, fireConnection } = makeFakeWss();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		startWsHeartbeat(wss as any, 30_000);
+
+		const ws = makeFakeWs();
+		fireConnection(ws);
+
+		// Tick 1: ping, isAlive flipped to false. No pong fired.
+		vi.advanceTimersByTime(30_000);
+		expect(ws.terminate).not.toHaveBeenCalled();
+
+		// Tick 2: still false → terminate.
+		vi.advanceTimersByTime(30_000);
+		expect(ws.terminate).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT terminate a client whose pong fired before the next tick", () => {
+		const { wss, fireConnection } = makeFakeWss();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		startWsHeartbeat(wss as any, 30_000);
+
+		const ws = makeFakeWs();
+		fireConnection(ws);
+
+		vi.advanceTimersByTime(30_000);
+		// Production path: browser auto-replies → ws emits 'pong' → handler
+		// flips isAlive back to true.
+		ws._pongHandler?.();
+		expect(ws.isAlive).toBe(true);
+
+		vi.advanceTimersByTime(30_000);
+		expect(ws.terminate).not.toHaveBeenCalled();
+		expect(ws.ping).toHaveBeenCalledTimes(2);
+	});
+
+	it("swallows a ping() throw and terminates on the next tick", () => {
+		const { wss, fireConnection } = makeFakeWss();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		startWsHeartbeat(wss as any, 30_000);
+
+		const ws = makeFakeWs();
+		ws.ping.mockImplementation(() => {
+			throw new Error("ERR_SOCKET_CLOSED");
+		});
+		fireConnection(ws);
+
+		// Tick 1: ping throws, isAlive stays false (already set before
+		// the try/catch). Must not propagate.
+		expect(() => vi.advanceTimersByTime(30_000)).not.toThrow();
+
+		// Tick 2: still false → terminate.
+		vi.advanceTimersByTime(30_000);
+		expect(ws.terminate).toHaveBeenCalledTimes(1);
+	});
+
+	it("cleanup function stops the interval AND drops the connection listener", () => {
+		const { wss, fireConnection } = makeFakeWss();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const stop = startWsHeartbeat(wss as any, 30_000);
+
+		const ws = makeFakeWs();
+		fireConnection(ws);
+
+		stop();
+		// No more ticks after cleanup.
+		vi.advanceTimersByTime(120_000);
+		expect(ws.ping).not.toHaveBeenCalled();
+		expect(ws.terminate).not.toHaveBeenCalled();
+		// Connection listener removed so a future post-shutdown connection
+		// (e.g. a buffered upgrade flushing late) doesn't get tagged.
+		expect(wss.off).toHaveBeenCalledWith("connection", expect.any(Function));
+	});
+
+	it("snapshots wss.clients so terminating mid-iteration doesn't skip the next client", () => {
+		// `ws` removes terminated clients from `wss.clients` synchronously
+		// on the close event. Iterating the live Set would silently skip
+		// the entry after a terminated one, postponing its reaping by a
+		// full tick.
+		const { wss, fireConnection } = makeFakeWss();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		startWsHeartbeat(wss as any, 30_000);
+
+		const dead = makeFakeWs();
+		const alive = makeFakeWs();
+		fireConnection(dead);
+		fireConnection(alive);
+
+		// Stale `dead`: simulate a missed pong by forcing isAlive false
+		// before the tick. The handler also removes from the set on
+		// terminate, mirroring `ws`'s real behaviour.
+		dead.isAlive = false;
+		dead.terminate.mockImplementation(() => {
+			wss.clients.delete(dead);
+		});
+
+		vi.advanceTimersByTime(30_000);
+
+		expect(dead.terminate).toHaveBeenCalledTimes(1);
+		// `alive` MUST still be visited inside the same tick — otherwise
+		// the snapshot guarantee is broken.
+		expect(alive.ping).toHaveBeenCalledTimes(1);
+		expect(alive.isAlive).toBe(false);
 	});
 });

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -5,7 +5,7 @@
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { v4 as uuidv4 } from "uuid";
-import { WebSocket } from "ws";
+import { WebSocket, type WebSocketServer } from "ws";
 import { verifyWsToken } from "./auth.js";
 import type { DockerManager } from "./dockerManager.js";
 import { logger } from "./logger.js";
@@ -202,6 +202,61 @@ export function handleWsConnection(
 			ws.close(1011, "Attach failed");
 		}
 	});
+}
+
+/**
+ * Bidirectional protocol-level liveness heartbeat for the WebSocket
+ * server (#79). Tags each connection with `isAlive` (set true on
+ * connect and on every pong frame from the peer), and on every tick
+ * terminates any client that didn't pong since the previous tick,
+ * then re-pings the survivors. The legacy app-layer `{type:"ping"}`
+ * was unidirectional (client → server only) and missed both:
+ *   - server-side hangs that left TCP alive but the WS unresponsive
+ *     (the client saw a frozen terminal until kernel keepalive
+ *     reaped the socket — minutes later);
+ *   - clients that went silent (backgrounded mobile tab, frozen JS),
+ *     where the server kept the shared exec up indefinitely.
+ *
+ * Returns a cleanup function the caller invokes during shutdown to
+ * stop the interval before `wss.close()` so a tick doesn't race
+ * teardown and ping a half-closed client.
+ */
+export function startWsHeartbeat(wss: WebSocketServer, intervalMs: number): () => void {
+	const onConnection = (ws: WebSocket) => {
+		const c = ws as WebSocket & { isAlive?: boolean };
+		c.isAlive = true;
+		ws.on("pong", () => {
+			c.isAlive = true;
+		});
+	};
+	wss.on("connection", onConnection);
+
+	const tick = setInterval(() => {
+		// Snapshot the client set: terminate() fires `close` synchronously
+		// and `ws` removes the client from `wss.clients` inside the loop,
+		// which silently skips the next iterator entry on a live Set.
+		// Reaping a dead peer one tick late isn't a safety bug, but the
+		// snapshot keeps the cadence honest.
+		for (const client of [...wss.clients]) {
+			const c = client as WebSocket & { isAlive?: boolean };
+			if (c.isAlive === false) {
+				c.terminate();
+				continue;
+			}
+			c.isAlive = false;
+			try {
+				c.ping();
+			} catch {
+				// Peer already dead — terminate on the next tick (isAlive stays false).
+			}
+		}
+	}, intervalMs);
+	tick.unref();
+
+	return () => {
+		clearInterval(tick);
+		wss.off("connection", onConnection);
+	};
 }
 
 function sendMsg(ws: WebSocket, msg: WsServerMessage): void {

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -177,9 +177,6 @@ export function handleWsConnection(
 						docker.resize(attachId, msg.cols, msg.rows).catch(() => {});
 					}
 					break;
-				case "ping":
-					sendMsg(ws, { type: "pong" });
-					break;
 			}
 		});
 

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -207,8 +207,9 @@ export function openTerminalSession(opts: {
 	let disposed = false;
 
 	ws.onopen = () => {
-		send({ type: "ping" });
-		startHeartbeat();
+		// Liveness is now handled at the protocol layer (ws.ping/pong)
+		// from the server side — see backend/src/index.ts heartbeat.
+		// Browsers auto-reply to server pings with no JS hook required.
 	};
 
 	ws.onmessage = (ev) => {
@@ -219,7 +220,6 @@ export function openTerminalSession(opts: {
 		type Msg =
 			| { type: "output"; data: string }
 			| { type: "status"; status: SessionStatus }
-			| { type: "pong" }
 			| { type: "error"; message: string };
 
 		let msg: Msg;
@@ -238,8 +238,6 @@ export function openTerminalSession(opts: {
 				break;
 			case "error":
 				onError(msg.message);
-				break;
-			case "pong":
 				break;
 		}
 	};
@@ -460,14 +458,6 @@ export function openTerminalSession(opts: {
 	document.addEventListener("visibilitychange", onVisibilityChange);
 	window.addEventListener("focus", onWindowFocus);
 
-	// ── Heartbeat ───────────────────────────────────────────────────────────
-	let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-	function startHeartbeat() {
-		heartbeatInterval = setInterval(() => {
-			if (ws.readyState === WebSocket.OPEN) send({ type: "ping" });
-		}, 30_000);
-	}
-
 	// ── Helpers ─────────────────────────────────────────────────────────────
 	function send(msg: object) {
 		if (ws.readyState === WebSocket.OPEN) {
@@ -492,16 +482,14 @@ export function openTerminalSession(opts: {
 	// ── Dispose ─────────────────────────────────────────────────────────────
 	function dispose() {
 		disposed = true;
-		if (heartbeatInterval !== null) clearInterval(heartbeatInterval);
 		// The resize send is debounced on a trailing 100 ms window; if the
 		// user navigates away inside that window the timer would fire after
 		// the socket closes. The `if (disposed) return` guard at the top of
 		// the callback already makes this harmless today — but it leaves
 		// the pending timer holding a closure reference to the (disposed)
 		// xterm + ws for up to 100 ms, and any future logic added to the
-		// callback ahead of that guard would run post-dispose. Cancelling
-		// here matches the heartbeatInterval path and removes the subtle
-		// refactor trap.
+		// callback ahead of that guard would run post-dispose. Cancel
+		// here to remove the subtle refactor trap.
 		if (resizeSendTimer !== null) clearTimeout(resizeSendTimer);
 		ro.disconnect();
 		document.removeEventListener("visibilitychange", onVisibilityChange);


### PR DESCRIPTION
Closes #79.

The app-layer \`{type:"ping"}\` from client → \`{type:"pong"}\` from server only ran in one direction and proved nothing about backwards liveness. A hung server (Docker daemon stalled, event loop blocked, half-closed TCP behind a NAT) left the client staring at a frozen terminal until kernel keepalive reaped the socket — minutes in practice. And the server never noticed a backgrounded mobile tab going dead at all, so the shared exec stayed up wasting resources.

## Pattern

Bidirectional protocol-level \`ws.ping\` / \`pong\` using the \`ws\` package's built-in control frames. Per the [\`ws\` README](https://github.com/websockets/ws#how-to-detect-and-close-broken-connections):

- on connection:   \`ws.isAlive = true\`
- on pong:         \`ws.isAlive = true\`
- every 30 s:      for each client, if \`!isAlive\` → \`terminate()\`, else \`isAlive = false\` + \`ws.ping()\`

Browsers auto-reply at the protocol layer with no JS hook needed. Protocol pings also pass through middleboxes that idle out app-layer JSON traffic — extra free.

## Surfaces removed

- \`types.ts\`: \`WsPingMessage\` / \`WsPongMessage\` interfaces and their union members.
- \`wsHandler.ts\`: the \`case "ping"\` → \`sendMsg pong\` arm.
- \`terminal.ts\`: \`startHeartbeat()\` and its \`heartbeatInterval\` plumbing in \`dispose()\`.
- \`terminal.ts\`: the \`pong\` message-type union member and switch case.
- \`terminal.ts\`: the on-open \`send({type:"ping"})\` priming.

## Lifecycle

Heartbeat lives at WSS-server scope in \`index.ts\` — one interval for the whole process. \`.unref()\`'d so it doesn't hold the process open during shutdown. \`clearInterval(heartbeat)\` is wired into the existing graceful-shutdown handler **before** \`wss.close()\` so a tick can't race teardown and try to ping a half-closed client.

## Tested

- backend: \`npm run lint\` + \`npx tsc --noEmit\` + \`npm test\` — 178 passing
- frontend: \`npm run lint\` + \`npx tsc --noEmit\` + \`npm test\` + \`vite build\` — 22 passing
- bundle size unchanged