### PR TITLE
fix(terminal): use pre-write flag for output viewport restore (regression in #157)

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -287,14 +287,23 @@ export function openTerminalSession(opts: {
 					break;
 				}
 				const yBefore = term.buffer.active.viewportY;
+				// Use the pre-write `wasOffBottom` for the restore decision —
+				// NOT a re-check at callback time. xterm's auto-track-to-bottom
+				// during the write fires `onScroll`, which our listener
+				// reads as `viewportY === baseY` and sets `userScrolled =
+				// false`. From inside `onScroll` there's no signal to
+				// distinguish that auto-snap from a user-initiated scroll-
+				// down, so re-checking inside the callback always sees the
+				// auto-snapped state and skips the restore — yanking the
+				// user back to the bottom on every output frame. The
+				// captured `wasOffBottom` is the only source of truth that
+				// survives the parse window; the trade-off is a user who
+				// genuinely scrolls back to the bottom mid-parse will be
+				// briefly restored to `yBefore` for ~one write before the
+				// next call's `wasOffBottom` correctly reads `false`. That
+				// edge case is far less disruptive than the previous bug
+				// (every output write snapped scroll-back to bottom).
 				term.write(msg.data, () => {
-					// Re-check at parser-drain time: a user who scrolled
-					// back to the bottom or cleared their selection during
-					// the parse window shouldn't get pinned to a stale
-					// viewport. (Selection clears synchronously on click;
-					// scroll fires its own onScroll, which already updated
-					// `userScrolled`.)
-					if (!userScrolled && !term.hasSelection()) return;
 					if (term.buffer.active.viewportY !== yBefore) {
 						term.scrollToLine(yBefore);
 					}


### PR DESCRIPTION
Hot-fix to the regression I introduced in #157 and you found while testing #177.

## Symptom

On bash main buffer, wheel-up only scrolls ~3 lines before snapping back to the bottom. Repro: run any continuous-output command (`seq 1 200` with a `sleep`, `tail -f`, claude streaming output) and try to scroll up while it streams. Same on idle bash if anything triggers an output write at all.

## Cause

#157 was supposed to keep the viewport parked while output streams. The shipped code re-checked `userScrolled || hasSelection()` inside the parser-drained callback as an "improvement" over the issue body's original sketch — and the re-check is structurally unable to do its job:

1. User wheels up → `term.scrollLines(-3)` → `onScroll` fires → `userScrolled = true`.
2. Output write begins. xterm auto-tracks to bottom *during* the write, which fires `onScroll` from inside `term.write()`.
3. Our `onScroll` handler reads `viewportY === baseY` and sets `userScrolled = false`.
4. Parser drains; callback fires; re-check `!userScrolled && !hasSelection()` is true → returns without restoring.
5. User is at the bottom again.

From inside `onScroll` there is no signal that distinguishes the auto-snap from a user-initiated scroll-down, so the re-check always sees the auto-snapped state.

## Fix

Use the pre-write `wasOffBottom` (captured before `term.write`) as the sole gate for the restore. That's what the issue body's original sketch did; my "improvement" was wrong.

```diff
const yBefore = term.buffer.active.viewportY;
term.write(msg.data, () => {
-    if (!userScrolled && !term.hasSelection()) return;
    if (term.buffer.active.viewportY !== yBefore) {
        term.scrollToLine(yBefore);
    }
});
```

**Trade-off:** a user who genuinely scrolls back to the bottom *during* the parse window will be briefly restored to `yBefore` for one write, before the next call's fresh `wasOffBottom` correctly reads `false`. That edge case is orders of magnitude less disruptive than the existing bug (every output frame nuked the scroll).

## Notes for the meta-record

The bot LGTM'd #157 — exactly the "bot LGTM ≠ correct for behavioural/UI bugs" failure mode that's already a saved feedback memory in this project. Re-checking the runtime state mid-callback *felt* defensive but bypassed the load-bearing invariant the captured value provides.

## Test plan

- [ ] **Repro the bug:** in bash, `for i in $(seq 1 500); do echo "line $i"; sleep 0.05; done`, then wheel up while it streams. Pre-fix: viewport snaps back to bottom on every line. Post-fix: viewport stays parked, line count keeps climbing in the background.
- [ ] **After the loop ends:** scroll back down to bottom, confirm output continues to track.
- [ ] **Live selection while output streams:** drag-select a few words above the prompt. The selection stays visible and viewport doesn't jump.
- [ ] **Ordinary "user at bottom":** unchanged — `wasOffBottom = false` → fast path with no callback.
- [ ] **No regression on the alt buffer scroll path** (#177): claude / less / man wheel-up still routes through tmux copy-mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)