### PR TITLE
fix(docker): append explicit cursor position to capture-pane replay

### DIFF
--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -331,11 +331,18 @@ describe("DockerManager shared-exec multiplexing", () => {
 	it("returns the tmux capture-pane snapshot as replay for new attachers without re-sending to existing ones", async () => {
 		// Capture-pane replay lets every joiner see the same canonical view of
 		// the pane regardless of when they joined. We script the snapshot via
-		// the one-shot hook so we don't need a live tmux.
+		// the one-shot hook so we don't need a live tmux. display-message is
+		// also called now (in parallel) to fetch tmux's actual cursor position
+		// so the replay can append a CUP escape — see the
+		// "appends cursor position" test below for the cursor-specific
+		// invariant.
 		const { dm } = makeDocker({
 			oneShot: (cmd) => {
 				if (cmd[1] === "capture-pane") {
 					return { stdout: "line-a\nline-b", exitCode: 0 };
+				}
+				if (cmd[1] === "display-message") {
+					return { stdout: "1;3\n", exitCode: 0 };
 				}
 				return undefined;
 			},
@@ -352,13 +359,62 @@ describe("DockerManager shared-exec multiplexing", () => {
 
 		const { replay } = await dm.attach("s1", "a2", 80, 24, a2, "tab-test");
 
-		// capture-pane stdout, with \n promoted to \r\n for xterm.
-		expect(replay).toBe("line-a\r\nline-b");
+		// capture-pane stdout with \n promoted to \r\n, plus the CUP escape
+		// derived from display-message (1;3 → row 2 col 4 in 1-based ANSI).
+		expect(replay).toBe("line-a\r\nline-b\x1b[2;4H");
 		// Second attach must not cross-fan to the first listener, and a2
 		// receives the replay via its return value (wsHandler, not the
 		// listener) so the listener stays unfired.
 		expect(a1).not.toHaveBeenCalled();
 		expect(a2).not.toHaveBeenCalled();
+	});
+
+	it("appends an explicit CUP escape derived from tmux's cursor position", async () => {
+		// Without this escape, xterm's local cursor lands one row past the
+		// last replay row (each \r\n advances the cursor) — typed input then
+		// renders below the visible prompt until tmux happens to redraw. The
+		// CUP suffix re-syncs xterm to where tmux says the shell's cursor
+		// actually is. tmux's #{cursor_y}/#{cursor_x} are 0-based, ANSI CUP
+		// is 1-based — pin the +1 conversion.
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				if (cmd[1] === "capture-pane") return { stdout: "$ ", exitCode: 0 };
+				if (cmd[1] === "display-message") return { stdout: "0;2\n", exitCode: 0 };
+				return undefined;
+			},
+		});
+		const { replay } = await dm.attach("s1", "a1", 80, 24, vi.fn(), "tab-cur");
+		// 0;2 → row 1 col 3 in 1-based ANSI.
+		expect(replay).toBe("$ \x1b[1;3H");
+	});
+
+	it("falls through to plain snapshot if display-message exits non-zero", async () => {
+		// Older tmux, race with `new-session -A`, or a malformed format
+		// string can all yield a non-zero exit on display-message. We
+		// deliberately accept the trailing-newline drift in that case
+		// rather than emit a malformed escape — the user gets the same
+		// behaviour as before this fix landed, not a broken one.
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				if (cmd[1] === "capture-pane") return { stdout: "$ ", exitCode: 0 };
+				if (cmd[1] === "display-message") return { stdout: "", exitCode: 1 };
+				return undefined;
+			},
+		});
+		const { replay } = await dm.attach("s1", "a1", 80, 24, vi.fn(), "tab-cur");
+		expect(replay).toBe("$ ");
+	});
+
+	it("falls through to plain snapshot if display-message returns unparseable output", async () => {
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				if (cmd[1] === "capture-pane") return { stdout: "$ ", exitCode: 0 };
+				if (cmd[1] === "display-message") return { stdout: "garbage\n", exitCode: 0 };
+				return undefined;
+			},
+		});
+		const { replay } = await dm.attach("s1", "a1", 80, 24, vi.fn(), "tab-cur");
+		expect(replay).toBe("$ ");
 	});
 
 	it("resizes the shared exec to min(cols) × min(rows) and recomputes on detach", async () => {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -885,24 +885,56 @@ export class DockerManager {
 	 */
 	private async capturePane(sessionId: string, tabId: string): Promise<string> {
 		try {
-			const { stdout, exitCode } = await this.execOneShot(sessionId, [
-				"tmux",
-				"capture-pane",
-				"-t",
-				tabId,
-				"-p",
-				"-e",
+			// Run capture-pane and display-message in parallel — both go
+			// through execOneShot (a fresh `docker exec`), so the round trip
+			// is the same as one alone. We need the cursor position because
+			// capture-pane only emits row content + newlines, no cursor
+			// escape. After feeding the snapshot to xterm, the local
+			// cursor ends up wherever the trailing \n's left it (typically
+			// one row past the last content row), which doesn't match where
+			// tmux thinks the shell's cursor actually is. Subsequent typed
+			// input renders at xterm's stale cursor — visibly "one row
+			// below the prompt" — until tmux happens to emit a cursor-
+			// position escape (often only when there's something to redraw).
+			// Appending an explicit CUP at the end of the replay puts xterm
+			// in sync with tmux from the first character.
+			const [snap, cur] = await Promise.all([
+				this.execOneShot(sessionId, ["tmux", "capture-pane", "-t", tabId, "-p", "-e"]),
+				this.execOneShot(sessionId, [
+					"tmux",
+					"display-message",
+					"-t",
+					tabId,
+					"-p",
+					"#{cursor_y};#{cursor_x}",
+				]),
 			]);
-			// A non-zero exit is the common "benign race" path: when
-			// spawnSharedExec's `new-session -A` has just restarted tmux,
-			// the server socket may not be ready when capture-pane races
-			// it — tmux prints "no server running" and exits 1. Returning
-			// "" here means the client starts with a blank pane and the
-			// very next byte of live output redraws it. Intentional.
-			if (exitCode !== 0) return "";
+			// A non-zero exit on capture-pane is the common "benign race"
+			// path: when spawnSharedExec's `new-session -A` has just
+			// restarted tmux, the server socket may not be ready when
+			// capture-pane races it — tmux prints "no server running" and
+			// exits 1. Returning "" here means the client starts with a
+			// blank pane and the very next byte of live output redraws it.
+			// Intentional.
+			if (snap.exitCode !== 0) return "";
 			// execOneShot returns clean stdout (no PTY, no \r). For a screen
 			// dump xterm needs CRLF line terminators — add the \r back.
-			return stdout.replace(/\n/g, "\r\n");
+			const screen = snap.stdout.replace(/\n/g, "\r\n");
+			// Cursor positioning: tmux's #{cursor_x}/#{cursor_y} are 0-based
+			// (column-from-left, row-from-top of the pane). ANSI CUP
+			// (CSI <row>;<col> H) is 1-based. If the display-message call
+			// failed or returned an unparseable string (older tmux, quote
+			// stripping mishaps), we fall through and accept the trailing-
+			// newline drift rather than emitting a malformed escape.
+			if (cur.exitCode === 0) {
+				const m = cur.stdout.trim().match(/^(\d+);(\d+)$/);
+				if (m) {
+					const y = Number.parseInt(m[1]!, 10) + 1;
+					const x = Number.parseInt(m[2]!, 10) + 1;
+					return `${screen}\x1b[${y};${x}H`;
+				}
+			}
+			return screen;
 		} catch (err) {
 			logger.warn(
 				`[docker] capture-pane failed for ${this.targetKey(sessionId, tabId)}: ${(err as Error).message}`,

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -900,6 +900,11 @@ export class DockerManager {
 			// in sync with tmux from the first character.
 			const [snap, cur] = await Promise.all([
 				this.execOneShot(sessionId, ["tmux", "capture-pane", "-t", tabId, "-p", "-e"]),
+				// Wrap in .catch so a display-message exception (e.g. container
+				// dies between the two execs) degrades to "no cursor escape"
+				// rather than rejecting the whole Promise.all and dropping a
+				// perfectly valid capture-pane snapshot. Same shape of fallback
+				// as exitCode !== 0 below.
 				this.execOneShot(sessionId, [
 					"tmux",
 					"display-message",
@@ -907,7 +912,7 @@ export class DockerManager {
 					tabId,
 					"-p",
 					"#{cursor_y};#{cursor_x}",
-				]),
+				]).catch(() => ({ stdout: "", exitCode: 1 })),
 			]);
 			// A non-zero exit on capture-pane is the common "benign race"
 			// path: when spawnSharedExec's `new-session -A` has just


### PR DESCRIPTION
Follow-up to #166. User reports the URL-params fix landed cleanly (cols look right, sidebar-toggle workaround no longer required for width), but a new symptom is visible: typed input appears one row *below* the visible prompt right after session select — until something prods tmux into a redraw.

## Root cause

\`capture-pane -p -e\` emits row content separated by \`\\n\`. Our code converts those to \`\\r\\n\` so xterm advances rows as it renders. With 24 rows of (mostly empty) content + the trailing \`\\n\`, xterm's local cursor ends one row *past* the last content row.

tmux's own cursor (the shell's actual cursor on row 1 col 3) is unchanged. The protocol relies on tmux to emit a CUP escape that re-syncs xterm's cursor to where the shell's is. tmux's resize-driven redraw normally does that — but on a quiet pane (no content beyond the prompt at row 1), the redraw is minimal and may not emit a cursor-position escape at all. xterm keeps its stale cursor position.

When the user then types, the shell echoes the byte at tmux's actual cursor (row 1 col 3). xterm receives the byte and writes it at xterm's local cursor (one row below the last replay row, e.g. row 25). User sees "text appearing one row below the prompt" and a blinking xterm cursor in the wrong row.

Toggling the sidebar masks it because the fresh resize triggers a more substantial redraw that does include a cursor-position escape.

## Fix

Run \`tmux display-message -p '#{cursor_y};#{cursor_x}'\` in parallel with \`capture-pane\` (same round-trip cost) and append an explicit ANSI CUP escape to the replay. xterm's cursor now lands where tmux thinks it is from the first byte — typed input renders on the right row, no resize prod required.

If \`display-message\` fails or returns an unparseable string we accept the existing trailing-newline drift rather than emit a malformed escape — same fallback as today.

## Test plan
- [x] \`npm run build\` (backend) passes
- [x] \`npm test\` — 201 tests pass (no regressions)
- [x] Biome clean
- [ ] Manual: hard refresh → click session → first tab auto-opens → type \`ls\`; characters render on the prompt row, no offset
- [ ] Manual: reconnect after a WS drop (Cloudflare Tunnel idle) — replay still positions cursor correctly
- [ ] Manual: alt-buffer apps (vim, claude interactive) — entering and exiting alt buffer doesn't desync (alt buffer has its own cursor handling, the CUP escape we append targets the regular pane buffer)

## Deploy
Backend-only change (\`dockerManager.ts\`). Redeploy on the host:

    cd /path/to/shared-terminal
    git pull origin main
    docker compose up -d --build

Cloudflare Pages doesn't need to redeploy — frontend is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)