### PR TITLE
feat(routes): rate-limit GET /auth/status (#148)

### DIFF
--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -423,16 +423,18 @@ describe("auth route rate limiting", () => {
 		invitesRevoke?: { ipMax: number; ipWindowMs: number };
 		fileUpload?: { ipMax: number; ipWindowMs: number };
 		logout?: { ipMax: number; ipWindowMs: number };
+		authStatus?: { ipMax: number; ipWindowMs: number };
 	}): Promise<void> {
-		// Invite + upload + logout limiters were added later; default each
-		// to a permissive setting so tests that only exercise login/register
-		// don't trip them.
+		// Invite + upload + logout + authStatus limiters were added later;
+		// default each to a permissive setting so tests that only exercise
+		// login/register don't trip them.
 		const fullCfg = {
 			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
 			invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
 			invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
 			fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
 			logout: { ipMax: 1000, ipWindowMs: 60_000 },
+			authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
 			...cfg,
 		};
 		const router = buildRouter(fakeSessions, fakeDocker, fullCfg);
@@ -734,5 +736,30 @@ describe("auth route rate limiting", () => {
 
 		expect(r.status).toBe(403);
 		expect(await r.json()).toMatchObject({ error: "Admin privileges required" });
+	});
+
+	// Regression test for #148. /auth/status is public-by-design (the
+	// frontend uses it on first load to decide between login and app),
+	// but every call hits D1 — without an IP limiter an attacker can
+	// amplify D1 cost / push the account toward Cloudflare's per-database
+	// query throttle.
+	it("GET /auth/status returns 429 after authStatus.ipMax from one IP", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+			authStatus: { ipMax: 3, ipWindowMs: 60_000 },
+		});
+
+		const r1 = await fetch(`${baseUrl}/api/auth/status`);
+		const r2 = await fetch(`${baseUrl}/api/auth/status`);
+		const r3 = await fetch(`${baseUrl}/api/auth/status`);
+		const r4 = await fetch(`${baseUrl}/api/auth/status`);
+
+		expect(r1.status).toBe(200);
+		expect(r2.status).toBe(200);
+		expect(r3.status).toBe(200);
+		expect(r4.status).toBe(429);
+		expect(r4.headers.get("retry-after")).not.toBeNull();
+		expect(await r4.json()).toMatchObject({ scope: "ip" });
 	});
 });

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -74,6 +74,18 @@ export interface RateLimitConfig {
 		ipMax: number;
 		ipWindowMs: number;
 	};
+	// Caps how often a single IP can hit GET /auth/status. The route
+	// is public (the frontend uses it to decide between login and app
+	// on first load, since the auth cookie is httpOnly), but every
+	// call runs hasAnyUsers() and — if a cookie is present — a second
+	// users SELECT for the admin lookup. Unbounded an attacker can
+	// spam D1 reads from a single IP. Sized permissively so legit UI
+	// polling never trips, but bounded enough that abuse is capped.
+	// See #148.
+	authStatus: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
 }
 
 // Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
@@ -117,6 +129,20 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 		ipMax: 30,
 		ipWindowMs: 15 * 60 * 1000,
 	},
+	// 60/min per IP for /auth/status. Public-by-design endpoint (it
+	// drives the login-vs-app routing decision when JS can't read the
+	// httpOnly cookie), but it runs two D1 round-trips per call —
+	// hasAnyUsers() always plus a users SELECT for the admin lookup if
+	// a cookie is present. Without a limiter an attacker IP can spam
+	// it indefinitely to amplify D1 cost / push the account toward
+	// Cloudflare's per-database query throttle. 60/min ≈ 1/sec
+	// sustained — well above any realistic UI cadence (the frontend
+	// hits this once on first load), well below sustained abuse rates.
+	// See #148.
+	authStatus: {
+		ipMax: 60,
+		ipWindowMs: 60 * 1000,
+	},
 };
 
 // ── IP-based limiters (express-rate-limit) ─────────────────────────────────
@@ -129,6 +155,7 @@ export interface AuthRateLimiters {
 	invitesRevokeIp: RateLimitRequestHandler;
 	fileUploadIp: RateLimitRequestHandler;
 	logoutIp: RateLimitRequestHandler;
+	authStatusIp: RateLimitRequestHandler;
 }
 
 export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
@@ -194,6 +221,13 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many logout attempts from this IP, try again later", scope: "ip" },
 	});
+	const authStatusIp = rateLimit({
+		windowMs: cfg.authStatus.ipWindowMs,
+		limit: cfg.authStatus.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: { error: "Too many auth-status requests from this IP, try again later", scope: "ip" },
+	});
 	return {
 		loginIp,
 		registerIp,
@@ -202,6 +236,7 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		invitesRevokeIp,
 		fileUploadIp,
 		logoutIp,
+		authStatusIp,
 	};
 }
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -59,6 +59,7 @@ export function buildRouter(
 		invitesRevokeIp,
 		fileUploadIp,
 		logoutIp,
+		authStatusIp,
 	} = createAuthRateLimiters(rateLimitConfig);
 	const usernameLimiter = new UsernameRateLimiter(
 		rateLimitConfig.login.usernameMax,
@@ -68,7 +69,15 @@ export function buildRouter(
 	// land in the limiter map or D1.
 	const USERNAME_MAX_LEN = 64;
 
-	router.get("/auth/status", async (req: Request, res: Response) => {
+	// Public-by-design (the frontend uses it to decide between login and
+	// app on first load, since the auth cookie is httpOnly), but it runs
+	// hasAnyUsers() on every call plus a users SELECT for the admin
+	// lookup if a cookie is present. Without authStatusIp, an attacker
+	// IP could spam this to amplify D1 cost or push the account toward
+	// Cloudflare's per-database query throttle. Sized permissively at
+	// 60/min so legit UI cadence (one call on page load, occasional
+	// re-checks) never trips it. See #148.
+	router.get("/auth/status", authStatusIp, async (req: Request, res: Response) => {
 		// `authenticated` lets the frontend decide between "show login" and
 		// "show app" on first load, since the cookie is httpOnly and JS
 		// can't observe it directly. Read from req.cookies (populated by


### PR DESCRIPTION
## Summary

- Fixes #148. `GET /auth/status` is public-by-design (drives the login-vs-app routing decision when JS can't read the httpOnly cookie), but every call runs `hasAnyUsers()` and — when a cookie is present — a second `users` SELECT for the admin lookup. Without an IP limiter an attacker can spam the endpoint to amplify D1 cost or push the account toward Cloudflare's per-database query throttle.
- Add `authStatusIp` (60/min per IP) via `createAuthRateLimiters`, same draft-7 `RateLimit-*` / `Retry-After` shape as the other auth-route limiters.
- 60/min ≈ 1/sec sustained: well above any realistic UI cadence (frontend hits this once on first load), well below sustained abuse rates.

## Test plan

- [x] `npm test` (backend) — 193/193 pass
- [x] New `rateLimit.test.ts` case asserts the route returns 429 with `Retry-After` after `authStatus.ipMax` requests from one IP