### PR TITLE
feat(sessions): bootstrap WS channel + live-tail UI (#185, PR 185b2b of 2)

### DIFF
--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const dbStubs = vi.hoisted(() => ({
 	d1Query: vi.fn(async () => ({
@@ -9,7 +9,14 @@ const dbStubs = vi.hoisted(() => ({
 }));
 vi.mock("./db.js", () => dbStubs);
 
-import { markBootstrapped } from "./bootstrap.js";
+import {
+	BootstrapBroadcaster,
+	type BootstrapMessage,
+	markBootstrapped,
+	runAsyncBootstrap,
+} from "./bootstrap.js";
+import type { DockerManager } from "./dockerManager.js";
+import type { SessionManager } from "./sessionManager.js";
 
 beforeEach(() => {
 	dbStubs.d1Query.mockReset();
@@ -64,5 +71,223 @@ describe("markBootstrapped", () => {
 	it("propagates D1 errors instead of silently swallowing", async () => {
 		dbStubs.d1Query.mockRejectedValueOnce(new Error("D1 transient"));
 		await expect(markBootstrapped("sess-1")).rejects.toThrow("D1 transient");
+	});
+});
+
+// ── BootstrapBroadcaster (PR 185b2b) ──────────────────────────────────────
+
+describe("BootstrapBroadcaster", () => {
+	let broadcaster: BootstrapBroadcaster;
+	let received: BootstrapMessage[];
+	const flush = () => new Promise<void>((r) => setImmediate(r));
+
+	beforeEach(() => {
+		broadcaster = new BootstrapBroadcaster();
+		received = [];
+	});
+
+	afterEach(() => {
+		broadcaster.clearForTesting();
+	});
+
+	it("fans live broadcasts to all subscribers", async () => {
+		const a: BootstrapMessage[] = [];
+		const b: BootstrapMessage[] = [];
+		broadcaster.subscribe("s1", (m) => a.push(m));
+		broadcaster.subscribe("s1", (m) => b.push(m));
+		await flush(); // microtask drains the (empty) replay queue
+
+		broadcaster.broadcast("s1", "hello\n");
+		expect(a).toEqual([{ type: "output", data: "hello\n" }]);
+		expect(b).toEqual([{ type: "output", data: "hello\n" }]);
+	});
+
+	it("replays buffered output to a late subscriber", async () => {
+		// Producer emits first; subscriber connects after.
+		broadcaster.broadcast("s1", "early\n");
+		broadcaster.subscribe("s1", (m) => received.push(m));
+		await flush();
+		expect(received).toEqual([{ type: "output", data: "early\n" }]);
+	});
+
+	it("delivers terminal message + buffered output to subscribers that joined after finish", async () => {
+		broadcaster.broadcast("s1", "step1\n");
+		broadcaster.finish("s1", { type: "done", success: true });
+		broadcaster.subscribe("s1", (m) => received.push(m));
+		await flush();
+		expect(received).toEqual([
+			{ type: "output", data: "step1\n" },
+			{ type: "done", success: true },
+		]);
+	});
+
+	it("ignores broadcasts after finish — runner shouldn't emit but if it does we don't surface stragglers", async () => {
+		broadcaster.subscribe("s1", (m) => received.push(m));
+		await flush();
+		broadcaster.broadcast("s1", "before\n");
+		broadcaster.finish("s1", { type: "fail", exitCode: 1 });
+		broadcaster.broadcast("s1", "after\n");
+		expect(received).toEqual([
+			{ type: "output", data: "before\n" },
+			{ type: "fail", exitCode: 1 },
+		]);
+	});
+
+	it("unsubscribe stops further deliveries", async () => {
+		const unsubscribe = broadcaster.subscribe("s1", (m) => received.push(m));
+		await flush();
+		unsubscribe();
+		broadcaster.broadcast("s1", "after-unsub\n");
+		expect(received).toEqual([]);
+	});
+
+	it("isolates per-session state — broadcast on s1 doesn't reach s2 listener", async () => {
+		const onS1: BootstrapMessage[] = [];
+		const onS2: BootstrapMessage[] = [];
+		broadcaster.subscribe("s1", (m) => onS1.push(m));
+		broadcaster.subscribe("s2", (m) => onS2.push(m));
+		await flush();
+		broadcaster.broadcast("s1", "x");
+		expect(onS1).toEqual([{ type: "output", data: "x" }]);
+		expect(onS2).toEqual([]);
+	});
+});
+
+// ── runAsyncBootstrap (PR 185b2b) ─────────────────────────────────────────
+
+describe("runAsyncBootstrap", () => {
+	function makeFakes(): {
+		sessions: SessionManager;
+		docker: DockerManager;
+		broadcaster: BootstrapBroadcaster;
+		final: BootstrapMessage[];
+		spies: {
+			updateStatus: ReturnType<typeof vi.fn>;
+			kill: ReturnType<typeof vi.fn>;
+			runPostCreate: ReturnType<typeof vi.fn>;
+			runPostStart: ReturnType<typeof vi.fn>;
+		};
+	} {
+		const updateStatus = vi.fn(async () => undefined);
+		const kill = vi.fn(async () => undefined);
+		const runPostCreate = vi.fn();
+		const runPostStart = vi.fn(async () => undefined);
+		const sessions = { updateStatus } as unknown as SessionManager;
+		const docker = { kill, runPostCreate, runPostStart } as unknown as DockerManager;
+		const broadcaster = new BootstrapBroadcaster();
+		const final: BootstrapMessage[] = [];
+		broadcaster.subscribe("sess-1", (m) => {
+			if (m.type === "done" || m.type === "fail") final.push(m);
+		});
+		return {
+			sessions,
+			docker,
+			broadcaster,
+			final,
+			spies: { updateStatus, kill, runPostCreate, runPostStart },
+		};
+	}
+
+	const settle = () => new Promise<void>((r) => setImmediate(r));
+
+	it("success path: streams output, marks bootstrapped, runs postStart, broadcasts done", async () => {
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		spies.runPostCreate.mockImplementation(
+			async (_id: string, _cmd: string, onOutput: (s: string) => void) => {
+				onOutput("step1\n");
+				onOutput("step2\n");
+				return { exitCode: 0 };
+			},
+		);
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 1, duration: 0, last_row_id: 0 },
+		});
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install", postStartCmd: "npm run dev" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.updateStatus).not.toHaveBeenCalled();
+		expect(spies.kill).not.toHaveBeenCalled();
+		expect(spies.runPostStart).toHaveBeenCalledWith("sess-1", "npm run dev");
+		// markBootstrapped fired the UPDATE on session_configs.
+		expect(dbStubs.d1Query).toHaveBeenCalled();
+		expect(final).toEqual([{ type: "done", success: true }]);
+	});
+
+	// Round-5 of PR 185b2a settled the order: status flip BEFORE kill,
+	// so reconcile never sees a (running, null) row that it would
+	// silently promote to stopped. Same rule applies to the async runner.
+	it("fail path: flips status to failed BEFORE kill, broadcasts fail with exitCode", async () => {
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		const order: string[] = [];
+		spies.updateStatus.mockImplementation(async () => {
+			order.push("updateStatus");
+		});
+		spies.kill.mockImplementation(async () => {
+			order.push("kill");
+		});
+		spies.runPostCreate.mockImplementation(
+			async (_id: string, _cmd: string, onOutput: (s: string) => void) => {
+				onOutput("npm ERR! ENOENT\n");
+				return { exitCode: 1 };
+			},
+		);
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "false" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+		// Ordering invariant — status flip lands BEFORE kill.
+		expect(order).toEqual(["updateStatus", "kill"]);
+		expect(spies.runPostStart).not.toHaveBeenCalled();
+		expect(final).toEqual([{ type: "fail", exitCode: 1 }]);
+	});
+
+	it("throw path: runPostCreate throws → still flip + kill + broadcast fail with error", async () => {
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		spies.runPostCreate.mockRejectedValueOnce(new Error("docker daemon down"));
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+		expect(final).toHaveLength(1);
+		expect(final[0]).toMatchObject({ type: "fail", exitCode: -1 });
+	});
+
+	// markBootstrapped failure on the success path is logged but not
+	// terminal — the hook DID complete cleanly, the user's environment
+	// is set up, the gate just couldn't be marked. A future restart
+	// would re-attempt the gate atomically.
+	it("markBootstrapped throws on success: still runs postStart + broadcasts done", async () => {
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		spies.runPostCreate.mockImplementation(async () => ({ exitCode: 0 }));
+		dbStubs.d1Query.mockRejectedValueOnce(new Error("D1 transient"));
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install", postStartCmd: "npm run dev" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.runPostStart).toHaveBeenCalledWith("sess-1", "npm run dev");
+		expect(final).toEqual([{ type: "done", success: true }]);
 	});
 });

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -11,9 +11,18 @@
  * `postStart` has no D1 gate — by design it runs on every container
  * start (a daemon that should die with the container, like
  * `npm run dev` or `code tunnel`).
+ *
+ * PR 185b2b adds the streaming side: `BootstrapBroadcaster` fans
+ * postCreate output to per-session WS subscribers, and
+ * `runAsyncBootstrap` wires the runner + broadcaster + status flips
+ * together so `POST /api/sessions` can return 201 immediately while
+ * the hook continues in the background.
  */
 
 import { d1Query } from "./db.js";
+import type { DockerManager } from "./dockerManager.js";
+import { logger } from "./logger.js";
+import type { SessionManager } from "./sessionManager.js";
 
 /**
  * Atomically mark `session_configs.bootstrapped_at` as set, but only
@@ -45,4 +54,323 @@ export async function markBootstrapped(sessionId: string): Promise<boolean> {
 		[sessionId],
 	);
 	return result.meta.changes === 1;
+}
+
+// ── Streaming broadcaster (PR 185b2b) ─────────────────────────────────────
+
+/** Server → client message shape on the bootstrap WS channel. */
+export type BootstrapMessage =
+	| { type: "output"; data: string }
+	| { type: "done"; success: true }
+	| { type: "fail"; exitCode: number; error?: string };
+
+export type BootstrapListener = (msg: BootstrapMessage) => void;
+
+interface SessionState {
+	listeners: Set<BootstrapListener>;
+	/**
+	 * Buffered output emitted before any subscriber connected — handed
+	 * to late joiners so the modal can still see the full log even if
+	 * its WS connection lagged behind the POST response. Capped at
+	 * `MAX_BUFFER_BYTES` total bytes; old chunks drop off the front
+	 * once the cap is reached. The cap is a hostile-input bound, not a
+	 * UX target; a hook spamming MB to stdout would otherwise pin the
+	 * broadcaster at the same memory footprint indefinitely.
+	 */
+	bufferedOutput: string[];
+	bufferedBytes: number;
+	/**
+	 * Terminal message (success / fail). Once set, all future
+	 * subscribers immediately receive every buffered chunk + this
+	 * terminal message and then the broadcaster removes the entry.
+	 * Late subscribers get a clean replay even after the runner has
+	 * fully exited.
+	 */
+	terminal: BootstrapMessage | null;
+	/**
+	 * GC timer that fires after the terminal message lands — keeps the
+	 * state alive long enough for any in-flight subscriber to attach
+	 * and replay, then drops the entry to free memory. Reset on every
+	 * subscribe so the GC clock restarts after each replay.
+	 */
+	gcTimer: NodeJS.Timeout | null;
+}
+
+const MAX_BUFFER_BYTES = 256 * 1024; // 256 KiB per session
+const POST_DONE_RETENTION_MS = 60_000; // keep buffered + terminal for 1 min after done
+
+/**
+ * Per-session broadcaster for postCreate hook output. WS subscribers
+ * (one per browser tab on the modal) get every chunk in arrival order
+ * plus a final terminal message. Late subscribers replay from the
+ * buffer + terminal so a slow WS connect doesn't lose log lines.
+ *
+ * Single-instance, owned by `index.ts`, passed into both the route
+ * (which calls `broadcast` / `finish`) and the WS handler (which
+ * calls `subscribe` / `unsubscribe`).
+ */
+export class BootstrapBroadcaster {
+	private readonly states = new Map<string, SessionState>();
+
+	/**
+	 * Returns the existing state for `sessionId` or creates a fresh
+	 * one. Lazy init so the first `broadcast` or `subscribe` for a
+	 * session sets up the entry without the caller having to remember
+	 * to "open" the session first.
+	 */
+	private ensure(sessionId: string): SessionState {
+		let s = this.states.get(sessionId);
+		if (!s) {
+			s = {
+				listeners: new Set(),
+				bufferedOutput: [],
+				bufferedBytes: 0,
+				terminal: null,
+				gcTimer: null,
+			};
+			this.states.set(sessionId, s);
+		}
+		return s;
+	}
+
+	/**
+	 * Append a stdout/stderr chunk to the session's buffer and fan it
+	 * out to every live listener. Caller must invoke this for every
+	 * chunk the postCreate hook emits, in order. After `finish` lands
+	 * for a session, further `broadcast` calls are dropped — the
+	 * runner shouldn't be emitting anything once it's signalled done,
+	 * and ignoring stragglers keeps the broadcaster idempotent.
+	 */
+	broadcast(sessionId: string, data: string): void {
+		const s = this.ensure(sessionId);
+		if (s.terminal) return;
+		const bytes = Buffer.byteLength(data, "utf-8");
+		s.bufferedOutput.push(data);
+		s.bufferedBytes += bytes;
+		// Trim the head of the buffer if we've blown past the cap. Keep
+		// the most-recent chunks because they're what the user wants to
+		// see when they finally subscribe (the tail is where the error
+		// usually lives). Loose: we drop full chunks rather than partial
+		// — the cap is a backstop, not a precise byte clock.
+		while (s.bufferedBytes > MAX_BUFFER_BYTES && s.bufferedOutput.length > 1) {
+			const dropped = s.bufferedOutput.shift();
+			if (dropped !== undefined) s.bufferedBytes -= Buffer.byteLength(dropped, "utf-8");
+		}
+		const msg: BootstrapMessage = { type: "output", data };
+		for (const l of s.listeners) {
+			try {
+				l(msg);
+			} catch (err) {
+				// Listener errors are deliberately swallowed — a thrown
+				// listener would break the fan-out for everyone else
+				// in the Set. WS handlers wrap their send in try/catch
+				// at the source already.
+				logger.warn(`[bootstrap] listener threw on broadcast: ${(err as Error).message}`);
+			}
+		}
+	}
+
+	/**
+	 * Mark the session's bootstrap as terminal (success or failure)
+	 * and notify all current + future subscribers. Schedules GC of
+	 * the entry after a retention window so a late subscriber can
+	 * still see the full replay; without retention, a modal that
+	 * raced the response → WS-connect would see "no such session"
+	 * for a session that just finished bootstrapping.
+	 */
+	finish(sessionId: string, msg: BootstrapMessage): void {
+		const s = this.ensure(sessionId);
+		if (s.terminal) return;
+		s.terminal = msg;
+		for (const l of s.listeners) {
+			try {
+				l(msg);
+			} catch (err) {
+				logger.warn(`[bootstrap] listener threw on finish: ${(err as Error).message}`);
+			}
+		}
+		this.scheduleGc(sessionId);
+	}
+
+	/**
+	 * Subscribe a listener. Immediately delivers any buffered chunks
+	 * + the terminal message (if set), so a late subscriber gets a
+	 * complete replay. Returns an `unsubscribe` thunk the caller
+	 * MUST call on WS close to avoid leaking the listener.
+	 */
+	subscribe(sessionId: string, listener: BootstrapListener): () => void {
+		const s = this.ensure(sessionId);
+		s.listeners.add(listener);
+		// Pause GC while a subscriber is active — restart the timer
+		// when they leave so the entry sticks around for any other
+		// late joiners.
+		if (s.gcTimer) {
+			clearTimeout(s.gcTimer);
+			s.gcTimer = null;
+		}
+		// Replay buffered output + terminal in a single microtask so
+		// the listener's first `onmessage` fire isn't synchronously
+		// re-entrant from inside `subscribe`.
+		queueMicrotask(() => {
+			for (const data of s.bufferedOutput) {
+				try {
+					listener({ type: "output", data });
+				} catch (err) {
+					logger.warn(`[bootstrap] listener threw on replay: ${(err as Error).message}`);
+				}
+			}
+			if (s.terminal) {
+				try {
+					listener(s.terminal);
+				} catch (err) {
+					logger.warn(`[bootstrap] listener threw on terminal replay: ${(err as Error).message}`);
+				}
+			}
+		});
+		return () => this.unsubscribe(sessionId, listener);
+	}
+
+	private unsubscribe(sessionId: string, listener: BootstrapListener): void {
+		const s = this.states.get(sessionId);
+		if (!s) return;
+		s.listeners.delete(listener);
+		// If the entry is already terminal AND the last subscriber
+		// just left, restart the GC timer so the state doesn't sit
+		// in memory forever.
+		if (s.terminal && s.listeners.size === 0) {
+			this.scheduleGc(sessionId);
+		}
+	}
+
+	private scheduleGc(sessionId: string): void {
+		const s = this.states.get(sessionId);
+		if (!s) return;
+		if (s.gcTimer) clearTimeout(s.gcTimer);
+		// `unref()` so a pending GC timer never holds the process open
+		// during shutdown. Loss of the entry on shutdown is fine —
+		// nothing in D1 depends on the in-memory replay buffer.
+		s.gcTimer = setTimeout(() => {
+			this.states.delete(sessionId);
+		}, POST_DONE_RETENTION_MS).unref();
+	}
+
+	/** Test-only: reset all state. */
+	clearForTesting(): void {
+		for (const s of this.states.values()) {
+			if (s.gcTimer) clearTimeout(s.gcTimer);
+		}
+		this.states.clear();
+	}
+}
+
+// ── Async runner (PR 185b2b) ──────────────────────────────────────────────
+
+/**
+ * Run postCreate (and on success, postStart) for a session out-of-band,
+ * streaming output to the broadcaster as it arrives. Called from
+ * `POST /api/sessions` AFTER the response has been sent (fire-and-forget),
+ * so a long-running hook can't tie up the HTTP request and the modal
+ * can subscribe to `/ws/bootstrap/<sessionId>` to see live output.
+ *
+ * Failure semantics match the synchronous flow that PR 185b2a shipped:
+ *   - non-zero `postCreate` exit → flip status to `failed` BEFORE
+ *     killing the container (so reconcile never sees a half-state row),
+ *     then kill, then broadcast `{type: "fail"}` so the modal renders
+ *     its inline error panel.
+ *   - any unexpected throw inside the runner is logged + treated as a
+ *     hard failure (same status flip + kill + broadcast).
+ *
+ * Caller: only invoke this if `postCreateCmd` is set. The
+ * markBootstrapped gate is single-use, and the route already checks
+ * `bootstrapped_at IS NULL` semantics by virtue of being on the
+ * create path.
+ */
+export async function runAsyncBootstrap(
+	sessionId: string,
+	cfg: { postCreateCmd: string; postStartCmd?: string },
+	deps: {
+		sessions: SessionManager;
+		docker: DockerManager;
+		broadcaster: BootstrapBroadcaster;
+	},
+): Promise<void> {
+	const { sessions, docker, broadcaster } = deps;
+	const onOutput = (chunk: string) => broadcaster.broadcast(sessionId, chunk);
+
+	let exitCode: number;
+	try {
+		const result = await docker.runPostCreate(sessionId, cfg.postCreateCmd, onOutput);
+		exitCode = result.exitCode;
+	} catch (err) {
+		logger.error(
+			`[bootstrap] postCreate threw for session ${sessionId}: ${(err as Error).message}`,
+		);
+		await failSession(sessionId, sessions, docker);
+		broadcaster.finish(sessionId, {
+			type: "fail",
+			exitCode: -1,
+			error: (err as Error).message,
+		});
+		return;
+	}
+
+	if (exitCode !== 0) {
+		await failSession(sessionId, sessions, docker);
+		broadcaster.finish(sessionId, { type: "fail", exitCode });
+		return;
+	}
+
+	// postCreate succeeded — mark the gate, then run postStart (if
+	// configured). markBootstrapped failure is logged but doesn't
+	// fail the session: the hook DID complete cleanly, the user's
+	// environment is set up, and a future restart attempting to
+	// re-run postCreate would just re-run the gate atomically.
+	try {
+		await markBootstrapped(sessionId);
+	} catch (err) {
+		logger.error(
+			`[bootstrap] markBootstrapped failed for session ${sessionId}: ${(err as Error).message}. ` +
+				"Hook ran successfully but the gate is unset — operator should manually update D1.",
+		);
+	}
+	if (cfg.postStartCmd) {
+		try {
+			await docker.runPostStart(sessionId, cfg.postStartCmd);
+		} catch (err) {
+			logger.warn(
+				`[bootstrap] postStart launch failed for session ${sessionId}: ${(err as Error).message}`,
+			);
+		}
+	}
+	broadcaster.finish(sessionId, { type: "done", success: true });
+}
+
+/**
+ * Hard-fail tear-down: status flip BEFORE kill so reconcile can't
+ * silently promote a (running, null) row to stopped — same rule the
+ * sync route enforces (PR 185b2a round 5). updateStatus is allowed to
+ * throw here; logging only because the broadcaster will still send a
+ * `fail` message and the user sees the failure regardless. The stale
+ * row will be cleaned up by an operator or a follow-up reconcile-aware
+ * pass.
+ */
+async function failSession(
+	sessionId: string,
+	sessions: SessionManager,
+	docker: DockerManager,
+): Promise<void> {
+	try {
+		await sessions.updateStatus(sessionId, "failed");
+	} catch (err) {
+		logger.error(
+			`[bootstrap] CRITICAL: could not flip session ${sessionId} to failed: ${(err as Error).message}. ` +
+				"Container will still be killed below; row likely shows running. Manual D1 update needed.",
+		);
+	}
+	await docker.kill(sessionId).catch((err) => {
+		logger.error(
+			`[bootstrap] CRITICAL: kill after failed postCreate ${sessionId} threw: ${(err as Error).message}. ` +
+				"Container may need manual `docker rm`.",
+		);
+	});
 }

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -1125,7 +1125,12 @@ describe("sanitiseHostname", () => {
 // ── Bootstrap hooks (#185) ─────────────────────────────────────────────────
 
 describe("DockerManager.runPostCreate", () => {
-	it("runs the cmd via `bash -c` and returns exit code + stdout", async () => {
+	// PR 185b2b switched runPostCreate to streaming: bytes flow via
+	// the optional `onOutput` callback as Docker emits them, and the
+	// return value is just `{exitCode}`. Older tests that asserted on
+	// a returned `output` string are gone — the buffering moved into
+	// `BootstrapBroadcaster` upstream.
+	it("runs the cmd via `bash -c`, streams output via onOutput, returns exitCode", async () => {
 		const { dm, container } = makeDocker({
 			oneShot: (cmd) => {
 				if (cmd[0] === "bash" && cmd[1] === "-c") {
@@ -1134,9 +1139,10 @@ describe("DockerManager.runPostCreate", () => {
 				return undefined;
 			},
 		});
-		const result = await dm.runPostCreate("s1", "npm install");
+		const chunks: string[] = [];
+		const result = await dm.runPostCreate("s1", "npm install", (c) => chunks.push(c));
 		expect(result.exitCode).toBe(0);
-		expect(result.output).toContain("installed");
+		expect(chunks.join("")).toContain("installed");
 		// Cmd shape: bash -c <user-script>. Argv form means tmux/exec
 		// gets the script as a single argument, no shell-quoting hazard.
 		const exec = mustFind(
@@ -1147,16 +1153,25 @@ describe("DockerManager.runPostCreate", () => {
 		expect(exec._cmd).toEqual(["bash", "-c", "npm install"]);
 	});
 
-	it("propagates a non-zero exit code so the route can hard-fail", async () => {
+	it("propagates a non-zero exit code so the runner can hard-fail", async () => {
 		const { dm } = makeDocker({
 			oneShot: (cmd) => {
 				if (cmd[0] === "bash") return { stdout: "boom\n", exitCode: 42 };
 				return undefined;
 			},
 		});
-		const result = await dm.runPostCreate("s1", "false");
+		const chunks: string[] = [];
+		const result = await dm.runPostCreate("s1", "false", (c) => chunks.push(c));
 		expect(result.exitCode).toBe(42);
-		expect(result.output).toContain("boom");
+		expect(chunks.join("")).toContain("boom");
+	});
+
+	it("works without an onOutput callback (streaming is opt-in)", async () => {
+		const { dm } = makeDocker({
+			oneShot: () => ({ stdout: "ok\n", exitCode: 0 }),
+		});
+		const result = await dm.runPostCreate("s1", "true");
+		expect(result.exitCode).toBe(0);
 	});
 
 	// Round-7 review fix: hooks must run from the workspace, not from
@@ -1174,33 +1189,6 @@ describe("DockerManager.runPostCreate", () => {
 			"bash -c exec for runPostCreate",
 		);
 		expect(exec._workingDir).toBe("/home/developer/workspace");
-	});
-
-	// Round-2 review fix: hook diagnostics go to stderr (`npm ERR!`,
-	// `bash: cmd: not found`, `tsc: error TS…`). The capture must
-	// include stderr, otherwise the hard-fail modal shows "(no output)"
-	// for the most common failure mode and the user can't see what
-	// went wrong.
-	it("captures stderr alongside stdout in the returned output", async () => {
-		const { dm } = makeDocker({
-			oneShot: (cmd) => {
-				// Inject a stderr frame ahead of an empty stdout to assert
-				// the combined demux walks both. The test harness packs
-				// whatever the hook returns as stdout (frame type 1), so
-				// we simulate by writing a custom multiplexed buffer
-				// directly. Easier path: use `mergeFrames` below.
-				if (cmd[0] === "bash") {
-					return { stdout: "bash: bad-cmd: not found\n", exitCode: 127 };
-				}
-				return undefined;
-			},
-		});
-		const result = await dm.runPostCreate("s1", "bad-cmd");
-		// Even with the harness packing as stdout, the combined demux
-		// must surface the bytes — exiting code 127 is the canonical
-		// "command not found" semaphore the modal now relies on.
-		expect(result.exitCode).toBe(127);
-		expect(result.output).toContain("bash: bad-cmd: not found");
 	});
 });
 

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -1174,6 +1174,37 @@ describe("DockerManager.runPostCreate", () => {
 		expect(result.exitCode).toBe(0);
 	});
 
+	// PR #208 round 1: `info.ExitCode === null` is Docker's "haven't
+	// recorded the exit yet" state. Falling back to 0 there would let
+	// the runner present an indeterminate outcome as success and
+	// permanently consume the markBootstrapped gate. Must throw
+	// instead so runAsyncBootstrap routes into its catch + fails the
+	// session.
+	it("throws when docker exec inspect returns null ExitCode (indeterminate is not success)", async () => {
+		const { dm } = makeDocker({
+			oneShot: () => ({ stdout: "", exitCode: 0 }),
+		});
+		// Force the inspect call to return null — overrides the
+		// harness's default ExitCode: 0.
+		const fakeDocker = (dm as unknown as { docker: { getContainer: () => unknown } }).docker;
+		const original = fakeDocker.getContainer;
+		fakeDocker.getContainer = () => {
+			const container = (original as () => { exec: (opts: unknown) => Promise<unknown> }).call(
+				fakeDocker,
+			);
+			const origExec = container.exec;
+			container.exec = async (opts: unknown) => {
+				const exec = (await origExec.call(container, opts)) as {
+					inspect: () => Promise<{ ExitCode: number | null }>;
+				};
+				exec.inspect = async () => ({ ExitCode: null });
+				return exec;
+			};
+			return container;
+		};
+		await expect(dm.runPostCreate("s1", "true")).rejects.toThrow(/null ExitCode/);
+	});
+
 	// Round-7 review fix: hooks must run from the workspace, not from
 	// the image's WORKDIR. Without WorkingDir on the exec, `npm install`
 	// would look for package.json in `/home/developer` and silently

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -763,38 +763,70 @@ export class DockerManager {
 	 * 1000); cwd is the workspace bind mount, so the hook lands in the
 	 * same place a freshly-attached terminal would.
 	 *
-	 * Output cap: `execOneShot` collects the whole stream into a Buffer
-	 * before returning. A runaway hook that streams MB of output could
-	 * push memory pressure on the backend. Acceptable for the foundation
-	 * because the user controls the command, the per-session disk quota
-	 * already bounds workspace bloat, and 185b2b's streaming runner will
-	 * forward bytes onward instead of buffering. Documented as a known
-	 * trade-off here so the streaming PR has a concrete reason to drop
-	 * the buffering.
+	 * Streaming: when `onOutput` is supplied, every demuxed chunk
+	 * (stdout + stderr, frame-arrival order) is delivered as soon as
+	 * Docker hands it to us — no full-buffer accumulation. The async
+	 * runner in `bootstrap.ts` uses this to fan output to WS subscribers
+	 * live, so a long hook (npm install, multi-stage build) doesn't
+	 * make the user stare at a blank modal for minutes.
 	 */
 	async runPostCreate(
 		sessionId: string,
 		cmd: string,
-	): Promise<{ exitCode: number; output: string }> {
-		// `combineStreams: true` so the captured output includes stderr
-		// (#207 round 2 review): npm/tsc/bash diagnostic messages all go
-		// to stderr by default, and a hook-failure modal that only
-		// displays stdout would render "(no output)" for the most common
-		// failure mode (`bash: <cmd>: command not found`).
-		//
-		// `cwd: /home/developer/workspace` so the hook lands in the same
-		// place a freshly-attached terminal would (#207 round 7 review).
-		// Without it, Docker uses the image's WORKDIR
-		// (`/home/developer`) and `npm install` / `pip install -r ...` /
-		// `cargo build` would all fail with ENOENT looking for project
-		// files in the wrong directory. `runPostStart`'s tmux-session
-		// path already gets this right via `tmux new-session -c …`;
-		// this brings the exec path in line.
-		const result = await this.execOneShot(sessionId, ["bash", "-c", cmd], {
-			combineStreams: true,
-			cwd: "/home/developer/workspace",
+		onOutput?: (chunk: string) => void,
+	): Promise<{ exitCode: number }> {
+		const meta = await this.sessions.getOrThrow(sessionId);
+		if (!meta.containerId) throw new Error("No container for this session");
+		const container = this.docker.getContainer(meta.containerId);
+
+		// Build the exec directly rather than going through `execOneShot`
+		// — we want to stream chunks via `onOutput` as they arrive, not
+		// buffer the whole stream and return at the end. Same shape on
+		// the wire (Tty:false, multiplexed frames, WorkingDir pinned to
+		// the workspace) as #207 round 7 settled.
+		const exec = await container.exec({
+			Cmd: ["bash", "-c", cmd],
+			AttachStdin: false,
+			AttachStdout: true,
+			AttachStderr: true,
+			Tty: false,
+			WorkingDir: "/home/developer/workspace",
 		});
-		return { exitCode: result.exitCode, output: result.stdout };
+		const stream = await exec.start({ hijack: false, stdin: false });
+
+		// Demux frames as they arrive so `onOutput` fires per-chunk.
+		// `pending` accumulates across `data` events when a frame
+		// header lands split across reads.
+		let pending: Buffer = Buffer.alloc(0);
+		stream.on("data", (chunk: Buffer) => {
+			pending = (pending.length === 0 ? chunk : Buffer.concat([pending, chunk])) as Buffer;
+			let off = 0;
+			while (off + 8 <= pending.length) {
+				const frameType = pending[off]!;
+				const size = pending.readUInt32BE(off + 4);
+				if (off + 8 + size > pending.length) break; // partial frame; wait for next chunk
+				const payload = pending.subarray(off + 8, off + 8 + size);
+				// Combine stdout (1) + stderr (2) into one stream — npm
+				// errors etc. live on stderr and the modal needs them.
+				if ((frameType === 1 || frameType === 2) && onOutput) {
+					try {
+						onOutput(payload.toString("utf-8"));
+					} catch (err) {
+						logger.warn(`[docker] postCreate onOutput threw: ${(err as Error).message}`);
+					}
+				}
+				off += 8 + size;
+			}
+			pending = off === pending.length ? Buffer.alloc(0) : pending.subarray(off);
+		});
+
+		await new Promise<void>((resolve, reject) => {
+			stream.on("end", () => resolve());
+			stream.on("close", () => resolve());
+			stream.on("error", reject);
+		});
+		const info = await exec.inspect();
+		return { exitCode: info.ExitCode ?? 0 };
 	}
 
 	/**

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -820,6 +820,10 @@ export class DockerManager {
 			pending = off === pending.length ? Buffer.alloc(0) : pending.subarray(off);
 		});
 
+		// Resolve on whichever fires first: a typical Readable emits
+		// `end` then `close`, but Dockerode streams can emit `close`
+		// without `end` on a dropped daemon connection. Promise spec
+		// silently drops the second resolve.
 		await new Promise<void>((resolve, reject) => {
 			stream.on("end", () => resolve());
 			stream.on("close", () => resolve());

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -826,7 +826,21 @@ export class DockerManager {
 			stream.on("error", reject);
 		});
 		const info = await exec.inspect();
-		return { exitCode: info.ExitCode ?? 0 };
+		// `info.ExitCode === null` is Docker's "the daemon hasn't
+		// recorded the process exit yet" state — a narrow window
+		// between stream-end and the daemon committing the exit
+		// status. Treat it as an unknown failure rather than success
+		// (PR #208 round 1): a `?? 0` fallback here would let
+		// runAsyncBootstrap call markBootstrapped + runPostStart on a
+		// hook whose actual outcome we don't know, presenting a
+		// possibly-broken environment as ready. Throwing routes into
+		// the runner's catch which broadcasts `{type:"fail",
+		// exitCode:-1}` — correct disposition for an indeterminate
+		// outcome. `ExitCode: undefined` covers the type's nullability.
+		if (info.ExitCode === null || info.ExitCode === undefined) {
+			throw new Error("docker exec inspect returned null ExitCode after stream end");
+		}
+		return { exitCode: info.ExitCode };
 	}
 
 	/**

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import {
 	validateJwtSecret,
 	warnIfWildcardCorsInProduction,
 } from "./auth.js";
+import { BootstrapBroadcaster } from "./bootstrap.js";
 import { migrateDb, validateD1Config } from "./db.js";
 import { DockerManager } from "./dockerManager.js";
 import { logger } from "./logger.js";
@@ -74,6 +75,14 @@ try {
 
 const sessions = new SessionManager();
 const docker = new DockerManager(sessions);
+// Single shared bootstrap broadcaster (PR 185b2b). Owned at the server
+// scope so the route's runAsyncBootstrap and the WS handler's
+// /ws/bootstrap subscriber see the same per-session listener sets and
+// buffered output. Process-local — a load-balanced multi-backend deploy
+// would lose live-tail bytes when the WS lands on a different replica
+// than the one running the hook; that's documented as a single-replica
+// constraint of the hook runner, same as the terminal-attach path.
+const bootstrapBroadcaster = new BootstrapBroadcaster();
 
 // ── Express app ───────────────────────────────────────────────────────────────
 
@@ -139,7 +148,13 @@ app.use((_req, res, next) => {
 	next();
 });
 
-app.use("/api", buildRouter(sessions, docker));
+app.use(
+	"/api",
+	// `undefined` for rateLimitConfig — buildRouter falls back to
+	// DEFAULT_RATE_LIMIT_CONFIG. Threading the broadcaster through is
+	// the only reason this call moved off the one-liner.
+	buildRouter(sessions, docker, undefined, bootstrapBroadcaster),
+);
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // ── HTTP + WebSocket server ───────────────────────────────────────────────────
@@ -152,7 +167,7 @@ const wss = new WebSocketServer({ noServer: true });
 
 server.on("upgrade", (req, socket, head) => {
 	const url = req.url ?? "";
-	if (!url.startsWith("/ws/sessions/")) {
+	if (!url.startsWith("/ws/sessions/") && !url.startsWith("/ws/bootstrap/")) {
 		// socket.end() drains the write buffer before closing, so the
 		// 404 line actually reaches the client. socket.write() +
 		// socket.destroy() (the previous form) issues immediate
@@ -208,7 +223,7 @@ server.on("upgrade", (req, socket, head) => {
 const stopHeartbeat = startWsHeartbeat(wss, 30_000);
 
 wss.on("connection", (ws, req) => {
-	handleWsConnection(ws, req, sessions, docker);
+	handleWsConnection(ws, req, sessions, docker, bootstrapBroadcaster);
 });
 
 // ── Startup ───────────────────────────────────────────────────────────────────

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -148,13 +148,12 @@ app.use((_req, res, next) => {
 	next();
 });
 
-app.use(
-	"/api",
-	// `undefined` for rateLimitConfig — buildRouter falls back to
-	// DEFAULT_RATE_LIMIT_CONFIG. Threading the broadcaster through is
-	// the only reason this call moved off the one-liner.
-	buildRouter(sessions, docker, undefined, bootstrapBroadcaster),
-);
+// Threading the broadcaster through as the third positional arg —
+// rateLimitConfig defaults to DEFAULT_RATE_LIMIT_CONFIG. Required
+// (not optional) on buildRouter so a future caller that omits it
+// surfaces as a TypeScript error rather than a silently-dropped
+// postCreate hook (PR #208 round 1 review).
+app.use("/api", buildRouter(sessions, docker, bootstrapBroadcaster));
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // ── HTTP + WebSocket server ───────────────────────────────────────────────────

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -437,7 +437,9 @@ describe("auth route rate limiting", () => {
 			authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
 			...cfg,
 		};
-		const router = buildRouter(fakeSessions, fakeDocker, fullCfg);
+		// rate-limit tests don't touch the bootstrap broadcaster — empty
+		// stub object satisfies the now-required parameter (PR #208).
+		const router = buildRouter(fakeSessions, fakeDocker, {} as never, fullCfg);
 		const app = express();
 		app.use(express.json());
 		app.use("/api", router);

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -160,21 +160,16 @@ afterEach(async () => {
 });
 
 async function spinUp(sessions: SessionManager, docker: DockerManager) {
-	const router = buildRouter(
-		sessions,
-		docker,
-		{
-			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
-			register: { ipMax: 1000, ipWindowMs: 60_000 },
-			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
-			invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
-			invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
-			fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
-			logout: { ipMax: 1000, ipWindowMs: 60_000 },
-			authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
-		},
-		broadcaster,
-	);
+	const router = buildRouter(sessions, docker, broadcaster, {
+		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+		register: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+		logout: { ipMax: 1000, ipWindowMs: 60_000 },
+		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+	});
 	const app = express();
 	app.use(express.json());
 	app.use("/api", router);

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -1,12 +1,17 @@
 /**
- * routes.create.test.ts — POST /sessions hard-fail path tests for #185 (PR 185b2a).
+ * routes.create.test.ts — POST /sessions tests for #185 / PR 185b2b.
  *
- * Round-4 review flagged that the 500-response shape on a postCreate
- * hook failure (`{ sessionId, bootstrapOutput, bootstrapExitCode }`)
- * was only exercised at the `DockerManager` unit level. The frontend
- * modal parses these specific fields to render the error panel — a
- * future refactor that drops one of them would silently break the
- * UX with no failing test. This file covers the full HTTP round-trip.
+ * The bootstrap runner became asynchronous in 185b2b: when a
+ * `postCreateCmd` is configured, the route returns 201 immediately
+ * with `{ bootstrapping: true }` and kicks off `runAsyncBootstrap`
+ * fire-and-forget. The runner itself owns the status flip /
+ * container kill / WS-broadcast on the failure path; the route's
+ * job is just to hand off cleanly.
+ *
+ * Heavy mocking pattern follows `rateLimit.test.ts`: stub `./auth.js`
+ * + `./db.js` + `./bootstrap.js` so the route can be exercised over a
+ * real Express HTTP server without touching D1 or kicking off real
+ * async work.
  */
 
 import http from "node:http";
@@ -66,16 +71,20 @@ const dbStubs = vi.hoisted(() => ({
 }));
 vi.mock("./db.js", () => dbStubs);
 
-// Stub `markBootstrapped` so the success-path test doesn't need a D1
-// UPDATE round-trip; the hard-fail path tested below never reaches it.
+// Mock the whole bootstrap module so the route's fire-and-forget call
+// to `runAsyncBootstrap` is fully observable + side-effect-free. Keeps
+// the runner's own behaviour out of route-level tests; runner is
+// exercised in bootstrap.test.ts.
 const bootstrapStubs = vi.hoisted(() => ({
-	markBootstrapped: vi.fn(async () => true),
+	runAsyncBootstrap: vi.fn(async () => undefined),
+	BootstrapBroadcaster: class {
+		clearForTesting() {
+			/* noop */
+		}
+	},
 }));
 vi.mock("./bootstrap.js", () => bootstrapStubs);
 
-// `persistSessionConfig` writes the session_configs row. Stub so the
-// test doesn't need to mock the full d1Query SQL flow for the
-// non-bootstrap fields.
 vi.mock("./sessionConfig.js", async () => {
 	const actual = await vi.importActual<typeof import("./sessionConfig.js")>("./sessionConfig.js");
 	return {
@@ -84,6 +93,7 @@ vi.mock("./sessionConfig.js", async () => {
 	};
 });
 
+import type { BootstrapBroadcaster } from "./bootstrap.js";
 import type { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
 import type { SessionManager } from "./sessionManager.js";
@@ -107,53 +117,38 @@ function makeMeta(): SessionMeta {
 
 interface Spies {
 	create: ReturnType<typeof vi.fn>;
-	updateStatus: ReturnType<typeof vi.fn>;
 	deleteRow: ReturnType<typeof vi.fn>;
 	kill: ReturnType<typeof vi.fn>;
 	spawn: ReturnType<typeof vi.fn>;
-	runPostCreate: ReturnType<typeof vi.fn>;
 	runPostStart: ReturnType<typeof vi.fn>;
 }
 
-function makeFakes(opts: { postCreateExit: number; postCreateOutput: string }): {
-	sessions: SessionManager;
-	docker: DockerManager;
-	spies: Spies;
-} {
+function makeFakes(): { sessions: SessionManager; docker: DockerManager; spies: Spies } {
 	const meta = makeMeta();
 	const create = vi.fn(async () => meta);
-	const updateStatus = vi.fn(async () => undefined);
 	const deleteRow = vi.fn(async () => undefined);
 	const sessions = {
 		create,
-		updateStatus,
 		deleteRow,
+		updateStatus: vi.fn(async () => undefined),
 		get: vi.fn(async () => meta),
 	} as unknown as SessionManager;
 
 	const kill = vi.fn(async () => undefined);
 	const spawn = vi.fn(async () => "container-abc");
-	const runPostCreate = vi.fn(async () => ({
-		exitCode: opts.postCreateExit,
-		output: opts.postCreateOutput,
-	}));
 	const runPostStart = vi.fn(async () => undefined);
 	const docker = {
 		getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
 		spawn,
 		kill,
-		runPostCreate,
 		runPostStart,
 	} as unknown as DockerManager;
-	return {
-		sessions,
-		docker,
-		spies: { create, updateStatus, deleteRow, kill, spawn, runPostCreate, runPostStart },
-	};
+	return { sessions, docker, spies: { create, deleteRow, kill, spawn, runPostStart } };
 }
 
 let server: http.Server | null = null;
 let baseUrl = "";
+const broadcaster = {} as BootstrapBroadcaster;
 
 afterEach(async () => {
 	if (server) {
@@ -165,16 +160,21 @@ afterEach(async () => {
 });
 
 async function spinUp(sessions: SessionManager, docker: DockerManager) {
-	const router = buildRouter(sessions, docker, {
-		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
-		register: { ipMax: 1000, ipWindowMs: 60_000 },
-		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
-		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
-		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
-		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
-		logout: { ipMax: 1000, ipWindowMs: 60_000 },
-		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
-	});
+	const router = buildRouter(
+		sessions,
+		docker,
+		{
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+			fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+			logout: { ipMax: 1000, ipWindowMs: 60_000 },
+			authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+		},
+		broadcaster,
+	);
 	const app = express();
 	app.use(express.json());
 	app.use("/api", router);
@@ -185,21 +185,15 @@ async function spinUp(sessions: SessionManager, docker: DockerManager) {
 	baseUrl = `http://127.0.0.1:${port}`;
 }
 
-describe("POST /sessions — postCreate hard-fail path", () => {
+describe("POST /sessions — async bootstrap dispatch (PR 185b2b)", () => {
 	beforeEach(() => {
 		dbStubs.d1Query.mockReset();
-		bootstrapStubs.markBootstrapped.mockReset();
-		bootstrapStubs.markBootstrapped.mockResolvedValue(true);
+		bootstrapStubs.runAsyncBootstrap.mockReset();
+		bootstrapStubs.runAsyncBootstrap.mockResolvedValue(undefined);
 	});
 
-	it("returns 500 with bootstrapOutput / bootstrapExitCode / sessionId on non-zero hook exit", async () => {
-		// Frontend modal parses exactly these three fields to render the
-		// inline failure panel — locking the response shape so a future
-		// refactor that drops any of them trips this test.
-		const { sessions, docker, spies } = makeFakes({
-			postCreateExit: 42,
-			postCreateOutput: "bash: bad-cmd: not found\nnpm ERR! exited 42",
-		});
+	it("returns 201 with bootstrapping=true and kicks off runAsyncBootstrap when postCreateCmd is set", async () => {
+		const { sessions, docker, spies } = makeFakes();
 		await spinUp(sessions, docker);
 
 		const res = await fetch(`${baseUrl}/api/sessions`, {
@@ -207,53 +201,34 @@ describe("POST /sessions — postCreate hard-fail path", () => {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
 				name: "test",
-				config: { postCreateCmd: "bad-cmd" },
+				config: { postCreateCmd: "npm install", postStartCmd: "npm run dev" },
 			}),
 		});
-		expect(res.status).toBe(500);
-		const body = (await res.json()) as {
-			error: string;
-			sessionId: string;
-			bootstrapOutput: string;
-			bootstrapExitCode: number;
-		};
-		expect(body.error).toMatch(/postCreate hook failed/);
-		expect(body.bootstrapExitCode).toBe(42);
-		expect(body.bootstrapOutput).toContain("bash: bad-cmd: not found");
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { sessionId: string; bootstrapping?: boolean };
+		// bootstrapping flag is what tells the client to open the WS
+		// live-tail rather than treating the create as immediately
+		// complete.
+		expect(body.bootstrapping).toBe(true);
 		expect(body.sessionId).toBe("sess-1");
-
-		// Container must be killed on hard-fail — leaving it running
-		// would leak a container the user can no longer reach (the row
-		// is now `failed`, /start refuses).
-		expect(spies.kill).toHaveBeenCalledWith("sess-1");
-		// Row is FLIPPED to failed, NOT deleted — the captured output
-		// has to survive so the user can audit it later.
-		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
-		expect(spies.deleteRow).not.toHaveBeenCalled();
-		// markBootstrapped MUST NOT be called on the failure path — the
-		// gate exists to ensure postCreate runs once per session, not
-		// once per attempt; flipping it would prevent a future recreate
-		// from re-running the corrected hook (the row is failed and
-		// can't be reused, but defence in depth).
-		expect(bootstrapStubs.markBootstrapped).not.toHaveBeenCalled();
+		// Async runner was invoked exactly once with the right cfg.
+		// runPostStart is NOT called from the route here — the runner
+		// fires it on the success branch instead.
+		expect(bootstrapStubs.runAsyncBootstrap).toHaveBeenCalledTimes(1);
+		expect(bootstrapStubs.runAsyncBootstrap.mock.calls[0]?.[0]).toBe("sess-1");
+		expect(bootstrapStubs.runAsyncBootstrap.mock.calls[0]?.[1]).toEqual({
+			postCreateCmd: "npm install",
+			postStartCmd: "npm run dev",
+		});
+		expect(spies.runPostStart).not.toHaveBeenCalled();
 	});
 
-	it("rolls back the row + kills the container if updateStatus throws on hard-fail", async () => {
-		// PR #207 round 5 fix (replaces round 3): a thrown updateStatus
-		// must propagate so the outer catch tears the half-state row
-		// down. The previous behaviour swallowed the throw, leaving the
-		// row at (running, null) — which reconcile() would silently
-		// promote to (stopped, null), letting /start respawn an
-		// unbootstrapped container. Trade-off accepted: on this rare
-		// D1-hiccup path the user loses bootstrapOutput in the 500
-		// body (the response never reaches `res.json` because the
-		// exception jumped out earlier), but they don't get a
-		// respawnable orphan. CRITICAL operator log + general 500.
-		const { sessions, docker, spies } = makeFakes({
-			postCreateExit: 1,
-			postCreateOutput: "boom",
-		});
-		spies.updateStatus.mockRejectedValueOnce(new Error("D1 transient"));
+	it("returns 201 without bootstrapping flag and runs postStart inline when only postStartCmd is set", async () => {
+		// No postCreateCmd → no async bootstrap runner. postStart runs
+		// synchronously here because there's no hook to wait on, and
+		// runPostStart is fire-and-forget at the tmux layer anyway
+		// (`tmux new-session -d` returns immediately).
+		const { sessions, docker, spies } = makeFakes();
 		await spinUp(sessions, docker);
 
 		const res = await fetch(`${baseUrl}/api/sessions`, {
@@ -261,30 +236,36 @@ describe("POST /sessions — postCreate hard-fail path", () => {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
 				name: "test",
-				config: { postCreateCmd: "false" },
+				config: { postStartCmd: "code tunnel" },
 			}),
 		});
-		expect(res.status).toBe(500);
-		const body = (await res.json()) as { bootstrapOutput?: string };
-		// Generic 500 — the bootstrapOutput field is GONE from the
-		// response (we never reached the json call inside the if).
-		expect(body.bootstrapOutput).toBeUndefined();
-		// Outer catch ran: row deleted, container killed (no orphan,
-		// no respawnable row).
-		expect(spies.deleteRow).toHaveBeenCalledWith("sess-1");
-		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { bootstrapping?: boolean };
+		expect(body.bootstrapping).toBeUndefined();
+		expect(spies.runPostStart).toHaveBeenCalledWith("sess-1", "code tunnel");
+		expect(bootstrapStubs.runAsyncBootstrap).not.toHaveBeenCalled();
 	});
 
-	// Round-6 review concern: `sessions.create()` itself throwing (D1
-	// transient before any row exists) means `meta` is still null in
-	// the outer catch. The rollback block must NOT call
-	// `meta.sessionId` outside the `if (meta)` guard. Locking the case
-	// so the rollback never crashes with TypeError on this path.
-	it("does not crash the rollback when sessions.create itself throws (meta is null)", async () => {
-		const { sessions, docker, spies } = makeFakes({
-			postCreateExit: 0,
-			postCreateOutput: "",
+	it("returns 201 normally for a bare-create session (no config)", async () => {
+		const { sessions, docker, spies } = makeFakes();
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "test" }),
 		});
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { bootstrapping?: boolean };
+		expect(body.bootstrapping).toBeUndefined();
+		expect(spies.runPostStart).not.toHaveBeenCalled();
+		expect(bootstrapStubs.runAsyncBootstrap).not.toHaveBeenCalled();
+	});
+
+	// Unchanged from PR 185b2a round 6: sessions.create itself failing
+	// must NOT crash the rollback even though `meta` is still null.
+	it("does not crash the rollback when sessions.create itself throws (meta is null)", async () => {
+		const { sessions, docker, spies } = makeFakes();
 		spies.create.mockRejectedValueOnce(new Error("D1 down"));
 		await spinUp(sessions, docker);
 
@@ -295,76 +276,10 @@ describe("POST /sessions — postCreate hard-fail path", () => {
 		});
 		expect(res.status).toBe(500);
 		const body = (await res.json()) as { error: string };
-		// The original D1 error is what surfaces — NOT a TypeError on
-		// `meta.sessionId`. If the rollback crashed, Express would
-		// return a different error or the test would observe a stale
-		// connection.
 		expect(body.error).toBe("D1 down");
-		// No spawn / kill / deleteRow — `meta` was null, the rollback
-		// block was skipped entirely.
 		expect(spies.spawn).not.toHaveBeenCalled();
 		expect(spies.kill).not.toHaveBeenCalled();
 		expect(spies.deleteRow).not.toHaveBeenCalled();
-	});
-
-	it("returns 201 + calls markBootstrapped + runPostStart on the success path", async () => {
-		// Round-5 NIT: every other test in this file covers a failure
-		// shape. Pinning the happy path ensures a future refactor that
-		// drops `markBootstrapped` (single-use gate that prevents
-		// postCreate re-runs) or that fires `runPostStart` before
-		// `markBootstrapped` (would re-run a fresh hook every restart
-		// in the wrong order) trips an obvious test.
-		const { sessions, docker, spies } = makeFakes({
-			postCreateExit: 0,
-			postCreateOutput: "installed\n",
-		});
-		await spinUp(sessions, docker);
-
-		const res = await fetch(`${baseUrl}/api/sessions`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				name: "test",
-				config: {
-					postCreateCmd: "npm install",
-					postStartCmd: "npm run dev",
-				},
-			}),
-		});
-		expect(res.status).toBe(201);
-		expect(spies.runPostCreate).toHaveBeenCalledWith("sess-1", "npm install");
-		expect(bootstrapStubs.markBootstrapped).toHaveBeenCalledWith("sess-1");
-		expect(spies.runPostStart).toHaveBeenCalledWith("sess-1", "npm run dev");
-		expect(spies.kill).not.toHaveBeenCalled();
-		expect(spies.updateStatus).not.toHaveBeenCalled();
-	});
-
-	it("kills the container in the outer catch even on a post-spawn / post-runPostCreate failure", async () => {
-		// PR #207 round 4 fix: any throw between docker.spawn and the
-		// 201 response (markBootstrapped, runPostStart, sessions.get,
-		// the synthetic invariant throw) used to deleteRow but leave
-		// the container running — orphaned forever. The outer catch now
-		// always kills first.
-		const { sessions, docker, spies } = makeFakes({
-			postCreateExit: 0,
-			postCreateOutput: "",
-		});
-		bootstrapStubs.markBootstrapped.mockRejectedValueOnce(new Error("D1 transient"));
-		await spinUp(sessions, docker);
-
-		const res = await fetch(`${baseUrl}/api/sessions`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				name: "test",
-				config: { postCreateCmd: "echo ok" },
-			}),
-		});
-		expect(res.status).toBe(500);
-		// kill was called by the outer catch — no orphaned container.
-		expect(spies.kill).toHaveBeenCalledWith("sess-1");
-		// And the row got rolled back (this is the standard "unexpected
-		// failure during create" path).
-		expect(spies.deleteRow).toHaveBeenCalledWith("sess-1");
+		expect(bootstrapStubs.runAsyncBootstrap).not.toHaveBeenCalled();
 	});
 });

--- a/backend/src/routes.start.test.ts
+++ b/backend/src/routes.start.test.ts
@@ -71,6 +71,7 @@ const dbStubs = vi.hoisted(() => ({
 }));
 vi.mock("./db.js", () => dbStubs);
 
+import type { BootstrapBroadcaster } from "./bootstrap.js";
 import type { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
 import type { SessionManager } from "./sessionManager.js";
@@ -126,7 +127,11 @@ afterEach(async () => {
 });
 
 async function spinUp(sessions: SessionManager, docker: DockerManager) {
-	const router = buildRouter(sessions, docker, {
+	// /start route doesn't touch the broadcaster — empty stub object
+	// satisfies the now-required parameter without dragging the
+	// real implementation in.
+	const broadcaster = {} as BootstrapBroadcaster;
+	const router = buildRouter(sessions, docker, broadcaster, {
 		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
 		register: { ipMax: 1000, ipWindowMs: 60_000 },
 		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -493,10 +493,26 @@ export function buildRouter(
 				// `no-floating-promises`; explicitly catching at the
 				// top level satisfies the linter and gives us a final
 				// safety net for anything the runner missed.
-				runAsyncBootstrap(meta.sessionId, cfg, { sessions, docker, broadcaster }).catch((err) => {
+				const startedSessionId = meta.sessionId;
+				runAsyncBootstrap(startedSessionId, cfg, { sessions, docker, broadcaster }).catch((err) => {
 					logger.error(
-						`[routes] async bootstrap escaped its own error handling for ${meta?.sessionId}: ${(err as Error).message}`,
+						`[routes] async bootstrap escaped its own error handling for ${startedSessionId}: ${(err as Error).message}`,
 					);
+					// Push a synthetic terminal so the modal's WS
+					// subscriber doesn't sit on "Bootstrapping…"
+					// forever (PR #208 round 2). runAsyncBootstrap
+					// is very defensive so this branch is unlikely,
+					// but a future edit that breaks its internal
+					// try/catch would otherwise leave the user
+					// with a hung modal and the row at status=running
+					// with no further flip path. broadcaster.finish
+					// lazy-creates the session entry, so it's safe
+					// even if the runner threw before any broadcast.
+					broadcaster.finish(startedSessionId, {
+						type: "fail",
+						exitCode: -1,
+						error: (err as Error).message,
+					});
 				});
 				res.status(201).json({ ...serializeMeta(updated), bootstrapping: true });
 				return;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -53,8 +53,8 @@ import type { SessionMeta } from "./types.js";
 export function buildRouter(
 	sessions: SessionManager,
 	docker: DockerManager,
+	broadcaster: BootstrapBroadcaster,
 	rateLimitConfig: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG,
-	broadcaster?: BootstrapBroadcaster,
 ): Router {
 	const router = Router();
 
@@ -482,7 +482,7 @@ export function buildRouter(
 			// (after markBootstrapped). For sessions with postStart but
 			// NO postCreate, fire it directly here — the async runner
 			// only kicks off when there's a postCreateCmd to wait on.
-			if (validatedConfig?.postCreateCmd && broadcaster) {
+			if (validatedConfig?.postCreateCmd) {
 				const cfg = {
 					postCreateCmd: validatedConfig.postCreateCmd,
 					postStartCmd: validatedConfig.postStartCmd,

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -451,15 +451,6 @@ export function buildRouter(
 				await persistSessionConfig(meta.sessionId, validatedConfig);
 			}
 			await docker.spawn(meta.sessionId);
-			// postCreate hook (#185): one-shot bootstrap that runs once
-			// per session. Synchronous wait here means the modal stays
-			// open until the hook exits; PR 185b2b will layer a streaming
-			// WS channel so the user sees output live instead of waiting
-			// blind on the HTTP request. Hard-fail semantics from #185:
-			// non-zero exit → kill the container, flip status to `failed`,
-			// return 500 with the captured output. The row stays so the
-			// user can read what the hook printed (and so a recreate
-			// doesn't collide with leftover state on the same name).
 			const updated = await sessions.get(meta.sessionId);
 			if (!updated) {
 				// Shouldn't happen: sessions.create above just inserted this row,

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -27,7 +27,7 @@ import {
 	UsernameTakenError,
 	verifyJwt,
 } from "./auth.js";
-import { markBootstrapped } from "./bootstrap.js";
+import { type BootstrapBroadcaster, runAsyncBootstrap } from "./bootstrap.js";
 import { d1Query } from "./db.js";
 import type { DockerManager } from "./dockerManager.js";
 import { UploadQuotaExceededError } from "./dockerManager.js";
@@ -54,6 +54,7 @@ export function buildRouter(
 	sessions: SessionManager,
 	docker: DockerManager,
 	rateLimitConfig: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG,
+	broadcaster?: BootstrapBroadcaster,
 ): Router {
 	const router = Router();
 
@@ -459,80 +460,6 @@ export function buildRouter(
 			// return 500 with the captured output. The row stays so the
 			// user can read what the hook printed (and so a recreate
 			// doesn't collide with leftover state on the same name).
-			if (validatedConfig?.postCreateCmd) {
-				const { exitCode, output } = await docker.runPostCreate(
-					meta.sessionId,
-					validatedConfig.postCreateCmd,
-				);
-				if (exitCode !== 0) {
-					// Status flip MUST land BEFORE the docker.kill, NOT
-					// after (round-5 review). If we flipped after, a D1
-					// transient on the flip would leave the row at
-					// `(running, null)` (kill nulled container_id), and
-					// reconcile() on the next backend boot would promote
-					// it to `stopped` — a state the /start 409 guard
-					// happily allows, silently respawning an
-					// unbootstrapped container.
-					//
-					// We deliberately do NOT swallow this UPDATE's error.
-					// If it throws, the exception propagates to the outer
-					// catch which tears down the row + container as a
-					// generic create failure. Trade-off: on a D1 hiccup
-					// the user loses the captured `bootstrapOutput` from
-					// the 500 body (we never reach the json call) and
-					// the sidebar never shows the failure row. That's
-					// strictly better than the alternative, which is a
-					// row that reconcile silently promotes to stopped
-					// and the user respawns into.
-					await sessions.updateStatus(meta.sessionId, "failed");
-					// Kill is best-effort. If it fails, we have an orphan
-					// container with status=failed — a leak, not a
-					// security issue: reconcile selects only `running`
-					// rows so it skips this one, the /start 409 guard
-					// refuses the row, and manual `docker rm` resolves
-					// the leak. CRITICAL log surfaces it for operators.
-					await docker.kill(meta.sessionId).catch((e) => {
-						logger.error(
-							`[routes] CRITICAL: kill after failed postCreate ${meta?.sessionId} threw: ${(e as Error).message}. ` +
-								"Row already flipped to failed; container may need manual `docker rm`.",
-						);
-					});
-					res.status(500).json({
-						error: `postCreate hook failed (exit ${exitCode})`,
-						sessionId: meta.sessionId,
-						bootstrapOutput: output,
-						bootstrapExitCode: exitCode,
-					});
-					return;
-				}
-				// Atomic UPDATE … WHERE bootstrapped_at IS NULL — the only
-				// place in the codebase that sets this column. A retry
-				// race (e.g. two concurrent retries of the same create
-				// after a partial network failure) sees changes === 0 on
-				// the loser and we just skip the no-op. Returns true if
-				// THIS caller won; we ignore the boolean here because the
-				// route is single-shot per session — the gate exists for
-				// the runner's own sanity in 185b2b's async flow.
-				await markBootstrapped(meta.sessionId);
-			}
-			// postStart hook fires from `docker.spawn` -> nope, spawn doesn't
-			// call it; only `startContainer`. The first start happens here
-			// inside spawn (via container.start), so trigger postStart for
-			// the create path explicitly. Subsequent /start calls go
-			// through `startContainer` which already runs postStart.
-			if (validatedConfig?.postStartCmd) {
-				try {
-					await docker.runPostStart(meta.sessionId, validatedConfig.postStartCmd);
-				} catch (err) {
-					// Like the runPostStartIfConfigured wrapper, don't fail the
-					// create on a postStart launch error — the container is
-					// up, postCreate succeeded, the user can still use the
-					// session.
-					logger.warn(
-						`[routes] postStart launch failed for ${meta.sessionId}: ${(err as Error).message}`,
-					);
-				}
-			}
 			const updated = await sessions.get(meta.sessionId);
 			if (!updated) {
 				// Shouldn't happen: sessions.create above just inserted this row,
@@ -541,6 +468,53 @@ export function buildRouter(
 				// runs the spawn rollback and returns 500 — correct disposition
 				// for a server-side invariant violation.
 				throw new Error(`session ${meta.sessionId} missing from D1 after create`);
+			}
+			// PR 185b2b: postCreate runs ASYNCHRONOUSLY when configured.
+			// The route returns 201 immediately so the modal can subscribe
+			// to `/ws/bootstrap/<sessionId>` and tail output live; the
+			// runner inside `runAsyncBootstrap` flips status to `failed`
+			// + kills the container on hard-fail, then broadcasts a
+			// terminal `{type:"fail"}` for the modal to render. The
+			// `bootstrapping: true` flag tells the client to open the WS
+			// instead of treating the create as immediately complete.
+			//
+			// postStart fires inside the runner on the success branch
+			// (after markBootstrapped). For sessions with postStart but
+			// NO postCreate, fire it directly here — the async runner
+			// only kicks off when there's a postCreateCmd to wait on.
+			if (validatedConfig?.postCreateCmd && broadcaster) {
+				const cfg = {
+					postCreateCmd: validatedConfig.postCreateCmd,
+					postStartCmd: validatedConfig.postStartCmd,
+				};
+				// Fire-and-forget; the runner internally catches every
+				// throw it can and translates them into broadcaster
+				// `fail` messages. A bare `void`-prefix triggers
+				// `no-floating-promises`; explicitly catching at the
+				// top level satisfies the linter and gives us a final
+				// safety net for anything the runner missed.
+				runAsyncBootstrap(meta.sessionId, cfg, { sessions, docker, broadcaster }).catch((err) => {
+					logger.error(
+						`[routes] async bootstrap escaped its own error handling for ${meta?.sessionId}: ${(err as Error).message}`,
+					);
+				});
+				res.status(201).json({ ...serializeMeta(updated), bootstrapping: true });
+				return;
+			}
+			// No postCreate (bare-create or only postStart configured).
+			// postStart fires synchronously here for the create path —
+			// `runPostStart` only kicks off a detached tmux session, so
+			// it returns quickly even though the daemon keeps running.
+			if (validatedConfig?.postStartCmd) {
+				try {
+					await docker.runPostStart(meta.sessionId, validatedConfig.postStartCmd);
+				} catch (err) {
+					// Don't fail create on a postStart launch error —
+					// the container is up and the user can still use it.
+					logger.warn(
+						`[routes] postStart launch failed for ${meta.sessionId}: ${(err as Error).message}`,
+					);
+				}
 			}
 			res.status(201).json(serializeMeta(updated));
 		} catch (err) {

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -50,7 +50,7 @@ export function handleWsConnection(
 	req: IncomingMessage,
 	sessions: SessionManager,
 	docker: DockerManager,
-	broadcaster?: BootstrapBroadcaster,
+	broadcaster: BootstrapBroadcaster,
 ): void {
 	// Synchronous safety net registered BEFORE any await or sync ws.close().
 	// Node's EventEmitter routes an 'error' emission with no listener to

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -7,6 +7,7 @@ import type { Duplex } from "node:stream";
 import { v4 as uuidv4 } from "uuid";
 import { WebSocket, type WebSocketServer } from "ws";
 import { verifyWsToken } from "./auth.js";
+import type { BootstrapBroadcaster, BootstrapMessage } from "./bootstrap.js";
 import type { DockerManager } from "./dockerManager.js";
 import { logger } from "./logger.js";
 import { TERMINAL_DIM_MAX } from "./routes.js";
@@ -49,6 +50,7 @@ export function handleWsConnection(
 	req: IncomingMessage,
 	sessions: SessionManager,
 	docker: DockerManager,
+	broadcaster?: BootstrapBroadcaster,
 ): void {
 	// Synchronous safety net registered BEFORE any await or sync ws.close().
 	// Node's EventEmitter routes an 'error' emission with no listener to
@@ -86,6 +88,27 @@ export function handleWsConnection(
 		return;
 	}
 	const userId = payload.sub;
+
+	// PR 185b2b: `/ws/bootstrap/<sessionId>` is the live-tail channel
+	// for the postCreate hook. Authed identically to the terminal-attach
+	// path, but routes to the broadcaster's per-session listener set
+	// instead of `docker.attach`. Owns its own auth-and-subscribe block
+	// below so terminal-attach logic doesn't have to special-case the
+	// bootstrap shape.
+	const bootstrapMatch = url.match(/\/ws\/bootstrap\/([^/?#]+)/);
+	if (bootstrapMatch) {
+		if (!broadcaster) {
+			// Defensive: server boot wires the broadcaster in, so this
+			// branch is unreachable in production. If we land here a
+			// future caller forgot to thread it through; loudly close.
+			sendError(ws, "Bootstrap channel not configured");
+			ws.close(1011, "Bootstrap channel not configured");
+			return;
+		}
+		const bootstrapSessionId = bootstrapMatch[1]!;
+		void handleBootstrapWs(ws, bootstrapSessionId, userId, sessions, broadcaster);
+		return;
+	}
 
 	const match = url.match(/\/ws\/sessions\/([^/?#]+)/);
 	if (!match) {
@@ -317,4 +340,60 @@ function sendMsg(ws: WebSocket, msg: WsServerMessage): void {
 
 function sendError(ws: WebSocket, message: string): void {
 	sendMsg(ws, { type: "error", message });
+}
+
+/**
+ * Bootstrap-channel attach (PR 185b2b). Subscribes the WS to the
+ * broadcaster's per-session listener set so the modal's live-tail
+ * panel sees output as it streams from `runPostCreate`. Auth +
+ * ownership match the terminal-attach path; on close (whether the
+ * client navigated away or the broadcaster sent a terminal message
+ * and we hung up) the listener is unsubscribed so the broadcaster's
+ * Set doesn't leak.
+ */
+async function handleBootstrapWs(
+	ws: WebSocket,
+	sessionId: string,
+	userId: string,
+	sessions: SessionManager,
+	broadcaster: BootstrapBroadcaster,
+): Promise<void> {
+	try {
+		await sessions.assertOwnership(sessionId, userId);
+	} catch (err) {
+		if (err instanceof NotFoundError) {
+			sendError(ws, "Session not found");
+			ws.close(1008, "Not found");
+			return;
+		}
+		if (err instanceof ForbiddenError) {
+			sendError(ws, "Forbidden");
+			ws.close(1008, "Forbidden");
+			return;
+		}
+		logger.error(`[ws] bootstrap auth failed for ${sessionId}: ${(err as Error).message}`);
+		ws.close(1011, "Internal error");
+		return;
+	}
+
+	const listener = (msg: BootstrapMessage) => {
+		if (ws.readyState !== WebSocket.OPEN) return;
+		try {
+			ws.send(JSON.stringify(msg));
+		} catch (sendErr) {
+			logger.warn(`[ws] bootstrap send failed for ${sessionId}: ${(sendErr as Error).message}`);
+		}
+		// Close the WS after a terminal message lands. Letting the
+		// connection idle would mean every browser tab leaks an
+		// open WS forever after the hook completes; explicit close
+		// also signals the client to clean up its modal handlers.
+		if (msg.type === "done" || msg.type === "fail") {
+			ws.close(1000, "Bootstrap complete");
+		}
+	};
+
+	const unsubscribe = broadcaster.subscribe(sessionId, listener);
+	ws.on("close", () => unsubscribe());
+	ws.on("error", () => unsubscribe());
+	logger.info(`[ws] user=${userId} subscribed to bootstrap channel for session=${sessionId}`);
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -163,29 +163,6 @@ export interface SessionConfigPayload {
 	envVars?: Record<string, string>;
 }
 
-/**
- * Thrown when the create succeeded up to the point of running the
- * `postCreate` hook (#185), but the hook itself exited non-zero. The
- * server has already killed the container and flipped the session
- * status to `failed`; the row stays so the user can read the captured
- * output (carried on this error). The new-session modal surfaces
- * `bootstrapOutput` inline so the user sees what their hook printed
- * before it died.
- */
-export class BootstrapFailedError extends Error {
-	readonly sessionId: string;
-	readonly exitCode: number;
-	readonly output: string;
-
-	constructor(sessionId: string, exitCode: number, output: string, message: string) {
-		super(message);
-		this.name = "BootstrapFailedError";
-		this.sessionId = sessionId;
-		this.exitCode = exitCode;
-		this.output = output;
-	}
-}
-
 // ── Bootstrap live-tail WS (#185 / PR 185b2b) ───────────────────────────────
 
 /** Server → client message shape on `/ws/bootstrap/<sessionId>`. */

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -6,6 +6,10 @@
 // e.g. https://api.terminal.yourdomain.com
 const BACKEND_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
 const API_BASE = `${BACKEND_URL}/api`;
+// http(s) → ws(s) for the same host. Used by the bootstrap live-tail
+// channel (PR 185b2b) and could be reused by the terminal-attach WS
+// helper if it ever moves into this module.
+const WS_BASE = BACKEND_URL.replace(/^http/, "ws");
 
 // ── Auth state (#18, #50) ───────────────────────────────────────────────────
 //
@@ -182,36 +186,109 @@ export class BootstrapFailedError extends Error {
 	}
 }
 
+// ── Bootstrap live-tail WS (#185 / PR 185b2b) ───────────────────────────────
+
+/** Server → client message shape on `/ws/bootstrap/<sessionId>`. */
+export type BootstrapServerMessage =
+	| { type: "output"; data: string }
+	| { type: "done"; success: true }
+	| { type: "fail"; exitCode: number; error?: string }
+	| { type: "error"; message: string };
+
+export interface BootstrapHandlers {
+	onOutput(chunk: string): void;
+	onDone(success: boolean, exitCode: number | null, error?: string): void;
+}
+
+/**
+ * Open the bootstrap live-tail WS for a session. Returns a `close()`
+ * thunk so the modal can tear it down on cancel. Auth is via the
+ * httpOnly JWT cookie — the browser auto-attaches it on the WS
+ * upgrade. The server handles late subscribers by replaying buffered
+ * output + the terminal message, so a slow connect doesn't lose log
+ * lines.
+ *
+ * Failure modes:
+ *   - WS close before any message: the server dropped us (auth fail,
+ *     ownership fail). Surface as a synthetic `fail` so the modal
+ *     doesn't sit on a stuck spinner.
+ *   - JSON parse error on a frame: log + skip; the next frame can
+ *     still recover.
+ */
+export function openBootstrapWs(
+	sessionId: string,
+	handlers: BootstrapHandlers,
+): { close: () => void } {
+	const ws = new WebSocket(`${WS_BASE}/ws/bootstrap/${encodeURIComponent(sessionId)}`);
+	let terminal = false;
+
+	ws.addEventListener("message", (e) => {
+		let msg: BootstrapServerMessage;
+		try {
+			msg = JSON.parse(e.data as string) as BootstrapServerMessage;
+		} catch {
+			console.warn("[bootstrap] dropped malformed frame");
+			return;
+		}
+		if (msg.type === "output") {
+			handlers.onOutput(msg.data);
+		} else if (msg.type === "done") {
+			terminal = true;
+			handlers.onDone(true, 0);
+		} else if (msg.type === "fail") {
+			terminal = true;
+			handlers.onDone(false, msg.exitCode, msg.error);
+		} else if (msg.type === "error") {
+			// Server-side auth/path failure — don't get a `fail`
+			// message after this, just a close. Hand a synthetic
+			// terminal up to the modal so it doesn't hang.
+			terminal = true;
+			handlers.onDone(false, null, msg.message);
+		}
+	});
+
+	ws.addEventListener("close", () => {
+		if (terminal) return;
+		// Server dropped us before sending a terminal. Most likely
+		// the session vanished or the broadcaster GC'd the entry.
+		// Synthetic fail so the modal can render an error instead
+		// of waiting indefinitely.
+		handlers.onDone(false, null, "Bootstrap channel closed unexpectedly");
+	});
+
+	return {
+		close: () => {
+			try {
+				ws.close(1000, "client cancelled");
+			} catch {
+				/* already closed */
+			}
+		},
+	};
+}
+
+/**
+ * Response shape for `POST /sessions`. The optional `bootstrapping`
+ * flag is set by the backend when a `postCreateCmd` was configured
+ * and the hook is running asynchronously — the modal subscribes to
+ * `/ws/bootstrap/<sessionId>` to tail output and waits for the
+ * terminal `done` / `fail` message before closing.
+ */
+export interface CreateSessionResponse extends SessionInfo {
+	bootstrapping?: boolean;
+}
+
 export async function createSession(
 	name: string,
 	envVars?: Record<string, string>,
 	config?: SessionConfigPayload,
-): Promise<SessionInfo> {
+): Promise<CreateSessionResponse> {
 	const res = await apiFetch("/sessions", {
 		method: "POST",
 		body: JSON.stringify({ name, envVars, config }),
 	});
 	if (!res.ok) {
-		const body = (await res.json().catch(() => ({}))) as {
-			error?: string;
-			sessionId?: string;
-			bootstrapOutput?: string;
-			bootstrapExitCode?: number;
-		};
-		// Distinguish hook-failed from generic create errors so the modal
-		// can surface the captured output instead of just a one-liner.
-		// The 500 carries `bootstrapOutput` only when the hook actually
-		// ran; a missing field means a different failure shape (D1
-		// transient, docker spawn EACCES, etc.) and the generic Error
-		// path is right.
-		if (body.bootstrapOutput !== undefined && body.sessionId !== undefined) {
-			throw new BootstrapFailedError(
-				body.sessionId,
-				body.bootstrapExitCode ?? -1,
-				body.bootstrapOutput,
-				body.error ?? "postCreate hook failed",
-			);
-		}
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
 		throw new Error(body.error ?? "Failed to create session");
 	}
 	return res.json();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -235,6 +235,14 @@ export function openBootstrapWs(
 
 	return {
 		close: () => {
+			// Mark `terminal` BEFORE the close so the asynchronous
+			// `close` event handler's guard short-circuits and we
+			// don't synthesize a fake `fail` message for an
+			// intentional cancel (PR #208 round 3). Without this the
+			// modal would render "Bootstrap channel closed unexpectedly"
+			// every time the user closed the new-session modal during
+			// a hook, even though they explicitly chose to cancel.
+			terminal = true;
 			try {
 				ws.close(1000, "client cancelled");
 			} catch {

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -625,6 +625,27 @@ main:not([data-sidebar-ready]) #sidebar {
   cursor: progress;
 }
 
+/* postCreate live-tail panel (#185 / PR 185b2b). The same DOM node
+   gets the `bootstrap-error` class added on top when the WS sends a
+   terminal `fail` message — `bootstrap-error` selectors below win
+   via specificity to recolor the border + heading. Don't merge them
+   into a single class set; the staged styling makes the user-visible
+   transition (running → failed) immediate without re-rendering. */
+.bootstrap-tail {
+  margin-top: 0.85rem;
+  background: rgba(88, 166, 255, 0.06);
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0.75rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.bootstrap-tail strong {
+  color: #58a6ff;
+  font-size: 0.85rem;
+}
+
 /* postCreate hard-fail panel inside the new-session modal (#185). */
 .bootstrap-error {
   margin-top: 0.85rem;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,7 +11,6 @@
 import "./main.css";
 
 import {
-	BootstrapFailedError,
 	checkAuthStatus,
 	createInvite,
 	createSession,
@@ -27,6 +26,7 @@ import {
 	listTabs,
 	login,
 	logout,
+	openBootstrapWs,
 	register,
 	revokeInvite,
 	SESSION_EXPIRED_EVENT,
@@ -1129,33 +1129,74 @@ function openNewSessionModal(opener: HTMLElement) {
 }
 
 /**
- * Render a postCreate-hook failure inline in the modal — the user sees
- * the captured stdout/stderr without losing the form they were filling
- * out. Clears on next open / next submit. PR 185b2b will replace the
- * static `<pre>` with a live-tail panel that shows output as it
- * streams.
+ * PR 185b2b live-tail state. While a bootstrap WS is open we hold onto
+ * the close thunk + the rendered `<pre>` so:
+ *   - cancelling the modal (Esc, X, backdrop) closes the WS and the
+ *     hook keeps running server-side; the user can re-open the
+ *     session later from the sidebar to attach to its terminal.
+ *   - submitting again while a previous WS is still draining
+ *     (shouldn't happen, modal disables the button, but defensive)
+ *     tears the old one down first.
  */
-function renderBootstrapError(err: BootstrapFailedError) {
+let activeBootstrap: { close: () => void } | null = null;
+
+function startBootstrapLiveTail(session: SessionInfo, name: string) {
 	clearBootstrapError();
 	const panel = document.createElement("div");
-	panel.className = "bootstrap-error";
-	panel.id = "bootstrap-error-panel";
+	panel.className = "bootstrap-tail";
+	panel.id = "bootstrap-error-panel"; // reused id so clearBootstrapError() removes either kind
 	const heading = document.createElement("strong");
-	heading.textContent = `postCreate hook failed (exit ${err.exitCode})`;
+	heading.textContent = "Bootstrapping session…";
 	panel.appendChild(heading);
 	const hint = document.createElement("p");
 	hint.className = "bootstrap-error-hint";
-	hint.textContent =
-		"The session was created but the bootstrap command exited non-zero, " +
-		"so the container was killed and the session marked failed. " +
-		"Captured output below — fix the command and create a new session.";
+	hint.textContent = "Live output from your postCreate hook. The modal will close on success.";
 	panel.appendChild(hint);
 	const pre = document.createElement("pre");
 	pre.className = "bootstrap-error-output";
-	pre.textContent = err.output || "(no output captured)";
+	pre.textContent = "";
 	panel.appendChild(pre);
-	const basicsPanel = document.getElementById("session-tab-basics");
-	basicsPanel?.appendChild(panel);
+	document.getElementById("session-tab-basics")?.appendChild(panel);
+
+	activeBootstrap = openBootstrapWs(session.sessionId, {
+		onOutput: (chunk) => {
+			pre.textContent += chunk;
+			// Auto-scroll to the bottom so the latest line is visible
+			// — `npm install`-style hooks emit hundreds of lines and
+			// the user expects the tail, not the head.
+			pre.scrollTop = pre.scrollHeight;
+		},
+		onDone: (success, exitCode, error) => {
+			activeBootstrap = null;
+			if (success) {
+				closeNewSessionModal();
+				void openSession(session.sessionId);
+				showToast(`Session "${name}" created`);
+				return;
+			}
+			// Hard fail: server already flipped row to `failed` and
+			// killed the container. Switch panel into the error
+			// styling, refresh sidebar so the failed row appears,
+			// re-enable the submit button so the user can fix the
+			// hook + try again.
+			panel.classList.add("bootstrap-error");
+			heading.textContent = error
+				? `postCreate hook failed (${error})`
+				: `postCreate hook failed (exit ${exitCode ?? "?"})`;
+			hint.textContent =
+				"The bootstrap command exited non-zero, so the container was killed and the session marked failed. " +
+				"Captured output above — fix the command and create a new session.";
+			void refreshSessions();
+			newSessionSubmitBtn.disabled = false;
+		},
+	});
+}
+
+function teardownBootstrapTail() {
+	if (activeBootstrap) {
+		activeBootstrap.close();
+		activeBootstrap = null;
+	}
 }
 
 function clearBootstrapError() {
@@ -1165,6 +1206,13 @@ function clearBootstrapError() {
 function closeNewSessionModal() {
 	newSessionModal.classList.remove("open");
 	newSessionModal.setAttribute("aria-hidden", "true");
+	// PR 185b2b: closing the modal mid-bootstrap MUST cancel the WS
+	// subscription. The hook itself keeps running server-side (the
+	// async runner is fire-and-forget); we just stop tailing it. The
+	// user can re-attach to the session from the sidebar once it
+	// reaches `running` (or see the failure in the row's status if it
+	// flipped to `failed`).
+	teardownBootstrapTail();
 	(newSessionOpener ?? newSessionBtn).focus();
 	newSessionOpener = null;
 }
@@ -1190,26 +1238,25 @@ newSessionForm.addEventListener("submit", async (e) => {
 	// sessions and burn quota silently).
 	newSessionSubmitBtn.disabled = true;
 	clearBootstrapError();
+	teardownBootstrapTail();
 	try {
 		showToast("Creating session…");
 		const session = await createSession(name);
 		sessions.unshift(session);
 		renderSessionList();
+		if (session.bootstrapping) {
+			// PR 185b2b: postCreate is running asynchronously on the
+			// server. Switch the modal into live-tail mode and wait
+			// for the WS terminal message before either closing
+			// (success) or rendering an error panel (failure).
+			startBootstrapLiveTail(session, name);
+			return;
+		}
 		closeNewSessionModal();
 		void openSession(session.sessionId);
 		showToast(`Session "${name}" created`);
 	} catch (err) {
-		if (err instanceof BootstrapFailedError) {
-			// postCreate hook hard-failed (#185). Server already killed
-			// the container and flipped status=failed. Refresh the
-			// sidebar so the failed row shows up, and surface the hook's
-			// captured stdout/stderr inline in the modal so the user can
-			// see what went wrong without leaving the form.
-			void refreshSessions();
-			renderBootstrapError(err);
-		} else {
-			showToast((err as Error).message, true);
-		}
+		showToast((err as Error).message, true);
 		newSessionSubmitBtn.disabled = false;
 	}
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1197,6 +1197,12 @@ function teardownBootstrapTail() {
 		activeBootstrap.close();
 		activeBootstrap = null;
 	}
+	// Clear any rendered tail / error panel too. Without this, a
+	// cancelled-mid-bootstrap close left the error-styled panel in
+	// the DOM; the next time the modal opened it briefly flashed a
+	// "postCreate hook failed" message that didn't apply to the new
+	// session (PR #208 round 3).
+	clearBootstrapError();
 }
 
 function clearBootstrapError() {


### PR DESCRIPTION
## Summary

**Closes #185** by completing the streaming half of the bootstrap runner. PR #207 (185b2a) shipped the synchronous version — `postCreate` ran inline on the POST request and the modal sat on a spinner until the hook exited. This PR (**185b2b**) makes it asynchronous: POST returns 201 immediately with `bootstrapping: true`, the runner streams stdout+stderr to a per-session WS channel, and the modal renders the output live as the hook runs.

After this PR merges, the entire epic #184 lineage is:
- PR #205 (185a) — schema + tabbed-modal scaffold
- PR #206 (185b1) — DockerManager applies env / cpu / mem at spawn
- PR #207 (185b2a) — sync postCreate + per-start postStart
- **PR (this one) (185b2b)** — async streaming + WS channel + live-tail UI

## Backend

- **`BootstrapBroadcaster`** — per-session listener fan-out, bounded byte buffer for late subscribers, GC retention after the terminal message lands. Bytes emitted before any WS connects are replayed when the modal joins, so a slow connect doesn't drop log lines.
- **`runAsyncBootstrap`** — streams hook output via callback, handles success (markBootstrapped → postStart → `done` broadcast) and failure (status flip BEFORE kill, preserving the round-5 invariant from 185b2a → `fail` broadcast). Throws inside the runner are caught and translated to `fail` messages so the modal never hangs.
- **`runPostCreate`** — now takes an optional `onOutput(chunk)` callback and streams Docker frames as they arrive instead of buffering the whole stream. Returns just `{exitCode}`; the broadcaster owns buffering now.
- **WS path `/ws/bootstrap/<sessionId>`** — auth + ownership match the terminal-attach path; subscribes the WS to the broadcaster and closes 1000 on terminal.
- **`POST /api/sessions`** — async dispatch when `postCreateCmd` is configured: returns 201 + `bootstrapping: true` and fires `runAsyncBootstrap` fire-and-forget.

## Frontend

- `openBootstrapWs(sessionId, handlers)` — synthesizes a terminal `fail` if the WS closes before any message lands, so the modal never sits on a stuck spinner.
- New-session modal switches into a live-tail `<pre>` panel when `bootstrapping: true` comes back. Output streams in with auto-scroll. On done success: modal closes + opens the new session. On fail: panel restyles to error + sidebar refreshes + submit re-enables.
- Closing the modal mid-bootstrap closes the WS but leaves the server-side hook running — the user can re-attach to the session from the sidebar once it reaches `running` (or sees the `failed` row if the hook bombed).
- `BootstrapFailedError` removed; the throw-based path is replaced by the WS terminal message.

## Test plan

- [x] `cd backend && npm test` — **283/283 passing**.
  - 12 new cases in `bootstrap.test.ts` (broadcaster fan-out, replay, terminal-after-finish, isolation; runner success/fail/throw paths; markBootstrapped failure tolerated on success).
  - 4 cases in `routes.create.test.ts` rewritten for the async dispatch shape.
  - `dockerManager.test.ts` runPostCreate tests updated to the streaming signature.
- [x] `cd backend && npm run lint` — clean.
- [x] `cd backend && npm run build` — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — clean.
- [ ] Live container check (create a session with `postCreateCmd: "for i in {1..5}; do echo step $i; sleep 1; done"` and observe live tail in the modal) — couldn't run in this session (dev D1 setup offline).

Refs #184. Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)