### PR TITLE
fix(terminal): scroll xterm scrollback locally on desktop wheel/trackpad (#171)

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -425,7 +425,7 @@ export function openTerminalSession(opts: {
 		// long downward swipe followed by a short upward flick would have
 		// to "spend" the accumulated downward residue before any upward
 		// scroll registered, which feels broken at the input boundary.
-		if ((deltaPx < 0) !== (wheelResidue < 0)) wheelResidue = 0;
+		if (deltaPx < 0 !== wheelResidue < 0) wheelResidue = 0;
 		wheelResidue += deltaPx;
 		const lines = Math.trunc(wheelResidue / cellH);
 		if (lines !== 0) {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -407,6 +407,15 @@ export function openTerminalSession(opts: {
 	// the leftover pixels across events — same trick as the touch handler's
 	// `lastTouchY -= lines * cellH`.
 	let wheelResidue = 0;
+	// Known limitation: tmux copy-mode (Ctrl-b [) is *not* the alternate
+	// screen — `pane_in_mode` is tmux-internal state that doesn't propagate
+	// to xterm.buffer.active.type, so this handler still hits the main-buffer
+	// branch in copy-mode and scrolls xterm's own scrollback instead of
+	// driving copy-mode's cursor. The visible result is the scrollback
+	// moves while copy-mode's selection cursor stays frozen. Querying
+	// `#{pane_in_mode}` from the frontend would need a side-channel we
+	// don't have. Workaround for users in copy-mode: use keyboard
+	// navigation (arrow keys, Page Up/Down) instead of the wheel.
 	term.attachCustomWheelEventHandler((ev) => {
 		if (term.buffer.active.type === "alternate") return true;
 		const cellH = getCellHeight();
@@ -425,7 +434,12 @@ export function openTerminalSession(opts: {
 		// long downward swipe followed by a short upward flick would have
 		// to "spend" the accumulated downward residue before any upward
 		// scroll registered, which feels broken at the input boundary.
-		if (deltaPx < 0 !== wheelResidue < 0) wheelResidue = 0;
+		// Gate on `deltaPx !== 0` so a horizontal-only wheel event
+		// (`ev.deltaY === 0`, common on trackpads doing diagonal/sideways
+		// gestures) doesn't trip the reset: `0 < 0` is false, which would
+		// always look like "opposite sign" against any upward (negative)
+		// residue and silently discard it mid-gesture.
+		if (deltaPx !== 0 && deltaPx < 0 !== wheelResidue < 0) wheelResidue = 0;
 		wheelResidue += deltaPx;
 		const lines = Math.trunc(wheelResidue / cellH);
 		if (lines !== 0) {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -384,6 +384,57 @@ export function openTerminalSession(opts: {
 	container.addEventListener("touchend", onTouchEnd, { passive: true });
 	container.addEventListener("touchcancel", onTouchCancel, { passive: true });
 
+	// ── Wheel scroll ────────────────────────────────────────────────────────
+	// Desktop wheel/trackpad must scroll xterm's own scrollback in the main
+	// buffer instead of being swallowed by tmux's mouse-tracking. With
+	// `set -g mouse on` (session-image/tmux.conf) xterm's default behaviour
+	// is to forward wheel events as SGR mouse-tracking sequences. tmux's
+	// `WheelUpPane`/`WheelDownPane` bindings discard those when no app
+	// requested mouse and the alt buffer isn't active, so without
+	// intercepting here the wheel is silently dead in the bash main buffer
+	// (#171). The buffer split mirrors onTouchMove above:
+	//   - Main buffer: scroll xterm's own scrollback locally; `return false`
+	//     cancels xterm's default forward so the SGR sequence never goes
+	//     out and tmux never gets a chance to discard it.
+	//   - Alt buffer (vim, less, claude TUI, htop, …): `return true` lets
+	//     xterm forward as before — those apps consume mouse events for
+	//     their own UI (or rely on tmux's `alternate_on` branch in the
+	//     WheelUpPane binding to send-keys -M to them).
+	//
+	// Sub-cell residue: trackpad two-finger swipes deliver many small
+	// `deltaY` values, each <1 cell. Truncating each event in isolation
+	// would silently consume the swipe with no visible scroll. Accumulate
+	// the leftover pixels across events — same trick as the touch handler's
+	// `lastTouchY -= lines * cellH`.
+	let wheelResidue = 0;
+	term.attachCustomWheelEventHandler((ev) => {
+		if (term.buffer.active.type === "alternate") return true;
+		const cellH = getCellHeight();
+		let deltaPx: number;
+		switch (ev.deltaMode) {
+			case 1: // DOM_DELTA_LINE
+				deltaPx = ev.deltaY * cellH;
+				break;
+			case 2: // DOM_DELTA_PAGE
+				deltaPx = ev.deltaY * cellH * term.rows;
+				break;
+			default: // DOM_DELTA_PIXEL — what trackpads and most mice emit
+				deltaPx = ev.deltaY;
+		}
+		// Reset the residue if the user reverses direction — otherwise a
+		// long downward swipe followed by a short upward flick would have
+		// to "spend" the accumulated downward residue before any upward
+		// scroll registered, which feels broken at the input boundary.
+		if ((deltaPx < 0) !== (wheelResidue < 0)) wheelResidue = 0;
+		wheelResidue += deltaPx;
+		const lines = Math.trunc(wheelResidue / cellH);
+		if (lines !== 0) {
+			wheelResidue -= lines * cellH;
+			term.scrollLines(lines);
+		}
+		return false;
+	});
+
 	// ── Resize ──────────────────────────────────────────────────────────────
 	// ResizeObserver fires continuously during mobile viewport churn (URL
 	// bar show/hide, soft-keyboard open/close, rotation) and desktop


### PR DESCRIPTION
Closes #171.

## Summary

- `set -g mouse on` in tmux.conf made xterm forward wheel events to tmux as SGR mouse-tracking. tmux's `WheelUpPane`/`WheelDownPane` bindings only re-emit `send-keys -M` when the pane is in copy-mode / the app requested mouse / the alt buffer is active — otherwise they do nothing. xterm had already swallowed the wheel into mouse-tracking output by then, so its own scrollback-scroll never fired and the bash main buffer was structurally unscrollable on desktop.
- Intercept via `term.attachCustomWheelEventHandler`. Main buffer → `term.scrollLines()` + `return false` (SGR sequence never leaves the browser). Alt buffer → `return true` (let xterm forward as before; vim/less/claude/htop handle wheel themselves or via tmux's `alternate_on` branch).
- Trackpad two-finger swipes emit many sub-cell `deltaY` events. Accumulate the leftover pixels across events with a direction-reversal reset so a downward-then-upward gesture starts scrolling on the first upward event rather than spending the accumulated downward residue first. Same residue trick as the touch handler's `lastTouchY -= lines * cellH`.

## Known limitation (documented inline)

tmux copy-mode (`Ctrl-b [`) is **not** the alternate screen — `pane_in_mode` is tmux-internal state with no DOM-side reflection on `term.buffer.active.type`. In copy-mode this handler still scrolls xterm's local scrollback, and copy-mode's cursor stays frozen. Workaround for users in copy-mode: keyboard navigation (arrow keys, Page Up/Down). Comment block above the handler explains.

## Test plan

- [ ] **Bash main buffer, mouse wheel:** scroll up — older lines from xterm's 5000-line scrollback come into view; scroll down — return to the prompt.
- [ ] **Bash main buffer, trackpad two-finger swipe (macOS):** small/slow swipes scroll smoothly with no "dead frames"; reversing direction starts scrolling immediately.
- [ ] **Bash main buffer, horizontal-only swipe:** `deltaY === 0` events don't reset accumulated vertical residue mid-gesture (`deltaPx !== 0 &&` guard).
- [ ] **Alt-buffer apps (vim, htop, less, `claude`):** wheel still drives the app's own scroll/cursor (vim moves the cursor row, htop scrolls the process list, less scrolls the file).
- [ ] **Mobile (touch):** unchanged — `attachCustomWheelEventHandler` only fires on wheel events; the existing touch handler keeps doing its thing.
- [ ] **Modifier keys:** `Shift+wheel` and `Ctrl+wheel` still behave reasonably — they emit wheel events too, but the handler only consumes `deltaY` for scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)