### PR TITLE
feat(terminal): auto-copy on selection-finalise + clipboard feedback (#158 layers 1+2)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -823,6 +823,7 @@ function openTab(tabId: string) {
 					if (tabId !== currentActiveTabId) return;
 					if (!ok) showToast("Copy failed — clipboard permission denied?", true);
 				},
+				isActive: () => activeSessionId === ownSessionId && tabId === currentActiveTabId,
 			});
 			entry = { pane, term };
 			currentTerminals.set(tabId, entry);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -813,10 +813,14 @@ function openTab(tabId: string) {
 					// Failure-only toast policy: silent on success matches
 					// the native Cmd-C feel and avoids flooding the user
 					// with chips on every selection-finalize (#158).
-					// Active-session guard so a stale copy attempt from a
-					// torn-down tab doesn't toast against whatever session
-					// is current now.
+					// Identity guards mirror onStatus / onError above:
+					// session match prevents stale toasts from a
+					// torn-down tab in a different session, and active-tab
+					// match prevents a background tab in the SAME session
+					// from toasting against whatever pane the user is
+					// currently looking at.
 					if (activeSessionId !== ownSessionId) return;
+					if (tabId !== currentActiveTabId) return;
 					if (!ok) showToast("Copy failed — clipboard permission denied?", true);
 				},
 			});

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -809,6 +809,16 @@ function openTab(tabId: string) {
 					// because the terminal still works, just slower.
 					showToast(`${msg} Reload the tab to retry GPU rendering.`);
 				},
+				onCopy: (ok: boolean) => {
+					// Failure-only toast policy: silent on success matches
+					// the native Cmd-C feel and avoids flooding the user
+					// with chips on every selection-finalize (#158).
+					// Active-session guard so a stale copy attempt from a
+					// torn-down tab doesn't toast against whatever session
+					// is current now.
+					if (activeSessionId !== ownSessionId) return;
+					if (!ok) showToast("Copy failed — clipboard permission denied?", true);
+				},
 			});
 			entry = { pane, term };
 			currentTerminals.set(tabId, entry);

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -764,6 +764,12 @@ export function openTerminalSession(opts: {
 		inputDisposable.dispose();
 		linkProviderDisposable.dispose();
 		scrollDisposable.dispose();
+		// dispose() cuts the onSelectionChange feed first; THEN cancel
+		// any already-queued debounce timer. Inverse order would also
+		// be safe today (clearTimeout returns nothing for an
+		// already-fired timer), but doing dispose-first guarantees no
+		// post-cancel re-arm is possible. Keep this order; symmetry
+		// with other dispose pairs above is intentional.
 		selectionDisposable.dispose();
 		if (selectionDebounceTimer !== null) clearTimeout(selectionDebounceTimer);
 		pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -27,6 +27,14 @@ export type RendererNoticeCallback = (message: string) => void;
  *  on failure only — a per-event success toast would be too chatty
  *  given the auto-copy path fires on every finalised selection (#158). */
 export type CopyCallback = (ok: boolean) => void;
+/** Predicate the session calls before writing to the system clipboard
+ *  on the auto-copy path. Returns true iff this session's tab is the
+ *  one the user is currently looking at — selections in a background
+ *  tab whose debounced finalise fires *after* the user switched away
+ *  must NOT clobber the clipboard with content from a pane the user
+ *  isn't viewing (#158 NIT). main.ts wires this against
+ *  `currentActiveTabId` / `activeSessionId`. */
+export type ActivePredicate = () => boolean;
 
 export function openTerminalSession(opts: {
 	container: HTMLElement;
@@ -37,9 +45,19 @@ export function openTerminalSession(opts: {
 	onError: ErrorCallback;
 	onRendererFallback?: RendererNoticeCallback;
 	onCopy?: CopyCallback;
+	isActive?: ActivePredicate;
 }): TerminalSession {
-	const { container, sessionId, tabId, fontSize, onStatus, onError, onRendererFallback, onCopy } =
-		opts;
+	const {
+		container,
+		sessionId,
+		tabId,
+		fontSize,
+		onStatus,
+		onError,
+		onRendererFallback,
+		onCopy,
+		isActive,
+	} = opts;
 	// Fires the fallback notice at most once per tab, regardless of how
 	// many times the WebGL context flaps (#55). A flapping driver
 	// shouldn't toast on every cycle.
@@ -244,6 +262,16 @@ export function openTerminalSession(opts: {
 			selectionDebounceTimer = null;
 			const sel = term.getSelection();
 			if (!sel || sel === lastCopiedSelection) return;
+			// Don't clobber the clipboard for a background tab — user
+			// might have switched to another tab during the 100 ms
+			// debounce window, in which case writing tab A's selection
+			// while they're looking at tab B is a footgun. `onCopy`'s
+			// failure toast already gates on the active-tab check; the
+			// write itself needs the same gate, otherwise the clipboard
+			// is silently overwritten with stale content. Cmd-C path
+			// doesn't need this guard because it requires keyboard
+			// focus, which a background tab can't have.
+			if (isActive && !isActive()) return;
 			lastCopiedSelection = sel;
 			copyToClipboard(sel);
 		}, SELECTION_DEBOUNCE_MS);

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -21,6 +21,12 @@ export type ErrorCallback = (message: string) => void;
  *  per terminal lifetime. Used by main.ts to surface a one-time toast
  *  so the user knows why their session feels slower (#55). */
 export type RendererNoticeCallback = (message: string) => void;
+/** Fired after a clipboard write attempt (Cmd-C or auto-copy on
+ *  selection-finalize). `ok=true` on success, `false` on rejection
+ *  (permission-denied, focus issue, etc.). main.ts uses it to toast
+ *  on failure only — a per-event success toast would be too chatty
+ *  given the auto-copy path fires on every finalised selection (#158). */
+export type CopyCallback = (ok: boolean) => void;
 
 export function openTerminalSession(opts: {
 	container: HTMLElement;
@@ -30,8 +36,10 @@ export function openTerminalSession(opts: {
 	onStatus: StatusCallback;
 	onError: ErrorCallback;
 	onRendererFallback?: RendererNoticeCallback;
+	onCopy?: CopyCallback;
 }): TerminalSession {
-	const { container, sessionId, tabId, fontSize, onStatus, onError, onRendererFallback } = opts;
+	const { container, sessionId, tabId, fontSize, onStatus, onError, onRendererFallback, onCopy } =
+		opts;
 	// Fires the fallback notice at most once per tab, regardless of how
 	// many times the WebGL context flaps (#55). A flapping driver
 	// shouldn't toast on every cycle.
@@ -174,6 +182,19 @@ export function openTerminalSession(opts: {
 
 	fitAddon.fit();
 
+	// Helper: write to clipboard and surface success/failure to the
+	// caller. Used by both the Cmd-C handler (explicit user gesture)
+	// and the onSelectionChange auto-copy path below (selection
+	// finalisation). Centralised so the same notification path runs
+	// for both, keeping toast policy (failure-only by default) in
+	// main.ts rather than duplicated here.
+	const copyToClipboard = (text: string) => {
+		navigator.clipboard.writeText(text).then(
+			() => onCopy?.(true),
+			() => onCopy?.(false),
+		);
+	};
+
 	// Cmd/Ctrl + C copies the current xterm selection to the clipboard.
 	// Without this, Cmd-C falls through to the terminal (Claude Code
 	// intercepts it as SIGINT) and nothing gets copied.
@@ -187,7 +208,7 @@ export function openTerminalSession(opts: {
 		) {
 			const sel = term.getSelection();
 			if (sel) {
-				navigator.clipboard.writeText(sel).catch(() => {});
+				copyToClipboard(sel);
 				return false;
 			}
 		}
@@ -199,6 +220,34 @@ export function openTerminalSession(opts: {
 	// complete URL. No-op when the app already emits OSC 8 (xterm's native
 	// hyperlink handling takes precedence per-cell).
 	const linkProviderDisposable = term.registerLinkProvider(new MultilineUrlLinkProvider(term));
+
+	// ── Auto-copy on selection-finalise ─────────────────────────────────────
+	// xterm fires `onSelectionChange` continuously while the user drags to
+	// select — once per cell of mouse movement. Copying on every fire would
+	// hit `navigator.clipboard.writeText` 50+ times per gesture, slow and
+	// rate-limited by browsers in some configurations. Debounce to ~100 ms
+	// so we copy once after the selection settles (mouse release / final
+	// shift-arrow), not on every intermediate frame.
+	//
+	// Skip empty selections — those fire on click-to-deselect and we don't
+	// want to clobber the user's clipboard with "" every time they click.
+	// `lastCopiedSelection` deduplicates the case where xterm fires
+	// onSelectionChange after we've already copied (e.g. xterm's
+	// post-render reconciliation pass) — without it we'd toast twice
+	// for the same logical selection.
+	const SELECTION_DEBOUNCE_MS = 100;
+	let selectionDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let lastCopiedSelection = "";
+	const selectionDisposable = term.onSelectionChange(() => {
+		if (selectionDebounceTimer !== null) clearTimeout(selectionDebounceTimer);
+		selectionDebounceTimer = setTimeout(() => {
+			selectionDebounceTimer = null;
+			const sel = term.getSelection();
+			if (!sel || sel === lastCopiedSelection) return;
+			lastCopiedSelection = sel;
+			copyToClipboard(sel);
+		}, SELECTION_DEBOUNCE_MS);
+	});
 
 	// Mouse clicks should focus xterm immediately. Touch taps are handled
 	// in onTouchEnd below — we wait until touchend to distinguish a tap
@@ -663,6 +712,8 @@ export function openTerminalSession(opts: {
 		inputDisposable.dispose();
 		linkProviderDisposable.dispose();
 		scrollDisposable.dispose();
+		selectionDisposable.dispose();
+		if (selectionDebounceTimer !== null) clearTimeout(selectionDebounceTimer);
 		pendingRestoreCanvas?.removeEventListener("webglcontextrestored", onContextRestored);
 		container.removeEventListener("webglcontextlost", onContextLost);
 		webgl?.dispose();

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -209,7 +209,16 @@ export function openTerminalSession(opts: {
 	const copyToClipboard = (text: string) => {
 		navigator.clipboard.writeText(text).then(
 			() => onCopy?.(true),
-			() => onCopy?.(false),
+			(err) => {
+				// Surface the underlying DOMException to the console so a
+				// developer debugging a field report can tell NotAllowedError
+				// (permission denied — fixable by the user) from a transient
+				// SecurityError (e.g. a context-restored race) without having
+				// to monkey-patch the helper. The user-facing toast in main.ts
+				// is intentionally generic; this is the diagnostic channel.
+				console.warn("[terminal] clipboard write failed:", err);
+				onCopy?.(false);
+			},
 		);
 	};
 	// Dedup state shared between the Cmd-C handler and the auto-copy

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -261,7 +261,20 @@ export function openTerminalSession(opts: {
 		selectionDebounceTimer = setTimeout(() => {
 			selectionDebounceTimer = null;
 			const sel = term.getSelection();
-			if (!sel || sel === lastCopiedSelection) return;
+			if (!sel) {
+				// Click-to-deselect. Reset the dedup so a subsequent
+				// re-selection of identical text WILL re-copy — the
+				// user may have intentionally written something else
+				// to the clipboard between the original copy and the
+				// re-selection (external app, manual Cmd-C of an
+				// unrelated string), and silently skipping that
+				// re-selection because of stale state would leave the
+				// user's clipboard out of sync with what they just
+				// re-selected.
+				lastCopiedSelection = "";
+				return;
+			}
+			if (sel === lastCopiedSelection) return;
 			// Don't clobber the clipboard for a background tab — user
 			// might have switched to another tab during the 100 ms
 			// debounce window, in which case writing tab A's selection

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -206,9 +206,12 @@ export function openTerminalSession(opts: {
 	// finalisation). Centralised so the same notification path runs
 	// for both, keeping toast policy (failure-only by default) in
 	// main.ts rather than duplicated here.
-	const copyToClipboard = (text: string) => {
-		navigator.clipboard.writeText(text).then(
-			() => onCopy?.(true),
+	const copyToClipboard = (text: string): Promise<boolean> => {
+		return navigator.clipboard.writeText(text).then(
+			() => {
+				onCopy?.(true);
+				return true;
+			},
 			(err) => {
 				// Surface the underlying DOMException to the console so a
 				// developer debugging a field report can tell NotAllowedError
@@ -218,6 +221,7 @@ export function openTerminalSession(opts: {
 				// is intentionally generic; this is the diagnostic channel.
 				console.warn("[terminal] clipboard write failed:", err);
 				onCopy?.(false);
+				return false;
 			},
 		);
 	};
@@ -246,7 +250,17 @@ export function openTerminalSession(opts: {
 				// Cmd-C inside the auto-copy debounce window doesn't
 				// fire a redundant write when the timer settles.
 				lastCopiedSelection = sel;
-				copyToClipboard(sel);
+				copyToClipboard(sel).then((ok) => {
+					// On failure, clear the dedup state we just set so a
+					// follow-up auto-copy of the same selection (after the
+					// user fixes the permission issue) actually fires
+					// instead of being silently skipped by the dedup
+					// guard. Identity-check against `sel` first because a
+					// later successful copy of a different selection may
+					// have advanced `lastCopiedSelection` in the
+					// meantime; we only want to clear our own poison.
+					if (!ok && lastCopiedSelection === sel) lastCopiedSelection = "";
+				});
 				return false;
 			}
 		}
@@ -305,7 +319,13 @@ export function openTerminalSession(opts: {
 			// focus, which a background tab can't have.
 			if (isActive && !isActive()) return;
 			lastCopiedSelection = sel;
-			copyToClipboard(sel);
+			copyToClipboard(sel).then((ok) => {
+				// See Cmd-C handler above for the rationale: on failure,
+				// undo our dedup poison so the user can re-trigger the
+				// copy by re-selecting the same text once they've
+				// resolved the permission issue.
+				if (!ok && lastCopiedSelection === sel) lastCopiedSelection = "";
+			});
 		}, SELECTION_DEBOUNCE_MS);
 	});
 

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -226,6 +226,10 @@ export function openTerminalSession(opts: {
 		) {
 			const sel = term.getSelection();
 			if (sel) {
+				// Sync the dedup state with the auto-copy path so a
+				// Cmd-C inside the auto-copy debounce window doesn't
+				// fire a redundant write when the timer settles.
+				lastCopiedSelection = sel;
 				copyToClipboard(sel);
 				return false;
 			}

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -212,6 +212,13 @@ export function openTerminalSession(opts: {
 			() => onCopy?.(false),
 		);
 	};
+	// Dedup state shared between the Cmd-C handler and the auto-copy
+	// onSelectionChange path below — declared up here so both writers
+	// see a fully-initialised binding (the Cmd-C closure was previously
+	// a forward reference into the auto-copy block; safe because the
+	// closure only runs at event time, but a footgun for any future
+	// refactor that runs the Cmd-C registration inside an IIFE).
+	let lastCopiedSelection = "";
 
 	// Cmd/Ctrl + C copies the current xterm selection to the clipboard.
 	// Without this, Cmd-C falls through to the terminal (Claude Code
@@ -259,7 +266,6 @@ export function openTerminalSession(opts: {
 	// for the same logical selection.
 	const SELECTION_DEBOUNCE_MS = 100;
 	let selectionDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-	let lastCopiedSelection = "";
 	const selectionDisposable = term.onSelectionChange(() => {
 		if (selectionDebounceTimer !== null) clearTimeout(selectionDebounceTimer);
 		selectionDebounceTimer = setTimeout(() => {


### PR DESCRIPTION
Partial close on #158 — covers layers 1 and 2 from the issue body. Layer 3 (mobile copy entry) stays open as a follow-up.

## Summary

**Layer 1 — feedback.** \`openTerminalSession\` gets an \`onCopy?: (ok: boolean) => void\` opt. Fired after every \`navigator.clipboard.writeText\` — both from the existing Cmd-C handler and the new auto-copy path. Centralises success/failure surfacing so toast policy lives in \`main.ts\` rather than duplicated inside \`terminal.ts\`.

\`main.ts\` wires \`onCopy\` to a **failure-only toast**: silent on success matches the native Cmd-C feel and avoids spamming a chip for every finalised selection on the auto-copy path.

**Layer 2 — auto-copy on selection-finalise.** Subscribe to \`term.onSelectionChange\` and copy after a 100 ms debounce so the per-cell fires during a drag (\`onSelectionChange\` triggers ~once per cell of mouse movement) coalesce into one clipboard write when the user releases. Empty selections (click-to-deselect) are skipped so the clipboard isn't clobbered with \`\"\"\` every time the user clicks. \`lastCopiedSelection\` deduplicates against xterm's post-render reconciliation pass which can fire a redundant change with the same content.

## Out of scope

Layer 3 — \"Select mode\" toggle + actions-menu \"Copy selection\" entry for mobile. Touch drag still routes through SGR mouse-tracking after #181 so there's no native xterm selection on touch; that needs a separate UX entry that's bigger than this PR's coherent change.

## Notes on desktop selection mechanics

With \`set -g mouse on\`, plain mouse drags forward to tmux as mouse-tracking. To produce an xterm-native selection, **hold Shift while dragging** — that bypasses tmux's mouse capture and lets xterm.js handle the selection natively. After release, our debounced \`onSelectionChange\` fires and the copy happens. Existing standard pattern; no change in this PR.

## Test plan

- [ ] **Shift-drag to select on desktop:** selection finalises → ~100 ms later the text is on the clipboard. No visible chip on success.
- [ ] **Cmd-C with existing selection:** copies (unchanged path).
- [ ] **Click outside selection:** selection clears, no toast, clipboard unchanged (empty-skip).
- [ ] **Select same range twice:** clipboard write fires on the first finalise; the redundant onSelectionChange afterwards is deduplicated.
- [ ] **Permission denied** (e.g. revoke clipboard permission in the browser): a toast \"Copy failed — clipboard permission denied?\" appears.
- [ ] **Active-session guard:** select in tab A, immediately switch to tab B before debounce fires → no stale toast attributed to tab B's session.
- [ ] **Dispose:** close the tab while debounce is pending → no clipboard write fires (timer cleared, listener disposed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)