### PR TITLE
fix(layout): hide xterm-viewport scrollbar (no scrollback to scroll)

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -891,6 +891,20 @@ main:not([data-sidebar-ready]) #sidebar {
 #terminal-container .xterm-screen {
   touch-action: none;
 }
+/* Hide xterm.js's built-in viewport scrollbar. xterm's local scrollback
+   is structurally empty in our stack — tmux manages the pane in-place
+   so bytes never flow off the top of xterm's buffer (see WheelUpPane
+   comment block in session-image/tmux.conf for the full rationale).
+   The scrollbar that xterm draws unconditionally for `overflow-y:
+   scroll` therefore reflects nothing scrollable; it's visual noise
+   and has no use. `overflow-y: hidden !important` (with !important
+   because xterm.js's own stylesheet sets `scroll`) hides it and
+   short-circuits the native scroll path. Pane history navigation
+   happens through tmux copy-mode (entered automatically on wheel-up
+   per the WheelUpPane binding), not xterm-viewport scroll. */
+#terminal-container .xterm-viewport {
+  overflow-y: hidden !important;
+}
 #empty-state {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

xterm.js draws a viewport scrollbar unconditionally because its default \`overflow-y: scroll\` rule reserves space for one. In our stack xterm's local scrollback is structurally empty — tmux manages the pane in-place, so bytes never flow off the top of xterm's buffer. The scrollbar therefore represents nothing scrollable; it's visual noise on the right edge of every pane.

Override with \`overflow-y: hidden !important\` on \`#terminal-container .xterm-viewport\`. The \`!important\` is load-bearing — xterm.js's own stylesheet would otherwise win specificity. Pane history navigation goes through tmux copy-mode (entered automatically by the WheelUpPane binding); the xterm-viewport scrollbar was never the right mechanism for it.

## Test plan

- [ ] Right edge of every terminal pane: no scrollbar.
- [ ] Wheel up in plain bash: still enters tmux copy-mode and scrolls (the wheel handler doesn't depend on xterm-viewport's overflow).
- [ ] Wheel up in claude TUI / less / man: same.
- [ ] vim / htop: still receive wheel events for their own scroll.
- [ ] Touch on mobile (current arrow-synthesis path): unchanged — that path doesn't go through xterm-viewport scroll either. (Mobile bash main-buffer touch is being addressed separately in #181.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)