### PR TITLE
fix(tmux): explicit scroll-up on auto-entry so first wheel actually scrolls

### DIFF
--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -71,10 +71,18 @@ unbind -n M-MouseDown3Pane
 # Trade-off: less/man lose their native wheel-scroll-the-app behaviour
 # and now scroll tmux's pane history instead. Their built-in keys (j/k,
 # Ctrl-D/Ctrl-U, space/b) still work for in-app navigation.
+# Note on the else branch: `copy-mode -e ; send-keys -M` looked right but
+# in practice the first wheel just silently enters copy-mode without
+# scrolling — the original mouse event doesn't carry over into the
+# just-entered mode. Use the explicit `send-keys -X -N 3 scroll-up`
+# form so the first wheel both enters copy-mode AND scrolls a chunk
+# the user can see. Subsequent wheel events take the `pane_in_mode`
+# branch above and use `send-keys -M`, which works once the mode is
+# already active.
 bind -n WheelUpPane \
   if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
     "send-keys -M" \
-    "copy-mode -e ; send-keys -M"
+    "copy-mode -e ; send-keys -X -N 3 scroll-up"
 bind -n WheelDownPane \
   if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
     "send-keys -M" \

--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -55,30 +55,34 @@ unbind -n M-MouseDown3Pane
 #                        app handles wheel itself.
 #   else (main buffer with no mouse-app, OR alt buffer with no mouse-app
 #                        — claude TUI / Ink, less, man, git diff, plain
-#                        bash, …): enter copy-mode and forward the same
-#                        wheel event so tmux interprets it as a scroll.
-#                        `-e` makes copy-mode auto-exit when the user
-#                        scrolls back to the bottom, so the mode feels
-#                        transient. This is the only way to reach pane
-#                        history in this stack, because tmux manages the
-#                        pane in-place — content never flows off the top
-#                        of xterm's buffer, so xterm's local scrollback
-#                        stays empty regardless of how much output has
-#                        rendered. tmux's `history-limit 50000` is the
-#                        only history available; copy-mode is the only
-#                        way to navigate it.
+#                        bash, …): WheelUpPane enters copy-mode -e and
+#                        explicitly issues `send-keys -X -N 3 scroll-up`.
+#                        We can't use `send-keys -M` here (forward the
+#                        original wheel event) because the event doesn't
+#                        carry into the just-entered mode — the first
+#                        wheel would silently enter copy-mode with no
+#                        visible scroll, and we have no status bar to
+#                        surface the mode change. The explicit scroll
+#                        gives the first wheel an immediately-visible
+#                        chunk; subsequent wheels match `pane_in_mode`
+#                        and use `send-keys -M` which works fine once
+#                        the mode is already active. `-e` makes
+#                        copy-mode auto-exit when the user scrolls back
+#                        to the bottom, so the mode feels transient.
+#                        WheelDownPane in this branch is a no-op `""`:
+#                        outside copy-mode there's nothing below the
+#                        live pane to scroll into.
+#
+# This is the only way to reach pane history in this stack, because
+# tmux manages the pane in-place — content never flows off the top
+# of xterm's buffer, so xterm's local scrollback stays empty
+# regardless of how much output has rendered. tmux's
+# `history-limit 50000` is the only history available; copy-mode is
+# the only way to navigate it.
 #
 # Trade-off: less/man lose their native wheel-scroll-the-app behaviour
 # and now scroll tmux's pane history instead. Their built-in keys (j/k,
 # Ctrl-D/Ctrl-U, space/b) still work for in-app navigation.
-# Note on the else branch: `copy-mode -e ; send-keys -M` looked right but
-# in practice the first wheel just silently enters copy-mode without
-# scrolling — the original mouse event doesn't carry over into the
-# just-entered mode. Use the explicit `send-keys -X -N 3 scroll-up`
-# form so the first wheel both enters copy-mode AND scrolls a chunk
-# the user can see. Subsequent wheel events take the `pane_in_mode`
-# branch above and use `send-keys -M`, which works once the mode is
-# already active.
 bind -n WheelUpPane \
   if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" \
     "send-keys -M" \


### PR DESCRIPTION
Follow-up to #180 — user-tested and the auto-entry path was broken in a subtle way.

## Why

After #180, the user reported that wheel-up in plain bash still did nothing. Diagnostic with \`tmux list-keys -T root WheelUpPane\` confirmed the new binding was loaded, and \`Ctrl-b [\` followed by wheel-up scrolled correctly inside copy-mode. So the chain was fine end-to-end **once already in copy-mode**, but auto-entry from plain bash didn't visibly scroll on the first wheel notch.

Root cause: \`copy-mode -e ; send-keys -M\` looks right but in practice the original wheel event doesn't carry into the just-entered copy-mode. The first wheel silently enters copy-mode, no scroll happens, and we have no tmux status bar (\`set -g status off\`) to surface that the mode changed — so it reads as "wheel does nothing".

## Fix

Replace \`send-keys -M\` with an explicit \`send-keys -X -N 3 scroll-up\` in the else branch. The first wheel both enters copy-mode AND scrolls 3 lines in one shot — immediately visible. Subsequent wheels still take the \`pane_in_mode\` branch above and use \`send-keys -M\`, which works fine once the mode is active.

\`-N 3\` matches OS-typical "3 lines per notch" scroll feel.

## Trade-off

Same scope as #180 — none new. less/man still scroll tmux pane history rather than their own view (already accepted in earlier design).

## Deploy friction

tmux.conf only — same dance: rebuild session image (\`cd backend && npm run docker:build-session\`) and **start a new session**.

## Test plan

- [ ] Rebuild session image, start a fresh session.
- [ ] **Bash main buffer:** wheel up — pane history scrolls back ~3 lines per notch from the very first notch. Wheel back down to the bottom — copy-mode auto-exits via \`-e\`.
- [ ] **Claude TUI:** wheel up — older claude responses scroll into view, same path.
- [ ] **vim with mouse-mode:** unchanged, wheel still scrolls vim's own buffer.
- [ ] **Manual Ctrl-b [:** still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)