### PR TITLE
revert: terminal scrollback-preserve and lineHeight changes (#161, #160)

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -55,16 +55,7 @@ export function openTerminalSession(opts: {
 		fontFamily:
 			'"Cascadia Code", "Fira Code", "JetBrains Mono", "Monaco", "Courier New", monospace',
 		fontSize: fontSize ?? 14,
-		// Stay at xterm's default 1.0. A non-integer factor (we previously had
-		// 1.2) yields a fractional cell pixel height at common DPRs — xterm
-		// rounds independently between the WebGL canvas and the DOM viewport,
-		// so the two paint surfaces disagree on where row N ends. The touch-
-		// scroll math in onTouchMove also derives cell height from
-		// container.clientHeight / term.rows, so a sub-pixel mismatch turns
-		// into a per-frame drift between fingers and content. Every fontSize
-		// in FONT_SIZE_STEPS (main.ts) is an integer, so factor 1.0 keeps the
-		// cell height integer at every step.
-		lineHeight: 1,
+		lineHeight: 1.2,
 		cursorBlink: true,
 		cursorInactiveStyle: "outline",
 		convertEol: true,

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -206,45 +206,6 @@ export function openTerminalSession(opts: {
 	};
 	container.addEventListener("pointerdown", focusOnPointer);
 
-	// ── Scrollback preservation ────────────────────────────────────────────
-	// While the user is reading scrollback (or has an active selection),
-	// streaming output from tmux must NOT yank the viewport back to the
-	// cursor. xterm's default is to track the cursor when the program
-	// writes — fine when the user is at the bottom, awful when they've
-	// scrolled up to read a build log or an OAuth URL that just disappeared.
-	//
-	// onScroll fires on every viewport movement (user wheel/swipe AND any
-	// scroll xterm does internally during a write). We sample
-	// `viewportY < baseY` to flip a flag. On the output-write path we
-	// capture viewportY pre-write and, if the flag was set, restore it
-	// in xterm's post-parse callback. Selection-active is the same case:
-	// the user is actively reading what they selected, so don't move them.
-	let userScrolled = false;
-	// `restoring` gates onScroll re-sampling during our own scrollToLine
-	// callback. scrollToLine in xterm v5 fires onScroll synchronously, and
-	// at that point baseY may already have advanced (the write that just
-	// completed appended rows), so a naive re-sample of viewportY < baseY
-	// could observe transient ordering and flip userScrolled to false for
-	// one tick — the next write would then snap the viewport to the
-	// cursor and the flag would re-latch on the user's next wheel/swipe,
-	// producing a visible jitter at the boundary case. Skipping the
-	// re-sample while we're the one driving the scroll keeps the flag
-	// monotonic for the lifetime of the user's scrollback session.
-	let restoring = false;
-	const scrollListener = term.onScroll(() => {
-		if (restoring) return;
-		userScrolled = term.buffer.active.viewportY < term.buffer.active.baseY;
-	});
-	// When the program switches between main and alternate buffers (vim,
-	// claude interactive, htop, …) the previous buffer's scrollback is
-	// no longer the buffer the user sees. Carry-over `userScrolled = true`
-	// from main → alt would currently be saved only by the coincidence
-	// that alt-buffer viewportY === baseY === 0; clear it explicitly so
-	// the invariant doesn't depend on an undocumented xterm assumption.
-	const bufferChangeListener = term.buffer.onBufferChange(() => {
-		userScrolled = false;
-	});
-
 	// ── WebSocket connection ────────────────────────────────────────────────
 	// Auth lives in an httpOnly cookie (#18). Browsers send cookies on the
 	// WS upgrade to the cookie's domain automatically — no token needs to
@@ -278,40 +239,9 @@ export function openTerminalSession(opts: {
 		}
 
 		switch (msg.type) {
-			case "output": {
-				// yBefore must be captured pre-write — that's the position
-				// we want to hold the user at if the write moves the viewport.
-				// The "should we preserve?" decision, by contrast, is sampled
-				// AT CALLBACK TIME: term.write is async (parser drain) and
-				// the user can scroll back to the live tail during that
-				// window. A stale capture would snap them away from the
-				// new bottom for one write before self-correcting.
-				const yBefore = term.buffer.active.viewportY;
-				term.write(msg.data, () => {
-					// xterm fires this after parsing the chunk. If the write
-					// triggered an internal scroll (cursor advanced past the
-					// visible viewport, alt-buffer cup, screen clear, …),
-					// viewportY will have moved; restore it so the user
-					// keeps reading whatever they were reading. Skip when
-					// disposed: the parent has already torn down the term.
-					if (disposed) return;
-					const preserve = userScrolled || term.hasSelection();
-					if (preserve && term.buffer.active.viewportY !== yBefore) {
-						restoring = true;
-						try {
-							term.scrollToLine(yBefore);
-						} finally {
-							// finally so a scrollToLine throw can't leave the
-							// flag latched on — it would silence onScroll for
-							// the rest of the session and the user could no
-							// longer "unlock" preservation by scrolling to
-							// the bottom.
-							restoring = false;
-						}
-					}
-				});
+			case "output":
+				term.write(msg.data);
 				break;
-			}
 			case "status":
 				onStatus(msg.status);
 				break;
@@ -613,8 +543,6 @@ export function openTerminalSession(opts: {
 		container.removeEventListener("touchcancel", onTouchCancel);
 		inputDisposable.dispose();
 		linkProviderDisposable.dispose();
-		scrollListener.dispose();
-		bufferChangeListener.dispose();
 		pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
 		container.removeEventListener("webglcontextlost", onContextLost);
 		webgl?.dispose();


### PR DESCRIPTION
Restores xterm + tmux to its native behaviour. Closes-as-not-fixing #156 and #157.

## Why

**#161 (scrollback preserve)** — the design uses \`term.onScroll\` for the \`userScrolled\` flag. xterm fires \`onScroll\` for **both** user wheel/touch *and* the terminal's own internal scrolls during a write. With tmux constantly emitting small writes (status bar, cursor blink, prompt redraws), the wheel-during-write window is always open: \`yBefore\` is captured pre-wheel, the in-flight callback restores to it, and the user feels like wheel just doesn't work. Three rounds of bot review missed this — it requires real-world usage to surface.

**#160 (lineHeight 1)** — Cascadia Code's descenders extend slightly below the em square; with no leading they have nowhere to render except outside the cell box. On the bottom visible row there's no next row to absorb them, so they clip and the bottom looks ragged. Reverting to the original 1.2 reinstates the leading.

**#159 (resize+atlas, kept)** — that fix is correct on its own merits (asymmetric atlas-clear path, debounce-during-shrink) and is unaffected by either of the issues above.

## What's lost

- The selection/scrollback "preserve viewport on streaming output" feature. After this revert, xterm's native behaviour is what runs: viewport stays where the user puts it via wheel/touch; new output appends at the cursor. tmux + a normal shell give exactly the "scroll up while prompt stays at the bottom of the buffer" experience the issue originally asked for, without any layer-on-top.
- Integer cell pixel heights at every fontSize. The drift between WebGL and DOM rounding that #160 was guarding against does exist in theory but, per the user, the practical bottom-of-screen artefacts \`lineHeight: 1\` introduces are worse than whatever the drift was contributing.

#157 and #156 will be re-investigated from scratch — neither is closed automatically by this revert.

## Test plan
- [x] \`npm run build\` (frontend) passes
- [x] Biome clean
- [x] Bundle hash matches post-#159 build (no other changes in the diff)
- [ ] Manual: wheel scroll on Mac while output is streaming — works, no yank-back
- [ ] Manual: bottom row of viewport on a session with descenders ('p', 'g', 'y') — clean, no clipping
- [ ] Manual: mobile resize fix from #159 still works (open soft keyboard while output streaming, no ghost rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)