### PR TITLE
fix(layout): show tab pane before constructing xterm

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -679,9 +679,18 @@ function openTab(tabId: string) {
 	let entry = currentTerminals.get(tabId);
 	if (!entry) {
 		const pane = document.createElement("div");
-		pane.className = "tab-pane";
+		// `active` from creation, and the parent flipped to display:block
+		// BEFORE openTerminalSession runs. xterm's fit() inside that call
+		// is synchronous and reads container.clientWidth/Height — if the
+		// pane is still inside a display:none subtree it sees 0, falls
+		// back to the 80x24 default, and the WS opens at that bogus
+		// geometry. tmux then attaches/resumes at 80x24 and the visible
+		// terminal shows mis-columned output until the next resize event
+		// (sidebar toggle, viewport change) bumps it to real cols/rows.
+		pane.className = "tab-pane active";
 		pane.dataset.tabId = tabId;
 		terminalContainer.appendChild(pane);
+		terminalContainer.style.display = "block";
 
 		// Capture the sessionId for this terminal — if the user switches
 		// sessions while this WS is closing, `onStatus("disconnected")`

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -795,6 +795,12 @@ function openTab(tabId: string) {
 			pane.remove();
 			if (prevActiveTabId) {
 				currentTerminals.get(prevActiveTabId)?.pane.classList.add("active");
+			} else {
+				// We just flipped terminalContainer to display:block to host
+				// the new pane; with no prev pane to swap back to and our
+				// pane removed, leaving display:block would render an empty
+				// dark box. Revert.
+				terminalContainer.style.display = "none";
 			}
 			throw err;
 		}


### PR DESCRIPTION
Follows up on #164. User reported: after a hard refresh and selecting a session, the auto-opened first tab still shows mis-columned text — but toggling the sidebar (which now has no transition, thanks to #164) makes it correct. That points to xterm getting bogus initial geometry, which a later ResizeObserver-driven fit corrects.

## Root cause

\`main.ts:680-684\` (pre-fix):

    const pane = document.createElement("div");
    pane.className = "tab-pane";
    pane.dataset.tabId = tabId;
    terminalContainer.appendChild(pane);

    // ... openTerminalSession runs synchronously here, calls fit() inside ...

\`#terminal-container\` is still \`display: none\` at this point — \`display: block\` only gets set at \`main.ts:795\`, *after* \`openTerminalSession\` returns. So xterm's synchronous \`fitAddon.fit()\` inside the constructor reads \`clientWidth/Height = 0\` and falls back to the 80×24 default. The WebSocket opens, the backend \`tmux new-session -A -s <tabId>\` runs at 80×24, and the visible terminal stays at that geometry until the next \`ResizeObserver\` trip (sidebar toggle, viewport change, etc.) bumps it to the real cols/rows.

In the gap, tmux is emitting at 80 cols while the container actually accommodates many more — output wraps in a place the container doesn't expect, producing the column-misalignment "glitches" right after session select. Toggling the sidebar fired ResizeObserver, fit() ran with real dimensions, and the user saw "the toggle fixed it".

## Fix

Mark the new \`.tab-pane\` as \`active\` from creation and flip \`#terminal-container\` to \`display: block\` *before* \`openTerminalSession\` runs. That way \`fit()\` reads the real container size on its first synchronous call, the WS opens with the right cols/rows, and tmux gets the right geometry from the start.

The post-construction \`entry.pane.classList.add("active")\` + \`display:block\` on line 794-795 stay — they remain necessary for the re-open-existing-tab path that skips the \`if (!entry)\` block.

## Test plan
- [x] \`npm run build\` (frontend) passes
- [x] Biome clean
- [ ] Manual: hard refresh → click a session → first tab auto-opens → terminal columns match the visible area on first render (no need to toggle sidebar)
- [ ] Manual: open a second tab in the same session — also renders cleanly
- [ ] Manual: terminate then re-open a tab → display:block / .active still applied (regression check on the re-open path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)