### PR TITLE
fix(terminal): atlas-clear and shrink-bypass on resize (#155, re-apply of #159)

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -556,7 +556,49 @@ export function openTerminalSession(opts: {
 				/* container detached mid-resize */
 			}
 			if (term.cols !== lastSentCols || term.rows !== lastSentRows) {
-				sendResizeDebounced();
+				// Soft-keyboard slide-in, URL bar reveal, font-size cycle, and
+				// rotation can all narrow xterm to fewer rows/cols mid-stream.
+				// Two failure modes (#155):
+				//
+				//   1. WebGL atlas stale — at a different cell pixel height
+				//      (font-size cycle, DPR change while we were fitting),
+				//      cached glyph textures don't align with the new grid;
+				//      tmux's repaint lands on top of misaligned cells and
+				//      leaves duplicated rows / ghost glyphs visible until
+				//      the next visibility change.
+				//   2. Backend lag on shrink — tmux is still painting at the
+				//      OLD size for the duration of the debounce window.
+				//      Anything it writes past the new bottom row lands on
+				//      cells xterm has already reflowed away. Bypassing the
+				//      debounce in the shrink direction tells tmux to resize
+				//      now so it stops over-painting; growth still coalesces
+				//      because nothing on the wire goes wrong if tmux paints
+				//      at a SMALLER size than xterm has already reflowed to.
+				//
+				// History note: this block was originally landed in #159 and
+				// reverted in #163 during a debugging session attributing
+				// "text outside input lines" / "Mac wheel dead" to it. Those
+				// symptoms have since been traced to other root causes —
+				// #169 (first-tab fit-before-tab-bar layout race) and #173
+				// (tmux mouse-on consuming wheel events) — and fixed
+				// independently. Re-applying with that diagnostic context.
+				const shrinking = term.rows < lastSentRows || term.cols < lastSentCols;
+				try {
+					webgl?.clearTextureAtlas();
+				} catch {
+					webgl?.dispose();
+					webgl = null;
+				}
+				term.refresh(0, term.rows - 1);
+				if (shrinking) {
+					if (resizeSendTimer !== null) clearTimeout(resizeSendTimer);
+					resizeSendTimer = null;
+					lastSentCols = term.cols;
+					lastSentRows = term.rows;
+					send({ type: "resize", cols: term.cols, rows: term.rows });
+				} else {
+					sendResizeDebounced();
+				}
 			}
 		});
 	};
@@ -575,6 +617,14 @@ export function openTerminalSession(opts: {
 	// row repaints.
 	const onVisibilityChange = () => {
 		if (document.hidden) return;
+		// scheduleFit's rAF will atlas-clear + refresh too, but only if the
+		// fit detects a dimension change. The synchronous pair below covers
+		// the no-change case — tab hidden then restored at the same size,
+		// where the GPU may still need a fresh atlas (DPR change, OS font-
+		// smoothing toggle) and the canvas needs a repaint to flush rows
+		// that streamed in while rAF was throttled. The double-fire on the
+		// dimension-change path is harmless: refresh is idempotent and
+		// atlas clear is cheap.
 		scheduleFit();
 		try {
 			webgl?.clearTextureAtlas();


### PR DESCRIPTION
Closes #155.

## Summary

- Soft-keyboard slide-in, URL-bar reveal, font-size cycle, and rotation can all narrow xterm to fewer rows/cols mid-stream. Two failure modes left ghost glyphs / duplicated rows visible until the next visibility change:
  1. **WebGL atlas stale.** At a different cell pixel height (font-size cycle, DPR change while fitting), cached glyph textures don't align with the new grid; tmux's repaint lands on misaligned cells.
  2. **Backend lag on shrink.** tmux keeps painting at the OLD size for the 100 ms debounce window, so anything past the new bottom row lands on cells xterm has already reflowed away.
- After every dimension-changing fit: drop the WebGL atlas + `term.refresh()`, then if shrinking send `{type:"resize"}` immediately (cancel any pending debounce). Growth still coalesces — nothing on the wire goes wrong if tmux paints at a smaller size than xterm reflowed to.
- Cross-reference comment in `onVisibilityChange`: its synchronous atlas-clear + refresh stays for the no-dimension-change case (tab hidden then restored at the same size, where DPR / font-smoothing may still need a fresh atlas).

## History — important context for review

This block was originally landed in **#159** and reverted in **#163** during a debugging session that attributed two reported symptoms — *"text outside input lines"* and *"Mac wheel scroll dead"* — to it. Both symptoms have since been traced to **other** root causes and fixed independently:

- *Text outside input lines* → first-tab `fit()` ran before the tab bar was laid out, so xterm fit at the wrong row count. Fixed in **#169** (`fix(layout): render tab bar before constructing first xterm`).
- *Mac wheel scroll dead* → tmux's `set -g mouse on` consumed wheel events into SGR mouse-tracking before xterm's local scrollback could fire. Fixed in **#173** (`fix(terminal): scroll xterm scrollback locally on desktop wheel/trackpad`).

So #159's actual fix wasn't proven to be the cause of those symptoms; it was the suspect that got reverted as a debugging step. Re-applying the same diff with that context explicit in the commit message.

## Test plan

- [ ] **Mobile soft-keyboard mid-stream (the original repro):** in a session running `seq 1 200 | while read i; do echo "line $i"; sleep 0.1; done`, tap an input on the page (or focus the address bar) to slide the keyboard in — xterm shrinks; verify no ghost rows or duplicated lines remain after the keyboard finishes its slide.
- [ ] **URL-bar reveal mid-stream (mobile Safari/Chrome):** same loop running, scroll up to reveal the URL bar — viewport shrinks; verify clean repaint.
- [ ] **Font-size cycle (`Aa` button):** while output is streaming, tap font-size to bump up/down — cell pixel height changes; verify glyphs render sharp at the new size with no leftovers from the old size.
- [ ] **Desktop window resize:** drag the browser window edge to grow then shrink — both directions land cleanly. Growth still coalesces (no flood of `{type:"resize"}` over the wire on a smooth drag).
- [ ] **Visibility change:** tab away, wait for some output, tab back — `onVisibilityChange`'s synchronous pair fires; subsequent fits do their own atlas-clear; both paths coexist without flicker.
- [ ] **Watch for the originally-suspected symptoms:** confirm "text outside input lines" and "Mac wheel scroll" still work correctly (they should — those root causes are gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)