### PR TITLE
revert: terminal resize/atlas fix (#159)

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -423,33 +423,7 @@ export function openTerminalSession(opts: {
 				/* container detached mid-resize */
 			}
 			if (term.cols !== lastSentCols || term.rows !== lastSentRows) {
-				// On a shrink (mobile keyboard slide-in, URL bar reveal, rotation
-				// to a smaller viewport), tmux is still painting at the OLD size
-				// for the duration of the debounce window. Anything it writes past
-				// the new bottom row lands on cells xterm has already reflowed,
-				// leaving duplicated lines and ghost glyphs until the next visibility
-				// change. Bypass the debounce in that direction and notify the
-				// backend immediately; growth can still coalesce.
-				const shrinking = term.rows < lastSentRows || term.cols < lastSentCols;
-				// Drop the WebGL atlas — at a different cell pixel height the cached
-				// glyph textures don't align with the new grid, even before tmux
-				// repaints. Mirrors what onVisibilityChange already does.
-				try {
-					webgl?.clearTextureAtlas();
-				} catch {
-					webgl?.dispose();
-					webgl = null;
-				}
-				term.refresh(0, term.rows - 1);
-				if (shrinking) {
-					if (resizeSendTimer !== null) clearTimeout(resizeSendTimer);
-					resizeSendTimer = null;
-					lastSentCols = term.cols;
-					lastSentRows = term.rows;
-					send({ type: "resize", cols: term.cols, rows: term.rows });
-				} else {
-					sendResizeDebounced();
-				}
+				sendResizeDebounced();
 			}
 		});
 	};
@@ -468,13 +442,6 @@ export function openTerminalSession(opts: {
 	// row repaints.
 	const onVisibilityChange = () => {
 		if (document.hidden) return;
-		// scheduleFit's rAF will atlas-clear + refresh too, but only if the fit
-		// detects a dimension change. The synchronous pair below covers the
-		// no-change case — tab hidden then restored at the same size, where
-		// the GPU may still need a fresh atlas (DPR change, OS font-smoothing
-		// toggle) and the canvas needs a repaint to flush rows that streamed
-		// in while rAF was throttled. The double-fire on the dimension-change
-		// path is harmless: refresh is idempotent and atlas clear is cheap.
 		scheduleFit();
 		try {
 			webgl?.clearTextureAtlas();


### PR DESCRIPTION
Reverts #159 to get back to the pre-session baseline (ca7df03).

## Why

After reverting #161 and #160 in #162, the user reports persistent issues — broken scroll on Mac and text appearing outside the prompt input area. Neither pattern matches anything that #161/#160 introduced. The remaining suspect from this session is #159's shrink-bypass logic, which fires \`tmux resize\` immediately (no debounce) when xterm shrinks: under load, that can race with output in flight and produce tmux ↔ xterm geometry desync (exactly the "text in wrong cells" pattern).

I want to fully revert my terminal work this session before doing any more diagnosis, so we can distinguish "issues I caused" from "issues that were already there". The scrollback-related issues #155 / #156 / #157 stay open for fresh investigation with proper repro.

## What's lost

- The post-fit \`clearTextureAtlas + term.refresh\` (visibility-change path is the only refresher again).
- The shrink-bypass on resize (debounce applies in both directions, as it did pre-#159).

The mobile soft-keyboard ghost-row issue from #155 may resurface — accept that for now; we can re-fix it once we know what else is going on.

## Test plan
- [x] \`npm run build\` (frontend) passes
- [x] Biome clean
- [ ] User verifies: hard refresh, do issues (broken scroll on Mac, text outside input lines) persist? If yes → not my changes, pre-existing. If no → my changes were the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)