### PR TITLE
fix(routes): validate POST /sessions name, cols, rows (#149)

### DIFF
--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -762,4 +762,71 @@ describe("auth route rate limiting", () => {
 		expect(r4.headers.get("retry-after")).not.toBeNull();
 		expect(await r4.json()).toMatchObject({ scope: "ip" });
 	});
+
+	// ── POST /sessions input validation (#149) ────────────────────────────
+	// These tests pin the request-boundary caps on session name / cols /
+	// rows. Without them, express.json's 100KB body limit would be the
+	// only upstream bound — a 50KB session name would land in D1 verbatim,
+	// and `cols: -1` / `cols: 1e9` would persist to the row.
+	//
+	// The auth.js mock passes requireAuth through as a no-op, so the
+	// handler runs with `req.userId === undefined`. All four cases below
+	// fail at the validation step BEFORE touching userId or sessions.create,
+	// so the missing userId is fine.
+
+	async function postSession(body: unknown): Promise<Response> {
+		return fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	}
+
+	it("POST /sessions rejects a name longer than 64 chars with 400", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+
+		const r = await postSession({ name: "a".repeat(65) });
+
+		expect(r.status).toBe(400);
+		expect(await r.json()).toMatchObject({ error: expect.stringContaining("64") });
+	});
+
+	it("POST /sessions rejects negative cols with 400", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+
+		const r = await postSession({ name: "ok", cols: -1 });
+
+		expect(r.status).toBe(400);
+		expect(await r.json()).toMatchObject({ error: expect.stringContaining("body.cols") });
+	});
+
+	it("POST /sessions rejects non-integer rows with 400", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+
+		const r = await postSession({ name: "ok", rows: 24.5 });
+
+		expect(r.status).toBe(400);
+		expect(await r.json()).toMatchObject({ error: expect.stringContaining("body.rows") });
+	});
+
+	it("POST /sessions rejects rows above the 1024 cap with 400", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+
+		const r = await postSession({ name: "ok", rows: 100_000 });
+
+		expect(r.status).toBe(400);
+		expect(await r.json()).toMatchObject({ error: expect.stringContaining("1024") });
+	});
 });

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -354,6 +354,34 @@ export function buildRouter(
 			res.status(400).json({ error: "body.name is required" });
 			return;
 		}
+		// Cap session name at the request boundary. The 100KB express.json
+		// body limit is the only upstream bound otherwise — a 50KB name
+		// would land in D1 verbatim and ride out on every list response.
+		// 64 matches USERNAME_MAX_LEN and the tab-label cap; same shape of
+		// "user-controlled string with no other natural limit" → same cap.
+		// The empty-string case is already handled by the `!name` guard
+		// above; only the upper bound needs to be checked here. See #149.
+		if (name.length > SESSION_NAME_MAX_LEN) {
+			res
+				.status(400)
+				.json({ error: `body.name must be at most ${SESSION_NAME_MAX_LEN} characters` });
+			return;
+		}
+		// Numeric dimensions: integer + sane range. xterm uses these to drive
+		// PTY size, and tmux can be unhappy with extreme values; also keeps
+		// nonsense like cols: -1 / cols: 1e9 out of the row.
+		if (cols !== undefined && !isValidTerminalDim(cols)) {
+			res.status(400).json({
+				error: `body.cols must be an integer in 1..${TERMINAL_DIM_MAX}`,
+			});
+			return;
+		}
+		if (rows !== undefined && !isValidTerminalDim(rows)) {
+			res.status(400).json({
+				error: `body.rows must be an integer in 1..${TERMINAL_DIM_MAX}`,
+			});
+			return;
+		}
 		let validatedEnvVars: Record<string, string>;
 		try {
 			validatedEnvVars = validateEnvVars(envVars);
@@ -777,6 +805,28 @@ export function buildRouter(
 	);
 
 	return router;
+}
+
+// POST /sessions input caps. Bound user-controlled fields at the
+// request boundary so D1 rows and future name-rendering UI don't
+// have to defend against multi-KB strings or absurd terminal sizes.
+// 64 for the name matches USERNAME_MAX_LEN and the tab-label cap
+// (same shape of "user-controlled string with no other natural
+// limit"). 1024 for cols/rows is well above any realistic terminal
+// (most clients stay under 500×200) and well below sizes that would
+// upset xterm/tmux. See #149.
+const SESSION_NAME_MAX_LEN = 64;
+const TERMINAL_DIM_MAX = 1024;
+
+// Type-guard for the cols/rows numeric inputs on POST /sessions.
+// Returns true only for finite integers in [1, TERMINAL_DIM_MAX] —
+// rejects NaN, Infinity, floats, negatives, and absurd values that
+// would persist in D1 even though tmux/xterm would clamp or refuse
+// them at runtime.
+function isValidTerminalDim(value: unknown): value is number {
+	return (
+		typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= TERMINAL_DIM_MAX
+	);
 }
 
 function serializeMeta(m: SessionMeta) {


### PR DESCRIPTION
## Summary

- Fixes #149. Username, invite code, and tab label were already capped at 64 chars each, but `POST /sessions` accepted `name` up to `express.json`'s 100KB body limit and never checked `cols`/`rows` types or ranges. A 50KB session name would land in D1 verbatim, and `cols: -1` / `cols: 1e9` would persist even though tmux/xterm clamp or refuse them at runtime.
- Add a 64-char cap on `body.name` (matches `USERNAME_MAX_LEN` and the tab-label cap) and an integer/[1,1024] range check on `body.cols` and `body.rows`.
- Defence-in-depth gap, not a security bug.

## Test plan

- [x] `npm test` (backend) — 196/196 pass
- [x] New `rateLimit.test.ts` cases cover: name > 64, negative cols, non-integer rows, rows > 1024