### PR TITLE
fix(terminal): route all wheel scroll through tmux copy-mode

### DIFF
--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -349,9 +349,9 @@ export function openTerminalSession(opts: {
 	//    or tmux copy-mode.
 	//  - Main buffer (shell): we still call `term.scrollLines` here, but
 	//    *that's a no-op in this stack* — see the wheel comment block
-	//    below and the `project_tmux_xterm_scrollback.md` rationale.
-	//    tmux manages the pane in-place, so xterm's local scrollback
-	//    stays empty regardless of how much output has rendered. The
+	//    below for the full rationale. tmux manages the pane in-place,
+	//    so xterm's local scrollback stays empty regardless of how much
+	//    output has rendered. The
 	//    real fix is to route this through tmux copy-mode the same way
 	//    the wheel path now does (forward as SGR mouse-tracking and let
 	//    tmux's `WheelUpPane` binding handle it), but synthesising

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -343,14 +343,24 @@ export function openTerminalSession(opts: {
 	// finger drags aren't forwarded as anything useful. We translate the
 	// drag into terminal scroll:
 	//
-	//  - Main buffer (shell prompt, command output): scroll xterm's own
-	//    scrollback with `scrollLines`. Users expect to pull older lines
-	//    back into view; we don't involve tmux at all, so there's no weird
-	//    copy-mode dance.
 	//  - Alt buffer (vim, less, Claude Code, htop, …): synthesise
 	//    up/down arrow keys. Every TUI app responds to arrows, so the
 	//    user can navigate without needing mouse-wheel support in the app
 	//    or tmux copy-mode.
+	//  - Main buffer (shell): we still call `term.scrollLines` here, but
+	//    *that's a no-op in this stack* — see the wheel comment block
+	//    below and the `project_tmux_xterm_scrollback.md` rationale.
+	//    tmux manages the pane in-place, so xterm's local scrollback
+	//    stays empty regardless of how much output has rendered. The
+	//    real fix is to route this through tmux copy-mode the same way
+	//    the wheel path now does (forward as SGR mouse-tracking and let
+	//    tmux's `WheelUpPane` binding handle it), but synthesising
+	//    mouse-tracking from touch coordinates is a bigger change —
+	//    tracked separately. The current call is left in place so the
+	//    finger-drag still suppresses xterm's drag-selection handler
+	//    (preventDefault above), which on mobile is the more visible
+	//    misbehaviour to avoid; users just won't see scrollback move
+	//    until that follow-up lands.
 	//
 	// Direction follows iOS/Android convention — content tracks the
 	// finger: drag up → view moves up → scroll toward newer (bottom).

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -234,13 +234,6 @@ export function openTerminalSession(opts: {
 	const scrollDisposable = term.onScroll(() => {
 		const buf = term.buffer.active;
 		userScrolled = buf.viewportY < buf.baseY;
-		// DEBUG (#178 follow-up). Remove once diagnosed.
-		console.log("[scroll-debug] onScroll", {
-			viewportY: buf.viewportY,
-			baseY: buf.baseY,
-			userScrolled,
-			bufType: buf.type,
-		});
 	});
 
 	// ── WebSocket connection ────────────────────────────────────────────────
@@ -450,122 +443,28 @@ export function openTerminalSession(opts: {
 	container.addEventListener("touchcancel", onTouchCancel, { passive: true });
 
 	// ── Wheel scroll ────────────────────────────────────────────────────────
-	// Desktop wheel/trackpad routing pairs with the WheelUpPane/WheelDownPane
-	// bindings in `session-image/tmux.conf`. xterm's default with
-	// `set -g mouse on` is to forward wheel events as SGR mouse-tracking; we
-	// intercept ahead of that:
+	// xterm's default with `set -g mouse on` (session-image/tmux.conf) is
+	// to forward wheel events as SGR mouse-tracking sequences. tmux's
+	// `WheelUpPane` / `WheelDownPane` bindings then decide what to do —
+	// see the rationale block above those bindings in tmux.conf.
 	//
-	//   - Main buffer (shell): scroll xterm's own scrollback via
-	//     `scrollLines`. `return false` cancels xterm's forward so the SGR
-	//     sequence never leaves the browser, and tmux can't discard it
-	//     (#171).
-	//   - Alt buffer (claude TUI, less, vim, htop, …): `return true`. Let
-	//     xterm forward as SGR mouse-tracking and let tmux's WheelUpPane
-	//     binding decide. tmux now routes that into copy-mode for apps
-	//     that don't request mouse (claude / Ink) so the user reaches the
-	//     pane history; vim/htop still get `send-keys -M` because they
-	//     set `mouse_any_flag`. See the binding rationale in tmux.conf.
-	//     Earlier attempts to synthesise arrow keys here (#176) ended up
-	//     navigating the *input* line history (readline-style) for claude
-	//     instead of scrolling the rendered output, so this path was
-	//     reverted to forward-and-let-tmux-handle.
+	// We deliberately do NOT register `term.attachCustomWheelEventHandler`.
+	// Earlier attempts (#171/#173, #176, #177) tried to drive
+	// `term.scrollLines()` against xterm's local scrollback for the main
+	// buffer, then alt-buffer arrow synthesis, then a hybrid. None worked
+	// because **tmux manages the pane in-place**: when content fills the
+	// pane height tmux scrolls in place via cursor-move + write escapes,
+	// so bytes never flow off the top of xterm's buffer and xterm's
+	// scrollback (`scrollback: 5000` above) effectively stays empty —
+	// confirmed empirically with debug logs in PR #179 (`baseY === 0`,
+	// `length === rows`, scroll calls all no-op). Pane history lives in
+	// tmux only (`history-limit 50000`), reachable only via tmux
+	// copy-mode. Letting xterm forward and tmux's bindings decide is the
+	// correct routing for every scenario; the frontend has nothing to
+	// add. Touch handling stays separate because there's no
+	// mouse-tracking to forward into on touch.
 	//
-	// Sensitivity: notched mice can deliver either `DOM_DELTA_LINE`
-	// (`deltaY === 1` per notch) or `DOM_DELTA_PIXEL` (`deltaY` close to
-	// `cellH` per notch). Both produced one-line-per-notch with a 1×
-	// multiplier, far slower than the OS-typical ~3 lines/notch. Apply a
-	// shared multiplier to both modes. Trackpad smooth-scroll (many
-	// small `DOM_DELTA_PIXEL` events) is amplified too, but the residue
-	// accumulator and small per-event `deltaY` keep the felt speed
-	// reasonable in practice; tunable up/down here without touching the
-	// rest of the handler.
-	const WHEEL_SENSITIVITY = 3;
-	let wheelResidue = 0;
-	// Known limitation: tmux copy-mode (Ctrl-b [) is *not* the alternate
-	// screen — `pane_in_mode` is tmux-internal state that doesn't propagate
-	// to `xterm.buffer.active.type`. When the user has manually entered
-	// copy-mode from the main buffer, this handler still scrolls xterm's
-	// own scrollback instead of driving copy-mode's cursor. Querying
-	// `#{pane_in_mode}` from the frontend would need a side-channel we
-	// don't have. Workaround for users in main-buffer copy-mode: arrow
-	// keys / Page Up/Down inside copy-mode instead of the wheel.
-	term.attachCustomWheelEventHandler((ev) => {
-		// DEBUG (#178 follow-up): user reports wheel does nothing in bash
-		// despite scrollback content. Log every wheel event + the buffer/
-		// scroll state so we can see whether the handler fires, what
-		// values the browser delivers, and whether `term.scrollLines`
-		// has any visible effect on `viewportY`. Remove once diagnosed.
-		const _bufBefore = term.buffer.active;
-		const _yBefore = _bufBefore.viewportY;
-		const _baseBefore = _bufBefore.baseY;
-		const _bufType = _bufBefore.type;
-		// Alt buffer → forward to xterm's default; tmux's binding takes it
-		// from there. Keep the early return *before* residue accounting so
-		// switching buffers mid-gesture doesn't carry residue across modes.
-		if (term.buffer.active.type === "alternate") {
-			console.log("[wheel-debug] ALT-BUFFER forward", {
-				deltaMode: ev.deltaMode,
-				deltaY: ev.deltaY,
-				bufType: _bufType,
-			});
-			return true;
-		}
-		const cellH = getCellHeight();
-		let deltaPx: number;
-		switch (ev.deltaMode) {
-			case 1: // DOM_DELTA_LINE
-				deltaPx = ev.deltaY * cellH * WHEEL_SENSITIVITY;
-				break;
-			case 2: // DOM_DELTA_PAGE
-				deltaPx = ev.deltaY * cellH * term.rows;
-				break;
-			default: // DOM_DELTA_PIXEL — what trackpads and most modern mice emit
-				deltaPx = ev.deltaY * WHEEL_SENSITIVITY;
-		}
-		// Reset the residue if the user reverses direction — otherwise a
-		// long downward swipe followed by a short upward flick would have
-		// to "spend" the accumulated downward residue before any upward
-		// scroll registered, which feels broken at the input boundary.
-		// Gate on `deltaPx !== 0` so a horizontal-only wheel event
-		// (`ev.deltaY === 0`, common on trackpads doing diagonal/sideways
-		// gestures) doesn't trip the reset: `0 < 0` is false, which would
-		// always look like "opposite sign" against any upward (negative)
-		// residue and silently discard it mid-gesture.
-		if (deltaPx !== 0 && deltaPx < 0 !== wheelResidue < 0) wheelResidue = 0;
-		wheelResidue += deltaPx;
-		const lines = Math.trunc(wheelResidue / cellH);
-		if (lines === 0) {
-			console.log("[wheel-debug] no-op", {
-				deltaMode: ev.deltaMode,
-				deltaY: ev.deltaY,
-				cellH,
-				deltaPx,
-				wheelResidue,
-				lines,
-				bufType: _bufType,
-				yBefore: _yBefore,
-				baseBefore: _baseBefore,
-			});
-			return false;
-		}
-		wheelResidue -= lines * cellH;
-		term.scrollLines(lines);
-		const _bufAfter = term.buffer.active;
-		console.log("[wheel-debug] scrollLines", {
-			deltaMode: ev.deltaMode,
-			deltaY: ev.deltaY,
-			cellH,
-			deltaPx,
-			lines,
-			bufType: _bufType,
-			yBefore: _yBefore,
-			yAfter: _bufAfter.viewportY,
-			baseBefore: _baseBefore,
-			baseAfter: _bufAfter.baseY,
-			scrolled: _bufAfter.viewportY !== _yBefore,
-		});
-		return false;
-	});
+	// `getCellHeight` (defined above) is still used by the touch handler.
 
 	// ── Resize ──────────────────────────────────────────────────────────────
 	// ResizeObserver fires continuously during mobile viewport churn (URL

--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -42,10 +42,10 @@ unbind -n MouseDown3StatusLeft
 unbind -n MouseDown3StatusRight
 unbind -n M-MouseDown3Pane
 
-# Rebind wheel scroll. The frontend (terminal.ts attachCustomWheelEventHandler)
-# scrolls xterm's local scrollback for the main buffer and never forwards mouse-
-# tracking, so this binding only fires when the pane is on the alt screen (or
-# when the user has manually entered copy-mode). Branches:
+# Rebind wheel scroll. The frontend (terminal.ts) deliberately does not
+# attach a custom wheel handler — xterm's default forwards every wheel
+# event as SGR mouse-tracking and these bindings decide what to do.
+# Branches:
 #
 #   #{pane_in_mode}    — already in copy-mode, keep scrolling: send-keys -M
 #                        forwards the wheel as mouse-tracking which tmux
@@ -53,25 +53,28 @@ unbind -n M-MouseDown3Pane
 #   #{mouse_any_flag}  — app requested xterm mouse (vim, htop, claude with
 #                        explicit mouse, …) — forward via send-keys -M so the
 #                        app handles wheel itself.
-#   #{alternate_on}    — alt-screen app that did NOT request mouse (claude
-#                        TUI / Ink, less, man, git diff, …). Previously this
-#                        also forwarded via send-keys -M on the assumption
-#                        less/man handled mouse natively, but that left
-#                        Ink-based TUIs (claude) with no way to access the
-#                        rendered output's history at all. Enter copy-mode -e
-#                        and scroll-up by a small chunk; subsequent wheel
-#                        events take the `pane_in_mode` branch above and
-#                        keep scrolling. `-e` makes copy-mode auto-exit
-#                        when the user scrolls back to the bottom, so it
-#                        feels transient. Trade-off: less/man lose their
-#                        native wheel-scroll; their built-in keys (j/k,
-#                        Ctrl-D/Ctrl-U, space/b) still work.
+#   else (main buffer with no mouse-app, OR alt buffer with no mouse-app
+#                        — claude TUI / Ink, less, man, git diff, plain
+#                        bash, …): enter copy-mode and forward the same
+#                        wheel event so tmux interprets it as a scroll.
+#                        `-e` makes copy-mode auto-exit when the user
+#                        scrolls back to the bottom, so the mode feels
+#                        transient. This is the only way to reach pane
+#                        history in this stack, because tmux manages the
+#                        pane in-place — content never flows off the top
+#                        of xterm's buffer, so xterm's local scrollback
+#                        stays empty regardless of how much output has
+#                        rendered. tmux's `history-limit 50000` is the
+#                        only history available; copy-mode is the only
+#                        way to navigate it.
+#
+# Trade-off: less/man lose their native wheel-scroll-the-app behaviour
+# and now scroll tmux's pane history instead. Their built-in keys (j/k,
+# Ctrl-D/Ctrl-U, space/b) still work for in-app navigation.
 bind -n WheelUpPane \
   if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
     "send-keys -M" \
-    "if-shell -F '#{alternate_on}' \
-      'copy-mode -e ; send-keys -M' \
-      ''"
+    "copy-mode -e ; send-keys -M"
 bind -n WheelDownPane \
   if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
     "send-keys -M" \


### PR DESCRIPTION
Real fix after the diagnostic landed in #179.

## Why

The debug logs from #179 confirmed: **xterm's local scrollback is structurally empty** in this stack regardless of how much output has rendered. tmux manages the pane in-place — when content fills the pane height it scrolls in place via cursor-move + write escapes, so bytes never flow off the top of xterm's buffer. Empirically: `term.buffer.active.baseY === 0` across many \`df -h\` runs, every \`term.scrollLines()\` call reporting \`scrolled: false\`.

That makes everything from #171/#173, #176, #177's main-buffer branch structurally a no-op: scroll a buffer that's always empty. Pane history lives in tmux only (\`history-limit 50000\`), reachable exclusively through tmux copy-mode.

## Changes

**\`frontend/src/terminal.ts\`** — drop \`attachCustomWheelEventHandler\` entirely.

- xterm's default forwards every wheel event as SGR mouse-tracking, which is the right routing.
- Removes the debug \`console.log\` lines from #179.
- The selection-/scrollback-preserving output write path stays (#157/#178). \`userScrolled\` will remain false in this stack but \`hasSelection()\` keeps the path relevant.

**\`session-image/tmux.conf\`** — collapse the two non-mouse branches into one.

Old: \`pane_in_mode || mouse_any_flag\` → \`send-keys -M\`; \`alternate_on\` → \`copy-mode -e ; send-keys -M\`; main buffer with no mouse-app → no-op (broken).

New: \`pane_in_mode || mouse_any_flag\` → \`send-keys -M\`; **everything else** → \`copy-mode -e ; send-keys -M\`. Main buffer and alt buffer alike now reach tmux pane history via the wheel. \`-e\` makes copy-mode auto-exit when the user scrolls back to the bottom, so it feels transient.

Touch handler unchanged — it has its own arrow-synthesis path because there's no mouse-tracking to forward into on touch.

## Trade-off (already discussed)

less / man lose their native wheel-scroll-the-app behaviour and now scroll tmux's pane history instead. Their built-in keys (\`j/k\`, \`Ctrl-D/Ctrl-U\`, \`space/b\`) still work for in-app navigation. You explicitly accepted this in earlier design Q&A.

## Deploy friction

tmux.conf changes need a session-image rebuild (\`docker build -t shared-terminal-session ./session-image\` or \`cd backend && npm run docker:build-session\`) and a **new session**. Existing sessions cache the old binding.

## Test plan

- [ ] Rebuild session image and start a new session.
- [ ] **Bash main buffer:** run \`for i in \$(seq 1 200); do echo \"line \$i\"; done\` to fill the pane, then wheel up. tmux enters copy-mode and scrolls back through the rendered history; copy-mode auto-exits when wheeling back to the bottom.
- [ ] **Claude TUI:** wheel up — older claude responses scroll into view (same path as bash, both pass through copy-mode now).
- [ ] **vim with mouse-mode:** wheel still scrolls vim's own buffer (vim sets \`mouse_any_flag\`).
- [ ] **htop:** wheel still selects rows in htop.
- [ ] **less:** wheel now scrolls tmux pane history (changed from before). Use \`j/k/Ctrl-D/Ctrl-U\` for in-less navigation.
- [ ] **No console spam:** debug logs from #179 are gone — devtools should stay quiet on wheel events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)