### PR TITLE
debug: status bar showing wheel-binding state (do not merge)

### DIFF
--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -21,11 +21,19 @@ set -g focus-events on
 # to apps that use them (neovim, fzf, …)
 set -g extended-keys on
 
-# Hide the tmux status bar. The frontend renders its own tab strip, so the
-# status bar just steals a terminal row — applications inside tmux believe they
-# have (cols × (rows-1)) cells and everything reflows one row too short. With
-# status off, the full xterm viewport is available to the running program.
-set -g status off
+# DEBUG: temporarily ON so we can read pane_in_mode / scroll_position /
+# mouse_any_flag / alternate_on live while diagnosing why wheel-up doesn't
+# auto-enter copy-mode + scroll for the user. status-interval 1 makes
+# the values refresh every second so they're visible in real time. To
+# revert, restore `set -g status off` and drop the status-right /
+# status-interval / status-left lines.
+set -g status on
+set -g status-interval 1
+set -g status-style 'bg=#1e1e2e fg=#cdd6f4'
+set -g status-left ''
+set -g status-left-length 0
+set -g status-right 'mode=#{pane_in_mode} scroll=#{scroll_position} mouse_any=#{mouse_any_flag} alt=#{alternate_on}'
+set -g status-right-length 80
 
 # Enable mouse so TUI apps (vim, htop, …) can receive click/drag events.
 set -g mouse on


### PR DESCRIPTION
Diagnostic-only, draft. Not for merge.

Adds tmux status bar with live values for the wheel-binding diagnosis:

    mode=#{pane_in_mode} scroll=#{scroll_position} mouse_any=#{mouse_any_flag} alt=#{alternate_on}

Refreshes every second (`status-interval 1`).

## How to test on your machine

```bash
git checkout debug/wheel-status-bar
cd backend && npm run docker:build-session
```

Then start a new session in the UI. You'll see a status bar at the bottom with the four values. Wheel up in plain bash and watch them tick — that tells us whether the binding fires (`mode=1` and `scroll>0` if it does) or whether wheel events never reach tmux (values stay at `mode=0 scroll=`).

## After diagnosis

Drop this branch — don't merge. Once we know what's broken we'll ship a real fix and you can revert by restoring `set -g status off` (or just rebuilding off main again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)