### PR TITLE
feat(uploads): relocate container bind from ~/workspace/uploads → ~/uploads (#188 prereq, PR 188a)

### DIFF
--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -216,16 +216,31 @@ export class DockerManager {
 
 		// Pre-create the per-session uploads dir at its OUT-OF-WORKSPACE
 		// location and bind-mount it read-only into the container at
-		// /home/developer/workspace/uploads/. Critical TOCTOU defence:
-		// because the container's view is a mount point, the container
-		// can NOT replace, rename, or rmdir the uploads/ entry from
-		// inside (the kernel rejects any modification to a mount point
-		// from the mount user's namespace). Read-only also stops the
+		// /home/developer/uploads/. Critical TOCTOU defence: because
+		// the container's view is a mount point, the container can NOT
+		// replace, rename, or rmdir the uploads/ entry from inside
+		// (the kernel rejects any modification to a mount point from
+		// the mount user's namespace). Read-only also stops the
 		// container from writing/modifying uploaded files, so an
 		// attacker can't poison files between writes — combined with
 		// writeUploads' atomic rename from .tmp-uploads/ into
 		// .uploads/<sessionId>/, the symlink-swap attack window the
 		// older in-workspace layout had is closed structurally.
+		//
+		// **Mount path** (#188 PR 188a): the bind target moved from
+		// /home/developer/workspace/uploads → /home/developer/uploads
+		// so the workspace bind is its own clean mount. Required for
+		// #188's repo-clone "replace workspace" mode, where the clone
+		// runs at the workspace root and a leftover `uploads/` dir
+		// would either collide with the clone or be hidden under it.
+		// Container path is purely cosmetic (the host path under
+		// `<WORKSPACE_ROOT>/.uploads/<sessionId>` is unchanged), so
+		// existing sessions just pick up the new path on their next
+		// container start. Old clients pasting an `~/workspace/uploads/`
+		// path in their command will see "no such file" — release notes
+		// flag this; the route's `containerPaths` returns the new path
+		// to the frontend so any newly-uploaded file lands on the new
+		// path automatically.
 		const uploadsHostDir = path.join(WORKSPACE_ROOT, ".uploads", sessionId);
 		await fs.mkdir(uploadsHostDir, { recursive: true });
 		// No chown — backend (typically root) owns the dir, container
@@ -249,7 +264,7 @@ export class DockerManager {
 			HostConfig: {
 				Binds: [
 					`${WORKSPACE_ROOT}/${sessionId}:/home/developer/workspace`,
-					`${uploadsHostDir}:/home/developer/workspace/uploads:ro`,
+					`${uploadsHostDir}:/home/developer/uploads:ro`,
 				],
 				// `mem_limit` / `cpu_limit` from session_configs override the
 				// hardcoded defaults. Docker pins HostConfig at create time,
@@ -548,7 +563,7 @@ export class DockerManager {
 				// tmp dir to the per-session uploads dir.
 				await fs.rename(file.path, finalPath);
 				remaining.delete(file.path);
-				containerPaths.push(`/home/developer/workspace/uploads/${filename}`);
+				containerPaths.push(`/home/developer/uploads/${filename}`);
 			}
 		} finally {
 			await this.cleanupTmp([...remaining].map((p) => ({ originalname: "", path: p })));

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -447,15 +447,17 @@ export class DockerManager {
 		// Architectural TOCTOU fix: the uploads directory lives at
 		// <WORKSPACE_ROOT>/.uploads/<sessionId>/ — OUTSIDE the
 		// container's bind-mount tree. spawn() bind-mounts this dir
-		// read-only into the container at /home/developer/workspace/
-		// uploads/, so:
-		//   1. The container CANNOT remove or replace /home/developer/
-		//      workspace/uploads (it's a mount point — kernel rejects
-		//      modification from the mount user's namespace).
+		// read-only into the container at /home/developer/uploads/
+		// (#188 PR 188a moved this out of the workspace tree so the
+		// repo-clone replace-workspace mode has a clean root), so:
+		//   1. The container CANNOT remove or replace
+		//      /home/developer/uploads (it's a mount point — kernel
+		//      rejects modification from the mount user's namespace).
 		//   2. The container CANNOT write into uploads/ (read-only mount).
 		//   3. The container's bind mount on /home/developer/workspace/
-		//      doesn't reach .uploads/ on the host, so nothing inside
-		//      the container can plant symlinks at the upload destination.
+		//      doesn't reach .uploads/ on the host (now in a sibling
+		//      mount under /home/developer/), so nothing inside the
+		//      container can plant symlinks at the upload destination.
 		// The earlier in-workspace layout needed a stack of defences
 		// (realpath, O_DIRECTORY|O_NOFOLLOW, pre+post inode sentinels)
 		// because the container could replace uploads/ with a symlink

--- a/backend/src/dockerManager.uploads.test.ts
+++ b/backend/src/dockerManager.uploads.test.ts
@@ -74,7 +74,9 @@ describe("writeUploads", () => {
 	// actually moves files to. Lives at <WORKSPACE_ROOT>/.uploads/
 	// <sessionId>/ — out-of-workspace by design (TOCTOU isolation,
 	// see writeUploadsImpl). spawn() bind-mounts this dir read-only
-	// into the container at /home/developer/workspace/uploads/, but
+	// into the container at /home/developer/uploads/ (#188 PR 188a
+	// moved it out of /home/developer/workspace/ so the workspace
+	// stays clean for #188's repo-clone replace-workspace mode), but
 	// these tests never construct containers — they only exercise
 	// host-side state.
 	const uploadsHostDir = (sid: string) => path.join(WORKSPACE_ROOT, ".uploads", sid);
@@ -88,7 +90,7 @@ describe("writeUploads", () => {
 
 		expect(result).toHaveLength(2);
 		for (const p of result) {
-			expect(p.startsWith("/home/developer/workspace/uploads/")).toBe(true);
+			expect(p.startsWith("/home/developer/uploads/")).toBe(true);
 		}
 		// The container paths' filenames map directly onto the
 		// host-side basenames — useful guarantee for tests that want

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -440,9 +440,11 @@ export async function revokeInvite(codeHash: string): Promise<void> {
 // ── File uploads ────────────────────────────────────────────────────────────
 
 /**
- * Upload one or more files to a session's workspace. The backend writes
- * them under `<workspace>/uploads/` and returns the in-container paths
- * the user can pass to Claude CLI.
+ * Upload one or more files to a session. The backend writes them
+ * under `~/uploads/` (in-container path, sibling of the workspace —
+ * #188 PR 188a moved it out of the workspace tree so a clone at the
+ * workspace root has a clean target) and returns the in-container
+ * paths the user can pass to Claude CLI.
  */
 export async function uploadSessionFiles(
 	sessionId: string,


### PR DESCRIPTION
## Summary

The first slice of **#188 (repo clone)**. Splitting the issue into focused PRs to keep each reviewable:

- **PR 188a** *(this PR)*: uploads relocation only.
- **PR 188b**: `repo` schema + clone-runner skeleton wired into the bootstrap pipeline.
- **PR 188c**: PAT auth path + no-leak tests.
- **PR 188d**: SSH auth path + bundled `known_hosts` for github/gitlab/bitbucket.
- **PR 188e**: frontend Repo tab.

This PR moves only the in-container bind target so the workspace stays clean for #188's "replace workspace" mode — a `git clone` running at the workspace root would otherwise either collide with the existing `uploads/` dir or hide it from the clone tree.

## What changes

- `DockerManager.spawn`: bind string flips from `/home/developer/workspace/uploads:ro` to `/home/developer/uploads:ro`. Host path under `<WORKSPACE_ROOT>/.uploads/<sessionId>` is unchanged — purely cosmetic on the container side.
- `writeUploads.containerPaths`: returned paths now `/home/developer/uploads/<filename>`, so any newly-uploaded file's reported path matches the new mount.
- Existing sessions pick the new mount up on their next container start (DELETE → POST /start, or natural restart). No D1 schema change.
- Block comment on the bind expanded to call out the rationale + the documented release-note: external scripts or pasted commands referring to `~/workspace/uploads/` will see "no such file" after the next container start; the upload route returns the new path so the path the user pastes from the UI is correct.

## Test plan

- [x] `cd backend && npm test` — **312/312 passing**. One test fixture in `dockerManager.uploads.test.ts` updated to assert the new `/home/developer/uploads/` path prefix; comment also updated to point at #188 PR 188a for the rationale.
- [x] `cd backend && npm run lint` — clean.
- [x] `cd backend && npm run build` — clean.
- [ ] Live container check (start a session, upload a file via the modal, paste the returned path inside the terminal, verify it resolves) — couldn't run this session because the dev D1 setup is offline.

Refs #188, #184. Closes #188 once PRs 188b–e land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)