### PR TITLE
feat(secrets): AES-256-GCM crypto module + boot validation (#186, PR 186a of 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,16 @@ PORT=3001
 JWT_SECRET=change-me-in-production
 JWT_EXPIRES_IN=7d
 
+# Secrets encryption key — REQUIRED (#186). Used to AES-256-GCM
+# encrypt `secret`-typed env-var entries before they land in D1, so
+# a D1 dump never contains plaintext API keys / DB URLs / tokens.
+# Must decode to exactly 32 bytes. Generate with:
+#   openssl rand -base64 32
+# Backend refuses to start if this is unset / malformed.
+# WARNING: changing this key strands every existing secret entry —
+# there's no rotation tooling in v1. Operator runbook lives in #204.
+SECRETS_ENCRYPTION_KEY=change-me-in-production-base64-32-bytes
+
 # CORS — comma-separated origins (your Cloudflare Pages URL)
 # e.g. https://shared-terminal.pages.dev,http://localhost:5173
 CORS_ORIGINS=*

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import { migrateDb, validateD1Config } from "./db.js";
 import { DockerManager } from "./dockerManager.js";
 import { logger } from "./logger.js";
 import { buildRouter } from "./routes.js";
+import { validateSecretsKey } from "./secrets.js";
 import { SessionManager } from "./sessionManager.js";
 import { parseTrustProxy, TrustProxyError, warnIfProductionMisconfigured } from "./trustProxy.js";
 import { endUpgradeSocketWithReply, handleWsConnection, startWsHeartbeat } from "./wsHandler.js";
@@ -45,6 +46,13 @@ const TRUST_PROXY_RAW = process.env.TRUST_PROXY;
 
 validateD1Config();
 validateJwtSecret();
+// Refuse to start without SECRETS_ENCRYPTION_KEY (#186). Mirrors the
+// validateD1Config / validateJwtSecret pattern: better to crash on
+// boot with a clear error than to start, accept a `secret`-typed env
+// var via POST /sessions, fail to encrypt at persist time, and either
+// store the plaintext (data leak) or 500 the create. Operator runbook
+// for key generation + rotation lives in #204.
+validateSecretsKey();
 
 // Warn early if NODE_ENV=production but TRUST_PROXY is unset — a likely
 // misconfig where per-IP rate limits collapse into a single bucket. Runs

--- a/backend/src/secrets.test.ts
+++ b/backend/src/secrets.test.ts
@@ -1,0 +1,185 @@
+/**
+ * secrets.test.ts — AES-256-GCM round-trip + boot-validation coverage
+ * for #186 PR 186a.
+ *
+ * The crypto guarantees (confidentiality + integrity via GCM auth
+ * tag) are enforced by Node's `crypto` module — these tests are a
+ * sanity layer over the wrapper rather than a re-validation of the
+ * primitive: they pin the wrapper's contract so a future refactor
+ * (e.g. switching to a different IV scheme, or moving the key
+ * source) doesn't silently break boot validation, round-trip, or
+ * tag-mismatch rejection.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	_clearKeyCacheForTesting,
+	decryptSecret,
+	type EncryptedSecret,
+	encryptSecret,
+	secretsEqual,
+	validateSecretsKey,
+} from "./secrets.js";
+
+// 32 bytes of `0x42` repeated, base64-encoded. Deterministic so the
+// boot-validation tests can flip between this, an "almost right"
+// 31-byte key, and an absent key.
+const VALID_KEY_B64 = Buffer.alloc(32, 0x42).toString("base64");
+
+beforeEach(() => {
+	process.env.SECRETS_ENCRYPTION_KEY = VALID_KEY_B64;
+	_clearKeyCacheForTesting();
+});
+
+afterEach(() => {
+	_clearKeyCacheForTesting();
+});
+
+// ── Boot validation ──────────────────────────────────────────────────────
+
+describe("validateSecretsKey", () => {
+	it("accepts a properly-formatted 32-byte base64 key", () => {
+		expect(() => validateSecretsKey()).not.toThrow();
+	});
+
+	it("throws when SECRETS_ENCRYPTION_KEY is unset (refuse-to-start)", () => {
+		process.env.SECRETS_ENCRYPTION_KEY = "";
+		_clearKeyCacheForTesting();
+		expect(() => validateSecretsKey()).toThrowError(/SECRETS_ENCRYPTION_KEY/);
+	});
+
+	it("throws when the key decodes to the wrong length", () => {
+		// 31 bytes — short by one. AES-256 demands exactly 32.
+		process.env.SECRETS_ENCRYPTION_KEY = Buffer.alloc(31, 0x42).toString("base64");
+		_clearKeyCacheForTesting();
+		expect(() => validateSecretsKey()).toThrowError(/32 bytes/);
+	});
+
+	// Boot must fail loudly so an operator who set a partially-bad
+	// key (typo, line-wrapped output of `openssl rand`) gets a clear
+	// error message rather than a silent-but-broken encryption path.
+	// The throw runs from `index.ts` before `server.listen`, so the
+	// process exits non-zero and the orchestrator (docker compose,
+	// systemd) sees the failure.
+	it("throws when the env value is non-base64 garbage", () => {
+		// Non-base64 characters that Buffer.from(…, 'base64') silently
+		// truncates rather than rejects — the resulting buffer will be
+		// the WRONG LENGTH (which is what the validator catches).
+		process.env.SECRETS_ENCRYPTION_KEY = "definitely-not-base64-and-too-short";
+		_clearKeyCacheForTesting();
+		expect(() => validateSecretsKey()).toThrowError(/32 bytes/);
+	});
+});
+
+// ── Round-trip ──────────────────────────────────────────────────────────
+
+describe("encryptSecret / decryptSecret round-trip", () => {
+	it("recovers the original plaintext", () => {
+		const blob = encryptSecret("sk-live-abcdef1234567890");
+		expect(decryptSecret(blob)).toBe("sk-live-abcdef1234567890");
+	});
+
+	it("handles empty strings", () => {
+		// Empty values shouldn't be stored as `secret` in practice
+		// (POST validation should reject), but the crypto primitive
+		// must not silently misbehave on the edge — empty plaintext
+		// → empty plaintext, full integrity envelope intact.
+		const blob = encryptSecret("");
+		expect(decryptSecret(blob)).toBe("");
+	});
+
+	it("handles UTF-8 multi-byte content", () => {
+		const plaintext = "naïve résumé — π ≈ 3.14 — 🔑";
+		const blob = encryptSecret(plaintext);
+		expect(decryptSecret(blob)).toBe(plaintext);
+	});
+
+	it("emits a fresh IV per encryption (no reuse across calls)", () => {
+		// IV reuse on the SAME key in GCM is catastrophic — leaks the
+		// XOR of the two plaintexts. Pin that two consecutive
+		// encryptSecret calls with the same plaintext produce
+		// distinct IVs (and therefore distinct ciphertexts).
+		const a = encryptSecret("same plaintext");
+		const b = encryptSecret("same plaintext");
+		expect(a.iv).not.toBe(b.iv);
+		expect(a.ciphertext).not.toBe(b.ciphertext);
+	});
+
+	// Reasonable upper bound: per-entry value cap is 16 KiB by the
+	// #186 spec. Round-trip the full cap so the wrapper isn't hiding
+	// a buffer-size assumption.
+	it("handles values up to the 16 KiB cap", () => {
+		const big = "x".repeat(16 * 1024);
+		const blob = encryptSecret(big);
+		expect(decryptSecret(blob)).toBe(big);
+	});
+});
+
+// ── Tag tampering ────────────────────────────────────────────────────────
+
+describe("decryptSecret integrity", () => {
+	it("rejects ciphertext with a flipped auth-tag bit", () => {
+		const blob = encryptSecret("payload");
+		// Flip the last byte of the tag.
+		const tag = Buffer.from(blob.tag, "base64");
+		tag[tag.length - 1] ^= 0x01;
+		const tampered: EncryptedSecret = { ...blob, tag: tag.toString("base64") };
+		expect(() => decryptSecret(tampered)).toThrow();
+	});
+
+	it("rejects ciphertext with a flipped IV bit", () => {
+		// IV is part of the GCM authentication input; tampering with
+		// it must surface as an auth-tag mismatch.
+		const blob = encryptSecret("payload");
+		const iv = Buffer.from(blob.iv, "base64");
+		iv[0] ^= 0x01;
+		const tampered: EncryptedSecret = { ...blob, iv: iv.toString("base64") };
+		expect(() => decryptSecret(tampered)).toThrow();
+	});
+
+	it("rejects ciphertext with a flipped data byte", () => {
+		const blob = encryptSecret("payload");
+		const ct = Buffer.from(blob.ciphertext, "base64");
+		ct[0] ^= 0x01;
+		const tampered: EncryptedSecret = { ...blob, ciphertext: ct.toString("base64") };
+		expect(() => decryptSecret(tampered)).toThrow();
+	});
+
+	it("rejects an IV that's the wrong length", () => {
+		const blob = encryptSecret("payload");
+		const tampered: EncryptedSecret = { ...blob, iv: Buffer.alloc(8).toString("base64") };
+		expect(() => decryptSecret(tampered)).toThrowError(/IV/);
+	});
+
+	it("rejects a tag that's the wrong length", () => {
+		const blob = encryptSecret("payload");
+		const tampered: EncryptedSecret = { ...blob, tag: Buffer.alloc(8).toString("base64") };
+		expect(() => decryptSecret(tampered)).toThrowError(/tag/);
+	});
+});
+
+// ── secretsEqual ─────────────────────────────────────────────────────────
+
+describe("secretsEqual", () => {
+	it("returns true for the same ciphertext bytes", () => {
+		const blob = encryptSecret("k");
+		// Compare the same blob to itself — `secretsEqual` only
+		// inspects ciphertext bytes (IVs differ between fresh
+		// encrypts of the same plaintext, so equality must NOT be
+		// based on plaintext content).
+		expect(secretsEqual(blob, blob)).toBe(true);
+	});
+
+	it("returns false when ciphertexts differ", () => {
+		const a = encryptSecret("k1");
+		const b = encryptSecret("k2");
+		expect(secretsEqual(a, b)).toBe(false);
+	});
+
+	it("returns false when ciphertext lengths differ", () => {
+		const a = encryptSecret("short");
+		const b = encryptSecret("very long plaintext value");
+		expect(secretsEqual(a, b)).toBe(false);
+	});
+});

--- a/backend/src/secrets.test.ts
+++ b/backend/src/secrets.test.ts
@@ -18,7 +18,6 @@ import {
 	decryptSecret,
 	type EncryptedSecret,
 	encryptSecret,
-	secretsEqual,
 	validateSecretsKey,
 } from "./secrets.js";
 
@@ -156,30 +155,5 @@ describe("decryptSecret integrity", () => {
 		const blob = encryptSecret("payload");
 		const tampered: EncryptedSecret = { ...blob, tag: Buffer.alloc(8).toString("base64") };
 		expect(() => decryptSecret(tampered)).toThrowError(/tag/);
-	});
-});
-
-// ── secretsEqual ─────────────────────────────────────────────────────────
-
-describe("secretsEqual", () => {
-	it("returns true for the same ciphertext bytes", () => {
-		const blob = encryptSecret("k");
-		// Compare the same blob to itself — `secretsEqual` only
-		// inspects ciphertext bytes (IVs differ between fresh
-		// encrypts of the same plaintext, so equality must NOT be
-		// based on plaintext content).
-		expect(secretsEqual(blob, blob)).toBe(true);
-	});
-
-	it("returns false when ciphertexts differ", () => {
-		const a = encryptSecret("k1");
-		const b = encryptSecret("k2");
-		expect(secretsEqual(a, b)).toBe(false);
-	});
-
-	it("returns false when ciphertext lengths differ", () => {
-		const a = encryptSecret("short");
-		const b = encryptSecret("very long plaintext value");
-		expect(secretsEqual(a, b)).toBe(false);
 	});
 });

--- a/backend/src/secrets.ts
+++ b/backend/src/secrets.ts
@@ -1,0 +1,163 @@
+/**
+ * secrets.ts — AES-256-GCM encrypt/decrypt for `secret`-typed env-var
+ * entries (#186).
+ *
+ * Threat model the encryption is solving:
+ * - **Storage at rest.** D1 dumps and backups should not contain
+ *   plaintext API keys / DB URLs / OAuth tokens that the user marked
+ *   secret. A compromised D1 export hands an attacker only ciphertext
+ *   plus IVs + auth tags; without `SECRETS_ENCRYPTION_KEY` (held in
+ *   the backend's env), they cannot recover plaintext.
+ * - **Listing endpoints.** Routes that return session metadata
+ *   (`GET /api/sessions/:id`) must NEVER serialize ciphertext or
+ *   plaintext for secret entries — only `isSet`. Encrypt-on-persist
+ *   means the route handler never has plaintext after validation, so
+ *   a future serialization mistake can leak ciphertext at worst,
+ *   never plaintext.
+ * - **Docker run.** The container itself has to receive plaintext
+ *   (env vars are passed via `execve`), so decrypt happens INSIDE
+ *   `DockerManager` at spawn time and the plaintext lives only in
+ *   memory for the duration of the `docker run` call. No log line
+ *   echoes the post-decrypt value.
+ *
+ * What this is NOT solving:
+ * - Compromise of the backend process (the key is in env, plaintext
+ *   passes through memory at spawn time, the container has the env).
+ *   That's a different problem with different mitigations (process
+ *   isolation, secrets-management service); not in scope.
+ * - Key rotation. If `SECRETS_ENCRYPTION_KEY` changes, every existing
+ *   secret entry becomes undecryptable. A future rotation tool is
+ *   tracked under #200's deferred work. Operator runbook: #204.
+ *
+ * Crypto choices:
+ * - AES-256-GCM. AEAD — confidentiality + integrity in one mode, no
+ *   separate MAC bookkeeping. The auth tag is the only thing standing
+ *   between us and a chosen-ciphertext attack so callers MUST persist
+ *   it alongside ciphertext + IV.
+ * - 96-bit IV (12 bytes), generated fresh per encryption via
+ *   `crypto.randomBytes`. NIST SP 800-38D explicitly recommends 96
+ *   bits as the GCM IV size; deterministic counter mode is an
+ *   alternative but adds state we don't need.
+ * - Key delivered as base64-encoded 32 bytes via env var. Validated
+ *   at boot — the process refuses to start if the key is missing or
+ *   the wrong length.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes, timingSafeEqual } from "node:crypto";
+
+const KEY_BYTES = 32; // AES-256 = 256-bit key
+const IV_BYTES = 12; // GCM-recommended 96-bit IV
+const TAG_BYTES = 16; // AES-GCM produces a 128-bit auth tag
+const ENV_VAR = "SECRETS_ENCRYPTION_KEY";
+
+let cachedKey: Buffer | null = null;
+
+/**
+ * Resolve the AES key from the env var. Memoised to avoid re-decoding
+ * + re-validating on every encrypt/decrypt call. Cleared by
+ * `validateSecretsKey` so tests can swap keys mid-run.
+ */
+function getKey(): Buffer {
+	if (cachedKey) return cachedKey;
+	const raw = process.env[ENV_VAR] ?? "";
+	if (!raw) {
+		throw new Error(
+			`${ENV_VAR} is not set; secrets cannot be encrypted/decrypted. ` +
+				"Generate one with `openssl rand -base64 32` and set it in your env.",
+		);
+	}
+	let decoded: Buffer;
+	try {
+		decoded = Buffer.from(raw, "base64");
+	} catch (err) {
+		throw new Error(`${ENV_VAR} is not valid base64: ${(err as Error).message}`);
+	}
+	if (decoded.length !== KEY_BYTES) {
+		throw new Error(
+			`${ENV_VAR} must decode to exactly ${KEY_BYTES} bytes (got ${decoded.length}). ` +
+				"Generate one with `openssl rand -base64 32`.",
+		);
+	}
+	cachedKey = decoded;
+	return cachedKey;
+}
+
+/**
+ * Boot-time check called from `index.ts` so the process refuses to
+ * start with no / malformed key — same shape as `validateD1Config`
+ * + `validateJwtSecret`. Resets the cache so a test setting the env
+ * var afterwards is picked up.
+ */
+export function validateSecretsKey(): void {
+	cachedKey = null;
+	getKey(); // throws if invalid
+}
+
+/**
+ * Encrypt a UTF-8 plaintext. Returns base64-encoded ciphertext + IV +
+ * auth tag — the three fields stored on a `secret` env-var entry.
+ * `randomBytes(IV_BYTES)` is fresh per call, never reused.
+ */
+export interface EncryptedSecret {
+	ciphertext: string; // base64
+	iv: string; // base64
+	tag: string; // base64
+}
+
+export function encryptSecret(plaintext: string): EncryptedSecret {
+	const key = getKey();
+	const iv = randomBytes(IV_BYTES);
+	const cipher = createCipheriv("aes-256-gcm", key, iv);
+	const ciphertext = Buffer.concat([cipher.update(plaintext, "utf-8"), cipher.final()]);
+	const tag = cipher.getAuthTag();
+	return {
+		ciphertext: ciphertext.toString("base64"),
+		iv: iv.toString("base64"),
+		tag: tag.toString("base64"),
+	};
+}
+
+/**
+ * Decrypt back to UTF-8 plaintext. Throws on auth-tag mismatch
+ * (tampered ciphertext / wrong key / corrupted IV) — the GCM mode's
+ * integrity check is the only thing that distinguishes valid
+ * ciphertext from any random byte string, so the throw must NOT be
+ * swallowed by callers.
+ */
+export function decryptSecret(blob: EncryptedSecret): string {
+	const key = getKey();
+	const iv = Buffer.from(blob.iv, "base64");
+	const tag = Buffer.from(blob.tag, "base64");
+	const ciphertext = Buffer.from(blob.ciphertext, "base64");
+	if (iv.length !== IV_BYTES) {
+		throw new Error(`secret IV must be ${IV_BYTES} bytes (got ${iv.length})`);
+	}
+	if (tag.length !== TAG_BYTES) {
+		throw new Error(`secret tag must be ${TAG_BYTES} bytes (got ${tag.length})`);
+	}
+	const decipher = createDecipheriv("aes-256-gcm", key, iv);
+	decipher.setAuthTag(tag);
+	const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+	return plaintext.toString("utf-8");
+}
+
+/**
+ * Constant-time compare two `EncryptedSecret` blobs by ciphertext.
+ * Used by the merge path that needs to detect "same secret already
+ * stored" without leaking timing on prefix-match. Currently unused
+ * in this PR but exported for #195 (templates) which dedups secrets
+ * across template loads. Kept here so the timing-safe primitive
+ * lives in the crypto module rather than duplicated at call sites.
+ */
+export function secretsEqual(a: EncryptedSecret, b: EncryptedSecret): boolean {
+	const aBuf = Buffer.from(a.ciphertext, "base64");
+	const bBuf = Buffer.from(b.ciphertext, "base64");
+	if (aBuf.length !== bBuf.length) return false;
+	return timingSafeEqual(aBuf, bBuf);
+}
+
+/** Test-only: clear the memoised key. Public-but-test-only, called
+ * from test setup that swaps `SECRETS_ENCRYPTION_KEY` between cases. */
+export function _clearKeyCacheForTesting(): void {
+	cachedKey = null;
+}

--- a/backend/src/secrets.ts
+++ b/backend/src/secrets.ts
@@ -43,7 +43,7 @@
  *   the wrong length.
  */
 
-import { createCipheriv, createDecipheriv, randomBytes, timingSafeEqual } from "node:crypto";
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
 const KEY_BYTES = 32; // AES-256 = 256-bit key
 const IV_BYTES = 12; // GCM-recommended 96-bit IV
@@ -66,12 +66,12 @@ function getKey(): Buffer {
 				"Generate one with `openssl rand -base64 32` and set it in your env.",
 		);
 	}
-	let decoded: Buffer;
-	try {
-		decoded = Buffer.from(raw, "base64");
-	} catch (err) {
-		throw new Error(`${ENV_VAR} is not valid base64: ${(err as Error).message}`);
-	}
+	// `Buffer.from(s, "base64")` does NOT throw on bad input — it
+	// silently drops non-base64 characters and returns a possibly-
+	// shortened buffer. The length check below is the only thing that
+	// catches typo'd / line-wrapped / wrong-encoding keys; don't wrap
+	// in try/catch because there's nothing to catch (#209 review).
+	const decoded = Buffer.from(raw, "base64");
 	if (decoded.length !== KEY_BYTES) {
 		throw new Error(
 			`${ENV_VAR} must decode to exactly ${KEY_BYTES} bytes (got ${decoded.length}). ` +
@@ -139,21 +139,6 @@ export function decryptSecret(blob: EncryptedSecret): string {
 	decipher.setAuthTag(tag);
 	const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 	return plaintext.toString("utf-8");
-}
-
-/**
- * Constant-time compare two `EncryptedSecret` blobs by ciphertext.
- * Used by the merge path that needs to detect "same secret already
- * stored" without leaking timing on prefix-match. Currently unused
- * in this PR but exported for #195 (templates) which dedups secrets
- * across template loads. Kept here so the timing-safe primitive
- * lives in the crypto module rather than duplicated at call sites.
- */
-export function secretsEqual(a: EncryptedSecret, b: EncryptedSecret): boolean {
-	const aBuf = Buffer.from(a.ciphertext, "base64");
-	const bBuf = Buffer.from(b.ciphertext, "base64");
-	if (aBuf.length !== bBuf.length) return false;
-	return timingSafeEqual(aBuf, bBuf);
 }
 
 /** Test-only: clear the memoised key. Public-but-test-only, called


### PR DESCRIPTION
## Summary

Foundation PR for #186 (env vars & secrets). Lays the AES-256-GCM crypto module and boot-time `SECRETS_ENCRYPTION_KEY` validation that the typed-entry schema will plug into in PR 186b. Intentionally small + focused so the crypto contract is reviewable in isolation before the schema churn lands.

## What lands

**`backend/src/secrets.ts`**
- `validateSecretsKey()` — refuse-to-start hook called from `index.ts` next to `validateD1Config` / `validateJwtSecret`. Throws on missing key, wrong-length decode, or non-base64 garbage (Node's `Buffer.from` silently truncates non-base64; the length check is the real guard).
- `encryptSecret(plaintext)` → `{ ciphertext, iv, tag }` (all base64). Fresh 96-bit IV per call via `randomBytes` — IV reuse on the same GCM key is catastrophic.
- `decryptSecret(blob)` → plaintext. Tag mismatch (tampered ct/iv, wrong key) throws and must not be swallowed.

**`.env.example`** — `SECRETS_ENCRYPTION_KEY` documented with `openssl rand -base64 32`, refuse-to-start semantics, and a forward reference to #204 for the operator runbook.

## Out of scope (PR 186b)

- Zod schema change from `Record<string,string>` envVars to typed `plain` / `secret` / `secret-slot` entry list.
- Encrypt-on-persist + decrypt-on-spawn integration in `routes.ts` / `dockerManager.ts`.
- GET-endpoint redaction + log scrubbing.
- Frontend Env tab UI + `.env` paste parser.

## Test plan

- [x] `cd backend && npm test` — **298/298 passing** (14 new vitest cases in `secrets.test.ts`):
  - Boot validation: valid 32-byte key / unset / 31-byte / non-base64 garbage.
  - Round-trip: ASCII / empty / multi-byte UTF-8 / 16 KiB cap (the per-entry value cap from #186).
  - Integrity: flipped auth-tag bit / IV bit / data byte all reject; wrong-length IV / tag reject early with shape errors.
- [x] `cd backend && npm run lint` — clean.
- [x] `cd backend && npm run build` — clean.

Refs #186, #184. Closes #186 once PR 186b merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)