### PR TITLE
feat(docker): apply session_configs env / cpu / mem at spawn (#185, PR 185b1 of 2)

### DIFF
--- a/backend/src/dockerManager.spawnConfig.test.ts
+++ b/backend/src/dockerManager.spawnConfig.test.ts
@@ -38,7 +38,7 @@ vi.mock("node:fs", () => ({
 	},
 }));
 
-import { DockerManager, mergeEnvForSpawn } from "./dockerManager.js";
+import { buildContainerEnv, DockerManager, mergeEnvForSpawn } from "./dockerManager.js";
 import type { SessionManager } from "./sessionManager.js";
 
 // ── Fakes ────────────────────────────────────────────────────────────────
@@ -122,6 +122,80 @@ describe("mergeEnvForSpawn", () => {
 		expect(mergeEnvForSpawn({ DUP: "legacy" }, { DUP: "from-config" })).toEqual([
 			"DUP=from-config",
 		]);
+	});
+});
+
+// ── buildContainerEnv ────────────────────────────────────────────────────
+
+describe("buildContainerEnv", () => {
+	function toMap(env: string[]): Record<string, string> {
+		const m: Record<string, string> = {};
+		for (const e of env) {
+			const eq = e.indexOf("=");
+			m[e.slice(0, eq)] = e.slice(eq + 1);
+		}
+		return m;
+	}
+	function countOccurrences(env: string[], name: string): number {
+		return env.filter((e) => e.startsWith(`${name}=`)).length;
+	}
+
+	it("emits SESSION_ID / SESSION_NAME / TERM / COLORTERM when no user env supplied", () => {
+		const env = buildContainerEnv("sess-x", "my-session", []);
+		const m = toMap(env);
+		expect(m.SESSION_ID).toBe("sess-x");
+		expect(m.SESSION_NAME).toBe("my-session");
+		expect(m.TERM).toBe("xterm-256color");
+		expect(m.COLORTERM).toBe("truecolor");
+	});
+
+	// Dedupe is the whole point of the helper — duplicates make the
+	// effective value depend on which reader resolves it (getenv first-
+	// wins vs bash startup last-wins). Asserting one entry per name
+	// regardless of input shape locks the invariant.
+	it("emits exactly one entry per name, even when defaults overlap with user env", () => {
+		const env = buildContainerEnv("sess-x", "my-session", ["TERM=tmux-256color", "FOO=bar"]);
+		expect(countOccurrences(env, "TERM")).toBe(1);
+		expect(countOccurrences(env, "COLORTERM")).toBe(1);
+		expect(countOccurrences(env, "SESSION_ID")).toBe(1);
+		expect(countOccurrences(env, "SESSION_NAME")).toBe(1);
+		expect(countOccurrences(env, "FOO")).toBe(1);
+	});
+
+	// Round-4 fix: user TERM/COLORTERM must be honoured. Previous
+	// ordering (hardcoded first, user spread last) made TERM hard-
+	// defaulted under getenv first-wins semantics.
+	it("user-supplied TERM / COLORTERM beat the hardcoded defaults", () => {
+		const env = buildContainerEnv("sess-x", "my-session", [
+			"TERM=tmux-256color",
+			"COLORTERM=24bit",
+		]);
+		const m = toMap(env);
+		expect(m.TERM).toBe("tmux-256color");
+		expect(m.COLORTERM).toBe("24bit");
+	});
+
+	// Defence-in-depth: SESSION_ID / SESSION_NAME come after user env in
+	// the precedence chain. The denylist already prevents these names
+	// from arriving in userEnv, but if a future caller bypasses validation
+	// (e.g. a direct D1 write) the infra values still win.
+	it("SESSION_ID / SESSION_NAME are immutable from user env", () => {
+		const env = buildContainerEnv("sess-x", "my-session", [
+			"SESSION_ID=spoofed",
+			"SESSION_NAME=other",
+		]);
+		const m = toMap(env);
+		expect(m.SESSION_ID).toBe("sess-x");
+		expect(m.SESSION_NAME).toBe("my-session");
+	});
+
+	it("skips malformed env entries missing '='", () => {
+		// Validators upstream already reject these, but a future regression
+		// shouldn't corrupt the Map iteration.
+		const env = buildContainerEnv("sess-x", "my-session", ["BAREWORD", "=NOKEY", "FOO=bar"]);
+		const m = toMap(env);
+		expect(m.FOO).toBe("bar");
+		expect(countOccurrences(env, "BAREWORD")).toBe(0);
 	});
 });
 

--- a/backend/src/dockerManager.spawnConfig.test.ts
+++ b/backend/src/dockerManager.spawnConfig.test.ts
@@ -171,6 +171,22 @@ describe("DockerManager.spawn config-applied", () => {
 		expect(hc.NanoCpus).toBe(4_000_000_000);
 	});
 
+	// Backend-injected fixed entries (SESSION_ID, SESSION_NAME, TERM,
+	// COLORTERM) must survive the merge — SESSION_ID in particular is
+	// load-bearing for #191 hook self-identification. The denylist
+	// already prevents users from setting SESSION_ID/SESSION_NAME in
+	// config; this test guards against an accidental refactor that
+	// drops the hardcoded entries entirely.
+	it("preserves backend-injected SESSION_ID / SESSION_NAME / TERM / COLORTERM in the final Env", async () => {
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const env = captured.opts.Env as string[];
+		expect(env).toContain("SESSION_ID=sess-1");
+		expect(env).toContain("SESSION_NAME=test");
+		expect(env).toContain("TERM=xterm-256color");
+		expect(env).toContain("COLORTERM=truecolor");
+	});
+
 	it("merges config.envVars into the docker-run Env (config-wins on collision)", async () => {
 		dbStubs.d1Query.mockResolvedValueOnce({
 			results: [
@@ -199,6 +215,37 @@ describe("DockerManager.spawn config-applied", () => {
 		// must NOT appear; only the config "wins" value.
 		expect(env).toContain("LEGACY_KEY=wins");
 		expect(env).not.toContain("LEGACY_KEY=legacy");
+	});
+
+	// One field set, the other null: the unset field must fall back to
+	// its respective default, NOT to 0 (which would be the value of a
+	// `?? 0` typo). Pinning the half-and-half case stops a refactor that
+	// loses one of the `?? DEFAULT_*` fallbacks from passing CI.
+	it("falls back to default for any cap that is null on the row", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [
+				{
+					session_id: "sess-1",
+					workspace_strategy: null,
+					cpu_limit: 4_000_000_000,
+					mem_limit: null,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: null,
+					ports_json: null,
+					env_vars_json: null,
+					bootstrapped_at: null,
+				},
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as { Memory: number; NanoCpus: number };
+		expect(hc.NanoCpus).toBe(4_000_000_000);
+		expect(hc.Memory).toBe(2 * 1024 * 1024 * 1024); // default, not 0
 	});
 
 	// Availability over correctness for config reads: a transient D1

--- a/backend/src/dockerManager.spawnConfig.test.ts
+++ b/backend/src/dockerManager.spawnConfig.test.ts
@@ -129,11 +129,9 @@ describe("mergeEnvForSpawn", () => {
 
 describe("DockerManager.spawn config-applied", () => {
 	it("falls back to default Memory/NanoCpus when no session_configs row exists", async () => {
-		dbStubs.d1Query.mockResolvedValueOnce({
-			results: [],
-			success: true,
-			meta: { changes: 0, duration: 0, last_row_id: 0 },
-		});
+		// `beforeEach` already resets d1Query to return `results: []`, so
+		// this test exercises the no-row path without needing a per-test
+		// mock override.
 		const { dm, captured } = makeDmWithCreateCapture();
 		await dm.spawn("sess-1");
 		const hc = captured.opts.HostConfig as { Memory: number; NanoCpus: number };

--- a/backend/src/dockerManager.spawnConfig.test.ts
+++ b/backend/src/dockerManager.spawnConfig.test.ts
@@ -1,0 +1,214 @@
+/**
+ * dockerManager.spawnConfig.test.ts — config-applied spawn tests for #185 (PR 185b1).
+ *
+ * The existing dockerManager.test.ts harness focuses on the attach + tmux
+ * side and never exercises `createContainer`. This file fills the gap:
+ * it mocks `Dockerode.createContainer` directly so we can assert the
+ * `HostConfig.Memory` / `HostConfig.NanoCpus` and `Env` values that PR
+ * 185b1 derives from `session_configs`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+// Stub the fs ops spawn() touches: mkdir creates the bind-mount target,
+// chown applies WORKSPACE_UID/GID. In tests the bind-mount path under
+// `/var/shared-terminal/workspaces/...` is unwritable; we don't actually
+// need a real dir since `createContainer` is mocked too. Keep the
+// signatures faithful so the behaviour matches what spawn expects.
+vi.mock("node:fs", () => ({
+	promises: {
+		mkdir: vi.fn(async () => undefined),
+		chown: vi.fn(async () => undefined),
+		readdir: vi.fn(async () => []),
+		stat: vi.fn(async () => ({ size: 0 })),
+		lstat: vi.fn(async () => ({ size: 0, isFile: () => false })),
+		chmod: vi.fn(async () => undefined),
+		rename: vi.fn(async () => undefined),
+		unlink: vi.fn(async () => undefined),
+		rm: vi.fn(async () => undefined),
+	},
+}));
+
+import { DockerManager, mergeEnvForSpawn } from "./dockerManager.js";
+import type { SessionManager } from "./sessionManager.js";
+
+// ── Fakes ────────────────────────────────────────────────────────────────
+
+function fakeSessions(): SessionManager {
+	const meta = {
+		sessionId: "sess-1",
+		userId: "u1",
+		name: "test",
+		status: "running" as const,
+		containerId: null,
+		containerName: "st-test",
+		cols: 80,
+		rows: 24,
+		envVars: { LEGACY_KEY: "legacy" },
+		createdAt: new Date(),
+		lastConnectedAt: null,
+	};
+	return {
+		getOrThrow: vi.fn(async () => meta),
+		get: vi.fn(async () => meta),
+		setContainerId: vi.fn(async () => {
+			/* noop */
+		}),
+	} as unknown as SessionManager;
+}
+
+interface CapturedCreate {
+	opts: Record<string, unknown>;
+}
+
+function makeDmWithCreateCapture(): { dm: DockerManager; captured: CapturedCreate } {
+	const captured: CapturedCreate = { opts: {} };
+	const dm = new DockerManager(fakeSessions());
+	const fakeContainer = {
+		id: "container-abc",
+		start: vi.fn(async () => {
+			/* noop */
+		}),
+	};
+	const fakeDocker = {
+		createContainer: vi.fn(async (opts: Record<string, unknown>) => {
+			captured.opts = opts;
+			return fakeContainer;
+		}),
+		getContainer: vi.fn(() => fakeContainer),
+	};
+	(dm as unknown as { docker: unknown }).docker = fakeDocker;
+	return { dm, captured };
+}
+
+beforeEach(() => {
+	dbStubs.d1Query.mockReset();
+	dbStubs.d1Query.mockResolvedValue({
+		results: [],
+		success: true,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	});
+});
+
+// ── mergeEnvForSpawn ─────────────────────────────────────────────────────
+
+describe("mergeEnvForSpawn", () => {
+	it("returns the legacy env unchanged when no config envVars are supplied", () => {
+		expect(mergeEnvForSpawn({ FOO: "1", BAR: "2" }, undefined).sort()).toEqual(["BAR=2", "FOO=1"]);
+	});
+
+	it("returns the config env unchanged when legacy is empty", () => {
+		expect(mergeEnvForSpawn({}, { ALPHA: "a" })).toEqual(["ALPHA=a"]);
+	});
+
+	it("unions both stores", () => {
+		const got = mergeEnvForSpawn({ A: "1" }, { B: "2" });
+		expect(got.sort()).toEqual(["A=1", "B=2"]);
+	});
+
+	// Round-3 documented decision: union with config-wins on key collision.
+	// The user typed an override into the new modal — they expect it to
+	// beat whatever is in the legacy store.
+	it("config takes precedence on key collisions", () => {
+		expect(mergeEnvForSpawn({ DUP: "legacy" }, { DUP: "from-config" })).toEqual([
+			"DUP=from-config",
+		]);
+	});
+});
+
+// ── DockerManager.spawn applies session_configs ──────────────────────────
+
+describe("DockerManager.spawn config-applied", () => {
+	it("falls back to default Memory/NanoCpus when no session_configs row exists", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as { Memory: number; NanoCpus: number };
+		expect(hc.Memory).toBe(2 * 1024 * 1024 * 1024);
+		expect(hc.NanoCpus).toBe(2_000_000_000);
+		// Bare-create env path: only the legacy session.envVars + the
+		// always-on terminal env. No config env merged in.
+		expect(captured.opts.Env).toContain("LEGACY_KEY=legacy");
+	});
+
+	it("applies cpu_limit / mem_limit from the session_configs row", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [
+				{
+					session_id: "sess-1",
+					workspace_strategy: null,
+					cpu_limit: 4_000_000_000,
+					mem_limit: 8 * 1024 * 1024 * 1024,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: null,
+					ports_json: null,
+					env_vars_json: null,
+					bootstrapped_at: null,
+				},
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as { Memory: number; NanoCpus: number };
+		expect(hc.Memory).toBe(8 * 1024 * 1024 * 1024);
+		expect(hc.NanoCpus).toBe(4_000_000_000);
+	});
+
+	it("merges config.envVars into the docker-run Env (config-wins on collision)", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [
+				{
+					session_id: "sess-1",
+					workspace_strategy: null,
+					cpu_limit: null,
+					mem_limit: null,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: null,
+					ports_json: null,
+					env_vars_json: JSON.stringify({ NEW_KEY: "from-config", LEGACY_KEY: "wins" }),
+					bootstrapped_at: null,
+				},
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const env = captured.opts.Env as string[];
+		expect(env).toContain("NEW_KEY=from-config");
+		// Round-3 decision: config-wins on collision. Legacy "legacy"
+		// must NOT appear; only the config "wins" value.
+		expect(env).toContain("LEGACY_KEY=wins");
+		expect(env).not.toContain("LEGACY_KEY=legacy");
+	});
+
+	// Availability over correctness for config reads: a transient D1
+	// failure shouldn't gate session creation. Logging-only fallback.
+	it("falls back to defaults if session_configs read throws", async () => {
+		dbStubs.d1Query.mockRejectedValueOnce(new Error("D1 transient"));
+		const { dm, captured } = makeDmWithCreateCapture();
+		await expect(dm.spawn("sess-1")).resolves.toBeDefined();
+		const hc = captured.opts.HostConfig as { Memory: number; NanoCpus: number };
+		expect(hc.Memory).toBe(2 * 1024 * 1024 * 1024);
+		expect(hc.NanoCpus).toBe(2_000_000_000);
+	});
+});

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -212,6 +212,19 @@ export class DockerManager {
 			Image: SESSION_IMAGE,
 			name: meta.containerName,
 			Hostname: hostname,
+			// Env order is intentional: hardcoded entries first, then user
+			// envArray. Linux execve is last-duplicate-wins, so:
+			//   - SESSION_ID / SESSION_NAME — protected by the
+			//     envVarValidation denylist (#206), so they CANNOT appear
+			//     in envArray; the placement here is for tidiness, not
+			//     defence. Hooks introduced in #191 read SESSION_ID as the
+			//     authoritative session identity.
+			//   - TERM / COLORTERM — deliberately user-overridable (e.g.
+			//     `TERM=tmux-256color` for nested-tmux workflows). Putting
+			//     them before envArray IS the mechanism that lets a user
+			//     opt out of the defaults; reordering would silently break
+			//     that affordance, so don't move `...envArray` above the
+			//     hardcoded entries without a replacement design.
 			Env: [
 				`SESSION_ID=${sessionId}`,
 				`SESSION_NAME=${meta.name}`,

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -14,10 +14,20 @@ import { StringDecoder } from "node:string_decoder";
 import Dockerode from "dockerode";
 import { d1Query } from "./db.js";
 import { logger } from "./logger.js";
+import { getSessionConfig, type SessionConfigRecord } from "./sessionConfig.js";
 import type { SessionManager } from "./sessionManager.js";
 
 const SESSION_IMAGE = process.env.SESSION_IMAGE ?? "shared-terminal-session";
 const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT ?? "/var/shared-terminal/workspaces";
+
+// Resource defaults applied at `docker run` when no per-session override
+// is set in `session_configs`. Match the values that have shipped in
+// production since #15. Caps the operator (and #194 in the future) can
+// override per session by writing `cpu_limit` / `mem_limit` on the
+// session_configs row. Hardcoding the floor here so a missing config
+// row doesn't change behaviour from today's deployment.
+const DEFAULT_MEMORY_BYTES = 2 * 1024 * 1024 * 1024;
+const DEFAULT_NANO_CPUS = 2_000_000_000;
 
 // Owner applied to freshly-created workspace directories. Must match the
 // `developer` user inside session-image/Dockerfile (uid/gid 1000 by default).
@@ -136,11 +146,42 @@ export class DockerManager {
 		return `${sessionId}:${tabId}`;
 	}
 
+	/**
+	 * Read the typed session config row for `sessionId`, used by `spawn`
+	 * to apply env vars / resource caps at `docker run` time.
+	 *
+	 * Returns null when no row exists (legitimate "no config supplied"
+	 * state — bare-create sessions). On a D1 transient (network blip,
+	 * Cloudflare API hiccup), logs a warning and returns null so we
+	 * fall back to defaults: a config-row read failure is an availability
+	 * concern, not a correctness one. The caps just reset to today's
+	 * defaults until the next spawn picks the row back up. Failing the
+	 * spawn here would gate every session creation on D1 being healthy,
+	 * which is a worse trade than briefly running with default caps.
+	 */
+	private async loadConfigForSpawn(sessionId: string): Promise<SessionConfigRecord | null> {
+		try {
+			return await getSessionConfig(sessionId);
+		} catch (err) {
+			logger.warn(
+				`[docker] session_configs read failed for ${sessionId}, falling back to defaults: ${(err as Error).message}`,
+			);
+			return null;
+		}
+	}
+
 	// ── Container lifecycle ─────────────────────────────────────────────────
 
 	async spawn(sessionId: string): Promise<string> {
 		const meta = await this.sessions.getOrThrow(sessionId);
-		const envArray = Object.entries(meta.envVars).map(([k, v]) => `${k}=${v}`);
+		// Read the typed session config (#185 / epic #184). When no row
+		// exists, `loadConfigForSpawn` returns null and we fall back to
+		// today's defaults — bare-create sessions stay byte-identical to
+		// pre-185 behaviour. Any D1 transient is downgraded to a warning
+		// inside the helper rather than failing the spawn; the alternative
+		// would gate every session creation on D1 health.
+		const config = await this.loadConfigForSpawn(sessionId);
+		const envArray = mergeEnvForSpawn(meta.envVars, config?.envVars);
 
 		// Pre-create the bind-mount target so Docker doesn't auto-create it
 		// as root. See `ensureWorkspaceOwnership` for the full story and the
@@ -183,8 +224,15 @@ export class DockerManager {
 					`${WORKSPACE_ROOT}/${sessionId}:/home/developer/workspace`,
 					`${uploadsHostDir}:/home/developer/workspace/uploads:ro`,
 				],
-				Memory: 2 * 1024 * 1024 * 1024,
-				NanoCpus: 2_000_000_000,
+				// `mem_limit` / `cpu_limit` from session_configs override the
+				// hardcoded defaults. Docker pins HostConfig at create time,
+				// so a later config-row UPDATE wouldn't take effect on an
+				// existing container — `startContainer`'s "respawn on stale
+				// id" path picks up new caps when the user fully recycles
+				// (DELETE + POST /start). #194 owns operator-tunable bounds
+				// and per-deployment caps; this PR just wires the consumer.
+				Memory: config?.memLimit ?? DEFAULT_MEMORY_BYTES,
+				NanoCpus: config?.cpuLimit ?? DEFAULT_NANO_CPUS,
 				RestartPolicy: { Name: "unless-stopped" },
 				// Defense-in-depth (issue #15): the image already runs as
 				// unprivileged UID 1000 with no sudo, but we still strip
@@ -1399,6 +1447,28 @@ export function sanitiseHostname(name: string, sessionId: string): string {
 			.slice(0, 63)
 			.replace(/^-+|-+$/g, "") || `session-${sessionId.slice(0, 8)}`
 	);
+}
+
+// Merge per-session env vars with config-supplied env vars for a fresh
+// `docker run`. Two stores coexist (see routes.ts comment): `body.envVars`
+// → `sessions.env_vars` (legacy) and `body.config.envVars` →
+// `session_configs.env_vars_json` (new). Union with config-wins on key
+// collision is the explicit choice — a user who typed an override into
+// the new modal expects it to beat whatever was set via the legacy POST
+// path. Both inputs are already validated through `validateEnvVars` at
+// ingest, so no extra sanitisation needed here. Returns the
+// `KEY=VALUE` array Docker's createContainer.Env wants.
+//
+// Exported for the test suite; not part of the public DockerManager API.
+export function mergeEnvForSpawn(
+	sessionEnv: Record<string, string>,
+	configEnv: Record<string, string> | undefined,
+): string[] {
+	const merged: Record<string, string> = { ...sessionEnv };
+	if (configEnv) {
+		for (const [k, v] of Object.entries(configEnv)) merged[k] = v;
+	}
+	return Object.entries(merged).map(([k, v]) => `${k}=${v}`);
 }
 
 // Sanitise an uploaded file's original name into a safe basename that's

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -212,26 +212,16 @@ export class DockerManager {
 			Image: SESSION_IMAGE,
 			name: meta.containerName,
 			Hostname: hostname,
-			// Env order is intentional: hardcoded entries first, then user
-			// envArray. Linux execve is last-duplicate-wins, so:
-			//   - SESSION_ID / SESSION_NAME — protected by the
-			//     envVarValidation denylist (#206), so they CANNOT appear
-			//     in envArray; the placement here is for tidiness, not
-			//     defence. Hooks introduced in #191 read SESSION_ID as the
-			//     authoritative session identity.
-			//   - TERM / COLORTERM — deliberately user-overridable (e.g.
-			//     `TERM=tmux-256color` for nested-tmux workflows). Putting
-			//     them before envArray IS the mechanism that lets a user
-			//     opt out of the defaults; reordering would silently break
-			//     that affordance, so don't move `...envArray` above the
-			//     hardcoded entries without a replacement design.
-			Env: [
-				`SESSION_ID=${sessionId}`,
-				`SESSION_NAME=${meta.name}`,
-				`TERM=xterm-256color`,
-				`COLORTERM=truecolor`,
-				...envArray,
-			],
+			// `buildContainerEnv` returns a deduplicated `KEY=VALUE[]` array
+			// so the precedence is unambiguous regardless of which reader
+			// resolves the var inside the container. Duplicates in
+			// Docker's `Env` are surprisingly hostile: glibc's `getenv(3)`
+			// is FIRST-wins (scans `environ` from index 0), bash's startup
+			// parser is LAST-wins (each `bind_variable` overwrites), and
+			// programs the user runs may use either. Emitting a single
+			// entry per name closes that ambiguity. See `buildContainerEnv`
+			// for the precedence rules.
+			Env: buildContainerEnv(sessionId, meta.name, envArray),
 			HostConfig: {
 				Binds: [
 					`${WORKSPACE_ROOT}/${sessionId}:/home/developer/workspace`,
@@ -1482,6 +1472,58 @@ export function mergeEnvForSpawn(
 		for (const [k, v] of Object.entries(configEnv)) merged[k] = v;
 	}
 	return Object.entries(merged).map(([k, v]) => `${k}=${v}`);
+}
+
+/**
+ * Build the deduplicated `Env` array Docker hands to the container.
+ *
+ * Precedence (highest → lowest), applied as a Map merge so each name
+ * appears exactly once in the result:
+ *
+ *   1. **SESSION_ID / SESSION_NAME** — backend infrastructure identity.
+ *      These cannot appear in `userEnv` because `validateEnvVars`
+ *      denylists them at ingest (#206). Set last so they overwrite any
+ *      pathological value that somehow slipped past the denylist (e.g.
+ *      via direct D1 write).
+ *   2. **userEnv** — the merged session+config user env. Beats the
+ *      defaults in (3).
+ *   3. **TERM / COLORTERM** — terminal driver hints. Deliberately
+ *      user-overridable (e.g. `TERM=tmux-256color` for nested-tmux
+ *      workflows), so they sit at the lowest precedence: applied first,
+ *      then user env can replace them.
+ *
+ * Why dedupe at all: passing duplicates through to Docker's `Env` is
+ * surprisingly hostile. glibc's `getenv(3)` returns the FIRST match;
+ * bash's startup parser uses the LAST (each `bind_variable_value`
+ * overwrites); programs the user runs inside the container may call
+ * either. A single entry per name closes that ambiguity entirely.
+ *
+ * Exported for the test suite.
+ */
+export function buildContainerEnv(
+	sessionId: string,
+	sessionName: string,
+	userEnv: string[],
+): string[] {
+	const out = new Map<string, string>();
+	// (3) Lowest-precedence defaults first.
+	out.set("TERM", "xterm-256color");
+	out.set("COLORTERM", "truecolor");
+	// (2) User entries override the defaults above. `userEnv` is the
+	// already-merged session+config array — itself dedup'd by
+	// `mergeEnvForSpawn`. Defensive guard: skip malformed entries
+	// missing `=` rather than crash; the validators upstream already
+	// reject these shapes, but a future caller bypassing them would
+	// otherwise corrupt the map.
+	for (const entry of userEnv) {
+		const eq = entry.indexOf("=");
+		if (eq <= 0) continue;
+		out.set(entry.slice(0, eq), entry.slice(eq + 1));
+	}
+	// (1) Highest-precedence infra identity. Overwrites anything else.
+	out.set("SESSION_ID", sessionId);
+	out.set("SESSION_NAME", sessionName);
+	return Array.from(out, ([k, v]) => `${k}=${v}`);
 }
 
 // Sanitise an uploaded file's original name into a safe basename that's

--- a/backend/src/envVarValidation.test.ts
+++ b/backend/src/envVarValidation.test.ts
@@ -178,6 +178,15 @@ describe("validateEnvVars", () => {
 		expect(() => validateEnvVars({ SHELL: "/bin/sh" })).toThrow(/reserved/);
 	});
 
+	// PR 206 review: SESSION_ID / SESSION_NAME are written by
+	// DockerManager.spawn from the authoritative D1 row. A user override
+	// would silently misdirect #191's hooks that read `$SESSION_ID` to
+	// identify their context.
+	it("rejects backend infrastructure identifiers SESSION_ID / SESSION_NAME", () => {
+		expect(() => validateEnvVars({ SESSION_ID: "../other" })).toThrow(/reserved/);
+		expect(() => validateEnvVars({ SESSION_NAME: "spoof" })).toThrow(/reserved/);
+	});
+
 	it("rejects all LD_* dynamic-linker variables (prefix match)", () => {
 		// LD_PRELOAD and friends are the obvious ones; the prefix
 		// match also catches less-well-known vectors (LD_AUDIT,

--- a/backend/src/envVarValidation.ts
+++ b/backend/src/envVarValidation.ts
@@ -108,6 +108,17 @@ const DENIED_ENV_VAR_NAMES = new Set([
 	// extends @INC.
 	"PERL5OPT",
 	"PERL5LIB",
+
+	// Backend-set infrastructure identifiers. DockerManager.spawn writes
+	// these into the container Env so #191's hooks (and any future per-
+	// session tooling) can read them as the authoritative session
+	// identity. Letting a user override them via session config would
+	// silently misdirect a hook that does `if [ "$SESSION_ID" = … ]`,
+	// which becomes load-bearing once PR 185b2 lands the postCreate /
+	// postStart runner. There is no legitimate user reason to set these
+	// — both are derived from the row the backend just inserted.
+	"SESSION_ID",
+	"SESSION_NAME",
 ]);
 
 // Prefix matches for categories that grow over time (new LD_* / DYLD_*

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -400,17 +400,17 @@ export function buildRouter(
 			}
 			throw err;
 		}
-		// Two env-var stores coexist after #185 lands:
-		//   - `body.envVars` →  `sessions.env_vars`            (legacy)
+		// Two env-var stores coexist after #185:
+		//   - `body.envVars` →  `sessions.env_vars`               (legacy)
 		//   - `body.config.envVars` → `session_configs.env_vars_json`
-		// A single POST can populate both. Today only the legacy store is
-		// applied at `docker run` time (see DockerManager.spawn). PR 185b
-		// (the runner) owns the merge-order decision: union semantics with
-		// config taking precedence on key collisions is the obvious choice,
-		// but it must be the *explicit* choice — accidental "first one
-		// wins by implementation order" would surprise users who expected
-		// the override they typed in the modal to win. Don't add merge
-		// logic here without that decision in 185b.
+		// Both are applied at `docker run` time by `mergeEnvForSpawn` in
+		// DockerManager.spawn — union with config-wins on key collisions
+		// (see PR #206). Both inputs flow through `validateEnvVars` here
+		// so the denylist (PATH, LD_*, SESSION_ID, …) and shape rules
+		// apply identically to either path. The dual-store split exists
+		// because #186 will swap `config.envVars` for typed entries with
+		// AES-GCM-encrypted secrets — the legacy column stays as the
+		// plain-string fast path for callers that don't need secrets.
 		// `body.config` is the new typed config object (#185 / epic #184).
 		// All sub-fields are optional, so an undefined / empty object is
 		// the bare-POST path and behaves exactly like before. A failed


### PR DESCRIPTION
## Summary

Continuation of #185 / epic #184 after [PR #205](https://github.com/gatof81/shared-terminal/pull/205) (185a) shipped the schema + tabbed-modal scaffold. This PR (**185b1 of 2**) wires `DockerManager.spawn` to the `session_configs` row so per-session `env_vars` / `cpu_limit` / `mem_limit` actually take effect at `docker run`. PR **185b2** (next) ships the bootstrap runner, the WS `bootstrap:<sessionId>` channel, the live-tail panel inside the new-session modal, and the hard-fail flow — together with this PR they close #185.

## What changes

- `DockerManager.spawn` reads the typed config row via the existing `getSessionConfig` helper. No row → byte-identical pre-185 behaviour (2 GiB / 2 vCPU defaults).
- When a row exists:
  - `cpu_limit` / `mem_limit` override `HostConfig.NanoCpus` / `HostConfig.Memory`.
  - `env_vars` get merged into the container's `Env`, **config-wins on key collision** — that's the explicit decision flagged in `routes.ts` during 185a round 3 ("user typed an override into the new modal, they expect it to beat the legacy POST path"). Both inputs already flow through `validateEnvVars` at ingest, so no extra sanitisation here. New `mergeEnvForSpawn` helper centralises and is exported for tests.
- D1 transients on the config-row read are downgraded to `logger.warn` and we fall back to defaults — failing the spawn here would gate every session creation on Cloudflare D1 health, a worse trade than running with documented defaults until the next spawn picks the row back up.

Docker pins `HostConfig` at create time, so a later config-row UPDATE only takes effect when the user fully recycles (`DELETE + POST /start`); `startContainer`'s "respawn on stale id" path automatically picks up the new caps. PR #194 owns operator-tunable bounds.

## Test plan

- [x] `cd backend && npm run build` — clean.
- [x] `cd backend && npm test` — **243/243 passing** (8 new tests in a dedicated `dockerManager.spawnConfig.test.ts` file: merge-helper unit tests + integration tests mocking `createContainer` and asserting `HostConfig.Memory` / `NanoCpus` / `Env` when a config row is present / absent / unreadable).
- [x] `cd backend && npm run lint` — clean.
- [ ] Live container check (start backend with a session that has `cpu_limit` set, observe `docker inspect` shows the override) — couldn't run in this session because the dev D1 setup is offline; will validate once PR 185b2's runner is live and the full create-with-config flow works end-to-end.

## Out of scope (PR 185b2)

- Bootstrap runner: `postCreate` (one-shot, gated by `session_configs.bootstrapped_at`) + `postStart` (per-start tmux window).
- WS channel `bootstrap:<sessionId>` + live-tail panel in the modal.
- Hard-fail: non-zero `postCreate` exit flips `sessions.status` to `failed` and surfaces the error inline.
- `ports`, `repos`, `workspaceStrategy` consumers — those land with #190 / #188.

Refs #185, #184. Closes #185 once PR 185b2 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)