### PR TITLE
fix(terminal): preserve viewport on output writes during scrollback/selection (#157)

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -208,6 +208,34 @@ export function openTerminalSession(opts: {
 	};
 	container.addEventListener("pointerdown", focusOnPointer);
 
+	// ── Scrollback / selection preservation ────────────────────────────────
+	// xterm auto-tracks output to the bottom of the buffer (cursor follows
+	// what tmux/the shell writes). When the user is either parked in
+	// scrollback OR holding a live selection, that auto-track yanks the
+	// viewport away from whatever they were reading mid-stream — every
+	// fresh byte of `tail -f`, a streaming build log, or a claude TUI
+	// pulse snaps the screen back to the prompt and erases their place
+	// (#157).
+	//
+	// Track scrollback parking via `term.onScroll` (the buffer geometry
+	// is `viewportY < baseY` whenever the user has scrolled up — at
+	// bottom both equal `baseY`), check `term.hasSelection()` at write
+	// time for selection state, and if either is true capture the
+	// pre-write viewport line and restore it from `term.write`'s
+	// parser-drained callback.
+	//
+	// Restoring from the callback (not synchronously after the call)
+	// is load-bearing: xterm parses input asynchronously, so a sync
+	// read of `viewportY` right after `term.write()` returns can land
+	// before the parser has applied the cursor moves the new bytes
+	// caused. The callback fires once the bytes have actually been
+	// written and the auto-snap (if any) has happened.
+	let userScrolled = false;
+	const scrollDisposable = term.onScroll(() => {
+		const buf = term.buffer.active;
+		userScrolled = buf.viewportY < buf.baseY;
+	});
+
 	// ── WebSocket connection ────────────────────────────────────────────────
 	// Auth lives in an httpOnly cookie (#18). Browsers send cookies on the
 	// WS upgrade to the cookie's domain automatically — no token needs to
@@ -249,9 +277,30 @@ export function openTerminalSession(opts: {
 		}
 
 		switch (msg.type) {
-			case "output":
-				term.write(msg.data);
+			case "output": {
+				// Fast path when the user is at the bottom with no selection:
+				// no callback, no closure allocation, identical to the prior
+				// behaviour for the common case (user typing at the prompt).
+				const wasOffBottom = userScrolled || term.hasSelection();
+				if (!wasOffBottom) {
+					term.write(msg.data);
+					break;
+				}
+				const yBefore = term.buffer.active.viewportY;
+				term.write(msg.data, () => {
+					// Re-check at parser-drain time: a user who scrolled
+					// back to the bottom or cleared their selection during
+					// the parse window shouldn't get pinned to a stale
+					// viewport. (Selection clears synchronously on click;
+					// scroll fires its own onScroll, which already updated
+					// `userScrolled`.)
+					if (!userScrolled && !term.hasSelection()) return;
+					if (term.buffer.active.viewportY !== yBefore) {
+						term.scrollToLine(yBefore);
+					}
+				});
 				break;
+			}
 			case "status":
 				onStatus(msg.status);
 				break;
@@ -585,6 +634,7 @@ export function openTerminalSession(opts: {
 		container.removeEventListener("touchcancel", onTouchCancel);
 		inputDisposable.dispose();
 		linkProviderDisposable.dispose();
+		scrollDisposable.dispose();
 		pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
 		container.removeEventListener("webglcontextlost", onContextLost);
 		webgl?.dispose();


### PR DESCRIPTION
Closes #157.

## Summary

- xterm auto-tracks output to the bottom of the buffer. When the user is parked in scrollback or has a live selection, every fresh byte of `tail -f`, a streaming build log, or a claude TUI pulse snapped the viewport back to the prompt and erased their place.
- Track scrollback parking via `term.onScroll` (`viewportY < baseY` whenever the user has scrolled up), check `term.hasSelection()` at write time, and if either is true capture the pre-write viewport line and restore it from `term.write`'s parser-drained callback. Restoring from the callback (not sync after the call) is load-bearing — xterm parses asynchronously, so a sync read after `write()` can fire before the cursor moves the new bytes caused are applied.
- Re-check both flags at callback time so a user who scrolled to the bottom or cleared their selection during the parse window isn't pinned to a stale viewport.
- Fast path: when `!userScrolled && !hasSelection()` we use plain `term.write(data)` — no callback closure overhead for the common "user typing at the prompt" case.

## Out of scope (per issue body)

- xterm's own auto-scroll while *actively* drag-selecting past the viewport edge — that's a deliberate xterm UX and our handler doesn't try to fight it.

## Test plan

- [ ] **Scrollback parked:** in bash, run `for i in $(seq 1 200); do echo "line $i"; sleep 0.05; done &`, then scroll up while it streams — viewport stays where you parked it; after the loop ends, scroll back down to bottom and confirm output continues to track.
- [ ] **Live selection at bottom:** while output is streaming, click-drag to select a few words near the prompt — selection stays visible and viewport doesn't jump on the next byte. Click outside to clear; viewport snaps back to bottom on the next output.
- [ ] **Live selection in scrollback:** scroll up, select inside scrollback, let output continue — both the viewport AND the highlight stay anchored to where you selected.
- [ ] **Mid-parse-window state change:** scroll up, then very quickly scroll back to the bottom while output is mid-burst — viewport ends up at the bottom (no false pin).
- [ ] **Alt-buffer apps (vim, claude TUI, htop):** unchanged — alt buffer has no scrollback (`baseY === 0`), so `userScrolled` stays `false`; selection inside an alt buffer behaves the same as before.
- [ ] **WebGL renderer:** all the above still work with the canvas renderer (the change is buffer-state level, not paint-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)