### PR TITLE
fix(tmux): replace debug status bar with minimal copy-mode indicator

### DIFF
--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -21,19 +21,34 @@ set -g focus-events on
 # to apps that use them (neovim, fzf, …)
 set -g extended-keys on
 
-# DEBUG: temporarily ON so we can read pane_in_mode / scroll_position /
-# mouse_any_flag / alternate_on live while diagnosing why wheel-up doesn't
-# auto-enter copy-mode + scroll for the user. status-interval 1 makes
-# the values refresh every second so they're visible in real time. To
-# revert, restore `set -g status off` and drop the status-right /
-# status-interval / status-left lines.
+# Status bar — always on, minimal. The wheel-up binding below auto-enters
+# tmux copy-mode to give the user access to pane history (xterm's local
+# scrollback is structurally empty in this stack — tmux manages the pane
+# in-place; see WheelUpPane comment block below). Without a status bar
+# there's no visible cue you're now scrolling history rather than at the
+# live prompt — diagnosed via debug PR #183 where the user reported
+# "scroll doesn't work" until the status bar was visible (it had been
+# working all along, just invisible).
+#
+# Cost: one row of pane height. Apps inside tmux see (cols × rows-1)
+# cells, which they handle via SIGWINCH on resize. Worth it for the
+# scroll-history visibility.
+#
+# Display strategy: empty when not in copy-mode (just the styled bar at
+# the bottom edge), `[Copy N/M]` on the right when in copy-mode where
+# N is `scroll_position` and M is `history_size`. status-interval 1 so
+# `scroll_position` updates while the user is actively scrolling.
+# Window-status segments are blanked so the centre stays empty too.
 set -g status on
 set -g status-interval 1
-set -g status-style 'bg=#1e1e2e fg=#cdd6f4'
+set -g status-style 'bg=#0d1117 fg=#8b949e'
 set -g status-left ''
 set -g status-left-length 0
-set -g status-right 'mode=#{pane_in_mode} scroll=#{scroll_position} mouse_any=#{mouse_any_flag} alt=#{alternate_on}'
-set -g status-right-length 80
+set -g status-right '#{?pane_in_mode,[Copy #{scroll_position}/#{history_size}],}'
+set -g status-right-length 30
+set -g window-status-format ''
+set -g window-status-current-format ''
+set -g window-status-separator ''
 
 # Enable mouse so TUI apps (vim, htop, …) can receive click/drag events.
 set -g mouse on


### PR DESCRIPTION
After #183's diagnostic confirmed the wheel binding works correctly, replace the debug status bar with the minimal final form.

## Why

The "scroll doesn't work" reports through #182 / #180 were actually "scroll happens but I can't tell I'm in copy-mode" — with \`status off\` there was no visible cue to distinguish plain bash from copy-mode scrolling pane history. The debug status bar in #183 surfaced \`pane_in_mode\` and \`scroll_position\` and revealed the binding had been firing all along.

## Final shape

- \`status-right\` shows \`[Copy N/M]\` only when \`pane_in_mode\` is true (\`scroll_position\` / \`history_size\`); empty otherwise.
- \`status-style\` \`bg=#0d1117 fg=#8b949e\` matches the app's dark theme so the bar reads as a thin baseline rather than visual noise.
- Window-name segments blanked (\`window-status-format\`, \`window-status-current-format\`, \`window-status-separator\`) so the centre stays empty too.
- \`status-interval 1\` so the scroll counter updates live while the user wheels.

## Trade-off (already accepted in design Q&A)

One row of pane height is now reserved unconditionally. Apps inside tmux see \`(cols × rows-1)\`; SIGWINCH on resize handles that — same way apps handle any pane resize. Worth it for the scroll-history visibility now that the wheel is the only way to reach pane history.

## Verified locally

\`\`\`
NOT in copy-mode: status-right = ''
IN copy-mode (after scroll-up 3): status-right = '[Copy 3/77]'
\`\`\`

## Deploy friction

tmux.conf only — same as the previous tmux PRs:

\`\`\`bash
git pull origin main
cd backend && npm run docker:build-session
\`\`\`

Then start a new session.

## Test plan

- [ ] Fresh session: bottom row shows a thin styled bar with no text on the right (status-right empty).
- [ ] Wheel up in plain bash: \`[Copy N/M]\` appears on the right; pane history scrolls; \`N\` increments per wheel notch.
- [ ] Wheel back down to bottom: indicator disappears; pane returns to live view (auto-exit via \`-e\`).
- [ ] Run vim / htop / claude: status bar stays visible (one row reserved); wheel inside vim/htop scrolls their own UI as before; wheel inside claude enters copy-mode and shows the indicator.
- [ ] Run \`stty size\` inside bash: rows is one less than the xterm row count — that's the row reserved for the status bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)