### PR TITLE
fix(ws): guard decodeURIComponent on tab query (#147)

### DIFF
--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -137,6 +137,24 @@ describe("handleWsConnection auth-first ordering", () => {
 		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
 		expect(errPayloads).toContain(JSON.stringify({ type: "error", message: "Missing tab id" }));
 	});
+
+	// Regression test for #147. decodeURIComponent throws URIError on
+	// malformed sequences like `%G%`; without the try/catch the throw
+	// propagates out of the wss connection emit and (with no
+	// uncaughtException handler) terminates the entire backend,
+	// dropping every other attached session.
+	it("authenticated caller with an undecodable tab gets 'Invalid tab', does not throw", () => {
+		const ws = makeFakeWs();
+		const req = makeReq("/ws/sessions/abc?tab=%G%", true);
+		expect(() => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			handleWsConnection(ws as any, req as any, fakeSessions, fakeDocker);
+		}).not.toThrow();
+
+		expect(ws.close).toHaveBeenCalledWith(1008, "Invalid tab");
+		const errPayloads = ws.send.mock.calls.map((c) => c[0] as string);
+		expect(errPayloads).toContain(JSON.stringify({ type: "error", message: "Invalid tab id" }));
+	});
 });
 
 // ── endUpgradeSocketWithReply ──────────────────────────────────────────────

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -100,10 +100,25 @@ export function handleWsConnection(
 	// (docker exec takes argv, not a shell line, but a defensive allowlist
 	// keeps surprising tmux targets like "main:1" out of the path).
 	const tabQueryMatch = url.match(/[?&]tab=([^&#]+)/);
-	const rawTab = tabQueryMatch ? decodeURIComponent(tabQueryMatch[1]!) : null;
-	if (rawTab === null) {
+	if (tabQueryMatch === null) {
 		sendError(ws, "Missing tab id");
 		ws.close(1008, "Missing tab");
+		return;
+	}
+	// decodeURIComponent throws URIError on malformed sequences (e.g.
+	// `?tab=%G%`). Without a guard the throw propagates out of
+	// wss.emit("connection", …) and there is no uncaughtException
+	// handler — Node terminates the process, dropping every other
+	// attached session. Auth runs before this so an unauth'd caller
+	// can't trigger it, but any logged-in user could DoS the entire
+	// server with one bad URL otherwise. Same shape of "one socket
+	// kills the process" bug as #91. See #147.
+	let rawTab: string;
+	try {
+		rawTab = decodeURIComponent(tabQueryMatch[1]!);
+	} catch {
+		sendError(ws, "Invalid tab id");
+		ws.close(1008, "Invalid tab");
 		return;
 	}
 	if (!/^[a-zA-Z0-9._-]{1,64}$/.test(rawTab)) {


### PR DESCRIPTION
## Summary

- Fixes #147 — a malformed `?tab=` query (e.g. `?tab=%G%`) made `decodeURIComponent` throw `URIError` synchronously in `handleWsConnection`. The early `ws.on("error", …)` listener only catches `ws`-emitted errors, not JS throws — the `URIError` propagated out of `wss.emit("connection", …)` and (with no `uncaughtException` handler) terminated the backend, dropping every other attached session.
- Wrap the decode in a try/catch that closes the WS with the existing "Invalid tab" reason. Same shape of "one socket kills the process" bug the early error listener was added for in #91.
- Add a regression test covering the URIError throw path.

## Test plan

- [x] `npm test` (backend) — 193/193 pass
- [x] New `wsHandler.test.ts` case asserts the handler does not throw and emits "Invalid tab" on `?tab=%G%`