### PR TITLE
fix(docker): bump tabId entropy to 64 bits (#150)

### DIFF
--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -622,7 +622,8 @@ describe("DockerManager tabs", () => {
 
 		const tab = await dm.createTab("s1", "git");
 
-		expect(tab.tabId).toMatch(/^tab-[0-9a-f]{8}$/);
+		// 8 random bytes → 16 hex chars (#150).
+		expect(tab.tabId).toMatch(/^tab-[0-9a-f]{16}$/);
 		expect(tab.label).toBe("git");
 		expect(tab.createdAt).toBeGreaterThan(0);
 

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -1137,7 +1137,11 @@ export class DockerManager {
 	 * instead, so the value stored equals the value accepted.
 	 */
 	async createTab(sessionId: string, label?: string): Promise<Tab> {
-		const tabId = `tab-${randomBytes(4).toString("hex")}`;
+		// 64 bits of entropy. 32 bits (the previous size) is unlikely to
+		// collide at realistic per-session tab counts, but if it ever does
+		// the inner `tmux new-session -d -s <tabId>` exits non-zero and
+		// the route surfaces a confusing 500. Bumping costs nothing. See #150.
+		const tabId = `tab-${randomBytes(8).toString("hex")}`;
 		// `label` is pre-validated by the route handler (non-empty,
 		// trimmed, no control chars). No normalisation here — the
 		// round-trip stored == sent invariant depends on it.


### PR DESCRIPTION
## Summary

- Fixes #150. 32 bits of entropy is unlikely to collide at realistic per-session tab counts, but if it ever does the inner `tmux new-session -d -s <tabId>` exits non-zero and the route surfaces a confusing 500.
- `randomBytes(4)` → `randomBytes(8)` produces a 16-hex-char id, well under the 64-char tab-id charset cap in `wsHandler.ts`.
- Adjust the matching regex in `dockerManager.test.ts` from `{8}` to `{16}`.

## Test plan

- [x] `npm test` (backend) — 192/192 pass