### PR TITLE
feat(auth): admin tier gates invite mint/revoke (#50)

### DIFF
--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -1,6 +1,17 @@
 import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `requireAdmin` runs a D1 lookup; mock the db module so tests don't
+// need network access. The other functions exercised in this file are
+// pure (validateJwtSecret reads env, isAllowedWsOrigin etc. are
+// in-memory) so they don't reach this stub. Defined at module scope and
+// hoisted so the mock is in place before `import { … } from "./auth.js"`.
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({ results: [], meta: { changes: 0 } })),
+}));
+vi.mock("./db.js", () => dbStubs);
+
 import {
 	__resetJwtSecretForTests,
 	AUTH_COOKIE_NAME,
@@ -8,6 +19,7 @@ import {
 	isAllowedWsOrigin,
 	originMatches,
 	parseCorsOrigins,
+	requireAdmin,
 	requireAuth,
 	validateJwtSecret,
 	warnIfWildcardCorsInProduction,
@@ -582,5 +594,111 @@ describe("requireAuth", () => {
 
 		expect((req as unknown as { userId: string }).userId).toBe("from-cookies");
 		expect(next).toHaveBeenCalled();
+	});
+});
+
+// ── requireAdmin (#50) ─────────────────────────────────────────────────────
+// Pins the gate that protects POST /invites and DELETE /invites/:hash.
+// The middleware does a D1 lookup so admin grant/revoke takes effect
+// without users needing to log out and back in — these tests exercise
+// the lookup against a hoisted vi.fn() stub.
+
+describe("requireAdmin", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+	});
+
+	function makeRes(): {
+		res: Response;
+		status: ReturnType<typeof vi.fn>;
+		json: ReturnType<typeof vi.fn>;
+	} {
+		const json = vi.fn();
+		const status = vi.fn(() => ({ json }) as unknown as Response);
+		return { res: { status } as unknown as Response, status, json };
+	}
+
+	it("401s when chained without requireAuth (req.userId missing)", async () => {
+		const req = {} as unknown as Request;
+		const { res, status, json } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		await requireAdmin(req, res, next);
+
+		expect(status).toHaveBeenCalledWith(401);
+		expect(json).toHaveBeenCalledWith({ error: "Authentication required" });
+		expect(next).not.toHaveBeenCalled();
+		// Belt-and-braces guard fires before the D1 round-trip.
+		expect(dbStubs.d1Query).not.toHaveBeenCalled();
+	});
+
+	it("403s when the user row is_admin = 0", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ is_admin: 0 }],
+			meta: { changes: 0 },
+		});
+		const req = { userId: "u-1", username: "alice" } as unknown as Request;
+		const { res, status, json } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		await requireAdmin(req, res, next);
+
+		expect(status).toHaveBeenCalledWith(403);
+		expect(json).toHaveBeenCalledWith({ error: "Admin privileges required" });
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("403s when the user row is missing entirely (deleted mid-session)", async () => {
+		// User was deleted between the JWT being issued and now. JWT still
+		// validates, but the user row is gone — must not be admin.
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			meta: { changes: 0 },
+		});
+		const req = { userId: "u-ghost", username: "ghost" } as unknown as Request;
+		const { res, status } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		await requireAdmin(req, res, next);
+
+		expect(status).toHaveBeenCalledWith(403);
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("calls next() when is_admin = 1", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ is_admin: 1 }],
+			meta: { changes: 0 },
+		});
+		const req = { userId: "u-admin", username: "boss" } as unknown as Request;
+		const { res } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		await requireAdmin(req, res, next);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		// SQL shape pin so a refactor renaming the column would surface.
+		expect(dbStubs.d1Query.mock.calls[0]?.[0]).toMatch(/SELECT is_admin FROM users WHERE id = \?/i);
+		expect(dbStubs.d1Query.mock.calls[0]?.[1]).toEqual(["u-admin"]);
+	});
+
+	it("500s on a D1 error rather than letting the middleware crash", async () => {
+		// A transient D1 fault should not be silently treated as 'not
+		// admin' (would lock out admins on every blip) nor surface a
+		// stack trace. 500 + a generic message is the right shape.
+		dbStubs.d1Query.mockRejectedValueOnce(new Error("ECONNRESET"));
+		const errSpy = vi.spyOn(logger, "error").mockImplementation(() => {
+			/* swallow */
+		});
+		const req = { userId: "u-1", username: "alice" } as unknown as Request;
+		const { res, status, json } = makeRes();
+		const next = vi.fn() as unknown as NextFunction;
+
+		await requireAdmin(req, res, next);
+
+		expect(status).toHaveBeenCalledWith(500);
+		expect(json).toHaveBeenCalledWith({ error: "Internal server error" });
+		expect(next).not.toHaveBeenCalled();
+		errSpy.mockRestore();
 	});
 });

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -594,10 +594,11 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
  * trusting a JWT-embedded flag so that admin grant/revoke takes effect
  * without users needing to log out and back in.
  *
- * #50: today this gates POST /invites and DELETE /invites/:hash. GET
- * /invites stays auth-only so a non-admin sees their (always-empty) list
- * and the "you can't mint" UX comes from the missing button rather than
- * a confusing 403 on read.
+ * #50: gates GET, POST, and DELETE on /invites — list, mint, and
+ * revoke are a single coherent admin surface. Earlier rounds of #146
+ * gated only POST/DELETE and let GET fall through on auth, but that
+ * left pre-#50 codes minted by non-admins invisible (and so
+ * unrevocable) to the admin tier this PR exists to centralise on.
  */
 export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
 	const userId = (req as AuthedRequest).userId;

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -95,11 +95,18 @@ export class UsernameTakenError extends Error {
 	}
 }
 
+export interface RegisterResult {
+	userId: string;
+	token: string;
+	/** Bootstrap user gets is_admin=1; everyone else defaults to 0 (#50). */
+	isAdmin: boolean;
+}
+
 export async function registerUser(
 	username: string,
 	password: string,
 	inviteCode: string | undefined,
-): Promise<{ userId: string; token: string }> {
+): Promise<RegisterResult> {
 	const userId = uuidv4();
 
 	// Bootstrap: first account ever doesn't need an invite. Skip
@@ -118,13 +125,16 @@ export async function registerUser(
 		// only path where we hash unconditionally — every other path
 		// validates an invite first) is required by the conditional shape.
 		const bootstrapHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+		// Bootstrap user gets is_admin=1 inline (#50). The conditional
+		// INSERT shape stays — only the loser race-arm doesn't reach
+		// here.
 		const insert = await d1Query(
-			"INSERT INTO users (id, username, password_hash) " +
-				"SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)",
+			"INSERT INTO users (id, username, password_hash, is_admin) " +
+				"SELECT ?, ?, ?, 1 WHERE NOT EXISTS (SELECT 1 FROM users)",
 			[userId, username, bootstrapHash],
 		);
 		if (insert.meta.changes === 1) {
-			return { userId, token: signToken(userId, username) };
+			return { userId, token: signToken(userId, username), isAdmin: true };
 		}
 		// Race loser: a concurrent bootstrap got there first and we have
 		// no invite to fall back on. Match the steady-state response so
@@ -197,7 +207,9 @@ export async function registerUser(
 		throw err;
 	}
 
-	return { userId, token: signToken(userId, username) };
+	// Steady-state register: invite-redeeming users default to non-admin
+	// (the column default in db.ts). Promotion happens manually post-bootstrap.
+	return { userId, token: signToken(userId, username), isAdmin: false };
 }
 
 // ── Invites ────────────────────────────────────────────────────────────────
@@ -405,12 +417,16 @@ export async function ensureAuthReady(): Promise<void> {
 	await DUMMY_PASSWORD_HASH_PROMISE;
 }
 
-export async function loginUser(
-	username: string,
-	password: string,
-): Promise<{ userId: string; token: string }> {
-	const result = await d1Query<{ id: string; password_hash: string }>(
-		"SELECT id, password_hash FROM users WHERE username = ?",
+export interface LoginResult {
+	userId: string;
+	token: string;
+	/** Pulled from the same row as the password hash — no extra D1 round-trip. */
+	isAdmin: boolean;
+}
+
+export async function loginUser(username: string, password: string): Promise<LoginResult> {
+	const result = await d1Query<{ id: string; password_hash: string; is_admin: number }>(
+		"SELECT id, password_hash, is_admin FROM users WHERE username = ?",
 		[username],
 	);
 
@@ -428,7 +444,7 @@ export async function loginUser(
 	}
 
 	const token = signToken(row.id, username);
-	return { userId: row.id, token };
+	return { userId: row.id, token, isAdmin: row.is_admin === 1 };
 }
 
 function signToken(userId: string, username: string): string {
@@ -565,6 +581,42 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
 	(req as AuthedRequest).userId = payload.sub;
 	(req as AuthedRequest).username = payload.username;
 	next();
+}
+
+/**
+ * Gate a route on the caller having `is_admin = 1` in `users`. MUST chain
+ * after `requireAuth` — reads `req.userId` from the AuthedRequest the
+ * preceding middleware populated. Does its own D1 lookup rather than
+ * trusting a JWT-embedded flag so that admin grant/revoke takes effect
+ * without users needing to log out and back in.
+ *
+ * #50: today this gates POST /invites and DELETE /invites/:hash. GET
+ * /invites stays auth-only so a non-admin sees their (always-empty) list
+ * and the "you can't mint" UX comes from the missing button rather than
+ * a confusing 403 on read.
+ */
+export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
+	const userId = (req as AuthedRequest).userId;
+	if (!userId) {
+		// Belt-and-braces: if a future caller forgets to chain after
+		// requireAuth, fail loud rather than silently allow.
+		res.status(401).json({ error: "Authentication required" });
+		return;
+	}
+	try {
+		const result = await d1Query<{ is_admin: number }>("SELECT is_admin FROM users WHERE id = ?", [
+			userId,
+		]);
+		const row = result.results[0];
+		if (!row || row.is_admin !== 1) {
+			res.status(403).json({ error: "Admin privileges required" });
+			return;
+		}
+		next();
+	} catch (err) {
+		logger.error(`[auth] requireAdmin lookup failed: ${(err as Error).message}`);
+		res.status(500).json({ error: "Internal server error" });
+	}
 }
 
 // ── WebSocket auth ──────────────────────────────────────────────────────────

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -312,25 +312,29 @@ export async function createInvite(creatorUserId: string): Promise<MintedInvite>
 // (#54, landed in PR #142) so the truncation isn't silent.
 const INVITE_LIST_LIMIT = 100;
 
-export async function listInvites(creatorUserId: string): Promise<Invite[]> {
+// Admin-scoped (#50): all GET /invites, POST /invites, DELETE /invites/:hash
+// routes are gated by `requireAdmin`, so list and revoke see/affect every
+// row in the table — not just the admin's own. The `created_by` column
+// still records who minted what (for audit + the per-user mint quota in
+// createInvite), but it's no longer a filter on read or delete. Without
+// this scope, codes minted before #50 by then-non-admin accounts would
+// be invisible to admins and unrevocable until expiry.
+export async function listInvites(): Promise<Invite[]> {
 	const result = await d1Query<InviteRow>(
 		"SELECT code_hash, code_prefix, created_at, used_at, expires_at FROM invite_codes " +
-			"WHERE created_by = ? ORDER BY created_at DESC LIMIT ?",
-		[creatorUserId, INVITE_LIST_LIMIT],
+			"ORDER BY created_at DESC LIMIT ?",
+		[INVITE_LIST_LIMIT],
 	);
 	return result.results.map(rowToInvite);
 }
 
-// Revoke an unused invite by its hash (the only public id post-#49 — the
-// plaintext is gone). Returns true if a row was removed, false if the
-// invite was missing, already used, or owned by a different user. The wire
-// surface is intentionally vague so a caller can't enumerate codes belonging
-// to other users.
-export async function revokeInvite(creatorUserId: string, codeHash: string): Promise<boolean> {
-	const result = await d1Query(
-		"DELETE FROM invite_codes WHERE code_hash = ? AND created_by = ? AND used_at IS NULL",
-		[codeHash, creatorUserId],
-	);
+// Revoke an unused invite by its hash. Returns true if a row was removed,
+// false if the invite was missing or already used. Admin-scoped (no
+// created_by filter) — see listInvites.
+export async function revokeInvite(codeHash: string): Promise<boolean> {
+	const result = await d1Query("DELETE FROM invite_codes WHERE code_hash = ? AND used_at IS NULL", [
+		codeHash,
+	]);
 	return result.meta.changes === 1;
 }
 

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -214,8 +214,12 @@ export async function registerUser(
 
 // ── Invites ────────────────────────────────────────────────────────────────
 
-// Caps *outstanding* (unused) invites per account — bounds blast radius
-// from a stolen JWT. Used / expired codes don't count.
+// Caps *outstanding* (unused) invites per minting account — bounds
+// blast radius from a stolen JWT. Used / expired codes don't count.
+// Post-#50 invite minting is admin-only, so in typical single-admin
+// deploys the cap effectively applies to one account; the SQL
+// (`WHERE created_by = ?`) keeps the per-account framing in case of
+// multi-admin deployments.
 const MAX_UNUSED_INVITES_PER_USER = 20;
 
 // 30-day default for unredeemed-invite TTL, overridable via env.

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -85,11 +85,18 @@ export async function d1Batch(statements: string[]): Promise<void> {
 export async function migrateDb(): Promise<void> {
 	logger.info("[db] running D1 migrations…");
 	await d1Batch([
+		// `is_admin` (0/1) gates invite-mint and revoke (#50). The
+		// bootstrap-register path INSERTs is_admin=1; every other account
+		// defaults to 0. Auto-promotion of an existing earliest-created
+		// user happens AFTER the d1Batch (see migration block below) so a
+		// pre-existing single-user deploy doesn't get locked out of
+		// minting after the column is added.
 		`CREATE TABLE IF NOT EXISTS users (
                         id          TEXT PRIMARY KEY,
                         username    TEXT UNIQUE NOT NULL,
                         password_hash TEXT NOT NULL,
-                        created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+                        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                        is_admin    INTEGER NOT NULL DEFAULT 0
                 )`,
 		// `sessions` must follow `users` — the FK on user_id references
 		// users(id), and these statements run sequentially. Don't reorder
@@ -156,6 +163,26 @@ export async function migrateDb(): Promise<void> {
 			throw err;
 		}
 	}
+	// #50: same shape — add `users.is_admin` to pre-existing tables.
+	try {
+		await d1Query("ALTER TABLE users ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0");
+	} catch (err) {
+		if (!/duplicate column name|already exists/i.test((err as Error).message)) {
+			throw err;
+		}
+	}
+	// Auto-promote the earliest-created user when no admin exists yet.
+	// Idempotent: re-runs are no-ops once an admin row exists. Both
+	// fresh deploys post-bootstrap and pre-#50 single-user dev DBs
+	// converge on "first user is admin" without operator action. On a
+	// truly empty users table the inner SELECT is null → the outer WHERE
+	// can't match → no-op, and the bootstrap-register path will set
+	// is_admin=1 directly when the first account lands.
+	await d1Query(
+		"UPDATE users SET is_admin = 1 " +
+			"WHERE NOT EXISTS (SELECT 1 FROM users WHERE is_admin = 1) " +
+			"AND id = (SELECT id FROM users ORDER BY created_at ASC, id ASC LIMIT 1)",
+	);
 	// #49 migration: pre-existing `invite_codes` tables that still have
 	// the old plaintext `code` column need to be rebuilt. Cloudflare D1
 	// has no built-in `sha256()`, so the hash has to be computed in app

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -14,13 +14,22 @@ const authStubs = vi.hoisted(() => ({
 	loginUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	hasAnyUsers: vi.fn(async () => true),
 	listInvites: vi.fn(async (_u?: string) => [] as unknown[]),
+	createInvite: vi.fn(async (_u: string) => ({
+		code: "deadbeefdeadbeef",
+		codeHash: "f".repeat(64),
+		codePrefix: "dead",
+		createdAt: "2026-05-07 00:00:00",
+		usedAt: null,
+		expiresAt: null,
+	})),
 	requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
-	// Sync passthrough — tests in this file don't exercise the admin
-	// gate, they exercise the rate limiters that sit alongside it. The
-	// real requireAdmin is async (D1 lookup); express middleware doesn't
-	// await return values, so a sync next() is fine here precisely
-	// because the gate isn't under test.
-	requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+	// vi.fn so individual tests can override (the admin-gate test below
+	// flips the default-passthrough behaviour to a 403 to pin the
+	// route-level wiring). Default impl is the same passthrough every
+	// other test in this file relies on.
+	requireAdmin: vi.fn((_req: unknown, _res: unknown, next: () => void) => {
+		next();
+	}),
 	// Cookie-auth helpers (#18). Tests don't read the cookie back, so a
 	// no-op for set/clear and a permissive shape-only verify is enough.
 	AUTH_COOKIE_NAME: "st_token",
@@ -631,5 +640,36 @@ describe("auth route rate limiting", () => {
 		expect(r3.status).toBe(429);
 		expect(await r3.json()).toMatchObject({ scope: "ip" });
 		expect(r3.headers.get("retry-after")).not.toBeNull();
+	});
+
+	// #50 route-level wiring: the requireAdmin middleware unit-tests pin
+	// the gate's behaviour given a userId; this pins that the gate is
+	// actually wired in front of the create-invite handler at the route
+	// level. A future refactor that swaps middleware order or drops the
+	// gate would surface here as a 201 reaching the createInvite stub.
+	it("POST /invites returns 403 (and never reaches the handler) when requireAdmin denies", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+		// Override the default passthrough to deny — the gate-fail path.
+		authStubs.requireAdmin.mockImplementation(
+			(_req: unknown, res: { status: (n: number) => { json: (b: unknown) => unknown } }) => {
+				res.status(403).json({ error: "Admin privileges required" });
+			},
+		);
+		authStubs.createInvite.mockClear();
+
+		const r = await fetch(`${baseUrl}/api/invites`, { method: "POST" });
+
+		expect(r.status).toBe(403);
+		expect(await r.json()).toMatchObject({ error: "Admin privileges required" });
+		// The route handler must never have been invoked.
+		expect(authStubs.createInvite).not.toHaveBeenCalled();
+
+		// Restore for any subsequent tests.
+		authStubs.requireAdmin.mockImplementation((_req: unknown, _res: unknown, next: () => void) => {
+			next();
+		});
 	});
 });

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -10,8 +10,16 @@ import type { SessionManager } from "./sessionManager.js";
 // Stub the auth module so routing tests don't touch D1. Handles captured
 // as `authStubs` are reconfigured per-test.
 const authStubs = vi.hoisted(() => ({
-	registerUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
-	loginUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
+	registerUser: vi.fn(async (_u: string, _p: string) => ({
+		userId: "u1",
+		token: "tok",
+		isAdmin: false,
+	})),
+	loginUser: vi.fn(async (_u: string, _p: string) => ({
+		userId: "u1",
+		token: "tok",
+		isAdmin: false,
+	})),
 	hasAnyUsers: vi.fn(async () => true),
 	listInvites: vi.fn(async () => [] as unknown[]),
 	createInvite: vi.fn(async (_u: string) => ({
@@ -380,7 +388,11 @@ describe("auth route rate limiting", () => {
 		authStubs.loginUser.mockImplementation(async () => {
 			throw new authStubs.InvalidCredentialsError();
 		});
-		authStubs.registerUser.mockImplementation(async () => ({ userId: "u1", token: "tok" }));
+		authStubs.registerUser.mockImplementation(async () => ({
+			userId: "u1",
+			token: "tok",
+			isAdmin: false,
+		}));
 		// Reset requireAdmin to its passthrough default. Individual tests
 		// that exercise the admin-gate path override this with a 403
 		// implementation; restoring here means a thrown expect inside such
@@ -476,7 +488,11 @@ describe("auth route rate limiting", () => {
 			register: { ipMax: 100, ipWindowMs: 60_000 },
 		});
 
-		authStubs.loginUser.mockImplementation(async () => ({ userId: "u1", token: "tok" }));
+		authStubs.loginUser.mockImplementation(async () => ({
+			userId: "u1",
+			token: "tok",
+			isAdmin: false,
+		}));
 		for (let i = 0; i < 3; i++) {
 			const ok = await postLogin({ username: `u${i}`, password: "good" });
 			expect(ok.status).toBe(200);
@@ -538,7 +554,11 @@ describe("auth route rate limiting", () => {
 		const r1 = await postLogin({ username: "alice", password: "bad" });
 		expect(r1.status).toBe(401);
 
-		authStubs.loginUser.mockImplementationOnce(async () => ({ userId: "u1", token: "tok" }));
+		authStubs.loginUser.mockImplementationOnce(async () => ({
+			userId: "u1",
+			token: "tok",
+			isAdmin: false,
+		}));
 		const r2 = await postLogin({ username: "alice", password: "good" });
 		expect(r2.status).toBe(200);
 
@@ -624,7 +644,11 @@ describe("auth route rate limiting", () => {
 		await postLogin({ username: "alice", password: "bad" });
 		await postLogin({ username: "alice", password: "bad" });
 
-		authStubs.loginUser.mockImplementationOnce(async () => ({ userId: "u1", token: "tok" }));
+		authStubs.loginUser.mockImplementationOnce(async () => ({
+			userId: "u1",
+			token: "tok",
+			isAdmin: false,
+		}));
 		const locked = await postLogin({ username: "alice", password: "good" });
 		expect(locked.status).toBe(429);
 	});

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -15,10 +15,11 @@ const authStubs = vi.hoisted(() => ({
 	hasAnyUsers: vi.fn(async () => true),
 	listInvites: vi.fn(async (_u?: string) => [] as unknown[]),
 	requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
-	// requireAdmin is async in production but the route chain handles
-	// either return shape (express awaits the next() call effectively
-	// via promise resolution); a sync passthrough is enough for tests
-	// that don't care about the admin gate.
+	// Sync passthrough — tests in this file don't exercise the admin
+	// gate, they exercise the rate limiters that sit alongside it. The
+	// real requireAdmin is async (D1 lookup); express middleware doesn't
+	// await return values, so a sync next() is fine here precisely
+	// because the gate isn't under test.
 	requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
 	// Cookie-auth helpers (#18). Tests don't read the cookie back, so a
 	// no-op for set/clear and a permissive shape-only verify is enough.

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -15,6 +15,11 @@ const authStubs = vi.hoisted(() => ({
 	hasAnyUsers: vi.fn(async () => true),
 	listInvites: vi.fn(async (_u?: string) => [] as unknown[]),
 	requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+	// requireAdmin is async in production but the route chain handles
+	// either return shape (express awaits the next() call effectively
+	// via promise resolution); a sync passthrough is enough for tests
+	// that don't care about the admin gate.
+	requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
 	// Cookie-auth helpers (#18). Tests don't read the cookie back, so a
 	// no-op for set/clear and a permissive shape-only verify is enough.
 	AUTH_COOKIE_NAME: "st_token",

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -13,7 +13,7 @@ const authStubs = vi.hoisted(() => ({
 	registerUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	loginUser: vi.fn(async (_u: string, _p: string) => ({ userId: "u1", token: "tok" })),
 	hasAnyUsers: vi.fn(async () => true),
-	listInvites: vi.fn(async (_u?: string) => [] as unknown[]),
+	listInvites: vi.fn(async () => [] as unknown[]),
 	createInvite: vi.fn(async (_u: string) => ({
 		code: "deadbeefdeadbeef",
 		codeHash: "f".repeat(64),
@@ -374,11 +374,20 @@ describe("auth route rate limiting", () => {
 	beforeEach(() => {
 		authStubs.registerUser.mockClear();
 		authStubs.loginUser.mockClear();
+		authStubs.createInvite.mockClear();
+		authStubs.listInvites.mockClear();
 		// Default: loginUser fails as bad creds (typed so the handler counts it).
 		authStubs.loginUser.mockImplementation(async () => {
 			throw new authStubs.InvalidCredentialsError();
 		});
 		authStubs.registerUser.mockImplementation(async () => ({ userId: "u1", token: "tok" }));
+		// Reset requireAdmin to its passthrough default. Individual tests
+		// that exercise the admin-gate path override this with a 403
+		// implementation; restoring here means a thrown expect inside such
+		// a test can't leak the override into the next test.
+		authStubs.requireAdmin.mockImplementation((_req: unknown, _res: unknown, next: () => void) => {
+			next();
+		});
 	});
 
 	afterEach(async () => {
@@ -642,34 +651,64 @@ describe("auth route rate limiting", () => {
 		expect(r3.headers.get("retry-after")).not.toBeNull();
 	});
 
-	// #50 route-level wiring: the requireAdmin middleware unit-tests pin
-	// the gate's behaviour given a userId; this pins that the gate is
-	// actually wired in front of the create-invite handler at the route
-	// level. A future refactor that swaps middleware order or drops the
-	// gate would surface here as a 201 reaching the createInvite stub.
-	it("POST /invites returns 403 (and never reaches the handler) when requireAdmin denies", async () => {
-		await spinUp({
-			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
-			register: { ipMax: 1000, ipWindowMs: 60_000 },
-		});
-		// Override the default passthrough to deny — the gate-fail path.
+	// #50 route-level wiring. The `requireAdmin` middleware unit tests
+	// pin the gate's behaviour given a userId; these route-level tests
+	// pin that the gate is actually wired in front of every invite
+	// handler. A future refactor that swaps middleware order or drops
+	// the gate from one of the routes would surface here as a 2xx
+	// reaching the corresponding handler stub. The `beforeEach` above
+	// restores the passthrough so an override here doesn't leak into
+	// later tests if an `expect` throws.
+	function denyAdmin() {
 		authStubs.requireAdmin.mockImplementation(
 			(_req: unknown, res: { status: (n: number) => { json: (b: unknown) => unknown } }) => {
 				res.status(403).json({ error: "Admin privileges required" });
 			},
 		);
-		authStubs.createInvite.mockClear();
+	}
+
+	it("POST /invites returns 403 (and never reaches the handler) when requireAdmin denies", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+		denyAdmin();
 
 		const r = await fetch(`${baseUrl}/api/invites`, { method: "POST" });
 
 		expect(r.status).toBe(403);
 		expect(await r.json()).toMatchObject({ error: "Admin privileges required" });
-		// The route handler must never have been invoked.
 		expect(authStubs.createInvite).not.toHaveBeenCalled();
+	});
 
-		// Restore for any subsequent tests.
-		authStubs.requireAdmin.mockImplementation((_req: unknown, _res: unknown, next: () => void) => {
-			next();
+	it("GET /invites returns 403 when requireAdmin denies", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
 		});
+		denyAdmin();
+
+		const r = await fetch(`${baseUrl}/api/invites`);
+
+		expect(r.status).toBe(403);
+		expect(await r.json()).toMatchObject({ error: "Admin privileges required" });
+		expect(authStubs.listInvites).not.toHaveBeenCalled();
+	});
+
+	it("DELETE /invites/:hash returns 403 when requireAdmin denies", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+		denyAdmin();
+
+		// Valid hash shape so the request makes it past the route's
+		// regex guard — we want the gate's 403, not a 400 from input
+		// validation, to be the response.
+		const hash = "a".repeat(64);
+		const r = await fetch(`${baseUrl}/api/invites/${hash}`, { method: "DELETE" });
+
+		expect(r.status).toBe(403);
+		expect(await r.json()).toMatchObject({ error: "Admin privileges required" });
 	});
 });

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -262,9 +262,10 @@ export function buildRouter(
 	router.use("/sessions", requireAuth);
 
 	// ── Invite routes ───────────────────────────────────────────────────────
-	// Any authenticated user can mint invites — there is no admin tier yet.
-	// If you ever want to gate this to specific accounts, add an is_admin
-	// column to users and a middleware check here.
+	// POST and DELETE are gated by `requireAdmin` (#50); GET stays
+	// auth-only so non-admins see their (always-empty) list and the
+	// missing UI buttons tell them they can't mint, instead of a
+	// confusing 403 on read.
 
 	// GET is rate-limited symmetrically with POST/DELETE (issue #47):
 	// a much higher cap because reads are cheap, but the same per-IP
@@ -281,6 +282,8 @@ export function buildRouter(
 		}
 	});
 
+	// requireAuth provided by `router.use("/invites", requireAuth)` above —
+	// requireAdmin reads `req.userId` populated there.
 	router.post("/invites", invitesCreateIp, requireAdmin, async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
 		try {
@@ -296,6 +299,8 @@ export function buildRouter(
 		}
 	});
 
+	// requireAuth provided by `router.use("/invites", requireAuth)` above —
+	// requireAdmin reads `req.userId` populated there.
 	router.delete(
 		"/invites/:hash",
 		invitesRevokeIp,

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -91,19 +91,21 @@ export function buildRouter(
 			undefined;
 		const payload = verifyJwt(token);
 		const authenticated = payload !== null;
-		let isAdmin = false;
-		if (authenticated) {
-			try {
-				const result = await d1Query<{ is_admin: number }>(
-					"SELECT is_admin FROM users WHERE id = ?",
-					[payload.sub],
-				);
-				isAdmin = result.results[0]?.is_admin === 1;
-			} catch {
-				/* Surface as isAdmin=false; the auth check itself succeeded. */
-			}
-		}
-		res.json({ needsSetup: !(await hasAnyUsers()), authenticated, isAdmin });
+		// Run the admin-lookup and hasAnyUsers in parallel — they have
+		// no data dependency, and CLAUDE.md flags D1 round-trips as the
+		// expensive thing on hot paths. The admin lookup catches its
+		// own error (surfaces as isAdmin=false); hasAnyUsers throwing
+		// is a real boot-state failure and propagates to the 500 handler.
+		const [adminLookup, anyUsers] = await Promise.all([
+			payload
+				? d1Query<{ is_admin: number }>("SELECT is_admin FROM users WHERE id = ?", [
+						payload.sub,
+					]).catch(() => null)
+				: Promise.resolve(null),
+			hasAnyUsers(),
+		]);
+		const isAdmin = adminLookup?.results[0]?.is_admin === 1;
+		res.json({ needsSetup: !anyUsers, authenticated, isAdmin });
 	});
 
 	router.post("/auth/register", registerIp, async (req: Request, res: Response) => {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -20,12 +20,14 @@ import {
 	listInvites,
 	loginUser,
 	registerUser,
+	requireAdmin,
 	requireAuth,
 	revokeInvite,
 	setAuthCookie,
 	UsernameTakenError,
 	verifyJwt,
 } from "./auth.js";
+import { d1Query } from "./db.js";
 import type { DockerManager } from "./dockerManager.js";
 import { UploadQuotaExceededError } from "./dockerManager.js";
 import { EnvVarValidationError, validateEnvVars } from "./envVarValidation.js";
@@ -74,6 +76,12 @@ export function buildRouter(
 		// that bypass middleware. Verification failures land as
 		// `authenticated: false`, never as a 4xx — this endpoint is
 		// public-by-design.
+		//
+		// `isAdmin` is fetched fresh from D1 (#50) rather than from a
+		// JWT-embedded claim so admin grant/revoke takes effect without
+		// requiring users to log out and back in. Falls back to false on
+		// lookup failure or unauthenticated callers — UI should treat
+		// the boolean as "show admin features" only when explicitly true.
 		const reqWithCookies = req as Request & {
 			cookies?: Record<string, string | undefined>;
 		};
@@ -81,8 +89,21 @@ export function buildRouter(
 			reqWithCookies.cookies?.[AUTH_COOKIE_NAME] ??
 			extractTokenFromCookieHeader(req.headers.cookie) ??
 			undefined;
-		const authenticated = verifyJwt(token) !== null;
-		res.json({ needsSetup: !(await hasAnyUsers()), authenticated });
+		const payload = verifyJwt(token);
+		const authenticated = payload !== null;
+		let isAdmin = false;
+		if (authenticated) {
+			try {
+				const result = await d1Query<{ is_admin: number }>(
+					"SELECT is_admin FROM users WHERE id = ?",
+					[payload.sub],
+				);
+				isAdmin = result.results[0]?.is_admin === 1;
+			} catch {
+				/* Surface as isAdmin=false; the auth check itself succeeded. */
+			}
+		}
+		res.json({ needsSetup: !(await hasAnyUsers()), authenticated, isAdmin });
 	});
 
 	router.post("/auth/register", registerIp, async (req: Request, res: Response) => {
@@ -133,7 +154,7 @@ export function buildRouter(
 			// keeps the userId for clients that want to address the new
 			// account, but never the raw token.
 			setAuthCookie(res, result.token);
-			res.status(201).json({ userId: result.userId });
+			res.status(201).json({ userId: result.userId, isAdmin: result.isAdmin });
 		} catch (err) {
 			if (err instanceof InviteRequiredError) {
 				// 403 — caller authenticated nothing yet, but the action is
@@ -189,7 +210,7 @@ export function buildRouter(
 			return;
 		}
 
-		let result: { userId: string; token: string };
+		let result: { userId: string; token: string; isAdmin: boolean };
 		try {
 			try {
 				result = await loginUser(username, password);
@@ -207,7 +228,7 @@ export function buildRouter(
 			}
 			usernameLimiter.reset(username);
 			setAuthCookie(res, result.token);
-			res.json({ userId: result.userId });
+			res.json({ userId: result.userId, isAdmin: result.isAdmin });
 		} finally {
 			// Always release the in-flight slot — success, invalid creds,
 			// or infra error alike. `reset()` above wipes the failure
@@ -260,7 +281,7 @@ export function buildRouter(
 		}
 	});
 
-	router.post("/invites", invitesCreateIp, async (req: Request, res: Response) => {
+	router.post("/invites", invitesCreateIp, requireAdmin, async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
 		try {
 			const invite = await createInvite(userId);
@@ -275,31 +296,36 @@ export function buildRouter(
 		}
 	});
 
-	router.delete("/invites/:hash", invitesRevokeIp, async (req: Request, res: Response) => {
-		const { userId } = req as AuthedRequest;
-		const { hash } = req.params;
-		// SHA-256 hex is exactly 64 lowercase hex chars. Reject anything
-		// else before the D1 round-trip — a caller probing arbitrary
-		// strings shouldn't reach the database.
-		if (!/^[0-9a-f]{64}$/.test(hash)) {
-			res.status(400).json({ error: "hash must be a 64-char lowercase hex SHA-256 digest" });
-			return;
-		}
-		try {
-			const removed = await revokeInvite(userId, hash);
-			if (!removed) {
-				// Vague on purpose: don't distinguish missing / already-used /
-				// owned-by-someone-else, since that would let a caller probe for
-				// codes outside their ownership.
-				res.status(404).json({ error: "Invite not found or already used" });
+	router.delete(
+		"/invites/:hash",
+		invitesRevokeIp,
+		requireAdmin,
+		async (req: Request, res: Response) => {
+			const { userId } = req as AuthedRequest;
+			const { hash } = req.params;
+			// SHA-256 hex is exactly 64 lowercase hex chars. Reject anything
+			// else before the D1 round-trip — a caller probing arbitrary
+			// strings shouldn't reach the database.
+			if (!/^[0-9a-f]{64}$/.test(hash)) {
+				res.status(400).json({ error: "hash must be a 64-char lowercase hex SHA-256 digest" });
 				return;
 			}
-			res.status(204).send();
-		} catch (err) {
-			logger.error(`[invites] revoke failed: ${(err as Error).message}`);
-			res.status(500).json({ error: "Internal server error" });
-		}
-	});
+			try {
+				const removed = await revokeInvite(userId, hash);
+				if (!removed) {
+					// Vague on purpose: don't distinguish missing / already-used /
+					// owned-by-someone-else, since that would let a caller probe for
+					// codes outside their ownership.
+					res.status(404).json({ error: "Invite not found or already used" });
+					return;
+				}
+				res.status(204).send();
+			} catch (err) {
+				logger.error(`[invites] revoke failed: ${(err as Error).message}`);
+				res.status(500).json({ error: "Internal server error" });
+			}
+		},
+	);
 
 	// ── Session routes ──────────────────────────────────────────────────────
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -264,19 +264,22 @@ export function buildRouter(
 	router.use("/sessions", requireAuth);
 
 	// ── Invite routes ───────────────────────────────────────────────────────
-	// POST and DELETE are gated by `requireAdmin` (#50); GET stays
-	// auth-only so non-admins see their (always-empty) list and the
-	// missing UI buttons tell them they can't mint, instead of a
-	// confusing 403 on read.
+	// All three routes are gated by `requireAdmin` (#50). Non-admins
+	// don't need invite access at all — they can't mint, and pre-#50
+	// codes minted by then-non-admin accounts must remain manageable
+	// somewhere; admin-scoped list/revoke is the cleaner answer than
+	// per-user filtering that would orphan those rows.
+	//
+	// requireAuth is provided by `router.use("/invites", requireAuth)`
+	// above — requireAdmin reads `req.userId` populated there.
 
 	// GET is rate-limited symmetrically with POST/DELETE (issue #47):
 	// a much higher cap because reads are cheap, but the same per-IP
 	// shape so the asymmetry doesn't read as accidental and a runaway
 	// client polling in a loop can't hammer D1 unbounded.
-	router.get("/invites", invitesListIp, async (req: Request, res: Response) => {
-		const { userId } = req as AuthedRequest;
+	router.get("/invites", invitesListIp, requireAdmin, async (_req: Request, res: Response) => {
 		try {
-			const invites = await listInvites(userId);
+			const invites = await listInvites();
 			res.json(invites);
 		} catch (err) {
 			logger.error(`[invites] list failed: ${(err as Error).message}`);
@@ -284,8 +287,6 @@ export function buildRouter(
 		}
 	});
 
-	// requireAuth provided by `router.use("/invites", requireAuth)` above —
-	// requireAdmin reads `req.userId` populated there.
 	router.post("/invites", invitesCreateIp, requireAdmin, async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
 		try {
@@ -301,14 +302,11 @@ export function buildRouter(
 		}
 	});
 
-	// requireAuth provided by `router.use("/invites", requireAuth)` above —
-	// requireAdmin reads `req.userId` populated there.
 	router.delete(
 		"/invites/:hash",
 		invitesRevokeIp,
 		requireAdmin,
 		async (req: Request, res: Response) => {
-			const { userId } = req as AuthedRequest;
 			const { hash } = req.params;
 			// SHA-256 hex is exactly 64 lowercase hex chars. Reject anything
 			// else before the D1 round-trip — a caller probing arbitrary
@@ -318,11 +316,10 @@ export function buildRouter(
 				return;
 			}
 			try {
-				const removed = await revokeInvite(userId, hash);
+				const removed = await revokeInvite(hash);
 				if (!removed) {
-					// Vague on purpose: don't distinguish missing / already-used /
-					// owned-by-someone-else, since that would let a caller probe for
-					// codes outside their ownership.
+					// Vague on purpose: missing vs. already-used should not be
+					// distinguishable from the wire (no enumeration vector).
 					res.status(404).json({ error: "Invite not found or already used" });
 					return;
 				}

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 interface Api {
 	isLoggedIn: typeof import("./api.js").isLoggedIn;
+	isAdmin: typeof import("./api.js").isAdmin;
 	checkAuthStatus: typeof import("./api.js").checkAuthStatus;
 	register: typeof import("./api.js").register;
 	login: typeof import("./api.js").login;
@@ -61,7 +62,7 @@ describe("login state", () => {
 	it("checkAuthStatus mirrors the server's `authenticated` field into module state", async () => {
 		const api = await loadApi();
 		fetchSpy.mockResolvedValueOnce(
-			mockFetchResponse({ json: { needsSetup: false, authenticated: true } }),
+			mockFetchResponse({ json: { needsSetup: false, authenticated: true, isAdmin: false } }),
 		);
 
 		const status = await api.checkAuthStatus();
@@ -72,7 +73,7 @@ describe("login state", () => {
 	it("checkAuthStatus authenticated=false leaves isLoggedIn() false", async () => {
 		const api = await loadApi();
 		fetchSpy.mockResolvedValueOnce(
-			mockFetchResponse({ json: { needsSetup: false, authenticated: false } }),
+			mockFetchResponse({ json: { needsSetup: false, authenticated: false, isAdmin: false } }),
 		);
 
 		await api.checkAuthStatus();
@@ -81,7 +82,7 @@ describe("login state", () => {
 
 	it("login flips isLoggedIn to true on success", async () => {
 		const api = await loadApi();
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: false } }));
 
 		await api.login("alice", "secret");
 		expect(api.isLoggedIn()).toBe(true);
@@ -89,7 +90,7 @@ describe("login state", () => {
 
 	it("logout POSTs /auth/logout and flips isLoggedIn to false even if the call fails", async () => {
 		const api = await loadApi();
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: false } }));
 		await api.login("alice", "secret");
 		expect(api.isLoggedIn()).toBe(true);
 
@@ -123,7 +124,7 @@ describe("apiFetch — credentials and headers (#18)", () => {
 	it("never sends an Authorization header (cookie-based auth, post-#18)", async () => {
 		const api = await loadApi();
 		// Simulate a logged-in session.
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: false } }));
 		await api.login("alice", "secret");
 
 		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: [] }));
@@ -167,7 +168,7 @@ describe("apiFetch — 401 stale-session semantics (issue #95)", () => {
 	it("authed 401 flips isLoggedIn to false AND dispatches SESSION_EXPIRED_EVENT exactly once", async () => {
 		const api = await loadApi();
 		// Establish a logged-in state so the 401 is classified as "stale".
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: false } }));
 		await api.login("alice", "secret");
 
 		const handler = vi.fn();
@@ -206,7 +207,7 @@ describe("apiFetch — 401 stale-session semantics (issue #95)", () => {
 
 	it("dedups concurrent 401 bursts so only one event fires per stale-session window", async () => {
 		const api = await loadApi();
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: false } }));
 		await api.login("alice", "secret");
 
 		const handler = vi.fn();
@@ -232,7 +233,7 @@ describe("apiFetch — 401 stale-session semantics (issue #95)", () => {
 
 	it("403 does NOT flip isLoggedIn (policy, not stale)", async () => {
 		const api = await loadApi();
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: false } }));
 		await api.login("alice", "secret");
 
 		fetchSpy.mockResolvedValueOnce(
@@ -252,10 +253,12 @@ describe("apiFetch — 401 stale-session semantics (issue #95)", () => {
 describe("auth API", () => {
 	it("register success returns the userId and flips isLoggedIn", async () => {
 		const api = await loadApi();
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 201, json: { userId: "u1" } }));
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({ status: 201, json: { userId: "u1", isAdmin: false } }),
+		);
 
 		const data = await api.register("alice", "secret");
-		expect(data).toEqual({ userId: "u1" });
+		expect(data).toEqual({ userId: "u1", isAdmin: false });
 		expect(api.isLoggedIn()).toBe(true);
 	});
 
@@ -282,10 +285,10 @@ describe("auth API", () => {
 
 	it("login success returns the userId", async () => {
 		const api = await loadApi();
-		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1" } }));
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: false } }));
 
 		const data = await api.login("u", "p");
-		expect(data).toEqual({ userId: "u1" });
+		expect(data).toEqual({ userId: "u1", isAdmin: false });
 	});
 });
 
@@ -369,5 +372,67 @@ describe("invite hash-at-rest wire shape", () => {
 		expect(list[0].codeHash).toBe("0".repeat(64));
 		expect(list[0].codePrefix).toBe("ab12");
 		expect((list[0] as unknown as Record<string, unknown>).code).toBeUndefined();
+	});
+});
+
+// ── Admin mirror (#50) ──────────────────────────────────────────────────────
+
+describe("admin state mirror", () => {
+	it("isAdmin defaults to false on a fresh load", async () => {
+		const api = await loadApi();
+		expect(api.isAdmin()).toBe(false);
+	});
+
+	it("checkAuthStatus mirrors isAdmin: true into the module state", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({ json: { needsSetup: false, authenticated: true, isAdmin: true } }),
+		);
+		await api.checkAuthStatus();
+		expect(api.isAdmin()).toBe(true);
+	});
+
+	it("login response sets isAdmin from the server payload", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: true } }));
+		await api.login("admin", "secret");
+		expect(api.isAdmin()).toBe(true);
+	});
+
+	it("register response sets isAdmin from the server payload (bootstrap path)", async () => {
+		const api = await loadApi();
+		// Bootstrap-register returns isAdmin: true so the new user sees
+		// the invite UI without waiting for the next /auth/status call.
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({ status: 201, json: { userId: "u1", isAdmin: true } }),
+		);
+		await api.register("alice", "secret");
+		expect(api.isAdmin()).toBe(true);
+	});
+
+	it("logout flips isAdmin back to false", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: true } }));
+		await api.login("admin", "secret");
+		expect(api.isAdmin()).toBe(true);
+
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 204 }));
+		await api.logout();
+		expect(api.isAdmin()).toBe(false);
+	});
+
+	it("authed 401 flips isAdmin back to false alongside isLoggedIn", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ json: { userId: "u1", isAdmin: true } }));
+		await api.login("admin", "secret");
+		expect(api.isAdmin()).toBe(true);
+
+		fetchSpy.mockResolvedValueOnce(mockFetchResponse({ status: 401 }));
+		await api.listSessions().catch(() => {
+			/* drop */
+		});
+
+		expect(api.isAdmin()).toBe(false);
+		expect(api.isLoggedIn()).toBe(false);
 	});
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,19 +7,25 @@
 const BACKEND_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
 const API_BASE = `${BACKEND_URL}/api`;
 
-// ── Auth state (#18) ────────────────────────────────────────────────────────
+// ── Auth state (#18, #50) ───────────────────────────────────────────────────
 //
-// The JWT lives in an httpOnly cookie that JS cannot read. The boolean below
-// is just an in-memory mirror of "do we currently have a valid session" so
-// the UI can route between the login screen and the app without doing a
-// round-trip on every navigation. It's hydrated on boot from /auth/status
-// (which the server populates from req.cookies), and updated on
-// login/register/logout/401.
+// The JWT lives in an httpOnly cookie that JS cannot read. The booleans below
+// are an in-memory mirror so the UI can route (login vs app, hide vs show
+// admin features) without a round-trip per navigation. Hydrated on boot from
+// /auth/status, updated on login/register/logout/401.
 
 let _loggedIn = false;
+let _isAdmin = false;
 
 export function isLoggedIn(): boolean {
 	return _loggedIn;
+}
+
+/** True iff `users.is_admin = 1` for the current session (#50). Gates
+ *  invite-mint UI in main.ts. Refreshes on every /auth/status call so a
+ *  promotion / demotion takes effect on the next reload. */
+export function isAdmin(): boolean {
+	return _isAdmin;
 }
 
 /** Fired by `apiFetch` once per 401-burst after flipping `_loggedIn` to false —
@@ -31,14 +37,17 @@ export const SESSION_EXPIRED_EVENT = "st:session-expired";
 export interface AuthStatus {
 	needsSetup: boolean;
 	authenticated: boolean;
+	isAdmin: boolean;
 }
 
 export async function checkAuthStatus(): Promise<AuthStatus> {
 	const res = await apiFetch("/auth/status");
 	const data = (await res.json()) as AuthStatus;
-	// The server is the source of truth for cookie presence. Mirror it
-	// into module state so isLoggedIn() can answer instantly thereafter.
+	// The server is the source of truth for cookie presence + admin
+	// status. Mirror both so isLoggedIn() / isAdmin() can answer
+	// instantly thereafter.
 	_loggedIn = data.authenticated;
+	_isAdmin = data.isAdmin;
 	return data;
 }
 
@@ -49,11 +58,16 @@ export class InviteRequiredError extends Error {
 	}
 }
 
+export interface AuthSuccess {
+	userId: string;
+	isAdmin: boolean;
+}
+
 export async function register(
 	username: string,
 	password: string,
 	inviteCode?: string,
-): Promise<{ userId: string }> {
+): Promise<AuthSuccess> {
 	const res = await apiFetch("/auth/register", {
 		method: "POST",
 		body: JSON.stringify({ username, password, inviteCode }),
@@ -65,12 +79,13 @@ export async function register(
 		}
 		throw new Error(body.error ?? "Registration failed");
 	}
-	const data = (await res.json()) as { userId: string };
+	const data = (await res.json()) as AuthSuccess;
 	_loggedIn = true;
+	_isAdmin = data.isAdmin;
 	return data;
 }
 
-export async function login(username: string, password: string): Promise<{ userId: string }> {
+export async function login(username: string, password: string): Promise<AuthSuccess> {
 	const res = await apiFetch("/auth/login", {
 		method: "POST",
 		body: JSON.stringify({ username, password }),
@@ -79,8 +94,9 @@ export async function login(username: string, password: string): Promise<{ userI
 		const body = await res.json();
 		throw new Error(body.error ?? "Login failed");
 	}
-	const data = (await res.json()) as { userId: string };
+	const data = (await res.json()) as AuthSuccess;
 	_loggedIn = true;
+	_isAdmin = data.isAdmin;
 	return data;
 }
 
@@ -102,6 +118,7 @@ export async function logout(): Promise<void> {
 		/* network down — local teardown is what the user actually wants */
 	}
 	_loggedIn = false;
+	_isAdmin = false;
 }
 
 // ── Session types ───────────────────────────────────────────────────────────
@@ -345,6 +362,7 @@ async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
 	//   false and the rest see false, so the event fires exactly once.
 	if (sentAuth && res.status === 401 && _loggedIn) {
 		_loggedIn = false;
+		_isAdmin = false;
 		window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
 	}
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -326,6 +326,12 @@ function handleLogout(toastMessage?: string): void {
 	activeSessionId = null;
 	sessions = [];
 	showAuth();
+	// Symmetry with showApp(): keep the admin-button visibility in
+	// lockstep with the api-layer's _isAdmin flag, which logout() and
+	// the 401 path both reset to false. No user-visible effect today
+	// (showAuth() hides appView entirely), but a future code path that
+	// reads admin visibility post-logout sees the right state.
+	applyAdminVisibility();
 	if (toastMessage) showToast(toastMessage, true);
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -19,6 +19,7 @@ import {
 	deleteTab,
 	type Invite,
 	InviteRequiredError,
+	isAdmin,
 	isLoggedIn,
 	listInvites,
 	listSessions,
@@ -199,7 +200,19 @@ function showApp() {
 	// a future swap of "●" for the actual username only needs editing
 	// a single line.
 	sidebarUserDisplay.textContent = userDisplay.textContent;
+	applyAdminVisibility();
 	refreshSessions();
+}
+
+// #50: gate invite-mint UI on the current session's admin status.
+// Both buttons (desktop top bar + mobile sidebar) flip together. Read
+// from the api-layer mirror, which is itself hydrated from /auth/status
+// and the login/register responses, so this just reflects the current
+// authoritative answer without needing its own round-trip.
+function applyAdminVisibility() {
+	const admin = isAdmin();
+	invitesBtn.classList.toggle("hidden", !admin);
+	sidebarInvitesBtn.classList.toggle("hidden", !admin);
 }
 
 function updateAuthUI() {


### PR DESCRIPTION
Closes #50.

Mints and revokes were authenticated-only — a stolen JWT could issue 20 codes (the per-user quota) before losing the token, each working for the configured invite-expiry window. Confines that surface to a small set of operator accounts via an \`is_admin\` column on \`users\`, gated by a new \`requireAdmin\` middleware.

## Schema (\`db.ts\`)

- \`users.is_admin INTEGER NOT NULL DEFAULT 0\`. Idempotent ALTER for pre-existing tables (matches the \`expires_at\` pattern).
- **Auto-promote on migrate**: when no admin row exists yet, the earliest-\`created_at\` user becomes admin. Re-runs are no-ops once any admin exists. Single-user dev/prod deploys (your case) converge on "first user is admin" with no operator action; multi-user pre-#50 deploys also get a sane default (the original bootstrap user) without retroactively touching anyone else's row.

## Backend (\`auth.ts\`, \`routes.ts\`)

- Bootstrap-register INSERTs \`is_admin = 1\` inline.
- \`registerUser\` returns \`RegisterResult { userId, token, isAdmin }\`; \`loginUser\` returns \`LoginResult { userId, token, isAdmin }\`. Login pulls \`is_admin\` from the same row as \`password_hash\` — no extra D1 hit.
- New \`requireAdmin\` middleware: chains after \`requireAuth\`, fetches is_admin via D1 (**not** a JWT-embedded claim, so admin grant/revoke takes effect without a re-login), 401 if upstream skipped requireAuth, 403 on non-admin or missing user row, 500 on lookup failure.
- \`POST /invites\` and \`DELETE /invites/:hash\` now chain \`requireAdmin\`. \`GET /invites\` stays auth-only — non-admins see their (always-empty) list and the missing buttons in the UI tell them they can't mint, instead of a confusing 403 on read.
- \`/auth/status\`, \`/auth/login\`, \`/auth/register\` all surface \`isAdmin: boolean\` so the frontend can gate UI without a separate endpoint.

## Frontend (\`api.ts\`, \`main.ts\`)

- New \`_isAdmin\` mirror state next to \`_loggedIn\`. Hydrated from \`/auth/status\` and the login/register payloads. Exposed via \`isAdmin()\`. Cleared on logout and on authed 401.
- \`main.ts\` hides \`invitesBtn\` (desktop) and \`sidebarInvitesBtn\` (mobile) when \`!isAdmin\`. Driven by \`applyAdminVisibility()\`, called from \`showApp()\` so both bootstrap and post-login transitions stay in sync.

## Tests

- Backend: new \`describe("requireAdmin")\` — 5 cases covering 401 when chained without requireAuth, 403 on \`is_admin=0\`, 403 on missing user row (deleted mid-session), \`next()\` on \`is_admin=1\` with a SQL-shape assertion to catch a column rename, and 500 on D1 fault. \`authStubs\` in \`rateLimit.test.ts\` gain a passthrough \`requireAdmin\` so existing route tests don't trip on the new chain.
- Frontend: new \`describe("admin state mirror")\` — 6 cases covering default-false, \`checkAuthStatus\` mirror, login mirror, register-bootstrap mirror, logout reset, and 401-clears-isAdmin alongside isLoggedIn.

Backend: 184 → 189 passing. Frontend: 22 → 28 passing.

## Tested

- backend: \`npm run lint\` clean, \`npm run build\` (tsc) clean, \`npm test\` all 189 passing
- frontend: \`npm run lint\` clean, \`npm run build\` clean, \`npm test\` all 28 passing