### PR TITLE
fix(ws): pass viewport cols/rows in upgrade URL

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -816,7 +816,9 @@ export function buildRouter(
 // (most clients stay under 500×200) and well below sizes that would
 // upset xterm/tmux. See #149.
 const SESSION_NAME_MAX_LEN = 64;
-const TERMINAL_DIM_MAX = 1024;
+// Exported so wsHandler can apply the same upper bound when validating
+// cols/rows from the WS upgrade URL — keep both guards moving together.
+export const TERMINAL_DIM_MAX = 1024;
 
 // Type-guard for the cols/rows numeric inputs on POST /sessions.
 // Returns true only for finite integers in [1, TERMINAL_DIM_MAX] —

--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -187,7 +187,12 @@ describe("handleWsConnection geometry from URL", () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		handleWsConnection(ws as any, req as any, sessions, docker);
 		// Drain the async IIFE that runs assertOwnership → docker.attach.
-		await new Promise((r) => setImmediate(r));
+		// Wait for the async IIFE (assertOwnership → docker.attach chain) to
+		// reach attach. waitFor polls until the assertion holds, robust
+		// against any number of intermediate awaits in the handler.
+		await vi.waitFor(() => {
+			expect(docker.attach).toHaveBeenCalled();
+		});
 
 		expect(docker.attach).toHaveBeenCalledWith(
 			"abc",
@@ -205,7 +210,12 @@ describe("handleWsConnection geometry from URL", () => {
 		const req = makeReq("/ws/sessions/abc?tab=tab-1", true);
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		handleWsConnection(ws as any, req as any, sessions, docker);
-		await new Promise((r) => setImmediate(r));
+		// Wait for the async IIFE (assertOwnership → docker.attach chain) to
+		// reach attach. waitFor polls until the assertion holds, robust
+		// against any number of intermediate awaits in the handler.
+		await vi.waitFor(() => {
+			expect(docker.attach).toHaveBeenCalled();
+		});
 
 		expect(docker.attach).toHaveBeenCalledWith(
 			"abc",
@@ -224,7 +234,12 @@ describe("handleWsConnection geometry from URL", () => {
 		const req = makeReq("/ws/sessions/abc?tab=tab-1&cols=0&rows=9999", true);
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		handleWsConnection(ws as any, req as any, sessions, docker);
-		await new Promise((r) => setImmediate(r));
+		// Wait for the async IIFE (assertOwnership → docker.attach chain) to
+		// reach attach. waitFor polls until the assertion holds, robust
+		// against any number of intermediate awaits in the handler.
+		await vi.waitFor(() => {
+			expect(docker.attach).toHaveBeenCalled();
+		});
 
 		expect(docker.attach).toHaveBeenCalledWith(
 			"abc",

--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -157,6 +157,86 @@ describe("handleWsConnection auth-first ordering", () => {
 	});
 });
 
+// ── Geometry forwarding ───────────────────────────────────────────────────
+// On WS upgrade, the client passes its post-fit cols/rows in the URL so
+// docker.attach (and capture-pane downstream) run at the actual viewport
+// size — not at D1's stored last-known size. Without this, the replay
+// arrives at the wrong cols and the user sees mis-aligned columns until
+// a frontend resize event triggers a manual reflow. Bounds are 1..1024
+// integer; out-of-range or missing values fall back to session.cols/rows.
+
+describe("handleWsConnection geometry from URL", () => {
+	function makeMocks(sessionCols = 80, sessionRows = 24) {
+		const sessions = {
+			assertOwnership: vi
+				.fn()
+				.mockResolvedValue({ status: "running", cols: sessionCols, rows: sessionRows }),
+			updateConnected: vi.fn().mockResolvedValue(undefined),
+		} as unknown as SessionManager;
+		const docker = {
+			attach: vi.fn().mockResolvedValue({ replay: null, flushTail: () => {} }),
+			detach: vi.fn(),
+		} as unknown as DockerManager;
+		return { sessions, docker };
+	}
+
+	it("uses cols/rows from URL when both are valid", async () => {
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks();
+		const req = makeReq("/ws/sessions/abc?tab=tab-1&cols=200&rows=60", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		// Drain the async IIFE that runs assertOwnership → docker.attach.
+		await new Promise((r) => setImmediate(r));
+
+		expect(docker.attach).toHaveBeenCalledWith(
+			"abc",
+			expect.any(String),
+			200,
+			60,
+			expect.any(Function),
+			"tab-1",
+		);
+	});
+
+	it("falls back to session.cols/rows when URL omits them", async () => {
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks(120, 40);
+		const req = makeReq("/ws/sessions/abc?tab=tab-1", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await new Promise((r) => setImmediate(r));
+
+		expect(docker.attach).toHaveBeenCalledWith(
+			"abc",
+			expect.any(String),
+			120,
+			40,
+			expect.any(Function),
+			"tab-1",
+		);
+	});
+
+	it("falls back to session.cols/rows when URL values are out of range", async () => {
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks(120, 40);
+		// 0 fails the >=1 guard, 9999 fails the <=1024 guard.
+		const req = makeReq("/ws/sessions/abc?tab=tab-1&cols=0&rows=9999", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await new Promise((r) => setImmediate(r));
+
+		expect(docker.attach).toHaveBeenCalledWith(
+			"abc",
+			expect.any(String),
+			120,
+			40,
+			expect.any(Function),
+			"tab-1",
+		);
+	});
+});
+
 // ── endUpgradeSocketWithReply ──────────────────────────────────────────────
 // Pins the half-close → bounded-destroy invariant from issue #67. A peer
 // that never FINs would otherwise hold the upgrade socket in CLOSE_WAIT

--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -186,7 +186,6 @@ describe("handleWsConnection geometry from URL", () => {
 		const req = makeReq("/ws/sessions/abc?tab=tab-1&cols=200&rows=60", true);
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		handleWsConnection(ws as any, req as any, sessions, docker);
-		// Drain the async IIFE that runs assertOwnership → docker.attach.
 		// Wait for the async IIFE (assertOwnership → docker.attach chain) to
 		// reach attach. waitFor polls until the assertion holds, robust
 		// against any number of intermediate awaits in the handler.

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -128,6 +128,22 @@ export function handleWsConnection(
 	}
 	const tabId = rawTab;
 
+	// Optional geometry hint from the client. Used in lieu of
+	// session.cols/rows (the persisted last-good size from D1) so
+	// capture-pane runs at the actual viewport size on this attach;
+	// otherwise the replay arrives at D1's stored size and the user
+	// sees mis-aligned columns until something fires a frontend
+	// resize. Bounds match POST /sessions in routes.ts.
+	const URL_DIM_MAX = 1024;
+	const parseDim = (re: RegExp): number | null => {
+		const m = url.match(re);
+		if (m === null) return null;
+		const n = Number.parseInt(m[1]!, 10);
+		return Number.isInteger(n) && n >= 1 && n <= URL_DIM_MAX ? n : null;
+	};
+	const urlCols = parseDim(/[?&]cols=([^&#]+)/);
+	const urlRows = parseDim(/[?&]rows=([^&#]+)/);
+
 	// Async auth + attach flow
 	(async () => {
 		// Authorise
@@ -157,8 +173,8 @@ export function handleWsConnection(
 		const { replay, flushTail } = await docker.attach(
 			sessionId,
 			attachId,
-			session.cols,
-			session.rows,
+			urlCols ?? session.cols,
+			urlRows ?? session.rows,
 			outputListener,
 			tabId,
 		);

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -9,6 +9,7 @@ import { WebSocket, type WebSocketServer } from "ws";
 import { verifyWsToken } from "./auth.js";
 import type { DockerManager } from "./dockerManager.js";
 import { logger } from "./logger.js";
+import { TERMINAL_DIM_MAX } from "./routes.js";
 import { ForbiddenError, NotFoundError, type SessionManager } from "./sessionManager.js";
 import type { WsClientMessage, WsServerMessage } from "./types.js";
 
@@ -133,16 +134,19 @@ export function handleWsConnection(
 	// capture-pane runs at the actual viewport size on this attach;
 	// otherwise the replay arrives at D1's stored size and the user
 	// sees mis-aligned columns until something fires a frontend
-	// resize. Bounds match POST /sessions in routes.ts.
-	const URL_DIM_MAX = 1024;
+	// resize. Bounds match POST /sessions (TERMINAL_DIM_MAX shared
+	// from routes.ts so both validators move together).
 	const parseDim = (re: RegExp): number | null => {
 		const m = url.match(re);
 		if (m === null) return null;
 		const n = Number.parseInt(m[1]!, 10);
-		return Number.isInteger(n) && n >= 1 && n <= URL_DIM_MAX ? n : null;
+		return Number.isInteger(n) && n >= 1 && n <= TERMINAL_DIM_MAX ? n : null;
 	};
-	const urlCols = parseDim(/[?&]cols=([^&#]+)/);
-	const urlRows = parseDim(/[?&]rows=([^&#]+)/);
+	// `\d{1,4}` (not `[^&#]+`) so values like `cols=100abc` don't
+	// silently truncate via parseInt's partial-parse — the value will
+	// just fail to match and fall through to session.cols.
+	const urlCols = parseDim(/[?&]cols=(\d{1,4})/);
+	const urlRows = parseDim(/[?&]rows=(\d{1,4})/);
 
 	// Async auth + attach flow
 	(async () => {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -207,21 +207,18 @@ export function openTerminalSession(opts: {
 	// Without this, the replay arrives at the wrong cols/rows and renders
 	// mis-aligned in xterm until the next resize event (sidebar toggle,
 	// viewport change). Validated server-side; backend falls back to D1
-	// if the params are missing or out of range.
+	// if the params are missing or out of range. Sending geometry as a
+	// WS message after open would be too late: the backend ships the
+	// replay before its `ws.on("message", …)` listener registers, so the
+	// frame would be silently dropped by EventEmitter.
+	//
+	// Liveness (post-open) is handled at the protocol layer (ws.ping/pong)
+	// from the server — see backend/src/index.ts heartbeat. Browsers
+	// auto-reply to server pings with no JS hook required, so there is
+	// no `ws.onopen` handler.
 	const wsUrl = buildWsUrl(sessionId, tabId, term.cols, term.rows);
 	const ws = new WebSocket(wsUrl);
 	let disposed = false;
-
-	ws.onopen = () => {
-		// Liveness is handled at the protocol layer (ws.ping/pong) from
-		// the server side — see backend/src/index.ts heartbeat. Browsers
-		// auto-reply to server pings with no JS hook required.
-		// Initial geometry is communicated via the upgrade URL (cols/rows
-		// query params consumed by wsHandler.attach). Sending it as a WS
-		// message here would be too late — the backend ships the replay
-		// before its `ws.on("message", …)` listener registers, so any
-		// frame from this hook is silently dropped by EventEmitter.
-	};
 
 	ws.onmessage = (ev) => {
 		// disposed: post-close frames buffered by the browser or in flight

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -684,7 +684,12 @@ class MultilineUrlLinkProvider implements ILinkProvider {
 
 // ── URL builder ─────────────────────────────────────────────────────────────
 
-function buildWsUrl(sessionId: string, tabId: string | undefined, cols: number, rows: number): string {
+function buildWsUrl(
+	sessionId: string,
+	tabId: string | undefined,
+	cols: number,
+	rows: number,
+): string {
 	// Use VITE_API_URL to derive the WebSocket URL
 	const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
 	const url = new URL(apiUrl);

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -202,28 +202,25 @@ export function openTerminalSession(opts: {
 	// WS upgrade to the cookie's domain automatically — no token needs to
 	// be threaded through here. Origin policy (CSWSH protection) is
 	// enforced server-side by isAllowedWsOrigin against CORS_ORIGINS.
-	const wsUrl = buildWsUrl(sessionId, tabId);
+	// Pass the post-fit geometry through the URL so capture-pane on the
+	// backend runs at the actual viewport size, not D1's stored default.
+	// Without this, the replay arrives at the wrong cols/rows and renders
+	// mis-aligned in xterm until the next resize event (sidebar toggle,
+	// viewport change). Validated server-side; backend falls back to D1
+	// if the params are missing or out of range.
+	const wsUrl = buildWsUrl(sessionId, tabId, term.cols, term.rows);
 	const ws = new WebSocket(wsUrl);
 	let disposed = false;
 
 	ws.onopen = () => {
-		// Send our geometry immediately. Backend's attach() resizes tmux to
-		// session.cols/rows from D1 (the persisted "last good" geometry, or
-		// the POST /sessions defaults — often 80×24) BEFORE running
-		// capture-pane and shipping the replay. If that differs from what
-		// fit() computed for the actual viewport, the replay arrives at the
-		// stored size and renders mis-columned in our wider/narrower xterm,
-		// and `scheduleFit` won't help because lastSentCols/Rows already
-		// equal term.cols/rows post-fit — nothing has *changed* to trip
-		// the "send if changed" guard. Forcing a resize here makes the
-		// first tmux resize-window happen as part of session start; the
-		// transient size mismatch is bounded by the round-trip (a frame
-		// or two) instead of "until the user happens to toggle the
-		// sidebar".
-		send({ type: "resize", cols: term.cols, rows: term.rows });
 		// Liveness is handled at the protocol layer (ws.ping/pong) from
 		// the server side — see backend/src/index.ts heartbeat. Browsers
 		// auto-reply to server pings with no JS hook required.
+		// Initial geometry is communicated via the upgrade URL (cols/rows
+		// query params consumed by wsHandler.attach). Sending it as a WS
+		// message here would be too late — the backend ships the replay
+		// before its `ws.on("message", …)` listener registers, so any
+		// frame from this hook is silently dropped by EventEmitter.
 	};
 
 	ws.onmessage = (ev) => {
@@ -687,20 +684,23 @@ class MultilineUrlLinkProvider implements ILinkProvider {
 
 // ── URL builder ─────────────────────────────────────────────────────────────
 
-function buildWsUrl(sessionId: string, tabId?: string): string {
+function buildWsUrl(sessionId: string, tabId: string | undefined, cols: number, rows: number): string {
 	// Use VITE_API_URL to derive the WebSocket URL
 	const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
 	const url = new URL(apiUrl);
 	const wsProto = url.protocol === "https:" ? "wss:" : "ws:";
 	const base = `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
+	const params = new URLSearchParams();
 	// tabId is server-issued and re-validated on the backend before any
 	// `tmux attach -t` — see backend/src/wsHandler.ts (rawTab regex
 	// /^[a-zA-Z0-9._-]{1,64}$/). Excluding `:` is the load-bearing part:
 	// tmux target syntax needs a colon to parse `session:window.pane`, so
 	// `.` alone can't escalate a tabId into a different tmux target.
-	if (tabId) {
-		const params = new URLSearchParams({ tab: tabId });
-		return `${base}?${params.toString()}`;
-	}
-	return base;
+	if (tabId) params.set("tab", tabId);
+	// Geometry is bounds-checked server-side (1..1024 integer); a missing
+	// or out-of-range value falls back to D1's stored session.cols/rows.
+	if (Number.isInteger(cols) && cols > 0) params.set("cols", String(cols));
+	if (Number.isInteger(rows) && rows > 0) params.set("rows", String(rows));
+	const qs = params.toString();
+	return qs ? `${base}?${qs}` : base;
 }

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -207,9 +207,23 @@ export function openTerminalSession(opts: {
 	let disposed = false;
 
 	ws.onopen = () => {
-		// Liveness is now handled at the protocol layer (ws.ping/pong)
-		// from the server side — see backend/src/index.ts heartbeat.
-		// Browsers auto-reply to server pings with no JS hook required.
+		// Send our geometry immediately. Backend's attach() resizes tmux to
+		// session.cols/rows from D1 (the persisted "last good" geometry, or
+		// the POST /sessions defaults — often 80×24) BEFORE running
+		// capture-pane and shipping the replay. If that differs from what
+		// fit() computed for the actual viewport, the replay arrives at the
+		// stored size and renders mis-columned in our wider/narrower xterm,
+		// and `scheduleFit` won't help because lastSentCols/Rows already
+		// equal term.cols/rows post-fit — nothing has *changed* to trip
+		// the "send if changed" guard. Forcing a resize here makes the
+		// first tmux resize-window happen as part of session start; the
+		// transient size mismatch is bounded by the round-trip (a frame
+		// or two) instead of "until the user happens to toggle the
+		// sidebar".
+		send({ type: "resize", cols: term.cols, rows: term.rows });
+		// Liveness is handled at the protocol layer (ws.ping/pong) from
+		// the server side — see backend/src/index.ts heartbeat. Browsers
+		// auto-reply to server pings with no JS hook required.
 	};
 
 	ws.onmessage = (ev) => {


### PR DESCRIPTION
Replaces the broken \`ws.onopen\` send (initial commit on this branch) with the URL-params approach the bot's review flagged as the right path. The first commit is left in history so the chain is readable; both commits are squash-merged together.

## Why the earlier approach didn't work

\`ws.onopen\` fires once the HTTP upgrade handshake ACKs. Backend then runs \`await sessions.assertOwnership(...)\` and \`await docker.attach(...)\` (network round-trips, tens of ms each) before registering \`ws.on("message", ...)\`. Node's EventEmitter discards messages emitted before any listener exists — the resize frame from \`onopen\` was being silently dropped on the floor.

## What this PR does

**Frontend** (\`terminal.ts\`):
- \`buildWsUrl\` now takes \`cols\`/\`rows\` and appends them to the URL when valid (\`Number.isInteger\` and \`> 0\`).
- The call site after \`fitAddon.fit()\` passes \`term.cols\`/\`term.rows\`.
- The dead \`ws.onopen\` send is removed; the comment block now explains why URL is the right channel.

**Backend** (\`wsHandler.ts\`):
- After tab-id parsing, parse \`cols\`/\`rows\` query params with the same regex+\`parseInt\` pattern as the existing tab parser.
- Validate \`1..1024\` integer (matches \`POST /sessions\` bounds in \`routes.ts\`).
- Pass \`urlCols ?? session.cols\`, \`urlRows ?? session.rows\` into \`docker.attach\` — fallback preserves existing behaviour for clients that don't yet send the params.

\`capture-pane\` therefore runs at the actual viewport size from the start, so the replay arrives at the right cols and the user no longer needs the sidebar-toggle workaround.

**Order-safe**: a frontend without the params falls through to \`session.cols/rows\` on the backend. A backend that doesn't parse the params has no behavioural change. Either side can deploy first; both must update for the fix to be active.

## Tests
Three new cases in \`wsHandler.test.ts\` verify \`docker.attach\` gets:
- the URL values when both are valid
- the session values when the URL omits them
- the session values when URL values are out of range (0, 9999)

All 198 existing tests still pass.

## Deploy notes for user
- Frontend is deployed by Cloudflare Pages on merge — automatic.
- Backend is on the self-hosted host: \`docker compose up -d --build\` from the repo root after pulling main.
- Until the backend is redeployed, the frontend params are sent but ignored — same as today's behaviour, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)