### PR TITLE
feat(sessions): bootstrap runner — sync postCreate + per-start postStart (#185, PR 185b2a of 2)

### DIFF
--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import { markBootstrapped } from "./bootstrap.js";
+
+beforeEach(() => {
+	dbStubs.d1Query.mockReset();
+});
+
+describe("markBootstrapped", () => {
+	it("issues a guarded UPDATE that only fires when bootstrapped_at IS NULL", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 1, duration: 0, last_row_id: 0 },
+		});
+		const won = await markBootstrapped("sess-1");
+		expect(won).toBe(true);
+		const [sql, params] = dbStubs.d1Query.mock.calls[0]!;
+		expect(sql).toMatch(/UPDATE session_configs/);
+		expect(sql).toMatch(/SET bootstrapped_at/);
+		// The IS NULL predicate is the lock — without it two concurrent
+		// callers would both think they won. Asserting on the SQL shape
+		// so a future caller can't drop the predicate by mistake.
+		expect(sql).toMatch(/WHERE session_id = \? AND bootstrapped_at IS NULL/);
+		expect(params).toEqual(["sess-1"]);
+	});
+
+	// Concurrent retry: two callers race on the same row, the slower
+	// one's UPDATE finds bootstrapped_at already set, changes === 0,
+	// we return false so the caller can skip a duplicate run.
+	it("returns false when another caller already won the race", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const won = await markBootstrapped("sess-1");
+		expect(won).toBe(false);
+	});
+
+	// No row at all (bare-create session, hook never configured) is
+	// treated as the race-loser path: changes === 0, returns false. The
+	// caller should never reach this method without a postCreateCmd, but
+	// degrading rather than throwing keeps the runner code simple.
+	it("returns false when no session_configs row exists", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const won = await markBootstrapped("sess-missing");
+		expect(won).toBe(false);
+	});
+
+	it("propagates D1 errors instead of silently swallowing", async () => {
+		dbStubs.d1Query.mockRejectedValueOnce(new Error("D1 transient"));
+		await expect(markBootstrapped("sess-1")).rejects.toThrow("D1 transient");
+	});
+});

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -1,0 +1,48 @@
+/**
+ * bootstrap.ts — postCreate / postStart lifecycle hooks (#185).
+ *
+ * The runner itself lives on `DockerManager` (it needs the
+ * Dockerode client + the same `execOneShot` plumbing every other
+ * tmux/docker command uses). This module owns the D1 side: the
+ * atomic `bootstrapped_at` gate that ensures `postCreate` runs
+ * exactly once per session, no matter how many concurrent
+ * `start()` calls race in.
+ *
+ * `postStart` has no D1 gate — by design it runs on every container
+ * start (a daemon that should die with the container, like
+ * `npm run dev` or `code tunnel`).
+ */
+
+import { d1Query } from "./db.js";
+
+/**
+ * Atomically mark `session_configs.bootstrapped_at` as set, but only
+ * if it was still NULL. Returns true iff THIS caller won the race.
+ *
+ * Called by the postCreate caller AFTER a successful run so that:
+ *
+ *   - two concurrent `POST /sessions` retries against the same
+ *     session id (e.g. user double-clicked Create) don't both
+ *     execute the hook,
+ *   - a respawn after a hard-fail can NOT silently re-run the hook
+ *     (the row stays at `bootstrapped_at = NULL` until the user
+ *     explicitly recreates the session),
+ *   - if D1 is briefly unavailable we surface the failure to the
+ *     caller rather than silently letting two postCreates run.
+ *
+ * The hook command itself runs BEFORE this UPDATE so a partial run
+ * that crashed the backend mid-flight still leaves the gate open
+ * for the next attempt — matching the issue-#185 hard-fail
+ * semantics ("the row stays so the user can read the streamed
+ * log"). Using SQLite-serialised semantics on D1 — same pattern
+ * as the invite-mint and session-quota INSERTs — so the
+ * `meta.changes === 1` predicate is the source of truth.
+ */
+export async function markBootstrapped(sessionId: string): Promise<boolean> {
+	const result = await d1Query(
+		"UPDATE session_configs SET bootstrapped_at = datetime('now') " +
+			"WHERE session_id = ? AND bootstrapped_at IS NULL",
+		[sessionId],
+	);
+	return result.meta.changes === 1;
+}

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -11,6 +11,7 @@ vi.mock("./db.js", () => dbStubs);
 
 import {
 	DockerManager,
+	demuxDockerOutputAll,
 	type OutputListener,
 	sanitiseHostname,
 	sanitiseUploadName,
@@ -1152,6 +1153,74 @@ describe("DockerManager.runPostCreate", () => {
 		const result = await dm.runPostCreate("s1", "false");
 		expect(result.exitCode).toBe(42);
 		expect(result.output).toContain("boom");
+	});
+
+	// Round-2 review fix: hook diagnostics go to stderr (`npm ERR!`,
+	// `bash: cmd: not found`, `tsc: error TS…`). The capture must
+	// include stderr, otherwise the hard-fail modal shows "(no output)"
+	// for the most common failure mode and the user can't see what
+	// went wrong.
+	it("captures stderr alongside stdout in the returned output", async () => {
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				// Inject a stderr frame ahead of an empty stdout to assert
+				// the combined demux walks both. The test harness packs
+				// whatever the hook returns as stdout (frame type 1), so
+				// we simulate by writing a custom multiplexed buffer
+				// directly. Easier path: use `mergeFrames` below.
+				if (cmd[0] === "bash") {
+					return { stdout: "bash: bad-cmd: not found\n", exitCode: 127 };
+				}
+				return undefined;
+			},
+		});
+		const result = await dm.runPostCreate("s1", "bad-cmd");
+		// Even with the harness packing as stdout, the combined demux
+		// must surface the bytes — exiting code 127 is the canonical
+		// "command not found" semaphore the modal now relies on.
+		expect(result.exitCode).toBe(127);
+		expect(result.output).toContain("bash: bad-cmd: not found");
+	});
+});
+
+// Direct unit tests on the combined-demux helper itself, since the
+// fake-container harness only emits stdout frames (type 1). Asserting
+// here that mixed stdout/stderr buffers — which Docker really does
+// produce in production — interleave correctly into a single output
+// string.
+describe("demuxDockerOutputAll", () => {
+	function frame(type: 1 | 2, payload: string): Buffer {
+		const data = Buffer.from(payload, "utf-8");
+		const header = Buffer.alloc(8);
+		header[0] = type;
+		header.writeUInt32BE(data.length, 4);
+		return Buffer.concat([header, data]);
+	}
+
+	it("collects type-1 (stdout) and type-2 (stderr) frames in arrival order", () => {
+		const raw = Buffer.concat([
+			frame(1, "step1\n"),
+			frame(2, "warn: something\n"),
+			frame(1, "step2\n"),
+			frame(2, "err: boom\n"),
+		]);
+		const out = demuxDockerOutputAll(raw);
+		expect(out).toBe("step1\nwarn: something\nstep2\nerr: boom\n");
+	});
+
+	it("ignores unknown frame types (defence against future Docker additions)", () => {
+		const raw = Buffer.concat([
+			frame(1, "kept\n"),
+			// type 3 doesn't exist today; skipping it lets a future
+			// Docker frame type appear without polluting the panel.
+			Buffer.concat([Buffer.from([3, 0, 0, 0, 0, 0, 0, 5]), Buffer.from("xxxxx")]),
+			frame(2, "kept-stderr\n"),
+		]);
+		expect(demuxDockerOutputAll(raw)).toBe("kept\nkept-stderr\n");
+	});
+
+	it("returns empty string for an empty buffer", () => {
+		expect(demuxDockerOutputAll(Buffer.alloc(0))).toBe("");
 	});
 });
 

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -62,6 +62,9 @@ interface FakeExec {
 	_resizes: Array<{ h: number; w: number }>;
 	_stream: PassThrough;
 	_cmd: string[];
+	// `WorkingDir` is captured for #207 round 7 — runPostCreate now
+	// pins cwd to the workspace and tests assert it.
+	_workingDir: string | undefined;
 }
 
 interface FakeContainer {
@@ -79,7 +82,7 @@ function makeFakeContainer(oneShot?: OneShotHook): FakeContainer {
 	const execs: FakeExec[] = [];
 
 	const container = {
-		exec: vi.fn(async (opts: { Cmd: string[]; Tty?: boolean }) => {
+		exec: vi.fn(async (opts: { Cmd: string[]; Tty?: boolean; WorkingDir?: string }) => {
 			const stream = new PassThrough();
 			const resizes: Array<{ h: number; w: number }> = [];
 			streams.push(stream);
@@ -132,6 +135,7 @@ function makeFakeContainer(oneShot?: OneShotHook): FakeContainer {
 				_resizes: resizes,
 				_stream: stream,
 				_cmd: opts.Cmd,
+				_workingDir: opts.WorkingDir,
 			};
 			execs.push(exec);
 			return exec;
@@ -1153,6 +1157,23 @@ describe("DockerManager.runPostCreate", () => {
 		const result = await dm.runPostCreate("s1", "false");
 		expect(result.exitCode).toBe(42);
 		expect(result.output).toContain("boom");
+	});
+
+	// Round-7 review fix: hooks must run from the workspace, not from
+	// the image's WORKDIR. Without WorkingDir on the exec, `npm install`
+	// would look for package.json in `/home/developer` and silently
+	// fail with ENOENT.
+	it("pins WorkingDir to the workspace so hooks run alongside the user's project files", async () => {
+		const { dm, container } = makeDocker({
+			oneShot: () => ({ stdout: "", exitCode: 0 }),
+		});
+		await dm.runPostCreate("s1", "npm install");
+		const exec = mustFind(
+			container._execs,
+			(e) => e._cmd[0] === "bash" && e._cmd[1] === "-c",
+			"bash -c exec for runPostCreate",
+		);
+		expect(exec._workingDir).toBe("/home/developer/workspace");
 	});
 
 	// Round-2 review fix: hook diagnostics go to stderr (`npm ERR!`,

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -83,25 +83,27 @@ function makeFakeContainer(oneShot?: OneShotHook): FakeContainer {
 			const resizes: Array<{ h: number; w: number }> = [];
 			streams.push(stream);
 
-			// One-shot tmux commands (list-sessions, new-session -d, set-option,
-			// kill-session, has-session) don't hijack the stream. If a test
-			// supplied a hook, let it decide the stdout + exit code. Attaches
-			// (`tmux attach` or the self-healing `tmux new-session -A`) are
-			// explicitly NOT one-shots — they keep a long-lived stream open and
-			// the test drives output by writing to `container._streams[...]`.
+			// One-shot commands (every Tty:false exec — tmux list-sessions,
+			// kill-session, capture-pane, new-session -d, set-option, AND
+			// the postCreate `bash -c <cmd>` introduced in #185 / PR
+			// 185b2a) don't hijack the stream. If a test supplied a hook,
+			// let it decide the stdout + exit code. Attaches (`tmux attach`
+			// or the self-healing `tmux new-session -A`) are explicitly
+			// NOT one-shots — they keep a long-lived stream open and the
+			// test drives output by writing to `container._streams[...]`.
 			const isAttach =
 				opts.Cmd[0] === "tmux" &&
 				(opts.Cmd[1] === "attach" || (opts.Cmd[1] === "new-session" && opts.Cmd.includes("-A")));
-			// Every one-shot tmux command (capture-pane, list-sessions, kill-session,
-			// set-option, new-session -d, …) needs SOME canned response — otherwise
-			// execOneShot's `await stream.on("end")` hangs the test forever. If the
-			// caller provided a hook and it answers for this command, use that; if
-			// the hook returns undefined or wasn't provided, default to an empty
-			// stdout + exit 0 so tests that don't care about the one-shot machinery
-			// (e.g. the fan-out test that doesn't use capture-pane) don't have to
-			// wire up a full oneShot mock just to unblock attach().
+			// Every one-shot exec (capture-pane, kill-session, set-option,
+			// new-session -d, bash -c, …) needs SOME canned response —
+			// otherwise execOneShot's `await stream.on("end")` hangs the
+			// test forever. If the caller provided a hook and it answers
+			// for this command, use that; if the hook returns undefined or
+			// wasn't provided, default to an empty stdout + exit 0 so
+			// tests that don't care about the one-shot machinery don't
+			// have to wire up a full oneShot mock just to unblock attach.
 			const oneShotResult =
-				!isAttach && opts.Cmd[0] === "tmux" && opts.Tty === false
+				!isAttach && opts.Tty === false
 					? (oneShot?.(opts.Cmd) ?? { stdout: "", exitCode: 0 })
 					: undefined;
 
@@ -1112,5 +1114,105 @@ describe("sanitiseHostname", () => {
 		const out = sanitiseHostname("x".repeat(200), sid);
 		expect(out.length).toBe(63);
 		expect(out).toBe("x".repeat(63));
+	});
+});
+
+// ── Bootstrap hooks (#185) ─────────────────────────────────────────────────
+
+describe("DockerManager.runPostCreate", () => {
+	it("runs the cmd via `bash -c` and returns exit code + stdout", async () => {
+		const { dm, container } = makeDocker({
+			oneShot: (cmd) => {
+				if (cmd[0] === "bash" && cmd[1] === "-c") {
+					return { stdout: "installed\n", exitCode: 0 };
+				}
+				return undefined;
+			},
+		});
+		const result = await dm.runPostCreate("s1", "npm install");
+		expect(result.exitCode).toBe(0);
+		expect(result.output).toContain("installed");
+		// Cmd shape: bash -c <user-script>. Argv form means tmux/exec
+		// gets the script as a single argument, no shell-quoting hazard.
+		const exec = mustFind(
+			container._execs,
+			(e) => e._cmd[0] === "bash" && e._cmd[1] === "-c",
+			"bash -c exec for runPostCreate",
+		);
+		expect(exec._cmd).toEqual(["bash", "-c", "npm install"]);
+	});
+
+	it("propagates a non-zero exit code so the route can hard-fail", async () => {
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				if (cmd[0] === "bash") return { stdout: "boom\n", exitCode: 42 };
+				return undefined;
+			},
+		});
+		const result = await dm.runPostCreate("s1", "false");
+		expect(result.exitCode).toBe(42);
+		expect(result.output).toContain("boom");
+	});
+});
+
+describe("DockerManager.runPostStart", () => {
+	it("kills any prior `bootstrap` tmux session, then creates a fresh detached one", async () => {
+		const calls: string[][] = [];
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				calls.push(cmd);
+				return { stdout: "", exitCode: 0 };
+			},
+		});
+		await dm.runPostStart("s1", "code tunnel");
+		// Idempotent on re-runs: the kill-session must come first so a
+		// stale daemon from the previous start can't race the new one.
+		expect(calls[0]).toEqual(["tmux", "kill-session", "-t", "bootstrap"]);
+		// new-session -d creates the daemon detached; -c pins cwd to the
+		// workspace so the hook runs from the same place a freshly-
+		// attached terminal would.
+		expect(calls[1]).toEqual([
+			"tmux",
+			"new-session",
+			"-d",
+			"-s",
+			"bootstrap",
+			"-c",
+			"/home/developer/workspace",
+			"bash",
+			"-c",
+			"code tunnel",
+		]);
+	});
+
+	it("treats a non-zero kill-session as expected (first start has no session to kill)", async () => {
+		// First-start path: kill-session returns 1 ("no such session")
+		// which is the COMMON case, not an error. Wrapped in .catch in
+		// runPostStart so it never propagates. The new-session call
+		// must still run.
+		const calls: string[][] = [];
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				calls.push(cmd);
+				if (cmd.includes("kill-session")) return { stdout: "", exitCode: 1 };
+				return { stdout: "", exitCode: 0 };
+			},
+		});
+		await dm.runPostStart("s1", "echo started");
+		expect(calls.length).toBe(2);
+		expect(calls[1]?.[1]).toBe("new-session");
+	});
+
+	it("logs a warning but does not throw if the new-session itself fails", async () => {
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+		const { dm } = makeDocker({
+			oneShot: (cmd) => {
+				if (cmd[1] === "new-session") return { stdout: "boom", exitCode: 99 };
+				return { stdout: "", exitCode: 0 };
+			},
+		});
+		await expect(dm.runPostStart("s1", "broken")).resolves.toBeUndefined();
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("postStart launch failed"));
+		warnSpy.mockRestore();
 	});
 });

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -776,7 +776,14 @@ export class DockerManager {
 		sessionId: string,
 		cmd: string,
 	): Promise<{ exitCode: number; output: string }> {
-		const result = await this.execOneShot(sessionId, ["bash", "-c", cmd]);
+		// `combineStreams: true` so the captured output includes stderr
+		// (#207 round 2 review): npm/tsc/bash diagnostic messages all go
+		// to stderr by default, and a hook-failure modal that only
+		// displays stdout would render "(no output)" for the most common
+		// failure mode (`bash: <cmd>: command not found`).
+		const result = await this.execOneShot(sessionId, ["bash", "-c", cmd], {
+			combineStreams: true,
+		});
 		return { exitCode: result.exitCode, output: result.stdout };
 	}
 
@@ -1405,6 +1412,7 @@ export class DockerManager {
 	private async execOneShot(
 		sessionId: string,
 		cmd: string[],
+		opts: { combineStreams?: boolean } = {},
 	): Promise<{ stdout: string; exitCode: number }> {
 		const meta = await this.sessions.getOrThrow(sessionId);
 		if (!meta.containerId) throw new Error("No container for this session");
@@ -1429,8 +1437,18 @@ export class DockerManager {
 			stream.on("error", reject);
 		});
 		const info = await exec.inspect();
+		// `combineStreams: true` is the bootstrap-hook caller (#207
+		// review): npm/tsc/bash diagnostics go to stderr, and a hook
+		// failure modal that only shows stdout would render
+		// "(no output captured)" for the common "command not found"
+		// path. The combined demux preserves frame-arrival order, so a
+		// shell snippet like `echo step1; bad-command` still reads as
+		// "step1\nbash: bad-command: not found\n" rather than the two
+		// streams separated.
 		return {
-			stdout: demuxDockerOutput(Buffer.concat(chunks), 1),
+			stdout: opts.combineStreams
+				? demuxDockerOutputAll(Buffer.concat(chunks))
+				: demuxDockerOutput(Buffer.concat(chunks), 1),
 			exitCode: info.ExitCode ?? 0,
 		};
 	}
@@ -1661,6 +1679,30 @@ function demuxDockerOutput(raw: Buffer, type: 1 | 2): string {
 		off += 8;
 		if (off + size > raw.length) break;
 		if (frameType === type) chunks.push(raw.subarray(off, off + size));
+		off += size;
+	}
+	return Buffer.concat(chunks).toString("utf-8");
+}
+
+// Same parser as `demuxDockerOutput` but collects BOTH stdout (type 1)
+// and stderr (type 2) in frame-arrival order. Used by the postCreate
+// hook runner (#207 review) so a `bash -c "echo step1; bad-cmd"`
+// failure renders as "step1\nbash: bad-cmd: not found\n" in the modal,
+// rather than just "step1\n" (stdout-only) or worse, "(no output)" if
+// the entire failure went to stderr. Frame-order interleaving is
+// approximate at the byte level — Docker only delivers complete
+// frames, and within a frame the ordering vs. the OTHER stream's
+// preceding bytes is whatever the writer happened to flush first —
+// but it's good enough for a log panel. Exported for tests.
+export function demuxDockerOutputAll(raw: Buffer): string {
+	const chunks: Buffer[] = [];
+	let off = 0;
+	while (off + 8 <= raw.length) {
+		const frameType = raw[off]!;
+		const size = raw.readUInt32BE(off + 4);
+		off += 8;
+		if (off + size > raw.length) break;
+		if (frameType === 1 || frameType === 2) chunks.push(raw.subarray(off, off + size));
 		off += size;
 	}
 	return Buffer.concat(chunks).toString("utf-8");

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -781,8 +781,18 @@ export class DockerManager {
 		// to stderr by default, and a hook-failure modal that only
 		// displays stdout would render "(no output)" for the most common
 		// failure mode (`bash: <cmd>: command not found`).
+		//
+		// `cwd: /home/developer/workspace` so the hook lands in the same
+		// place a freshly-attached terminal would (#207 round 7 review).
+		// Without it, Docker uses the image's WORKDIR
+		// (`/home/developer`) and `npm install` / `pip install -r ...` /
+		// `cargo build` would all fail with ENOENT looking for project
+		// files in the wrong directory. `runPostStart`'s tmux-session
+		// path already gets this right via `tmux new-session -c …`;
+		// this brings the exec path in line.
 		const result = await this.execOneShot(sessionId, ["bash", "-c", cmd], {
 			combineStreams: true,
+			cwd: "/home/developer/workspace",
 		});
 		return { exitCode: result.exitCode, output: result.stdout };
 	}
@@ -1412,7 +1422,7 @@ export class DockerManager {
 	private async execOneShot(
 		sessionId: string,
 		cmd: string[],
-		opts: { combineStreams?: boolean } = {},
+		opts: { combineStreams?: boolean; cwd?: string } = {},
 	): Promise<{ stdout: string; exitCode: number }> {
 		const meta = await this.sessions.getOrThrow(sessionId);
 		if (!meta.containerId) throw new Error("No container for this session");
@@ -1420,6 +1430,15 @@ export class DockerManager {
 
 		const exec = await container.exec({
 			Cmd: cmd,
+			// `WorkingDir: undefined` preserves Docker's image-WORKDIR
+			// default for callers that don't pass `cwd` (every tmux
+			// one-shot — `-c` on `new-session` controls the tmux
+			// session's cwd, not the exec's, and tmux runs without
+			// caring about its own cwd anyway). The bootstrap-runner
+			// caller (#207 round 7 review) sets cwd to the workspace
+			// so hooks like `npm install` find the user's
+			// package.json instead of looking in `/home/developer`.
+			WorkingDir: opts.cwd,
 			AttachStdin: false,
 			AttachStdout: true,
 			AttachStderr: true,

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -682,6 +682,7 @@ export class DockerManager {
 			await this.spawn(sessionId);
 			await this.sessions.updateStatus(sessionId, "running");
 			logger.info(`[docker] respawned container for session ${sessionId}`);
+			await this.runPostStartIfConfigured(sessionId);
 			return;
 		}
 
@@ -701,6 +702,26 @@ export class DockerManager {
 			await this.sessions.setContainerId(sessionId, null);
 			await this.spawn(sessionId);
 			await this.sessions.updateStatus(sessionId, "running");
+		}
+		await this.runPostStartIfConfigured(sessionId);
+	}
+
+	/**
+	 * Look up `session_configs.post_start_cmd` and run it if present.
+	 * Wrapper that keeps `startContainer` readable and centralises the
+	 * config-read + warn-on-D1-transient pattern, mirroring
+	 * `loadConfigForSpawn`. Doesn't throw — a failed postStart is
+	 * logged inside `runPostStart` and the container stays usable.
+	 */
+	private async runPostStartIfConfigured(sessionId: string): Promise<void> {
+		const config = await this.loadConfigForSpawn(sessionId);
+		if (!config?.postStartCmd) return;
+		try {
+			await this.runPostStart(sessionId, config.postStartCmd);
+		} catch (err) {
+			logger.warn(
+				`[docker] postStart hook threw for session ${sessionId}: ${(err as Error).message}`,
+			);
 		}
 	}
 
@@ -727,6 +748,82 @@ export class DockerManager {
 				`SecurityOpt=${JSON.stringify(securityOpt)}). ` +
 				`Recycle via DELETE /api/sessions/${sessionId} then POST /start to apply current HostConfig.`,
 		);
+	}
+
+	// ── Bootstrap hooks (#185) ─────────────────────────────────────────────
+
+	/**
+	 * Run the postCreate hook synchronously and return its exit code +
+	 * combined output. PR 185b2a uses this from `POST /api/sessions`
+	 * inline; PR 185b2b layers a streaming WS channel on top so the
+	 * client doesn't have to wait on the HTTP request for output.
+	 *
+	 * `bash -c` so the user's command can use shell features
+	 * (`npm i && tsc`). User is the unprivileged container user (uid
+	 * 1000); cwd is the workspace bind mount, so the hook lands in the
+	 * same place a freshly-attached terminal would.
+	 *
+	 * Output cap: `execOneShot` collects the whole stream into a Buffer
+	 * before returning. A runaway hook that streams MB of output could
+	 * push memory pressure on the backend. Acceptable for the foundation
+	 * because the user controls the command, the per-session disk quota
+	 * already bounds workspace bloat, and 185b2b's streaming runner will
+	 * forward bytes onward instead of buffering. Documented as a known
+	 * trade-off here so the streaming PR has a concrete reason to drop
+	 * the buffering.
+	 */
+	async runPostCreate(
+		sessionId: string,
+		cmd: string,
+	): Promise<{ exitCode: number; output: string }> {
+		const result = await this.execOneShot(sessionId, ["bash", "-c", cmd]);
+		return { exitCode: result.exitCode, output: result.stdout };
+	}
+
+	/**
+	 * Run the postStart hook detached in a tmux session named `bootstrap`
+	 * inside the container. Returns once the session is created, NOT
+	 * when the command exits — by design, the hook runs asynchronously
+	 * for the whole life of the container so `npm run dev` / `code
+	 * tunnel`-style daemons stay alive in the background. Visible to
+	 * the user via the regular tab list (the session shows up next to
+	 * user-created tabs); dies with the container because tmux
+	 * server is per-PID-namespace.
+	 *
+	 * Idempotent on re-runs: a second `start()` on the same container
+	 * is the most common case (user stopped + restarted). Killing any
+	 * existing `bootstrap` session first avoids a stale daemon racing
+	 * the new one.
+	 */
+	async runPostStart(sessionId: string, cmd: string): Promise<void> {
+		// kill-session is idempotent — exits non-zero if no such
+		// session exists, which is the expected state on the very first
+		// start. Swallow the non-zero so we don't log a spurious warning
+		// for the common path.
+		await this.execOneShot(sessionId, ["tmux", "kill-session", "-t", "bootstrap"]).catch(() => {
+			/* may not exist yet */
+		});
+		const create = await this.execOneShot(sessionId, [
+			"tmux",
+			"new-session",
+			"-d",
+			"-s",
+			"bootstrap",
+			"-c",
+			"/home/developer/workspace",
+			"bash",
+			"-c",
+			cmd,
+		]);
+		if (create.exitCode !== 0) {
+			// Don't fail the whole start path on a postStart launch
+			// error — the container is up, the user can still use it.
+			// Surface in logs so an operator notices the daemon never
+			// came up.
+			logger.warn(
+				`[docker] postStart launch failed for session ${sessionId} (exit ${create.exitCode}): ${create.stdout}`,
+			);
+		}
 	}
 
 	async stopContainer(sessionId: string): Promise<void> {

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -238,11 +238,17 @@ describe("POST /sessions — postCreate hard-fail path", () => {
 		expect(bootstrapStubs.markBootstrapped).not.toHaveBeenCalled();
 	});
 
-	it("preserves the failed row even when D1 transient breaks updateStatus", async () => {
-		// PR #207 round 3 fix: a thrown updateStatus must not propagate
-		// to the outer catch (which would deleteRow). The user-visible
-		// 500 with bootstrapOutput is what matters — operator picks up
-		// the CRITICAL log and flips the row manually.
+	it("rolls back the row + kills the container if updateStatus throws on hard-fail", async () => {
+		// PR #207 round 5 fix (replaces round 3): a thrown updateStatus
+		// must propagate so the outer catch tears the half-state row
+		// down. The previous behaviour swallowed the throw, leaving the
+		// row at (running, null) — which reconcile() would silently
+		// promote to (stopped, null), letting /start respawn an
+		// unbootstrapped container. Trade-off accepted: on this rare
+		// D1-hiccup path the user loses bootstrapOutput in the 500
+		// body (the response never reaches `res.json` because the
+		// exception jumped out earlier), but they don't get a
+		// respawnable orphan. CRITICAL operator log + general 500.
 		const { sessions, docker, spies } = makeFakes({
 			postCreateExit: 1,
 			postCreateOutput: "boom",
@@ -260,11 +266,45 @@ describe("POST /sessions — postCreate hard-fail path", () => {
 		});
 		expect(res.status).toBe(500);
 		const body = (await res.json()) as { bootstrapOutput?: string };
-		// The captured output still rides out in the response — that's
-		// the user-visible escape hatch.
-		expect(body.bootstrapOutput).toBe("boom");
-		// Row was NOT deleted by the outer catch.
-		expect(spies.deleteRow).not.toHaveBeenCalled();
+		// Generic 500 — the bootstrapOutput field is GONE from the
+		// response (we never reached the json call inside the if).
+		expect(body.bootstrapOutput).toBeUndefined();
+		// Outer catch ran: row deleted, container killed (no orphan,
+		// no respawnable row).
+		expect(spies.deleteRow).toHaveBeenCalledWith("sess-1");
+		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+	});
+
+	it("returns 201 + calls markBootstrapped + runPostStart on the success path", async () => {
+		// Round-5 NIT: every other test in this file covers a failure
+		// shape. Pinning the happy path ensures a future refactor that
+		// drops `markBootstrapped` (single-use gate that prevents
+		// postCreate re-runs) or that fires `runPostStart` before
+		// `markBootstrapped` (would re-run a fresh hook every restart
+		// in the wrong order) trips an obvious test.
+		const { sessions, docker, spies } = makeFakes({
+			postCreateExit: 0,
+			postCreateOutput: "installed\n",
+		});
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "test",
+				config: {
+					postCreateCmd: "npm install",
+					postStartCmd: "npm run dev",
+				},
+			}),
+		});
+		expect(res.status).toBe(201);
+		expect(spies.runPostCreate).toHaveBeenCalledWith("sess-1", "npm install");
+		expect(bootstrapStubs.markBootstrapped).toHaveBeenCalledWith("sess-1");
+		expect(spies.runPostStart).toHaveBeenCalledWith("sess-1", "npm run dev");
+		expect(spies.kill).not.toHaveBeenCalled();
+		expect(spies.updateStatus).not.toHaveBeenCalled();
 	});
 
 	it("kills the container in the outer catch even on a post-spawn / post-runPostCreate failure", async () => {

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -1,0 +1,298 @@
+/**
+ * routes.create.test.ts — POST /sessions hard-fail path tests for #185 (PR 185b2a).
+ *
+ * Round-4 review flagged that the 500-response shape on a postCreate
+ * hook failure (`{ sessionId, bootstrapOutput, bootstrapExitCode }`)
+ * was only exercised at the `DockerManager` unit level. The frontend
+ * modal parses these specific fields to render the error panel — a
+ * future refactor that drops one of them would silently break the
+ * UX with no failing test. This file covers the full HTTP round-trip.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authStubs = vi.hoisted(() => ({
+	requireAuth: (req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	},
+	requireAdmin: (req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	},
+	AUTH_COOKIE_NAME: "st_token",
+	setAuthCookie: vi.fn(),
+	clearAuthCookie: vi.fn(),
+	extractTokenFromCookieHeader: vi.fn(() => null),
+	verifyJwt: vi.fn(() => null),
+	hasAnyUsers: vi.fn(async () => true),
+	registerUser: vi.fn(),
+	loginUser: vi.fn(),
+	listInvites: vi.fn(async () => [] as unknown[]),
+	createInvite: vi.fn(),
+	revokeInvite: vi.fn(),
+	InvalidCredentialsError: class extends Error {
+		constructor() {
+			super("invalid");
+		}
+	},
+	UsernameTakenError: class extends Error {
+		constructor() {
+			super("taken");
+		}
+	},
+	InviteRequiredError: class extends Error {
+		constructor() {
+			super("invite required");
+		}
+	},
+	InviteQuotaExceededError: class extends Error {
+		constructor() {
+			super("invite quota");
+		}
+	},
+}));
+vi.mock("./auth.js", () => authStubs);
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+// Stub `markBootstrapped` so the success-path test doesn't need a D1
+// UPDATE round-trip; the hard-fail path tested below never reaches it.
+const bootstrapStubs = vi.hoisted(() => ({
+	markBootstrapped: vi.fn(async () => true),
+}));
+vi.mock("./bootstrap.js", () => bootstrapStubs);
+
+// `persistSessionConfig` writes the session_configs row. Stub so the
+// test doesn't need to mock the full d1Query SQL flow for the
+// non-bootstrap fields.
+vi.mock("./sessionConfig.js", async () => {
+	const actual = await vi.importActual<typeof import("./sessionConfig.js")>("./sessionConfig.js");
+	return {
+		...actual,
+		persistSessionConfig: vi.fn(async () => undefined),
+	};
+});
+
+import type { DockerManager } from "./dockerManager.js";
+import { buildRouter } from "./routes.js";
+import type { SessionManager } from "./sessionManager.js";
+import type { SessionMeta } from "./types.js";
+
+function makeMeta(): SessionMeta {
+	return {
+		sessionId: "sess-1",
+		userId: "u1",
+		name: "test",
+		status: "running",
+		containerId: "container-abc",
+		containerName: "st-test",
+		cols: 80,
+		rows: 24,
+		envVars: {},
+		createdAt: new Date(),
+		lastConnectedAt: null,
+	};
+}
+
+interface Spies {
+	create: ReturnType<typeof vi.fn>;
+	updateStatus: ReturnType<typeof vi.fn>;
+	deleteRow: ReturnType<typeof vi.fn>;
+	kill: ReturnType<typeof vi.fn>;
+	spawn: ReturnType<typeof vi.fn>;
+	runPostCreate: ReturnType<typeof vi.fn>;
+	runPostStart: ReturnType<typeof vi.fn>;
+}
+
+function makeFakes(opts: { postCreateExit: number; postCreateOutput: string }): {
+	sessions: SessionManager;
+	docker: DockerManager;
+	spies: Spies;
+} {
+	const meta = makeMeta();
+	const create = vi.fn(async () => meta);
+	const updateStatus = vi.fn(async () => undefined);
+	const deleteRow = vi.fn(async () => undefined);
+	const sessions = {
+		create,
+		updateStatus,
+		deleteRow,
+		get: vi.fn(async () => meta),
+	} as unknown as SessionManager;
+
+	const kill = vi.fn(async () => undefined);
+	const spawn = vi.fn(async () => "container-abc");
+	const runPostCreate = vi.fn(async () => ({
+		exitCode: opts.postCreateExit,
+		output: opts.postCreateOutput,
+	}));
+	const runPostStart = vi.fn(async () => undefined);
+	const docker = {
+		getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
+		spawn,
+		kill,
+		runPostCreate,
+		runPostStart,
+	} as unknown as DockerManager;
+	return {
+		sessions,
+		docker,
+		spies: { create, updateStatus, deleteRow, kill, spawn, runPostCreate, runPostStart },
+	};
+}
+
+let server: http.Server | null = null;
+let baseUrl = "";
+
+afterEach(async () => {
+	if (server) {
+		await new Promise<void>((resolve, reject) => {
+			server?.close((e) => (e ? reject(e) : resolve()));
+		});
+		server = null;
+	}
+});
+
+async function spinUp(sessions: SessionManager, docker: DockerManager) {
+	const router = buildRouter(sessions, docker, {
+		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+		register: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+		logout: { ipMax: 1000, ipWindowMs: 60_000 },
+		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+	});
+	const app = express();
+	app.use(express.json());
+	app.use("/api", router);
+	const s = http.createServer(app);
+	server = s;
+	await new Promise<void>((resolve) => s.listen(0, "127.0.0.1", resolve));
+	const { port } = s.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+}
+
+describe("POST /sessions — postCreate hard-fail path", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+		bootstrapStubs.markBootstrapped.mockReset();
+		bootstrapStubs.markBootstrapped.mockResolvedValue(true);
+	});
+
+	it("returns 500 with bootstrapOutput / bootstrapExitCode / sessionId on non-zero hook exit", async () => {
+		// Frontend modal parses exactly these three fields to render the
+		// inline failure panel — locking the response shape so a future
+		// refactor that drops any of them trips this test.
+		const { sessions, docker, spies } = makeFakes({
+			postCreateExit: 42,
+			postCreateOutput: "bash: bad-cmd: not found\nnpm ERR! exited 42",
+		});
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "test",
+				config: { postCreateCmd: "bad-cmd" },
+			}),
+		});
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as {
+			error: string;
+			sessionId: string;
+			bootstrapOutput: string;
+			bootstrapExitCode: number;
+		};
+		expect(body.error).toMatch(/postCreate hook failed/);
+		expect(body.bootstrapExitCode).toBe(42);
+		expect(body.bootstrapOutput).toContain("bash: bad-cmd: not found");
+		expect(body.sessionId).toBe("sess-1");
+
+		// Container must be killed on hard-fail — leaving it running
+		// would leak a container the user can no longer reach (the row
+		// is now `failed`, /start refuses).
+		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+		// Row is FLIPPED to failed, NOT deleted — the captured output
+		// has to survive so the user can audit it later.
+		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+		expect(spies.deleteRow).not.toHaveBeenCalled();
+		// markBootstrapped MUST NOT be called on the failure path — the
+		// gate exists to ensure postCreate runs once per session, not
+		// once per attempt; flipping it would prevent a future recreate
+		// from re-running the corrected hook (the row is failed and
+		// can't be reused, but defence in depth).
+		expect(bootstrapStubs.markBootstrapped).not.toHaveBeenCalled();
+	});
+
+	it("preserves the failed row even when D1 transient breaks updateStatus", async () => {
+		// PR #207 round 3 fix: a thrown updateStatus must not propagate
+		// to the outer catch (which would deleteRow). The user-visible
+		// 500 with bootstrapOutput is what matters — operator picks up
+		// the CRITICAL log and flips the row manually.
+		const { sessions, docker, spies } = makeFakes({
+			postCreateExit: 1,
+			postCreateOutput: "boom",
+		});
+		spies.updateStatus.mockRejectedValueOnce(new Error("D1 transient"));
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "test",
+				config: { postCreateCmd: "false" },
+			}),
+		});
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { bootstrapOutput?: string };
+		// The captured output still rides out in the response — that's
+		// the user-visible escape hatch.
+		expect(body.bootstrapOutput).toBe("boom");
+		// Row was NOT deleted by the outer catch.
+		expect(spies.deleteRow).not.toHaveBeenCalled();
+	});
+
+	it("kills the container in the outer catch even on a post-spawn / post-runPostCreate failure", async () => {
+		// PR #207 round 4 fix: any throw between docker.spawn and the
+		// 201 response (markBootstrapped, runPostStart, sessions.get,
+		// the synthetic invariant throw) used to deleteRow but leave
+		// the container running — orphaned forever. The outer catch now
+		// always kills first.
+		const { sessions, docker, spies } = makeFakes({
+			postCreateExit: 0,
+			postCreateOutput: "",
+		});
+		bootstrapStubs.markBootstrapped.mockRejectedValueOnce(new Error("D1 transient"));
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "test",
+				config: { postCreateCmd: "echo ok" },
+			}),
+		});
+		expect(res.status).toBe(500);
+		// kill was called by the outer catch — no orphaned container.
+		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+		// And the row got rolled back (this is the standard "unexpected
+		// failure during create" path).
+		expect(spies.deleteRow).toHaveBeenCalledWith("sess-1");
+	});
+});

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -275,6 +275,38 @@ describe("POST /sessions — postCreate hard-fail path", () => {
 		expect(spies.kill).toHaveBeenCalledWith("sess-1");
 	});
 
+	// Round-6 review concern: `sessions.create()` itself throwing (D1
+	// transient before any row exists) means `meta` is still null in
+	// the outer catch. The rollback block must NOT call
+	// `meta.sessionId` outside the `if (meta)` guard. Locking the case
+	// so the rollback never crashes with TypeError on this path.
+	it("does not crash the rollback when sessions.create itself throws (meta is null)", async () => {
+		const { sessions, docker, spies } = makeFakes({
+			postCreateExit: 0,
+			postCreateOutput: "",
+		});
+		spies.create.mockRejectedValueOnce(new Error("D1 down"));
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "test" }),
+		});
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: string };
+		// The original D1 error is what surfaces — NOT a TypeError on
+		// `meta.sessionId`. If the rollback crashed, Express would
+		// return a different error or the test would observe a stale
+		// connection.
+		expect(body.error).toBe("D1 down");
+		// No spawn / kill / deleteRow — `meta` was null, the rollback
+		// block was skipped entirely.
+		expect(spies.spawn).not.toHaveBeenCalled();
+		expect(spies.kill).not.toHaveBeenCalled();
+		expect(spies.deleteRow).not.toHaveBeenCalled();
+	});
+
 	it("returns 201 + calls markBootstrapped + runPostStart on the success path", async () => {
 		// Round-5 NIT: every other test in this file covers a failure
 		// shape. Pinning the happy path ensures a future refactor that

--- a/backend/src/routes.start.test.ts
+++ b/backend/src/routes.start.test.ts
@@ -1,0 +1,200 @@
+/**
+ * routes.start.test.ts — POST /sessions/:id/start route tests for #185 (PR 185b2a).
+ *
+ * The bootstrap-runner PR adds a `failed` SessionStatus and the docs
+ * promise that a `failed` session is unrecoverable via /start (the user
+ * must recreate). This file pins that behaviour: a 409 response with
+ * the captured-output guidance, never a silent respawn that hides the
+ * unbootstrapped state behind a healthy-looking "running" badge.
+ *
+ * Heavy mocking pattern follows `rateLimit.test.ts`: stub `./auth.js`
+ * so routing tests don't touch D1, then exercise the express app via
+ * a real HTTP server bound to an ephemeral port.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authStubs = vi.hoisted(() => ({
+	requireAuth: (req: { userId?: string }, _res: unknown, next: () => void) => {
+		// Inject a userId so routes downstream of `assertOwnership` see
+		// "u1" as the caller. Real `requireAuth` reads the JWT cookie.
+		req.userId = "u1";
+		next();
+	},
+	requireAdmin: (req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	},
+	AUTH_COOKIE_NAME: "st_token",
+	setAuthCookie: vi.fn(),
+	clearAuthCookie: vi.fn(),
+	extractTokenFromCookieHeader: vi.fn(() => null),
+	verifyJwt: vi.fn(() => null),
+	hasAnyUsers: vi.fn(async () => true),
+	registerUser: vi.fn(),
+	loginUser: vi.fn(),
+	listInvites: vi.fn(async () => [] as unknown[]),
+	createInvite: vi.fn(),
+	revokeInvite: vi.fn(),
+	InvalidCredentialsError: class extends Error {
+		constructor() {
+			super("invalid");
+		}
+	},
+	UsernameTakenError: class extends Error {
+		constructor() {
+			super("taken");
+		}
+	},
+	InviteRequiredError: class extends Error {
+		constructor() {
+			super("invite required");
+		}
+	},
+	InviteQuotaExceededError: class extends Error {
+		constructor() {
+			super("invite quota");
+		}
+	},
+}));
+vi.mock("./auth.js", () => authStubs);
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import type { DockerManager } from "./dockerManager.js";
+import { buildRouter } from "./routes.js";
+import type { SessionManager } from "./sessionManager.js";
+import type { SessionMeta, SessionStatus } from "./types.js";
+
+function makeMeta(overrides: Partial<SessionMeta> = {}): SessionMeta {
+	return {
+		sessionId: "sess-1",
+		userId: "u1",
+		name: "test",
+		status: "stopped",
+		containerId: null,
+		containerName: "st-test",
+		cols: 80,
+		rows: 24,
+		envVars: {},
+		createdAt: new Date(),
+		lastConnectedAt: null,
+		...overrides,
+	};
+}
+
+function makeFakeSessions(status: SessionStatus): SessionManager {
+	const meta = makeMeta({ status });
+	return {
+		assertOwnership: vi.fn(async () => meta),
+		get: vi.fn(async () => ({ ...meta, status: "running" as const })),
+	} as unknown as SessionManager;
+}
+
+function makeFakeDocker(): {
+	docker: DockerManager;
+	startSpy: ReturnType<typeof vi.fn>;
+} {
+	const startSpy = vi.fn(async () => undefined);
+	const docker = {
+		getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
+		startContainer: startSpy,
+	} as unknown as DockerManager;
+	return { docker, startSpy };
+}
+
+let server: http.Server | null = null;
+let baseUrl = "";
+
+afterEach(async () => {
+	if (server) {
+		await new Promise<void>((resolve, reject) => {
+			server?.close((e) => (e ? reject(e) : resolve()));
+		});
+		server = null;
+	}
+});
+
+async function spinUp(sessions: SessionManager, docker: DockerManager) {
+	const router = buildRouter(sessions, docker, {
+		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+		register: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+		logout: { ipMax: 1000, ipWindowMs: 60_000 },
+		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+	});
+	const app = express();
+	app.use(express.json());
+	app.use("/api", router);
+	const s = http.createServer(app);
+	server = s;
+	await new Promise<void>((resolve) => s.listen(0, "127.0.0.1", resolve));
+	const { port } = s.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+}
+
+describe("POST /sessions/:id/start", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+	});
+
+	it("rejects a `failed` session with 409 and never invokes startContainer", async () => {
+		const sessions = makeFakeSessions("failed");
+		const { docker, startSpy } = makeFakeDocker();
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions/sess-1/start`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+		});
+		expect(res.status).toBe(409);
+		const body = (await res.json()) as { error: string };
+		// Message must point the user at "recreate" — the bot called this
+		// out as the central UX promise of the failed status.
+		expect(body.error).toMatch(/recreate/i);
+		// Critical: startContainer is never called for failed sessions.
+		// Letting it through would silently respawn without postCreate.
+		expect(startSpy).not.toHaveBeenCalled();
+	});
+
+	it("allows a `stopped` session through to startContainer (regression guard)", async () => {
+		const sessions = makeFakeSessions("stopped");
+		const { docker, startSpy } = makeFakeDocker();
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions/sess-1/start`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+		});
+		expect(res.status).toBe(200);
+		expect(startSpy).toHaveBeenCalledWith("sess-1");
+	});
+
+	it("allows a `terminated` session through (soft-delete -> respawn is the documented path)", async () => {
+		// CLAUDE.md: "soft delete by default... user can later POST /start
+		// to respawn". The new failed-status guard MUST NOT regress that.
+		const sessions = makeFakeSessions("terminated");
+		const { docker, startSpy } = makeFakeDocker();
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions/sess-1/start`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+		});
+		expect(res.status).toBe(200);
+		expect(startSpy).toHaveBeenCalledWith("sess-1");
+	});
+});

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -465,26 +465,36 @@ export function buildRouter(
 					validatedConfig.postCreateCmd,
 				);
 				if (exitCode !== 0) {
+					// Status flip MUST land BEFORE the docker.kill, NOT
+					// after (round-5 review). If we flipped after, a D1
+					// transient on the flip would leave the row at
+					// `(running, null)` (kill nulled container_id), and
+					// reconcile() on the next backend boot would promote
+					// it to `stopped` — a state the /start 409 guard
+					// happily allows, silently respawning an
+					// unbootstrapped container.
+					//
+					// We deliberately do NOT swallow this UPDATE's error.
+					// If it throws, the exception propagates to the outer
+					// catch which tears down the row + container as a
+					// generic create failure. Trade-off: on a D1 hiccup
+					// the user loses the captured `bootstrapOutput` from
+					// the 500 body (we never reach the json call) and
+					// the sidebar never shows the failure row. That's
+					// strictly better than the alternative, which is a
+					// row that reconcile silently promotes to stopped
+					// and the user respawns into.
+					await sessions.updateStatus(meta.sessionId, "failed");
+					// Kill is best-effort. If it fails, we have an orphan
+					// container with status=failed — a leak, not a
+					// security issue: reconcile selects only `running`
+					// rows so it skips this one, the /start 409 guard
+					// refuses the row, and manual `docker rm` resolves
+					// the leak. CRITICAL log surfaces it for operators.
 					await docker.kill(meta.sessionId).catch((e) => {
 						logger.error(
-							`[routes] kill after failed postCreate ${meta?.sessionId} threw: ${(e as Error).message}`,
-						);
-					});
-					// Swallow D1 transients here on purpose: a thrown
-					// `updateStatus` would propagate to the outer catch,
-					// which would then call `sessions.deleteRow` — wiping
-					// the very row the `failed` status is meant to
-					// preserve for audit (the captured output already
-					// went into the response below, but the sidebar
-					// would never show the failure). Loud log so an
-					// operator can manually flip the row from `running`
-					// to `failed` after the fact; the user still sees
-					// the captured `bootstrapOutput` in this response.
-					await sessions.updateStatus(meta.sessionId, "failed").catch((e) => {
-						logger.error(
-							`[routes] CRITICAL: could not flip session ${meta?.sessionId} to failed: ${(e as Error).message}. ` +
-								"Container is killed; row likely still shows status=running. " +
-								"Operator must update D1 manually to reflect the failure.",
+							`[routes] CRITICAL: kill after failed postCreate ${meta?.sessionId} threw: ${(e as Error).message}. ` +
+								"Row already flipped to failed; container may need manual `docker rm`.",
 						);
 					});
 					res.status(500).json({

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -624,7 +624,24 @@ export function buildRouter(
 	router.post("/sessions/:id/start", async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
 		try {
-			await sessions.assertOwnership(req.params.id, userId);
+			const meta = await sessions.assertOwnership(req.params.id, userId);
+			// `failed` (#185) means the create-time postCreate hook
+			// exited non-zero. Refuse the restart explicitly — letting it
+			// through would spawn a fresh container without re-running
+			// postCreate (the gate is single-use), leaving the user with
+			// what looks like a healthy "running" session whose
+			// environment was never bootstrapped. The session can carry
+			// partial workspace artefacts from the failed attempt; the
+			// safe path is `recreate it to retry`. 409 Conflict reflects
+			// "valid request, current state forbids it" — not 400 (the
+			// payload is fine) and not 403 (it's not an auth issue).
+			if (meta.status === "failed") {
+				res.status(409).json({
+					error:
+						"Session failed during postCreate; recreate it to retry. The original output is still in the failed-row history.",
+				});
+				return;
+			}
 			await docker.startContainer(req.params.id);
 			const updated = await sessions.get(req.params.id);
 			if (!updated) {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -555,6 +555,13 @@ export function buildRouter(
 			}
 			logger.error(`[routes] session create failed: ${(err as Error).message}`);
 			if (meta) {
+				// Capture the id once so the closures below don't have to
+				// reach back through the outer mutable `let meta` (TS
+				// can't narrow `meta` through a closure even though we're
+				// already inside `if (meta)`). One const, no optional
+				// chains, no ambiguity for future readers about whether
+				// meta could ever be null on these lines.
+				const rollbackId = meta.sessionId;
 				// Best-effort rollback. If deleteRow itself fails (D1 blip),
 				// the reconciler will eventually flip status to stopped but
 				// the row remains — we log loudly so an operator can clean
@@ -568,23 +575,23 @@ export function buildRouter(
 				// reach it through — `reconcile()` queries
 				// `WHERE status='running'`, so a deleted row means the
 				// container survives until the next host reboot. The
-				// non-zero-exit path inside the try/ catch already kills
+				// non-zero-exit path inside the try/catch already kills
 				// the container before throwing; this guard covers every
 				// other post-spawn failure shape (markBootstrapped,
 				// runPostStart, sessions.get, the synthetic invariant
 				// throw above). Idempotent: the failure-branch
 				// `docker.kill` already ran on hard-fail, and `kill`
 				// swallows "no such container" internally.
-				await docker.kill(meta.sessionId).catch((killErr) => {
+				await docker.kill(rollbackId).catch((killErr) => {
 					logger.error(
-						`[routes] CRITICAL: kill during create rollback for session ${meta?.sessionId} failed: ${(killErr as Error).message}`,
+						`[routes] CRITICAL: kill during create rollback for session ${rollbackId} failed: ${(killErr as Error).message}`,
 					);
 				});
 				try {
-					await sessions.deleteRow(meta.sessionId);
+					await sessions.deleteRow(rollbackId);
 				} catch (cleanupErr) {
 					logger.error(
-						`[routes] CRITICAL: spawn rollback failed for session ${meta.sessionId}: ${(cleanupErr as Error).message}`,
+						`[routes] CRITICAL: spawn rollback failed for session ${rollbackId}: ${(cleanupErr as Error).message}`,
 					);
 				}
 			}

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -549,6 +549,27 @@ export function buildRouter(
 				// the reconciler will eventually flip status to stopped but
 				// the row remains — we log loudly so an operator can clean
 				// it up manually.
+				//
+				// Kill any running container BEFORE deleting the D1 row.
+				// Without this, the post-spawn failure paths (e.g.
+				// `markBootstrapped` throws on a D1 transient AFTER
+				// `docker.spawn` succeeded and `runPostCreate` exited
+				// cleanly) would orphan a live container with no row to
+				// reach it through — `reconcile()` queries
+				// `WHERE status='running'`, so a deleted row means the
+				// container survives until the next host reboot. The
+				// non-zero-exit path inside the try/ catch already kills
+				// the container before throwing; this guard covers every
+				// other post-spawn failure shape (markBootstrapped,
+				// runPostStart, sessions.get, the synthetic invariant
+				// throw above). Idempotent: the failure-branch
+				// `docker.kill` already ran on hard-fail, and `kill`
+				// swallows "no such container" internally.
+				await docker.kill(meta.sessionId).catch((killErr) => {
+					logger.error(
+						`[routes] CRITICAL: kill during create rollback for session ${meta?.sessionId} failed: ${(killErr as Error).message}`,
+					);
+				});
 				try {
 					await sessions.deleteRow(meta.sessionId);
 				} catch (cleanupErr) {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -470,7 +470,23 @@ export function buildRouter(
 							`[routes] kill after failed postCreate ${meta?.sessionId} threw: ${(e as Error).message}`,
 						);
 					});
-					await sessions.updateStatus(meta.sessionId, "failed");
+					// Swallow D1 transients here on purpose: a thrown
+					// `updateStatus` would propagate to the outer catch,
+					// which would then call `sessions.deleteRow` — wiping
+					// the very row the `failed` status is meant to
+					// preserve for audit (the captured output already
+					// went into the response below, but the sidebar
+					// would never show the failure). Loud log so an
+					// operator can manually flip the row from `running`
+					// to `failed` after the fact; the user still sees
+					// the captured `bootstrapOutput` in this response.
+					await sessions.updateStatus(meta.sessionId, "failed").catch((e) => {
+						logger.error(
+							`[routes] CRITICAL: could not flip session ${meta?.sessionId} to failed: ${(e as Error).message}. ` +
+								"Container is killed; row likely still shows status=running. " +
+								"Operator must update D1 manually to reflect the failure.",
+						);
+					});
 					res.status(500).json({
 						error: `postCreate hook failed (exit ${exitCode})`,
 						sessionId: meta.sessionId,

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -27,6 +27,7 @@ import {
 	UsernameTakenError,
 	verifyJwt,
 } from "./auth.js";
+import { markBootstrapped } from "./bootstrap.js";
 import { d1Query } from "./db.js";
 import type { DockerManager } from "./dockerManager.js";
 import { UploadQuotaExceededError } from "./dockerManager.js";
@@ -449,6 +450,63 @@ export function buildRouter(
 				await persistSessionConfig(meta.sessionId, validatedConfig);
 			}
 			await docker.spawn(meta.sessionId);
+			// postCreate hook (#185): one-shot bootstrap that runs once
+			// per session. Synchronous wait here means the modal stays
+			// open until the hook exits; PR 185b2b will layer a streaming
+			// WS channel so the user sees output live instead of waiting
+			// blind on the HTTP request. Hard-fail semantics from #185:
+			// non-zero exit → kill the container, flip status to `failed`,
+			// return 500 with the captured output. The row stays so the
+			// user can read what the hook printed (and so a recreate
+			// doesn't collide with leftover state on the same name).
+			if (validatedConfig?.postCreateCmd) {
+				const { exitCode, output } = await docker.runPostCreate(
+					meta.sessionId,
+					validatedConfig.postCreateCmd,
+				);
+				if (exitCode !== 0) {
+					await docker.kill(meta.sessionId).catch((e) => {
+						logger.error(
+							`[routes] kill after failed postCreate ${meta?.sessionId} threw: ${(e as Error).message}`,
+						);
+					});
+					await sessions.updateStatus(meta.sessionId, "failed");
+					res.status(500).json({
+						error: `postCreate hook failed (exit ${exitCode})`,
+						sessionId: meta.sessionId,
+						bootstrapOutput: output,
+						bootstrapExitCode: exitCode,
+					});
+					return;
+				}
+				// Atomic UPDATE … WHERE bootstrapped_at IS NULL — the only
+				// place in the codebase that sets this column. A retry
+				// race (e.g. two concurrent retries of the same create
+				// after a partial network failure) sees changes === 0 on
+				// the loser and we just skip the no-op. Returns true if
+				// THIS caller won; we ignore the boolean here because the
+				// route is single-shot per session — the gate exists for
+				// the runner's own sanity in 185b2b's async flow.
+				await markBootstrapped(meta.sessionId);
+			}
+			// postStart hook fires from `docker.spawn` -> nope, spawn doesn't
+			// call it; only `startContainer`. The first start happens here
+			// inside spawn (via container.start), so trigger postStart for
+			// the create path explicitly. Subsequent /start calls go
+			// through `startContainer` which already runs postStart.
+			if (validatedConfig?.postStartCmd) {
+				try {
+					await docker.runPostStart(meta.sessionId, validatedConfig.postStartCmd);
+				} catch (err) {
+					// Like the runPostStartIfConfigured wrapper, don't fail the
+					// create on a postStart launch error — the container is
+					// up, postCreate succeeded, the user can still use the
+					// session.
+					logger.warn(
+						`[routes] postStart launch failed for ${meta.sessionId}: ${(err as Error).message}`,
+					);
+				}
+			}
 			const updated = await sessions.get(meta.sessionId);
 			if (!updated) {
 				// Shouldn't happen: sessions.create above just inserted this row,

--- a/backend/src/sessionManager.test.ts
+++ b/backend/src/sessionManager.test.ts
@@ -1,0 +1,72 @@
+/**
+ * sessionManager.test.ts — quota-filter tests for #185 (PR 185b2a review).
+ *
+ * Round-2 reviewer flagged that `failed` sessions occupied a quota slot,
+ * which combined with the `/start` 409 guard meant a user with N typo'd
+ * postCreate hooks would get locked out at the cap. Quota count must
+ * exclude both `terminated` AND `failed`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 1, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import { SessionManager } from "./sessionManager.js";
+
+beforeEach(() => {
+	dbStubs.d1Query.mockReset();
+});
+
+describe("SessionManager.create — quota filter", () => {
+	it("excludes both 'terminated' and 'failed' rows from the quota count", async () => {
+		// First call is the atomic INSERT … WHERE COUNT(*) < cap; second
+		// is the `get` that materialises the inserted row. We only care
+		// about the SQL shape on the first call.
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 1, duration: 0, last_row_id: 0 },
+		});
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [
+				{
+					session_id: "sess-new",
+					user_id: "u1",
+					name: "test",
+					status: "running",
+					container_id: null,
+					container_name: "st-test",
+					cols: 80,
+					rows: 24,
+					env_vars: "{}",
+					created_at: "2026-05-09 02:00:00",
+					last_connected_at: null,
+				},
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+
+		const mgr = new SessionManager();
+		await mgr.create({ userId: "u1", name: "test" });
+
+		const [insertSql] = dbStubs.d1Query.mock.calls[0]!;
+		// `failed` is in the exclusion list — without this, a user with
+		// N typo'd postCreate hooks gets locked out at the cap with no
+		// /start path to recover (the 409 guard refuses failed sessions).
+		expect(insertSql).toMatch(/status NOT IN \('terminated', 'failed'\)/);
+		// Sanity: a 429 wouldn't fire for the legacy `terminated`-only
+		// filter either, so make sure both terms are present (a regex
+		// that matched only one would silently regress the new
+		// `failed` exclusion).
+		expect(insertSql).toMatch(/'terminated'/);
+		expect(insertSql).toMatch(/'failed'/);
+	});
+});

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -148,16 +148,23 @@ export class SessionManager {
 		// race loser observes `meta.changes === 0` and raises a typed error
 		// the route can map to 429.
 		//
-		// The count filter matches `listForUser`, which is what the UI shows —
-		// so "active" here means the same thing the user sees in their sidebar.
-		// Terminated rows don't count against the cap; they'll be garbage-
-		// collected by the hard-delete path or left as history.
+		// `terminated` rows don't count (the user soft-deleted them — slot
+		// frees immediately so they can recycle).
+		// `failed` rows ALSO don't count (PR #207 review): a postCreate
+		// hook that exits non-zero leaves the row in `failed` to preserve
+		// the captured output for the user to read, but the user can NO
+		// LONGER /start it (we 409 on that), so the only valid next step
+		// is "fix the hook and create a fresh session". Counting failed
+		// rows would mean N typo'd hooks would lock the user out at the
+		// quota cap with no recourse short of deleting their failure
+		// history, which we want them to keep so they can audit what
+		// went wrong.
 		const insert = await d1Query(
 			`INSERT INTO sessions (session_id, user_id, name, container_name, cols, rows, env_vars)
                          SELECT ?, ?, ?, ?, ?, ?, ?
                          WHERE (
                                  SELECT COUNT(*) FROM sessions
-                                 WHERE user_id = ? AND status != 'terminated'
+                                 WHERE user_id = ? AND status NOT IN ('terminated', 'failed')
                          ) < ?`,
 			[
 				sessionId,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -4,7 +4,12 @@
 
 // ── Session ─────────────────────────────────────────────────────────────────
 
-export type SessionStatus = "running" | "stopped" | "terminated";
+// `failed` (#185) is set when a postCreate hook exits non-zero. The row
+// stays so operators can audit, but the container is killed and the
+// session can't be /start-ed (the runner refuses to retry — the user
+// has to recreate). `terminated` is hard-delete; `stopped` is the
+// normal "container off, will respawn on /start" state.
+export type SessionStatus = "running" | "stopped" | "terminated" | "failed";
 
 export interface SessionMeta {
 	sessionId: string;

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -158,6 +158,21 @@ export function handleWsConnection(
 			ws.close(1008, "Session terminated");
 			return;
 		}
+		// `failed` (#185) means the postCreate hook exited non-zero, the
+		// container was killed, and the user can no longer /start the
+		// session (REST returns 409). Without this short-circuit
+		// `docker.attach` would try `getContainer(meta.containerId)` on
+		// a null id, throw "No container for this session", and close
+		// the socket with 1011 Internal Error — a misleading code that
+		// also pollutes server logs with a spurious error for an
+		// avoidable path. 1008 ("policy violation") is the same code
+		// `terminated` uses; matching it gives the client a single
+		// "session is in a non-attachable state" signal to handle.
+		if (session.status === "failed") {
+			sendError(ws, "Session failed during postCreate; recreate it to retry.");
+			ws.close(1008, "Session failed");
+			return;
+		}
 
 		// Attach to Docker container
 		const attachId = `${sessionId}:${uuidv4().slice(0, 8)}`;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -159,6 +159,29 @@ export interface SessionConfigPayload {
 	envVars?: Record<string, string>;
 }
 
+/**
+ * Thrown when the create succeeded up to the point of running the
+ * `postCreate` hook (#185), but the hook itself exited non-zero. The
+ * server has already killed the container and flipped the session
+ * status to `failed`; the row stays so the user can read the captured
+ * output (carried on this error). The new-session modal surfaces
+ * `bootstrapOutput` inline so the user sees what their hook printed
+ * before it died.
+ */
+export class BootstrapFailedError extends Error {
+	readonly sessionId: string;
+	readonly exitCode: number;
+	readonly output: string;
+
+	constructor(sessionId: string, exitCode: number, output: string, message: string) {
+		super(message);
+		this.name = "BootstrapFailedError";
+		this.sessionId = sessionId;
+		this.exitCode = exitCode;
+		this.output = output;
+	}
+}
+
 export async function createSession(
 	name: string,
 	envVars?: Record<string, string>,
@@ -169,7 +192,26 @@ export async function createSession(
 		body: JSON.stringify({ name, envVars, config }),
 	});
 	if (!res.ok) {
-		const body = await res.json();
+		const body = (await res.json().catch(() => ({}))) as {
+			error?: string;
+			sessionId?: string;
+			bootstrapOutput?: string;
+			bootstrapExitCode?: number;
+		};
+		// Distinguish hook-failed from generic create errors so the modal
+		// can surface the captured output instead of just a one-liner.
+		// The 500 carries `bootstrapOutput` only when the hook actually
+		// ran; a missing field means a different failure shape (D1
+		// transient, docker spawn EACCES, etc.) and the generic Error
+		// path is right.
+		if (body.bootstrapOutput !== undefined && body.sessionId !== undefined) {
+			throw new BootstrapFailedError(
+				body.sessionId,
+				body.bootstrapExitCode ?? -1,
+				body.bootstrapOutput,
+				body.error ?? "postCreate hook failed",
+			);
+		}
 		throw new Error(body.error ?? "Failed to create session");
 	}
 	return res.json();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -126,7 +126,7 @@ export async function logout(): Promise<void> {
 export interface SessionInfo {
 	sessionId: string;
 	name: string;
-	status: "running" | "stopped" | "terminated";
+	status: "running" | "stopped" | "terminated" | "failed";
 	containerId: string | null;
 	containerName: string;
 	createdAt: string;

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -736,6 +736,14 @@ main:not([data-sidebar-ready]) #sidebar {
 .session-dot.terminated {
   background: #f85149;
 }
+/* `failed` (#185) — postCreate hook exited non-zero. Distinct from
+   terminated (red) so users can tell at a glance which sessions need
+   recreation vs which were soft-deleted. Amber matches the "needs
+   user attention" semantics elsewhere in the UI. */
+.session-dot.failed {
+  background: #db6d28;
+  box-shadow: 0 0 0 1px rgba(248, 81, 73, 0.45);
+}
 .session-name {
   flex: 1;
   font-size: 0.82rem;

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -624,6 +624,41 @@ main:not([data-sidebar-ready]) #sidebar {
   opacity: 0.6;
   cursor: progress;
 }
+
+/* postCreate hard-fail panel inside the new-session modal (#185). */
+.bootstrap-error {
+  margin-top: 0.85rem;
+  background: rgba(248, 81, 73, 0.08);
+  border: 1px solid #f85149;
+  border-radius: 8px;
+  padding: 0.75rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.bootstrap-error strong {
+  color: #ff8682;
+  font-size: 0.85rem;
+}
+.bootstrap-error-hint {
+  color: #b3a4a3;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  margin: 0;
+}
+.bootstrap-error-output {
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  max-height: 200px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
 #session-list {
   flex: 1;
   overflow-y: auto;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -496,6 +496,12 @@ function renderSessionList() {
 				void openSession(s.sessionId);
 			} else if (s.status === "stopped") {
 				showToast("Start the session first", true);
+			} else if (s.status === "failed") {
+				// Failed sessions are unrecoverable via /start (the server
+				// 409s); clicking them used to silently no-op which left
+				// the user wondering if the click registered. Toast points
+				// them at the recovery path: recreate to retry.
+				showToast("Session failed during postCreate — recreate to retry", true);
 			}
 		});
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -386,8 +386,16 @@ function renderSessionList() {
 	sessionList.innerHTML = "";
 	for (const s of sessions) {
 		const item = document.createElement("div");
-		const terminatedCls = s.status === "terminated" ? " terminated" : "";
-		item.className = `session-item${s.sessionId === activeSessionId ? " active" : ""}${terminatedCls}`;
+		// Status class on the wrapper mirrors the session-dot rules so
+		// future CSS can target failed/terminated items uniformly (dim
+		// them, cross them out, etc.) without re-deriving the status
+		// from a child element. Today only `terminated` has a wrapper
+		// rule (.session-item.terminated dims the row); failed shows
+		// up via the dot only — adding the class now means a follow-up
+		// styling tweak doesn't have to touch this line.
+		const statusCls =
+			s.status === "terminated" || s.status === "failed" ? ` ${s.status}` : "";
+		item.className = `session-item${s.sessionId === activeSessionId ? " active" : ""}${statusCls}`;
 
 		const dot = document.createElement("span");
 		dot.className = `session-dot ${s.status}`;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,6 +11,7 @@
 import "./main.css";
 
 import {
+	BootstrapFailedError,
 	checkAuthStatus,
 	createInvite,
 	createSession,
@@ -1105,12 +1106,47 @@ function openNewSessionModal(opener: HTMLElement) {
 	setActiveSessionTab("basics");
 	newSessionInput.value = "";
 	newSessionSubmitBtn.disabled = false;
+	clearBootstrapError();
 	newSessionModal.classList.add("open");
 	newSessionModal.setAttribute("aria-hidden", "false");
 	// Defer focus to the next paint so the input is reliably focusable
 	// (some browsers ignore .focus() on an element that just transitioned
 	// from display:none in the same frame).
 	requestAnimationFrame(() => newSessionInput.focus());
+}
+
+/**
+ * Render a postCreate-hook failure inline in the modal — the user sees
+ * the captured stdout/stderr without losing the form they were filling
+ * out. Clears on next open / next submit. PR 185b2b will replace the
+ * static `<pre>` with a live-tail panel that shows output as it
+ * streams.
+ */
+function renderBootstrapError(err: BootstrapFailedError) {
+	clearBootstrapError();
+	const panel = document.createElement("div");
+	panel.className = "bootstrap-error";
+	panel.id = "bootstrap-error-panel";
+	const heading = document.createElement("strong");
+	heading.textContent = `postCreate hook failed (exit ${err.exitCode})`;
+	panel.appendChild(heading);
+	const hint = document.createElement("p");
+	hint.className = "bootstrap-error-hint";
+	hint.textContent =
+		"The session was created but the bootstrap command exited non-zero, " +
+		"so the container was killed and the session marked failed. " +
+		"Captured output below — fix the command and create a new session.";
+	panel.appendChild(hint);
+	const pre = document.createElement("pre");
+	pre.className = "bootstrap-error-output";
+	pre.textContent = err.output || "(no output captured)";
+	panel.appendChild(pre);
+	const basicsPanel = document.getElementById("session-tab-basics");
+	basicsPanel?.appendChild(panel);
+}
+
+function clearBootstrapError() {
+	document.getElementById("bootstrap-error-panel")?.remove();
 }
 
 function closeNewSessionModal() {
@@ -1140,6 +1176,7 @@ newSessionForm.addEventListener("submit", async (e) => {
 	// double-click doesn't fire two POSTs (which would create two
 	// sessions and burn quota silently).
 	newSessionSubmitBtn.disabled = true;
+	clearBootstrapError();
 	try {
 		showToast("Creating session…");
 		const session = await createSession(name);
@@ -1149,7 +1186,17 @@ newSessionForm.addEventListener("submit", async (e) => {
 		void openSession(session.sessionId);
 		showToast(`Session "${name}" created`);
 	} catch (err) {
-		showToast((err as Error).message, true);
+		if (err instanceof BootstrapFailedError) {
+			// postCreate hook hard-failed (#185). Server already killed
+			// the container and flipped status=failed. Refresh the
+			// sidebar so the failed row shows up, and surface the hook's
+			// captured stdout/stderr inline in the modal so the user can
+			// see what went wrong without leaving the form.
+			void refreshSessions();
+			renderBootstrapError(err);
+		} else {
+			showToast((err as Error).message, true);
+		}
 		newSessionSubmitBtn.disabled = false;
 	}
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -393,8 +393,7 @@ function renderSessionList() {
 		// rule (.session-item.terminated dims the row); failed shows
 		// up via the dot only — adding the class now means a follow-up
 		// styling tweak doesn't have to touch this line.
-		const statusCls =
-			s.status === "terminated" || s.status === "failed" ? ` ${s.status}` : "";
+		const statusCls = s.status === "terminated" || s.status === "failed" ? ` ${s.status}` : "";
 		item.className = `session-item${s.sessionId === activeSessionId ? " active" : ""}${statusCls}`;
 
 		const dot = document.createElement("span");


### PR DESCRIPTION
## Summary

Third PR closing #185 / epic #184. After PR #205 (185a, schema + tabbed-modal scaffold) and PR #206 (185b1, DockerManager applies env/cpu/mem at spawn), this PR (**185b2a**) wires the `postCreate` and `postStart` lifecycle hooks. PR 185b2b (next) layers a streaming WS channel + live-tail UI on top — together with this PR they close #185.

## What changes

**Backend**
- New `bootstrap.ts` with the atomic `markBootstrapped` helper: a guarded `UPDATE session_configs SET bootstrapped_at = datetime('now') WHERE session_id = ? AND bootstrapped_at IS NULL`. Concurrent callers race through a single `meta.changes === 1` predicate; the loser sees `false` and skips. Hard-fail before this UPDATE leaves the gate open for retry — matching the issue's "row stays so the user can read the streamed log" semantics.
- `DockerManager.runPostCreate(sessionId, cmd)` — synchronous, uses `execOneShot` (`bash -c <cmd>`) so users can chain commands. Returns `{ exitCode, output }`.
- `DockerManager.runPostStart(sessionId, cmd)` — detached tmux session named `bootstrap` so daemons (`code tunnel`, `npm run dev`) stay alive in the background, are visible to the user via the regular tab list, and die when the container dies. Idempotent: kill-session before new-session so a stale daemon from a previous start can't race the new one.
- `POST /api/sessions` runs postCreate inline after spawn. Non-zero exit → `docker.kill` + `sessions.status = failed` + 500 carrying `{ sessionId, bootstrapOutput, bootstrapExitCode }`. The session row stays so the user can audit; postCreate success → `markBootstrapped`, then postStart fires.
- `DockerManager.startContainer` runs postStart on every restart via a small `runPostStartIfConfigured` wrapper.
- New `failed` SessionStatus.

**Frontend**
- `BootstrapFailedError` distinguishes hook failures from generic create errors.
- New-session modal renders a `<pre>` panel with the captured output + a hint inline, so the user sees what their hook printed without leaving the form.

## Test plan

- [x] `cd backend && npm test` — **260/260 passing** (4 new in `bootstrap.test.ts`, 6 new in `dockerManager.test.ts` for runPostCreate/runPostStart).
- [x] `cd backend && npm run build` — clean.
- [x] `cd backend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — clean.
- [ ] Live container check (create a session with a postCreate that fails, observe the modal renders captured output and the session row shows `failed`) — couldn't run in this session because the dev D1 setup is offline; will validate once the full stack runs end-to-end.

## Trade-off accepted in this PR

`postCreate` runs synchronously inside the HTTP request, so a long hook (60+ s `npm install`) ties up the request for that long. Cloudflare Tunnel + Express both let it through, but the user sees a spinner with no output until the hook exits. **That's the exact seam PR 185b2b addresses**: it splits the create response from the bootstrap channel — POST returns immediately after spawn, output streams over `/ws/bootstrap/<sessionId>`, the modal waits on the channel rather than the HTTP request.

## Out of scope (PR 185b2b)

- WS bootstrap channel (`/ws/bootstrap/<sessionId>`).
- Live-tail panel: bytes streamed into the modal as the hook runs.
- Async POST flow: 201 returns after spawn; bootstrap completes in the background.

Refs #185, #184. Closes #185 once 185b2b merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)