### PR TITLE
fix(layout): drop sidebar grid transition to stop tmux/xterm width race

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -417,16 +417,24 @@ main {
   display: grid;
   grid-template-columns: 0 1fr;
   overflow: hidden;
-  transition: grid-template-columns 0.2s ease;
   position: relative;
 }
 main.sidebar-open {
   grid-template-columns: 260px 1fr;
 }
-/* Suppress the column transition during the JS-driven init pass so
-   desktop doesn't see a 0→260px expand on every page load. main.ts
-   removes this attribute after applying the initial state. */
-main:not([data-sidebar-ready]),
+/* No transition on the grid: an animated grid-template-columns change
+   races the terminal's resize path. ResizeObserver fires every frame
+   of the animation, fitAddon recomputes cols immediately, but the
+   backend resize message is debounced 100 ms — so for ~300 ms after
+   each toggle, tmux is still emitting at the old col count while
+   xterm renders at the new one. Output (prompt redraw, key echo,
+   status bar) lands in cells that don't match what's on screen,
+   producing visible glyph drift and "text outside the input line".
+   Instant grid change keeps the two sides locked.
+   The mobile sidebar drawer (transform on #sidebar inside the
+   max-width media query) is unaffected because its open/close does
+   not change the terminal's width — the drawer floats above the
+   terminal on mobile rather than pushing it. */
 main:not([data-sidebar-ready]) #sidebar {
   transition: none !important;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1098,10 +1098,12 @@ mobileMql.addEventListener("change", () => {
 	setChromeOpen(chromeDefaultOpen());
 });
 
-// Default state: open on desktop, closed on mobile. The HTML+CSS start in
-// the closed state with transitions suppressed via `[data-sidebar-ready]`,
-// so this synchronous flip-then-enable avoids the 0→260px expand animation
-// that would otherwise fire on every desktop page load.
+// Default state: open on desktop, closed on mobile. The HTML+CSS start
+// with the mobile drawer's transform-transition suppressed via
+// `[data-sidebar-ready]`, so the synchronous flip below doesn't slide
+// the drawer in on every page load. (The desktop grid-template-columns
+// transition was removed in a fix for the resize race — see
+// main.css `main { ... }`.)
 setSidebarOpen(!isMobile());
 mainEl.setAttribute("data-sidebar-ready", "");
 


### PR DESCRIPTION
Fixes the issue diagnosed in this session: text appearing in wrong columns / "outside the input line" while typing, especially on viewports where the terminal touches the screen edge (mobile, MacBook). User confirmed by setting \`transition: none\` on \`main\` in dev tools — glitches stopped immediately.

## Root cause

\`main\` had \`transition: grid-template-columns 0.2s ease;\`. On sidebar toggle, the terminal area's width animated frame-by-frame. ResizeObserver fired every frame; \`fitAddon.fit()\` recomputed cols and called \`term.resize(cols, rows)\` locally. But the backend resize message in \`terminal.ts:398-414\` is trailing-debounced at 100 ms.

Result: for ~300 ms after each toggle (200 ms animation + 100 ms debounce), tmux was emitting output at the *old* col count while xterm rendered at the *new* one. Output during that window — prompt redraw, key echo, tmux status bar — landed in cells that didn't line up with what was on screen. On narrow viewports the visual mismatch was loud (text bleeding past the right edge); on the 4k screen with slack everywhere the user never noticed.

This also covers the originally-reported "bottom-row glitches on mobile" — same race, height dimension, triggered by URL bar reveal / soft-keyboard slide instead of sidebar toggle.

## Fix

Remove the grid-template-columns transition. Sidebar toggle now changes the grid instantly; xterm fits to the new geometry on the next frame; the backend resize message debounces from a stable starting size; tmux and xterm stay in sync.

The mobile sidebar drawer (\`#sidebar { transform: translateX(...); transition: transform 0.2s }\` inside the max-width:768px media query) is unaffected — on mobile the grid is 1fr always, so the drawer floats above the terminal rather than pushing it. The init-suppress \`[data-sidebar-ready]\` rule was tightened to only cover that mobile transform (its desktop role is now obsolete).

## Trade-off
Lost the 0.2s sidebar-toggle slide on desktop. Acceptable: instant toggle is a minor UX regression, the geometry race was a real correctness bug.

## Test plan
- [x] \`npm run build\` (frontend) passes
- [x] Biome clean
- [x] User-confirmed in dev tools: \`transition: none\` on \`main\` makes the glitches stop
- [ ] Manual: with sidebar open + claude/yes streaming, type rapidly — text appears in the right columns
- [ ] Manual: toggle sidebar mid-stream — no flicker, no wrong-column text after settle
- [ ] Manual: mobile soft-keyboard open while output streams — no ghost glyphs (this issue isn't directly addressed here but should also improve since the height-dimension race has the same shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)