### PR TITLE
fix(terminal): wheel in alt buffer enters tmux copy-mode for pane history

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -434,64 +434,61 @@ export function openTerminalSession(opts: {
 	container.addEventListener("touchcancel", onTouchCancel, { passive: true });
 
 	// ── Wheel scroll ────────────────────────────────────────────────────────
-	// Desktop wheel/trackpad routing matches the touch handler's buffer-type
-	// split, with a cell-pixel residue accumulator so trackpad two-finger
-	// swipes don't drop sub-cell deltas. With `set -g mouse on`
-	// (session-image/tmux.conf) xterm's default would forward wheel events
-	// as SGR mouse-tracking sequences; tmux's `WheelUpPane`/`WheelDownPane`
-	// bindings then discard or re-emit them depending on `pane_in_mode` /
-	// `mouse_any_flag` / `alternate_on`. We intercept ahead of that:
+	// Desktop wheel/trackpad routing pairs with the WheelUpPane/WheelDownPane
+	// bindings in `session-image/tmux.conf`. xterm's default with
+	// `set -g mouse on` is to forward wheel events as SGR mouse-tracking; we
+	// intercept ahead of that:
 	//
 	//   - Main buffer (shell): scroll xterm's own scrollback via
 	//     `scrollLines`. `return false` cancels xterm's forward so the SGR
-	//     sequence never leaves the browser (#171).
-	//   - Alt buffer (claude TUI, less, htop, vim, …): synthesise Up/Down
-	//     arrow keys, mirroring `onTouchMove`. Every TUI navigates with
-	//     arrows; relying on mouse-tracking for alt-buffer scroll only
-	//     worked for apps that explicitly handle SGR mouse (vim, htop) —
-	//     for claude / Ink-based TUIs the forwarded event landed on the
-	//     floor and the user couldn't scroll at all. Trade-off: in vim
-	//     this means wheel moves the cursor instead of scrolling the
-	//     viewport; that's the same trade-off the touch path has shipped
-	//     with for months.
+	//     sequence never leaves the browser, and tmux can't discard it
+	//     (#171).
+	//   - Alt buffer (claude TUI, less, vim, htop, …): `return true`. Let
+	//     xterm forward as SGR mouse-tracking and let tmux's WheelUpPane
+	//     binding decide. tmux now routes that into copy-mode for apps
+	//     that don't request mouse (claude / Ink) so the user reaches the
+	//     pane history; vim/htop still get `send-keys -M` because they
+	//     set `mouse_any_flag`. See the binding rationale in tmux.conf.
+	//     Earlier attempts to synthesise arrow keys here (#176) ended up
+	//     navigating the *input* line history (readline-style) for claude
+	//     instead of scrolling the rendered output, so this path was
+	//     reverted to forward-and-let-tmux-handle.
 	//
-	// Line-mode sensitivity: `WheelEvent.deltaMode === 1` (a notched mouse
-	// reporting in lines) typically delivers `deltaY === 1` per notch.
-	// Without a sensitivity multiplier that became one-line-per-notch,
-	// far slower than the OS-typical 3 lines/notch and the convention
-	// xterm's own `scrollSensitivity` config defaults users towards.
-	// Multiplier applies ONLY to line-mode — pixel-mode events (Magic
-	// Mouse, trackpads, modern smooth-scroll mice) already deliver
-	// pixel chunks that divide naturally into multiple lines via
-	// `cellH`, and amplifying those would make a casual flick scroll
-	// hundreds of rows.
-	const WHEEL_LINE_SENSITIVITY = 3;
-	// Cap arrow-key bursts in the alt buffer. Mirrors the touch-handler
-	// cap so a fast wheel flick doesn't synthesise a hundred arrows in
-	// a single frame and queue keypresses past the user's actual gesture.
-	const MAX_ARROWS_PER_EVENT = 20;
+	// Sensitivity: notched mice can deliver either `DOM_DELTA_LINE`
+	// (`deltaY === 1` per notch) or `DOM_DELTA_PIXEL` (`deltaY` close to
+	// `cellH` per notch). Both produced one-line-per-notch with a 1×
+	// multiplier, far slower than the OS-typical ~3 lines/notch. Apply a
+	// shared multiplier to both modes. Trackpad smooth-scroll (many
+	// small `DOM_DELTA_PIXEL` events) is amplified too, but the residue
+	// accumulator and small per-event `deltaY` keep the felt speed
+	// reasonable in practice; tunable up/down here without touching the
+	// rest of the handler.
+	const WHEEL_SENSITIVITY = 3;
 	let wheelResidue = 0;
 	// Known limitation: tmux copy-mode (Ctrl-b [) is *not* the alternate
 	// screen — `pane_in_mode` is tmux-internal state that doesn't propagate
-	// to xterm.buffer.active.type, so this handler still hits the main-buffer
-	// branch in copy-mode and scrolls xterm's own scrollback instead of
-	// driving copy-mode's cursor. The visible result is the scrollback
-	// moves while copy-mode's selection cursor stays frozen. Querying
+	// to `xterm.buffer.active.type`. When the user has manually entered
+	// copy-mode from the main buffer, this handler still scrolls xterm's
+	// own scrollback instead of driving copy-mode's cursor. Querying
 	// `#{pane_in_mode}` from the frontend would need a side-channel we
-	// don't have. Workaround for users in copy-mode: use keyboard
-	// navigation (arrow keys, Page Up/Down) instead of the wheel.
+	// don't have. Workaround for users in main-buffer copy-mode: arrow
+	// keys / Page Up/Down inside copy-mode instead of the wheel.
 	term.attachCustomWheelEventHandler((ev) => {
+		// Alt buffer → forward to xterm's default; tmux's binding takes it
+		// from there. Keep the early return *before* residue accounting so
+		// switching buffers mid-gesture doesn't carry residue across modes.
+		if (term.buffer.active.type === "alternate") return true;
 		const cellH = getCellHeight();
 		let deltaPx: number;
 		switch (ev.deltaMode) {
 			case 1: // DOM_DELTA_LINE
-				deltaPx = ev.deltaY * cellH * WHEEL_LINE_SENSITIVITY;
+				deltaPx = ev.deltaY * cellH * WHEEL_SENSITIVITY;
 				break;
 			case 2: // DOM_DELTA_PAGE
 				deltaPx = ev.deltaY * cellH * term.rows;
 				break;
-			default: // DOM_DELTA_PIXEL — what trackpads and most mice emit
-				deltaPx = ev.deltaY;
+			default: // DOM_DELTA_PIXEL — what trackpads and most modern mice emit
+				deltaPx = ev.deltaY * WHEEL_SENSITIVITY;
 		}
 		// Reset the residue if the user reverses direction — otherwise a
 		// long downward swipe followed by a short upward flick would have
@@ -507,16 +504,7 @@ export function openTerminalSession(opts: {
 		const lines = Math.trunc(wheelResidue / cellH);
 		if (lines === 0) return false;
 		wheelResidue -= lines * cellH;
-		if (term.buffer.active.type === "alternate") {
-			const n = Math.min(Math.abs(lines), MAX_ARROWS_PER_EVENT);
-			// `lines > 0` = scroll down (toward newer content) → Down
-			// arrow `\x1b[B`; negative = up → `\x1b[A`. Same direction
-			// convention as `onTouchMove`'s alt-buffer branch.
-			const key = lines > 0 ? "\x1b[B" : "\x1b[A";
-			send({ type: "input", data: key.repeat(n) });
-		} else {
-			term.scrollLines(lines);
-		}
+		term.scrollLines(lines);
 		return false;
 	});
 

--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -42,20 +42,38 @@ unbind -n MouseDown3StatusLeft
 unbind -n MouseDown3StatusRight
 unbind -n M-MouseDown3Pane
 
-# Rebind wheel scroll so it uses xterm.js's native scrollback in the shell
-# (main buffer) rather than entering tmux copy-mode. Pass the event through
-# when any of these are true:
-#   #{pane_in_mode}    — already in copy-mode, keep scrolling
-#   #{mouse_any_flag}  — app requested xterm mouse (vim, htop, …); let app handle it
-#   #{alternate_on}    — alt-screen app without mouse (less, man, git diff, …);
-#                        forward to the app via send-keys -M; less/man handle
-#                        xterm mouse scroll natively without copy-mode
+# Rebind wheel scroll. The frontend (terminal.ts attachCustomWheelEventHandler)
+# scrolls xterm's local scrollback for the main buffer and never forwards mouse-
+# tracking, so this binding only fires when the pane is on the alt screen (or
+# when the user has manually entered copy-mode). Branches:
+#
+#   #{pane_in_mode}    — already in copy-mode, keep scrolling: send-keys -M
+#                        forwards the wheel as mouse-tracking which tmux
+#                        interprets as scroll-up/down inside the mode.
+#   #{mouse_any_flag}  — app requested xterm mouse (vim, htop, claude with
+#                        explicit mouse, …) — forward via send-keys -M so the
+#                        app handles wheel itself.
+#   #{alternate_on}    — alt-screen app that did NOT request mouse (claude
+#                        TUI / Ink, less, man, git diff, …). Previously this
+#                        also forwarded via send-keys -M on the assumption
+#                        less/man handled mouse natively, but that left
+#                        Ink-based TUIs (claude) with no way to access the
+#                        rendered output's history at all. Enter copy-mode -e
+#                        and scroll-up by a small chunk; subsequent wheel
+#                        events take the `pane_in_mode` branch above and
+#                        keep scrolling. `-e` makes copy-mode auto-exit
+#                        when the user scrolls back to the bottom, so it
+#                        feels transient. Trade-off: less/man lose their
+#                        native wheel-scroll; their built-in keys (j/k,
+#                        Ctrl-D/Ctrl-U, space/b) still work.
 bind -n WheelUpPane \
-  if-shell -F "#{||:#{pane_in_mode},#{||:#{mouse_any_flag},#{alternate_on}}}" \
+  if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
     "send-keys -M" \
-    ""
+    "if-shell -F '#{alternate_on}' \
+      'copy-mode -e ; send-keys -M' \
+      ''"
 bind -n WheelDownPane \
-  if-shell -F "#{||:#{pane_in_mode},#{||:#{mouse_any_flag},#{alternate_on}}}" \
+  if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
     "send-keys -M" \
     ""
 


### PR DESCRIPTION
Follow-up to #176 (which got the alt-buffer behaviour wrong).

## Why

#176 synthesised Up/Down arrows in the alt buffer to give claude users *something* in response to the wheel, but Up/Down at claude's prompt navigates the **readline-style input history** (past prompts the user typed), not the **output history** (what claude said back). The user wants pane scrollback — every byte that's been rendered, which is exactly tmux's `history-limit 50000` pane buffer.

## Changes

**`frontend/src/terminal.ts`**

- Alt buffer returns to `return true` (forward mouse-tracking and let tmux's wheel binding decide).
- Sensitivity multiplier now applies to **both** `DOM_DELTA_LINE` and `DOM_DELTA_PIXEL` modes — notched mice that report in pixel mode (one cell-height of `deltaY` per notch) were giving exactly one line per notch despite #176; bumping pixel mode to 3× brings them in line. Trackpad smooth-scroll is amplified ~3×; the residue accumulator keeps it feeling sane in practice but the constant is in one place if it needs tuning down.

**`session-image/tmux.conf`**

Split the previous unified `alternate_on` branch:

- `mouse_any_flag` (vim / htop / claude-with-explicit-mouse) → `send-keys -M` (forward, app handles wheel).
- `pane_in_mode` (already in copy-mode) → `send-keys -M` (continue scrolling).
- `alternate_on` AND not the above (claude TUI / Ink, less, man, git diff, …) → **`copy-mode -e ; send-keys -M`** — enter copy-mode and forward the same wheel event so tmux interprets it as a scroll. `-e` makes copy-mode auto-exit when scrolled back to the bottom, so the mode feels transient.

Validated with `tmux source-file` on tmux 3.4 (the version Ubuntu 24.04 ships in the session image).

## Trade-off

less / man lose their native wheel-scroll-the-app behaviour and now scroll tmux's pane history instead. Their built-in keys (j/k, Ctrl-D/Ctrl-U, space/b) still work for in-app navigation. You explicitly accepted this in the design Q&A — flagging it again here for the record.

## Deploy friction

tmux.conf changes only take effect for sessions started **after** `docker build -t shared-terminal-session ./session-image` rebuilds the image (or `cd backend && npm run docker:build-session` per CLAUDE.md). Existing sessions retain the old binding until restart, so to test you'll need to either rebuild + open a new session, or `tmux source-file ~/.tmux.conf` inside an existing session's main pane.

## Test plan

- [ ] **Rebuild session image and start a new session.** Old sessions won't pick this up.
- [ ] **Claude TUI:** wheel up — older claude responses scroll into view from tmux's pane history. Wheel back down to the bottom — copy-mode auto-exits (`-e`).
- [ ] **Bash, notched mouse:** wheel scrolls roughly 3 lines per notch — both line-mode and pixel-mode mice should now feel similar.
- [ ] **Bash, trackpad / Magic Mouse:** smooth scroll feels ~3× faster than before. If this is too fast, ping back; the constant is `WHEEL_SENSITIVITY` in `terminal.ts`.
- [ ] **vim:** wheel still scrolls vim's own buffer (vim sets `mouse_any_flag`).
- [ ] **htop:** wheel still selects rows in htop (htop sets `mouse_any_flag`).
- [ ] **less:** **changed** — wheel now scrolls tmux pane history, not less's own view. Use `j/k/Ctrl-D/Ctrl-U` for in-less navigation.
- [ ] **man:** same as less.
- [ ] **claude with explicit mouse mode** (if such a thing ships in a future claude version): would set `mouse_any_flag` and bypass the copy-mode branch.
- [ ] **Manual copy-mode** (`Ctrl-b [`) in bash main buffer: still works as before; subsequent wheels scroll within copy-mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)