### PR TITLE
feat(env): Env tab UI + .env paste parser (#186, PR 186c — closes #186)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -272,7 +272,50 @@
             role="tabpanel"
             aria-labelledby="session-tab-env-tab"
             hidden
-          ></div>
+          >
+            <p class="modal-hint">
+              Plain values are stored verbatim; secrets are
+              AES-GCM-encrypted at rest and never echoed back. Names use
+              POSIX shell convention (uppercase letters, digits,
+              underscore; must start with a letter or _).
+            </p>
+            <div class="env-paste-toolbar">
+              <button
+                type="button"
+                id="env-paste-toggle"
+                class="env-paste-toggle"
+                aria-controls="env-paste-panel"
+                aria-expanded="false"
+              >
+                Paste .env
+              </button>
+              <span id="env-paste-status" class="env-paste-status" aria-live="polite"></span>
+            </div>
+            <div id="env-paste-panel" class="env-paste-panel" hidden>
+              <textarea
+                id="env-paste-textarea"
+                rows="6"
+                placeholder="DATABASE_URL=postgres://...&#10;OPENAI_KEY=sk-...&#10;# comments are ignored"
+                spellcheck="false"
+              ></textarea>
+              <div class="env-paste-actions">
+                <button type="button" id="env-paste-cancel">Cancel</button>
+                <button type="button" id="env-paste-import">Import as plain</button>
+              </div>
+            </div>
+            <table class="env-table" id="env-table">
+              <thead>
+                <tr>
+                  <th scope="col">Name</th>
+                  <th scope="col">Value</th>
+                  <th scope="col">Type</th>
+                  <th scope="col"><span class="visually-hidden">Remove</span></th>
+                </tr>
+              </thead>
+              <tbody id="env-table-body"></tbody>
+            </table>
+            <button type="button" id="env-add-row" class="env-add-row">+ Add entry</button>
+          </div>
           <div
             class="session-tab-panel"
             id="session-tab-ports"

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -151,6 +151,19 @@ export interface SessionInfo {
  * (#186, #188, #190, #191, #194) flesh out their respective fields as they
  * ship. Keep this in sync with the backend Zod schema or the call will 400.
  */
+/**
+ * Typed env-var entry on the wire (#186 / PR 186c). Mirrors the
+ * backend `EnvVarEntryInput` discriminated union from
+ * `backend/src/sessionConfig.ts`. Both `plain` and `secret` carry
+ * plaintext `value`; the backend encrypts secret values before they
+ * reach D1, so plaintext is in scope only inside the request handler.
+ * `secret-slot` is template-load-only (#195) and rejected at POST.
+ */
+export type EnvVarEntryInput =
+	| { name: string; type: "plain"; value: string }
+	| { name: string; type: "secret"; value: string }
+	| { name: string; type: "secret-slot" };
+
 export interface SessionConfigPayload {
 	workspaceStrategy?: "preserve" | "clone";
 	cpuLimit?: number;
@@ -160,7 +173,7 @@ export interface SessionConfigPayload {
 	postStartCmd?: string;
 	repos?: Array<{ url: string; ref?: string }>;
 	ports?: Array<{ port: number; protocol?: "http" | "tcp" }>;
-	envVars?: Record<string, string>;
+	envVars?: EnvVarEntryInput[];
 }
 
 // ── Bootstrap live-tail WS (#185 / PR 185b2b) ───────────────────────────────

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -143,15 +143,6 @@ export interface SessionInfo {
 // ── Session API ─────────────────────────────────────────────────────────────
 
 /**
- * Typed session configuration sent under POST /sessions `body.config`.
- *
- * Mirrors `SessionConfigSchema` in the backend (`backend/src/sessionConfig.ts`).
- * Every sub-field is optional; today the new-session modal only fills in the
- * `name` (Basics tab) and leaves `config` undefined — children of epic #184
- * (#186, #188, #190, #191, #194) flesh out their respective fields as they
- * ship. Keep this in sync with the backend Zod schema or the call will 400.
- */
-/**
  * Typed env-var entry on the wire (#186 / PR 186c). Mirrors the
  * backend `EnvVarEntryInput` discriminated union from
  * `backend/src/sessionConfig.ts`. Both `plain` and `secret` carry
@@ -164,6 +155,16 @@ export type EnvVarEntryInput =
 	| { name: string; type: "secret"; value: string }
 	| { name: string; type: "secret-slot" };
 
+/**
+ * Typed session configuration sent under POST /sessions `body.config`.
+ *
+ * Mirrors `SessionConfigSchema` in the backend (`backend/src/sessionConfig.ts`).
+ * Every sub-field is optional; today the new-session modal only fills in the
+ * `name` (Basics tab) and `envVars` (Env tab) and leaves the rest undefined
+ * — children of epic #184 (#188, #190, #191, #194) flesh out their respective
+ * fields as they ship. Keep this in sync with the backend Zod schema or the
+ * call will 400.
+ */
 export interface SessionConfigPayload {
 	workspaceStrategy?: "preserve" | "clone";
 	cpuLimit?: number;

--- a/frontend/src/envParser.test.ts
+++ b/frontend/src/envParser.test.ts
@@ -124,6 +124,31 @@ BAZ=qux
 		]);
 	});
 
+	// PR #211 round 1: `MSG='it's alive'` — `indexOf` finds the
+	// first `'` at position 3 (the apostrophe in "it's"), not the
+	// real close at the end. Without the tail-validation guard the
+	// parser silently returns `MSG=it`. Pin the skip path so the
+	// "no silent drops" contract holds.
+	it("skips quoted lines whose closing quote is followed by non-comment text (embedded same-quote)", () => {
+		const r = parseDotEnv(`MSG='it's alive'\nOK=ok\n`);
+		expect(r.parsed).toEqual([{ name: "OK", value: "ok" }]);
+		expect(r.skipped).toEqual([
+			{
+				line: 1,
+				reason: "embedded single-quote in value (use the other quote char or remove the quote)",
+			},
+		]);
+	});
+
+	it("skips quoted lines with a stray non-comment tail after closing quote", () => {
+		// `FOO="bar" baz` — closing quote is correct but `baz` after
+		// is neither whitespace nor `# comment`; ambiguous, skip.
+		const r = parseDotEnv(`FOO="bar" baz\n`);
+		expect(r.parsed).toEqual([]);
+		expect(r.skipped).toHaveLength(1);
+		expect(r.skipped[0]?.reason).toMatch(/embedded double-quote/);
+	});
+
 	it("returns counts of parsed + skipped so the modal can summarise", () => {
 		// "Imported 2, skipped 1 (line 2: missing =)" UX shape.
 		const r = parseDotEnv("FOO=bar\ngarbage\nBAZ=qux\n");

--- a/frontend/src/envParser.test.ts
+++ b/frontend/src/envParser.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { parseDotEnv } from "./envParser.js";
+
+describe("parseDotEnv", () => {
+	it("parses simple KEY=value lines", () => {
+		const r = parseDotEnv("FOO=bar\nBAZ=qux\n");
+		expect(r.parsed).toEqual([
+			{ name: "FOO", value: "bar" },
+			{ name: "BAZ", value: "qux" },
+		]);
+		expect(r.skipped).toEqual([]);
+	});
+
+	it("ignores blank lines and full-line comments", () => {
+		const r = parseDotEnv(`
+# top comment
+
+FOO=bar
+   # indented comment
+BAZ=qux
+`);
+		expect(r.parsed).toEqual([
+			{ name: "FOO", value: "bar" },
+			{ name: "BAZ", value: "qux" },
+		]);
+		expect(r.skipped).toEqual([]);
+	});
+
+	it("strips matching double quotes", () => {
+		const r = parseDotEnv(`FOO="hello world"\n`);
+		expect(r.parsed).toEqual([{ name: "FOO", value: "hello world" }]);
+	});
+
+	it("strips matching single quotes", () => {
+		const r = parseDotEnv(`FOO='hello world'\n`);
+		expect(r.parsed).toEqual([{ name: "FOO", value: "hello world" }]);
+	});
+
+	it("preserves embedded `=` characters in unquoted values", () => {
+		// e.g. base64 / URL-encoded values often contain literal `=`.
+		// Only the FIRST `=` is the separator.
+		const r = parseDotEnv("DATABASE_URL=postgres://u:p@h/db?a=1&b=2\n");
+		expect(r.parsed).toEqual([{ name: "DATABASE_URL", value: "postgres://u:p@h/db?a=1&b=2" }]);
+	});
+
+	it("accepts the `export FOO=bar` shell-import idiom", () => {
+		// Common when copy-pasting from a `~/.bashrc` or a heroku
+		// config dump. We strip the `export ` prefix.
+		const r = parseDotEnv("export FOO=bar\n");
+		expect(r.parsed).toEqual([{ name: "FOO", value: "bar" }]);
+	});
+
+	it("trims surrounding whitespace on unquoted values", () => {
+		const r = parseDotEnv("FOO=  bar  \n");
+		expect(r.parsed).toEqual([{ name: "FOO", value: "bar" }]);
+	});
+
+	it("preserves whitespace inside quoted values", () => {
+		const r = parseDotEnv(`FOO="  bar  "\n`);
+		expect(r.parsed).toEqual([{ name: "FOO", value: "  bar  " }]);
+	});
+
+	it("accepts an empty value", () => {
+		const r = parseDotEnv("FOO=\n");
+		expect(r.parsed).toEqual([{ name: "FOO", value: "" }]);
+	});
+
+	it("skips lines with no `=` separator and records the line number", () => {
+		const r = parseDotEnv("FOO=bar\njust a sentence\nBAZ=qux\n");
+		expect(r.parsed).toEqual([
+			{ name: "FOO", value: "bar" },
+			{ name: "BAZ", value: "qux" },
+		]);
+		expect(r.skipped).toEqual([{ line: 2, reason: "missing '=' separator (or empty name)" }]);
+	});
+
+	it("skips lines with `=` at position 0 (no name)", () => {
+		const r = parseDotEnv("=value\n");
+		expect(r.parsed).toEqual([]);
+		expect(r.skipped).toEqual([{ line: 1, reason: "missing '=' separator (or empty name)" }]);
+	});
+
+	it("rejects names that fail the POSIX regex", () => {
+		const r = parseDotEnv("foo=lower\nFOO-BAR=dash\n0NUM=numstart\n");
+		expect(r.parsed).toEqual([]);
+		// All three skip with the regex-rejection reason.
+		expect(r.skipped).toHaveLength(3);
+		for (const s of r.skipped) {
+			expect(s.reason).toMatch(/must match/);
+		}
+	});
+
+	it("skips lines with an unterminated quote (multi-line out of scope)", () => {
+		const r = parseDotEnv(`FOO="hello\nBAR=ok\n`);
+		expect(r.parsed).toEqual([{ name: "BAR", value: "ok" }]);
+		expect(r.skipped).toEqual([
+			{ line: 1, reason: "unterminated double-quote (multi-line values not supported)" },
+		]);
+	});
+
+	it("tolerates a trailing comment after a quoted value", () => {
+		// The closing quote ends the value; everything after it is
+		// dropped. A literal `#` inside the quotes is preserved.
+		const r = parseDotEnv(`FOO="bar"   # description\nBAZ="x#y"\n`);
+		expect(r.parsed).toEqual([
+			{ name: "FOO", value: "bar" },
+			{ name: "BAZ", value: "x#y" },
+		]);
+	});
+
+	it("preserves a literal `#` in an unquoted value (trailing comments are ambiguous, kept verbatim)", () => {
+		// URL fragments, shell-shifted tokens, etc. We don't second-
+		// guess the user; the line was unquoted so we treat it as
+		// "value is everything after `=`".
+		const r = parseDotEnv("ANCHOR=https://example.com/page#section\n");
+		expect(r.parsed).toEqual([{ name: "ANCHOR", value: "https://example.com/page#section" }]);
+	});
+
+	it("handles CRLF line endings (Windows .env files)", () => {
+		const r = parseDotEnv("FOO=bar\r\nBAZ=qux\r\n");
+		expect(r.parsed).toEqual([
+			{ name: "FOO", value: "bar" },
+			{ name: "BAZ", value: "qux" },
+		]);
+	});
+
+	it("returns counts of parsed + skipped so the modal can summarise", () => {
+		// "Imported 2, skipped 1 (line 2: missing =)" UX shape.
+		const r = parseDotEnv("FOO=bar\ngarbage\nBAZ=qux\n");
+		expect(r.parsed).toHaveLength(2);
+		expect(r.skipped).toHaveLength(1);
+	});
+});

--- a/frontend/src/envParser.ts
+++ b/frontend/src/envParser.ts
@@ -1,0 +1,131 @@
+/**
+ * envParser.ts — bulk-paste `.env` parser for #186's Env tab.
+ *
+ * Scope (per the issue spec):
+ * - `KEY=value` — literal value to end of line.
+ * - `KEY="value"` / `KEY='value'` — quoted value, both quote chars.
+ * - `# comments` — full-line comments (any leading whitespace).
+ * - blank lines — ignored.
+ *
+ * Out of scope:
+ * - **Multi-line values.** A line whose value opens a quote but
+ *   doesn't close on the same line is logged as a parse failure;
+ *   continuation lines are not concatenated. Multi-line values would
+ *   surface ambiguous newline handling that no `.env` consumer agrees
+ *   on, and the issue spec explicitly defers them.
+ * - **Variable interpolation** (`KEY=$OTHER` / `${OTHER}`). The user
+ *   pastes raw values; the modal stores them as-is.
+ * - **Escape sequences inside quoted values** (e.g. `\n`, `\t`).
+ *   We treat the contents of a quoted value as opaque — Docker's
+ *   `Env` field doesn't process escapes either.
+ *
+ * Returns parsed entries plus a per-line skip log so the modal can
+ * surface "Imported 14 lines, skipped 2 (line 7: missing closing
+ * quote, line 12: invalid name)". Skipped lines never silently drop
+ * — the user gets a visible count and a reason for each.
+ */
+
+export interface ParsedEnvLine {
+	name: string;
+	value: string;
+}
+
+export interface EnvParseResult {
+	parsed: ParsedEnvLine[];
+	skipped: Array<{ line: number; reason: string }>;
+}
+
+// Same POSIX-name regex the backend's Zod schema enforces. Catching
+// it client-side too means the user gets immediate feedback for an
+// obviously-bad name in the paste rather than a 400 on submit.
+const ENV_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+
+export function parseDotEnv(text: string): EnvParseResult {
+	const parsed: ParsedEnvLine[] = [];
+	const skipped: EnvParseResult["skipped"] = [];
+
+	const lines = text.split(/\r?\n/);
+	for (let i = 0; i < lines.length; i++) {
+		const lineNo = i + 1;
+		const raw = lines[i] ?? "";
+		const trimmed = raw.trim();
+
+		// Blank or comment — silently skip, not an error.
+		if (trimmed === "" || trimmed.startsWith("#")) continue;
+
+		// Optional leading `export ` so `export FOO=bar` (a common
+		// `.env` shell-import idiom) parses the same as `FOO=bar`.
+		const stripped = trimmed.startsWith("export ") ? trimmed.slice("export ".length) : trimmed;
+
+		const eqIdx = stripped.indexOf("=");
+		if (eqIdx <= 0) {
+			// No `=` at all, or `=` at position 0 (no name). Either is
+			// malformed; record + skip.
+			skipped.push({
+				line: lineNo,
+				reason: "missing '=' separator (or empty name)",
+			});
+			continue;
+		}
+
+		const name = stripped.slice(0, eqIdx).trim();
+		const rawValue = stripped.slice(eqIdx + 1);
+
+		if (!ENV_NAME_PATTERN.test(name)) {
+			skipped.push({
+				line: lineNo,
+				reason: `name '${name}' must match ${ENV_NAME_PATTERN.source}`,
+			});
+			continue;
+		}
+
+		// Strip surrounding `"..."` or `'...'` if both quotes are
+		// present on the same line. A leading quote with no matching
+		// trailing quote is a multi-line value attempt — out of scope.
+		const value = stripQuotes(rawValue, lineNo, skipped);
+		if (value === null) continue;
+
+		parsed.push({ name, value });
+	}
+
+	return { parsed, skipped };
+}
+
+/**
+ * Returns the dequoted value, or `null` if the line is malformed
+ * (logged into `skipped`). Trailing comments after a quoted value
+ * (`KEY="x" # comment`) are tolerated; trailing comments after an
+ * unquoted value would be ambiguous (the literal `#` could be part
+ * of a URL fragment or shell-shifted token), so we DON'T strip them
+ * — the user pasted something with a literal `#` and we believe
+ * them.
+ */
+function stripQuotes(
+	rawValue: string,
+	lineNo: number,
+	skipped: EnvParseResult["skipped"],
+): string | null {
+	const trimmed = rawValue.trim();
+	if (trimmed.length === 0) return "";
+	const firstCh = trimmed[0];
+	if (firstCh !== '"' && firstCh !== "'") {
+		// Unquoted — return verbatim (with leading/trailing whitespace
+		// trimmed, matching Docker's own Env handling).
+		return trimmed;
+	}
+	// Quoted: find the closing quote of the same kind. Scan ONE
+	// character at a time; a line-internal escape sequence is opaque
+	// to us (we treat the bytes as literal). The matching close must
+	// be on the same line — otherwise it's a multi-line value attempt.
+	const closeIdx = trimmed.indexOf(firstCh, 1);
+	if (closeIdx === -1) {
+		skipped.push({
+			line: lineNo,
+			reason: `unterminated ${firstCh === '"' ? "double" : "single"}-quote (multi-line values not supported)`,
+		});
+		return null;
+	}
+	// Anything after the closing quote we tolerate as a comment-or-
+	// whitespace tail. We don't validate it; the user pasted it.
+	return trimmed.slice(1, closeIdx);
+}

--- a/frontend/src/envParser.ts
+++ b/frontend/src/envParser.ts
@@ -72,9 +72,15 @@ export function parseDotEnv(text: string): EnvParseResult {
 		const rawValue = stripped.slice(eqIdx + 1);
 
 		if (!ENV_NAME_PATTERN.test(name)) {
+			// Truncate the name in the skip-reason so a 50 KB
+			// "garbage paste" line doesn't blow out the modal's
+			// status bar with one unreadable string. textContent
+			// is the rendering path so there's no injection risk;
+			// this is purely visual hygiene (#211 round 2).
+			const displayName = name.length > 40 ? `${name.slice(0, 40)}…` : name;
 			skipped.push({
 				line: lineNo,
-				reason: `name '${name}' must match ${ENV_NAME_PATTERN.source}`,
+				reason: `name '${displayName}' must match ${ENV_NAME_PATTERN.source}`,
 			});
 			continue;
 		}

--- a/frontend/src/envParser.ts
+++ b/frontend/src/envParser.ts
@@ -125,7 +125,21 @@ function stripQuotes(
 		});
 		return null;
 	}
-	// Anything after the closing quote we tolerate as a comment-or-
-	// whitespace tail. We don't validate it; the user pasted it.
+	// Validate the tail after `closeIdx`: anything that's whitespace
+	// (often before a `# trailing comment`) or a `#` directly is fine
+	// — those are tolerated as comment-or-whitespace tails. Anything
+	// else implies the `closeIdx` we found was actually an embedded
+	// quote in the middle of the value (e.g. `MSG='it's alive'`),
+	// which `indexOf` greedily matches before the real close. The
+	// module's "no silent drops" guarantee says we must skip + log,
+	// not return a truncated value (#211 round 1).
+	const tail = trimmed.slice(closeIdx + 1).trimStart();
+	if (tail !== "" && !tail.startsWith("#")) {
+		skipped.push({
+			line: lineNo,
+			reason: `embedded ${firstCh === '"' ? "double" : "single"}-quote in value (use the other quote char or remove the quote)`,
+		});
+		return null;
+	}
 	return trimmed.slice(1, closeIdx);
 }

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -625,6 +625,172 @@ main:not([data-sidebar-ready]) #sidebar {
   cursor: progress;
 }
 
+/* Env tab — typed entry table + .env paste panel (#186 / PR 186c). */
+.env-paste-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.4rem;
+}
+.env-paste-toggle {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.35rem 0.7rem;
+  color: #e6edf3;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+.env-paste-toggle:hover {
+  background: #30363d;
+}
+.env-paste-status {
+  font-size: 0.75rem;
+  color: #8b949e;
+  flex: 1;
+}
+.env-paste-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+  padding: 0.6rem;
+  background: rgba(88, 166, 255, 0.04);
+  border: 1px dashed #30363d;
+  border-radius: 6px;
+}
+.env-paste-panel textarea {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+  color: #e6edf3;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  outline: none;
+  resize: vertical;
+  min-height: 80px;
+}
+.env-paste-panel textarea:focus {
+  border-color: #58a6ff;
+}
+.env-paste-actions {
+  display: flex;
+  gap: 0.4rem;
+  justify-content: flex-end;
+}
+.env-paste-actions button {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.35rem 0.65rem;
+  color: #e6edf3;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+.env-paste-actions button:hover {
+  background: #30363d;
+}
+#env-paste-import {
+  background: #238636;
+  border-color: #2ea043;
+  color: #fff;
+}
+#env-paste-import:hover {
+  background: #2ea043;
+}
+.env-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+.env-table thead th {
+  text-align: left;
+  font-weight: 500;
+  color: #8b949e;
+  padding: 0.3rem 0.4rem;
+  border-bottom: 1px solid #21262d;
+}
+.env-table tbody td {
+  padding: 0.25rem 0.4rem;
+  vertical-align: middle;
+}
+.env-row .env-input {
+  width: 100%;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  padding: 0.3rem 0.5rem;
+  color: #e6edf3;
+  font-size: 0.8rem;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  outline: none;
+}
+.env-row .env-input:focus {
+  border-color: #58a6ff;
+}
+.env-input-name {
+  text-transform: uppercase;
+}
+.env-type-toggle {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  padding: 0.25rem 0.55rem;
+  color: #e6edf3;
+  font-size: 0.75rem;
+  cursor: pointer;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+.env-type-toggle:hover {
+  background: #30363d;
+}
+.env-type-toggle.env-type-secret {
+  background: rgba(248, 81, 73, 0.12);
+  border-color: rgba(248, 81, 73, 0.45);
+  color: #ff8682;
+}
+.env-row-remove {
+  background: transparent;
+  border: none;
+  color: #8b949e;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0 0.3rem;
+  border-radius: 4px;
+}
+.env-row-remove:hover {
+  color: #f85149;
+  background: rgba(248, 81, 73, 0.08);
+}
+.env-add-row {
+  background: transparent;
+  border: 1px dashed #30363d;
+  border-radius: 6px;
+  padding: 0.4rem 0.7rem;
+  color: #8b949e;
+  font-size: 0.8rem;
+  cursor: pointer;
+  align-self: flex-start;
+}
+.env-add-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: #e6edf3;
+  border-style: solid;
+}
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 /* postCreate live-tail panel (#185 / PR 185b2b). The same DOM node
    gets the `bootstrap-error` class added on top when the WS sends a
    terminal `fail` message — `bootstrap-error` selectors below win

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -17,6 +17,7 @@ import {
 	createTab,
 	deleteSession,
 	deleteTab,
+	type EnvVarEntryInput,
 	type Invite,
 	InviteRequiredError,
 	isAdmin,
@@ -37,6 +38,7 @@ import {
 	TabNotFoundError,
 	uploadSessionFiles,
 } from "./api.js";
+import { parseDotEnv } from "./envParser.js";
 import { openTerminalSession, type SessionStatus, type TerminalSession } from "./terminal.js";
 
 // ── DOM refs ────────────────────────────────────────────────────────────────
@@ -1055,11 +1057,6 @@ const SESSION_TAB_PLACEHOLDERS: Record<string, { title: string; body: string; is
 			body: "Public or private (PAT / SSH), pick a branch or ref, optionally replace the workspace.",
 			issueUrl: "https://github.com/gatof81/shared-terminal/issues/188",
 		},
-		env: {
-			title: "Environment variables and secrets",
-			body: "Plain values are stored in cleartext; secrets are AES-GCM-encrypted at rest and never echoed by listing endpoints.",
-			issueUrl: "https://github.com/gatof81/shared-terminal/issues/186",
-		},
 		ports: {
 			title: "Expose ports to the outside",
 			body: "Per-session subdomains, dynamic host ports, auth-gated by default (independent of session ownership).",
@@ -1120,6 +1117,7 @@ function openNewSessionModal(opener: HTMLElement) {
 	newSessionInput.value = "";
 	newSessionSubmitBtn.disabled = false;
 	clearBootstrapError();
+	resetEnvTab();
 	newSessionModal.classList.add("open");
 	newSessionModal.setAttribute("aria-hidden", "false");
 	// Defer focus to the next paint so the input is reliably focusable
@@ -1232,6 +1230,225 @@ newSessionModal.addEventListener("click", (e) => {
 	if (tab?.dataset.sessionTab) setActiveSessionTab(tab.dataset.sessionTab);
 });
 
+// ── Env tab (#186 / PR 186c) ────────────────────────────────────────────────
+//
+// State + render + wiring for the typed env-var Env tab. Each row
+// holds `{ name, value, type }`; the type cell is a toggle that flips
+// between plain and secret. Secret rows mask the value input
+// (`type="password"`) so the value isn't shoulder-surfable; the
+// underlying string still flows out via the form's submit handler.
+//
+// Invariant: the in-memory `envRows` is the source of truth. We
+// re-render rows from the array on every mutation rather than mutating
+// the DOM in place — keeps the table mirror of state simple and
+// avoids drift between input values and the array.
+
+interface EnvRow {
+	id: string; // stable per-row key for the DOM (not sent to the server)
+	name: string;
+	value: string;
+	type: "plain" | "secret";
+}
+
+let envRows: EnvRow[] = [];
+
+const envTableBody = document.getElementById("env-table-body") as HTMLTableSectionElement;
+const envAddRowBtn = document.getElementById("env-add-row") as HTMLButtonElement;
+const envPasteToggle = document.getElementById("env-paste-toggle") as HTMLButtonElement;
+const envPastePanel = document.getElementById("env-paste-panel") as HTMLDivElement;
+const envPasteTextarea = document.getElementById("env-paste-textarea") as HTMLTextAreaElement;
+const envPasteCancel = document.getElementById("env-paste-cancel") as HTMLButtonElement;
+const envPasteImport = document.getElementById("env-paste-import") as HTMLButtonElement;
+const envPasteStatus = document.getElementById("env-paste-status") as HTMLSpanElement;
+
+function newEnvRowId(): string {
+	// Random per-row id stays stable across re-renders so input focus
+	// can be preserved (we read DOM input values BEFORE re-rendering;
+	// the id is the table row's `data-row-id`).
+	return `env-row-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function renderEnvRows() {
+	envTableBody.textContent = "";
+	for (const row of envRows) {
+		const tr = document.createElement("tr");
+		tr.className = "env-row";
+		tr.dataset.rowId = row.id;
+
+		const nameCell = document.createElement("td");
+		const nameInput = document.createElement("input");
+		nameInput.type = "text";
+		nameInput.value = row.name;
+		nameInput.placeholder = "FOO";
+		nameInput.spellcheck = false;
+		nameInput.autocapitalize = "characters";
+		nameInput.className = "env-input env-input-name";
+		nameInput.dataset.field = "name";
+		nameCell.appendChild(nameInput);
+		tr.appendChild(nameCell);
+
+		const valueCell = document.createElement("td");
+		const valueInput = document.createElement("input");
+		// Secret rows mask the value visually — the user-typed string
+		// still flows through `.value` on submit; password masking is
+		// purely UX (shoulder-surfing defence).
+		valueInput.type = row.type === "secret" ? "password" : "text";
+		valueInput.value = row.value;
+		valueInput.placeholder = row.type === "secret" ? "••••••••" : "value";
+		valueInput.spellcheck = false;
+		valueInput.autocomplete = "off";
+		valueInput.className = "env-input env-input-value";
+		valueInput.dataset.field = "value";
+		valueCell.appendChild(valueInput);
+		tr.appendChild(valueCell);
+
+		const typeCell = document.createElement("td");
+		const typeToggle = document.createElement("button");
+		typeToggle.type = "button";
+		typeToggle.className = `env-type-toggle env-type-${row.type}`;
+		typeToggle.textContent = row.type === "secret" ? "secret" : "plain";
+		typeToggle.title =
+			row.type === "secret"
+				? "Click to mark this entry plain (value visible)"
+				: "Click to mark this entry secret (value masked + encrypted server-side)";
+		typeToggle.dataset.action = "toggle-type";
+		typeCell.appendChild(typeToggle);
+		tr.appendChild(typeCell);
+
+		const removeCell = document.createElement("td");
+		const removeBtn = document.createElement("button");
+		removeBtn.type = "button";
+		removeBtn.className = "env-row-remove";
+		removeBtn.textContent = "✕";
+		removeBtn.title = "Remove this entry";
+		removeBtn.setAttribute("aria-label", `Remove ${row.name || "entry"}`);
+		removeBtn.dataset.action = "remove";
+		removeCell.appendChild(removeBtn);
+		tr.appendChild(removeCell);
+
+		envTableBody.appendChild(tr);
+	}
+}
+
+/**
+ * Pull the latest input values out of the DOM into `envRows` before
+ * any operation that re-renders. Without this, a user typing into a
+ * row and then clicking Add / toggle / Delete on a different row
+ * would lose their pending edit when render wipes the table.
+ */
+function syncEnvRowsFromDom() {
+	const trs = envTableBody.querySelectorAll<HTMLTableRowElement>(".env-row");
+	for (const tr of trs) {
+		const id = tr.dataset.rowId ?? "";
+		const row = envRows.find((r) => r.id === id);
+		if (!row) continue;
+		const nameInput = tr.querySelector<HTMLInputElement>('[data-field="name"]');
+		const valueInput = tr.querySelector<HTMLInputElement>('[data-field="value"]');
+		if (nameInput) row.name = nameInput.value;
+		if (valueInput) row.value = valueInput.value;
+	}
+}
+
+function resetEnvTab() {
+	envRows = [];
+	renderEnvRows();
+	envPastePanel.hidden = true;
+	envPasteToggle.setAttribute("aria-expanded", "false");
+	envPasteTextarea.value = "";
+	envPasteStatus.textContent = "";
+}
+
+envAddRowBtn.addEventListener("click", () => {
+	syncEnvRowsFromDom();
+	envRows.push({ id: newEnvRowId(), name: "", value: "", type: "plain" });
+	renderEnvRows();
+	// Focus the new row's name input so the user can type immediately.
+	const last =
+		envTableBody.lastElementChild?.querySelector<HTMLInputElement>('[data-field="name"]');
+	last?.focus();
+});
+
+envTableBody.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	const action = target.dataset.action;
+	if (!action) return;
+	const tr = target.closest<HTMLTableRowElement>(".env-row");
+	const id = tr?.dataset.rowId ?? "";
+	syncEnvRowsFromDom();
+	if (action === "toggle-type") {
+		const row = envRows.find((r) => r.id === id);
+		if (row) row.type = row.type === "secret" ? "plain" : "secret";
+		renderEnvRows();
+	} else if (action === "remove") {
+		envRows = envRows.filter((r) => r.id !== id);
+		renderEnvRows();
+	}
+});
+
+envPasteToggle.addEventListener("click", () => {
+	const isOpen = !envPastePanel.hidden;
+	envPastePanel.hidden = isOpen;
+	envPasteToggle.setAttribute("aria-expanded", String(!isOpen));
+	if (!isOpen) requestAnimationFrame(() => envPasteTextarea.focus());
+});
+
+envPasteCancel.addEventListener("click", () => {
+	envPastePanel.hidden = true;
+	envPasteToggle.setAttribute("aria-expanded", "false");
+	envPasteTextarea.value = "";
+	envPasteStatus.textContent = "";
+});
+
+envPasteImport.addEventListener("click", () => {
+	syncEnvRowsFromDom();
+	const result = parseDotEnv(envPasteTextarea.value);
+	for (const entry of result.parsed) {
+		// Spec: imported entries default to `plain`. User flips to
+		// `secret` afterwards by clicking the type toggle on the row.
+		envRows.push({
+			id: newEnvRowId(),
+			name: entry.name,
+			value: entry.value,
+			type: "plain",
+		});
+	}
+	const skippedSummary = result.skipped
+		.slice(0, 3) // first 3 reasons; "+N more" if longer
+		.map((s) => `line ${s.line}: ${s.reason}`)
+		.join("; ");
+	const moreCount = result.skipped.length - 3;
+	const more = moreCount > 0 ? ` (+${moreCount} more)` : "";
+	envPasteStatus.textContent =
+		result.skipped.length === 0
+			? `Imported ${result.parsed.length} entr${result.parsed.length === 1 ? "y" : "ies"}.`
+			: `Imported ${result.parsed.length}, skipped ${result.skipped.length} — ${skippedSummary}${more}`;
+	envPasteTextarea.value = "";
+	envPastePanel.hidden = true;
+	envPasteToggle.setAttribute("aria-expanded", "false");
+	renderEnvRows();
+});
+
+/**
+ * Collect the in-memory `envRows` into the wire shape the backend
+ * accepts under `body.config.envVars`. Drops fully-empty rows
+ * (user added an entry then deleted both fields) but DOES surface
+ * partially-filled rows so the backend's clear 400 covers the typo
+ * cases the user is most likely to hit.
+ */
+function collectEnvVarsForSubmit(): EnvVarEntryInput[] | undefined {
+	syncEnvRowsFromDom();
+	const out: EnvVarEntryInput[] = [];
+	for (const row of envRows) {
+		if (row.name === "" && row.value === "") continue;
+		out.push(
+			row.type === "secret"
+				? { name: row.name, type: "secret", value: row.value }
+				: { name: row.name, type: "plain", value: row.value },
+		);
+	}
+	return out.length > 0 ? out : undefined;
+}
+
 newSessionForm.addEventListener("submit", async (e) => {
 	e.preventDefault();
 	const name = newSessionInput.value.trim();
@@ -1247,7 +1464,9 @@ newSessionForm.addEventListener("submit", async (e) => {
 	teardownBootstrapTail();
 	try {
 		showToast("Creating session…");
-		const session = await createSession(name);
+		const envVars = collectEnvVarsForSubmit();
+		const config = envVars ? { envVars } : undefined;
+		const session = await createSession(name, undefined, config);
 		sessions.unshift(session);
 		renderSessionList();
 		if (session.bootstrapping) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1117,7 +1117,9 @@ function openNewSessionModal(opener: HTMLElement) {
 	newSessionInput.value = "";
 	newSessionSubmitBtn.disabled = false;
 	clearBootstrapError();
-	resetEnvTab();
+	// `resetEnvTab` no longer fires here — `closeNewSessionModal`
+	// already wiped state on the previous close, and the initial
+	// declaration of `envRows = []` covers the very first open.
 	newSessionModal.classList.add("open");
 	newSessionModal.setAttribute("aria-hidden", "false");
 	// Defer focus to the next paint so the input is reliably focusable
@@ -1217,6 +1219,11 @@ function closeNewSessionModal() {
 	// reaches `running` (or see the failure in the row's status if it
 	// flipped to `failed`).
 	teardownBootstrapTail();
+	// Reset Env-tab state on close (#211 round 2) so the in-memory
+	// `envRows` doesn't drift from the now-hidden DOM between close
+	// and re-open. The redundant reset on `openNewSessionModal` is
+	// gone — closing always leaves the array empty.
+	resetEnvTab();
 	(newSessionOpener ?? newSessionBtn).focus();
 	newSessionOpener = null;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1344,7 +1344,14 @@ function syncEnvRowsFromDom() {
 		if (!row) continue;
 		const nameInput = tr.querySelector<HTMLInputElement>('[data-field="name"]');
 		const valueInput = tr.querySelector<HTMLInputElement>('[data-field="value"]');
-		if (nameInput) row.name = nameInput.value;
+		// Uppercase at the read site (#211 round 1). The Env-table CSS
+		// applies `text-transform: uppercase` for visual consistency,
+		// but DOM `.value` returns raw keystrokes — a desktop user
+		// typing `foo` sees `FOO` rendered and then hits the backend's
+		// `^[A-Z_][A-Z0-9_]*$` regex with the lowercase value on
+		// submit. `.toUpperCase()` here keeps state aligned with the
+		// rendering. `autocapitalize` already handled mobile.
+		if (nameInput) row.name = nameInput.value.toUpperCase();
 		if (valueInput) row.value = valueInput.value;
 	}
 }


### PR DESCRIPTION
## Summary

**Closes #186.** Wires the frontend Env tab the typed-entry backend (PR #210) was expecting. Together with PR #209 (crypto module + boot validation) and PR #210 (typed schema + encrypt-on-persist + decrypt-on-spawn), this completes the Env vars & secrets epic.

## Frontend

- **Env tab in the create-session modal** (was a placeholder pointing at this issue). Now a `name | value | type | ×` table with per-row CRUD: Add appends an empty row, ✕ removes one, the type toggle flips between `plain` (visible value) and `secret` (masked via `type=password`, encrypted server-side).
- **"Paste .env" panel** — collapsed by default, expand to a textarea + Cancel + "Import as plain". Imported entries land in the table tagged `plain`; the user flips them to `secret` afterwards. Status line reports `Imported N, skipped M (line X: reason; …)` so a malformed paste doesn't disappear silently.
- **`envParser.ts` module** — factored out for testability. Handles `KEY=value`, `KEY="value"`, `KEY='value'`, `# comments`, blank lines, the `export FOO=bar` shell-import idiom, CRLF line endings, embedded `=` in unquoted values, trailing comments after a quoted value. Multi-line values explicitly out of scope per the issue spec — unterminated quotes log a parse failure with the line number.
- **`api.ts`** — `SessionConfigPayload.envVars` swapped from `Record<string,string>` to the typed `EnvVarEntryInput[]` shape PR #210 expects.
- **`main.ts` state machine** — in-memory `EnvRow[]` is the source of truth, re-rendered from state on every mutation, with a `syncEnvRowsFromDom` step before any structural change so pending edits aren't lost when the table re-renders. Modal open resets state; close tears it down.

## Test plan

- [x] `cd frontend && npm test` — **45/45** (17 new vitest cases on the parser: simple parses, quotes, blanks/comments, `export` prefix, CRLF, embedded `=`, name regex, unterminated quote, trailing comments after quoted/unquoted values, summarisable counts).
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — clean.
- [ ] Live browser smoke (open modal, type a couple of plain entries + a secret, paste a `.env`, submit, verify the session has the env vars set inside the container) — couldn't run in this session because the dev D1 setup is offline; will validate once the full stack runs end-to-end.

## Out of scope

- "Editing a session in detail view" (the spec section that lets users see the env list on an existing session) — that requires `serializeMeta` to surface `session_configs.envVars` via `redactStoredEntries`. Tracked as a follow-up PR; the redact helper is exported and tested in #210 ready for the wire-up.
- Template-load `secret-slot` flow — deferred to #195.

Refs #186, #184. Closes #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)