### PR TITLE
fix(layout): render tab bar before constructing first xterm

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -550,6 +550,27 @@ async function openSession(sessionId: string) {
 	// covering the top of the viewport.
 	if (isMobile()) setChromeOpen(false);
 
+	// Render the tab bar BEFORE calling openTab — disposeAllCurrentTerminals()
+	// at the top of openSession set #terminal-tabs to display:none, and
+	// openTab's own renderTabBar() runs at its tail (after the new pane has
+	// been mounted and openTerminalSession's synchronous fitAddon.fit() has
+	// already read pane dimensions). Without this pre-render the first auto-
+	// opened tab fits at the too-tall geometry of a tab-bar-less layout, the
+	// WS opens at that wrong cols/rows (geometry is baked into the upgrade
+	// URL — see terminal.ts buildWsUrl), and the backend's attach() / tmux
+	// resize-window runs at the wrong size. ResizeObserver corrects xterm
+	// locally on the next frame but the backend resize is debounced 100 ms,
+	// so the snapshot replay and the first ~100 ms of tmux output land at
+	// the wrong row count — visible as a one-row drift where typed input
+	// renders below where the prompt actually is, only fixable by a
+	// subsequent layout-changing event (sidebar toggle) that bumps tmux
+	// into a full repaint at the correct geometry. Subsequent openTab
+	// calls (chip clicks, +-add) don't hit this because the tabs row is
+	// already laid out by then. openTab's own renderTabBar() at its tail
+	// re-runs to mark the active chip — this pre-render just ensures the
+	// height is settled.
+	renderTabBar();
+
 	// openTab can throw synchronously (openTerminalSession init failure) —
 	// openSession is called with `void`, so an unhandled throw here would
 	// become an unhandled rejection with no toast and the UI left mid-switch.


### PR DESCRIPTION
## Summary

- The first tab auto-opened on session-select rendered with a one-row drift: typing landed a row below the prompt and only a sidebar toggle (or any other layout-changing event) cleared it. Diagnosed as a layout race in `openTab` — `fitAddon.fit()` ran while `#terminal-tabs` was still `display:none` (cleared by `disposeAllCurrentTerminals`), so xterm fit at the inflated geometry of a tab-bar-less layout and the WS opened at those wrong cols/rows (geometry is baked into the upgrade URL).
- ResizeObserver corrects xterm locally on the next frame but the backend resize is debounced 100 ms, so the snapshot replay and the first ~100 ms of tmux output landed at the wrong row count. Subsequent `openTab` calls (chip clicks, `+`-add) were already fine because the tabs row was laid out by then.
- Fix: render the tab bar in `openSession` before calling `openTab`, so `#terminal-container` is at its final height when `fit()` reads it. `openTab`'s own tail `renderTabBar()` still runs to mark the new chip active.

## Test plan

- [ ] Refresh, select a session — first auto-opened tab no longer drifts; type at the prompt and confirm input renders on the prompt's row, not one below.
- [ ] Verify on both bash and claude tabs.
- [ ] Sidebar toggle still works as a manual repaint.
- [ ] Switching to a second tab still has no drift.
- [ ] `+`-add a new tab — no regression in fit/attach.
- [ ] Mobile: chrome drawer still collapses on session-select; first tab fits correctly inside the visible viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)