### PR TITLE
fix(terminal): drop convertEol so Ink's bare \n keeps column

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -58,7 +58,18 @@ export function openTerminalSession(opts: {
 		lineHeight: 1.2,
 		cursorBlink: true,
 		cursorInactiveStyle: "outline",
-		convertEol: true,
+		// `convertEol` (default false in xterm) was previously `true`, which
+		// rewrote every standalone \n into \r\n on write. tmux, bash, and
+		// most TUIs already emit \r\n where they want both line-feed and
+		// carriage-return; the option was harmless for them. But Ink
+		// (Claude CLI's renderer) emits standalone \n in places where it
+		// wants pure line-feed — keep cursor in the same column on the next
+		// row — and tracks cursor state assuming that behaviour. With
+		// convertEol:true xterm moved the cursor to col 1 instead of
+		// preserving the column, so Ink's next absolute write landed in a
+		// cell it didn't expect: visible as "after typing for a while in
+		// claude, text jumps to the next row and stays one row off". Default
+		// false matches what Ink (and standard TUI conventions) expect.
 		allowProposedApi: true,
 		// Apps like Claude Code emit OSC 8 hyperlink escapes. xterm renders
 		// them (underline + pointer cursor) but needs an explicit handler


### PR DESCRIPTION
Follow-up to #167. With cursor positioning fixed at attach time, the user reports a remaining symptom: in claude CLI specifically (plain bash is fine), after typing a few characters and pausing, the typed text jumps to the next row and the offset stays.

## Diagnosis

The trigger fingerprints to xterm's \`convertEol\` option. When \`convertEol: true\` is set (and we had it on since the initial commit), xterm rewrites every standalone \`\\n\` it receives into \`\\r\\n\` on \`write()\`. tmux, bash, and most TUIs explicitly emit \`\\r\\n\` where they want both effects, so the option is a no-op for them. **Ink** — Claude CLI's renderer, used for the input box and TUI layout — emits standalone \`\\n\` in places where it expects pure line-feed semantics: cursor moves down one row, **stays at the same column**. With our \`convertEol: true\` xterm was moving the cursor to col 1 instead. Ink's subsequent absolute writes landed in a cell it didn't expect; the visible result is the typed text appearing to jump rows.

The behaviour is cumulative — only manifests once Ink's internal cursor model has drifted enough — which matches the user's "after a few characters / a pause" trigger. It also matches "stays one row off after the jump": once Ink and xterm disagree, every subsequent write inherits the offset until something forces a full redraw (sidebar toggle, claude state change).

## Fix

Remove \`convertEol: true\` from the xterm config. xterm's default is \`false\`, which respects the standard distinction:
- \`\\n\` alone → cursor down, same column
- \`\\r\` alone → col 1, same row
- \`\\r\\n\` → both

Apps that emit proper \`\\r\\n\` (tmux/bash) are unaffected. Apps that emit bare \`\\n\` (Ink) get the semantics they expect.

The original \`convertEol: true\` was set in the initial \`feat: shared terminal service\` commit with no inline rationale beyond what looks like xterm-example copy-paste.

## Test plan
- [x] \`npm run build\` (frontend) passes
- [x] Biome clean
- [ ] Manual: open claude CLI, type a long-ish line, pause, keep typing — text stays on the prompt row, no jump
- [ ] Manual: plain bash regression — \`for i in {1..30}; do echo line $i; done\` — output renders correctly, no overlapping rows
- [ ] Manual: vim/htop — full-screen TUI rendering still correct (those apps emit \`\\r\\n\` explicitly, should be unaffected)
- [ ] Manual: paste a multi-line block — pasted lines don't collapse into a single row (they shouldn't; bracketed-paste wraps the bytes and tmux/shell handle the \`\\r\\n\`)

Frontend-only — Cloudflare Pages auto-deploys on merge. Backend doesn't need redeployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)