### PR TITLE
fix(terminal): repaint and bypass debounce on shrink (#155)

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -423,7 +423,33 @@ export function openTerminalSession(opts: {
 				/* container detached mid-resize */
 			}
 			if (term.cols !== lastSentCols || term.rows !== lastSentRows) {
-				sendResizeDebounced();
+				// On a shrink (mobile keyboard slide-in, URL bar reveal, rotation
+				// to a smaller viewport), tmux is still painting at the OLD size
+				// for the duration of the debounce window. Anything it writes past
+				// the new bottom row lands on cells xterm has already reflowed,
+				// leaving duplicated lines and ghost glyphs until the next visibility
+				// change. Bypass the debounce in that direction and notify the
+				// backend immediately; growth can still coalesce.
+				const shrinking = term.rows < lastSentRows || term.cols < lastSentCols;
+				// Drop the WebGL atlas — at a different cell pixel height the cached
+				// glyph textures don't align with the new grid, even before tmux
+				// repaints. Mirrors what onVisibilityChange already does.
+				try {
+					webgl?.clearTextureAtlas();
+				} catch {
+					webgl?.dispose();
+					webgl = null;
+				}
+				term.refresh(0, term.rows - 1);
+				if (shrinking) {
+					if (resizeSendTimer !== null) clearTimeout(resizeSendTimer);
+					resizeSendTimer = null;
+					lastSentCols = term.cols;
+					lastSentRows = term.rows;
+					send({ type: "resize", cols: term.cols, rows: term.rows });
+				} else {
+					sendResizeDebounced();
+				}
 			}
 		});
 	};

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -468,6 +468,13 @@ export function openTerminalSession(opts: {
 	// row repaints.
 	const onVisibilityChange = () => {
 		if (document.hidden) return;
+		// scheduleFit's rAF will atlas-clear + refresh too, but only if the fit
+		// detects a dimension change. The synchronous pair below covers the
+		// no-change case — tab hidden then restored at the same size, where
+		// the GPU may still need a fresh atlas (DPR change, OS font-smoothing
+		// toggle) and the canvas needs a repaint to flush rows that streamed
+		// in while rAF was throttled. The double-fire on the dimension-change
+		// path is harmless: refresh is idempotent and atlas clear is cheap.
 		scheduleFit();
 		try {
 			webgl?.clearTextureAtlas();


### PR DESCRIPTION
Closes #155.

## Summary
- Drop the WebGL texture atlas and force a full \`term.refresh(0, rows-1)\` after every \`fitAddon.fit()\` that changed dimensions. The visibility/focus path already did this; the resize path didn't, so a soft-keyboard slide left ghost rows in place until the tab was backgrounded.
- Bypass the 100 ms debounce when the new geometry is smaller than the last-sent size. tmux otherwise keeps painting past the new bottom row for the full debounce window, and those bytes land on cells xterm has already reflowed — duplicated lines and garbled glyphs.

Growth still coalesces through \`sendResizeDebounced()\` (a window-edge drag can cross cell boundaries ~50× per second; that path's reasoning is unchanged).

## Test plan
- [x] \`npm run build\` (frontend) passes
- [x] Biome clean
- [ ] Manual: open a session on mobile, run \`yes | head -1000\` (or similar streaming output), pop the soft keyboard while output is streaming — no duplicated rows after the keyboard settles
- [ ] Manual: rotate to landscape and back — terminal repaints cleanly, no ghost glyphs
- [ ] Manual: desktop browser window-edge drag still feels smooth (growth path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)