### PR TITLE
fix(terminal): use integer lineHeight (#156)

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -55,7 +55,16 @@ export function openTerminalSession(opts: {
 		fontFamily:
 			'"Cascadia Code", "Fira Code", "JetBrains Mono", "Monaco", "Courier New", monospace',
 		fontSize: fontSize ?? 14,
-		lineHeight: 1.2,
+		// Stay at xterm's default 1.0. A non-integer factor (we previously had
+		// 1.2) yields a fractional cell pixel height at common DPRs — xterm
+		// rounds independently between the WebGL canvas and the DOM viewport,
+		// so the two paint surfaces disagree on where row N ends. The touch-
+		// scroll math in onTouchMove also derives cell height from
+		// container.clientHeight / term.rows, so a sub-pixel mismatch turns
+		// into a per-frame drift between fingers and content. Every fontSize
+		// in FONT_SIZE_STEPS (main.ts) is an integer, so factor 1.0 keeps the
+		// cell height integer at every step.
+		lineHeight: 1,
 		cursorBlink: true,
 		cursorInactiveStyle: "outline",
 		convertEol: true,


### PR DESCRIPTION
Closes #156.

## Summary
- \`lineHeight: 1.2\` → \`lineHeight: 1\`. At fontSize 14, the prior factor produced a non-integer cell pixel height at common DPRs; xterm rounded independently between WebGL canvas and DOM viewport, so the two paint surfaces disagreed on row boundaries — compounding the resize glitches addressed in #159.
- The touch-scroll math (\`onTouchMove\`'s \`getCellHeight = container.clientHeight / term.rows\`) is also DOM-derived, so the same sub-pixel mismatch produced per-frame drift between finger and content on flicks.
- \`FONT_SIZE_STEPS\` in main.ts is all integers, so factor 1.0 keeps the cell height an exact integer at every step.

## Test plan
- [x] \`npm run build\` (frontend) passes
- [x] Biome clean
- [ ] Manual: visual check at fontSize 14 — rows look readable, not cramped (xterm's default leading is room enough for monospace)
- [ ] Manual: touch flick on mobile — content tracks the finger pixel-for-pixel, no per-frame jitter
- [ ] Manual: cycle through font sizes via the toolbar — no glyph clipping at any step

🤖 Generated with [Claude Code](https://claude.com/claude-code)