### PR TITLE
fix(layout): drop overflow-x scrollbar from #terminal-tabs (#170)

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -775,8 +775,15 @@ main:not([data-sidebar-ready]) #sidebar {
   padding: 4px 8px 0 8px;
   background: #0d1117;
   border-bottom: 1px solid #30363d;
-  overflow-x: auto;
-  scrollbar-width: thin;
+  /* `overflow-x: clip` (not `auto`/`hidden`) — clip avoids establishing a
+     scroll container, so the previous thin horizontal scrollbar that ate
+     ~6 px from the ~32 px strip height (and visually jittered the chips
+     once it appeared) goes away. Chips that exceed the strip width are
+     simply not painted; reaching them needs a separate affordance
+     (wrap-to-row, fade+arrows, picker) which is intentionally out of
+     scope for this issue. `clip` over `hidden` because we don't want a
+     positioning context here either. */
+  overflow-x: clip;
   flex-shrink: 0;
 }
 .tab-chip {


### PR DESCRIPTION
Closes #170.

## Summary

- The tab strip's `overflow-x: auto; scrollbar-width: thin` painted a horizontal scrollbar across the ~32 px strip whenever the chips overflowed, eating ~6 px of strip height and visually jittering the chips when it appeared/disappeared.
- Switch to `overflow-x: clip`: chips that exceed the strip width simply aren't painted, no scrollbar is reserved or drawn, and we don't establish a scroll container as a side effect (`clip` over `hidden` for that reason).
- Reaching off-strip chips needs a separate affordance — wrap-to-row, fade-gradient with arrow buttons, or a picker dropdown. Intentionally out of scope; issue #170 is just removing the auto scrollbar.

## Test plan

- [ ] Open a session with few tabs (1–3): visual unchanged from main.
- [ ] Open many tabs (`+` until they overflow): no horizontal scrollbar appears in the strip; chips beyond the width are clipped at the right edge.
- [ ] Toggle the sidebar / change window width — strip doesn't reflow with a sudden scrollbar appearing/disappearing as it crosses the threshold.
- [ ] Verify the active chip's bottom-edge offset (`.tab-chip.active { top: 1px }`) still aligns with the terminal-container border below.
- [ ] Mobile: chrome drawer expand/collapse, tabs strip behaves the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)