### PR TITLE
feat(repo): typed repo+auth schema with encrypt-on-persist (#188, PR 188b of 3)

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -198,6 +198,7 @@ export async function migrateDb(): Promise<void> {
                         repos_json          TEXT,
                         ports_json          TEXT,
                         env_vars_json       TEXT,
+                        auth_json           TEXT,
                         bootstrapped_at     TEXT,
                         created_at          TEXT NOT NULL DEFAULT (datetime('now')),
                         FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
@@ -218,6 +219,18 @@ export async function migrateDb(): Promise<void> {
 	// #50: same shape — add `users.is_admin` to pre-existing tables.
 	try {
 		await d1Query("ALTER TABLE users ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0");
+	} catch (err) {
+		if (!/duplicate column name|already exists/i.test((err as Error).message)) {
+			throw err;
+		}
+	}
+	// #188 PR 188b: `auth_json` column on `session_configs` — encrypted
+	// repo-clone credentials (PAT / SSH key + known_hosts). Same idiom
+	// as the columns above: ADD COLUMN unguarded, swallow the duplicate
+	// error so re-running migrations on a fresh-deploy DB (where the
+	// CREATE TABLE above already declared the column) is a no-op.
+	try {
+		await d1Query("ALTER TABLE session_configs ADD COLUMN auth_json TEXT");
 	} catch (err) {
 		if (!/duplicate column name|already exists/i.test((err as Error).message)) {
 			throw err;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -40,6 +40,7 @@ import {
 	UsernameRateLimiter,
 } from "./rateLimit.js";
 import {
+	encryptAuthCredentials,
 	encryptSecretEntries,
 	isEmptyConfig,
 	type PersistableSessionConfig,
@@ -459,6 +460,11 @@ export function buildRouter(
 					envVars: validatedConfig.envVars
 						? encryptSecretEntries(validatedConfig.envVars)
 						: undefined,
+					// #188 PR 188b: encrypt PAT / SSH credentials at the
+					// route boundary, same shape as envVars secrets. The
+					// helper returns undefined for an empty/absent blob
+					// so `jsonOrNull` collapses the column to NULL.
+					auth: encryptAuthCredentials(validatedConfig.auth),
 				};
 				await persistSessionConfig(meta.sessionId, persistable);
 			}

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -196,6 +196,38 @@ describe("validateSessionConfig", () => {
 		).toThrowError(SessionConfigValidationError);
 	});
 
+	// PR #213 round 1 SHOULD-FIX: a URL like
+	// `https://user:ghp_xxxx@github.com/o/p` would otherwise store the
+	// PAT verbatim in `repos_json`, bypassing the AES-GCM encrypt-on-
+	// persist that `auth_json` enforces. Reject `@` in HTTPS URLs at
+	// the regex layer; users must put credentials through `auth.pat`.
+	it("rejects HTTPS URLs with embedded user:password credentials", () => {
+		for (const url of [
+			"https://user:ghp_token@github.com/o/p",
+			"https://user@github.com/o/p",
+			"https://:secret@github.com/o/p",
+		]) {
+			for (const auth of ["none", "pat"] as const) {
+				const config: { repo: { url: string; auth: "none" | "pat" }; auth?: object } = {
+					repo: { url, auth },
+				};
+				if (auth === "pat") config.auth = { pat: "ghp_orphan" };
+				expect(() => validateSessionConfig(config)).toThrowError(SessionConfigValidationError);
+			}
+		}
+	});
+
+	// PR #213 round 1 NIT: SSH URL path component allowed `..`
+	// (`git@github.com:o/../etc`) — same uniform rejection as ref/target.
+	it("rejects SSH URLs containing '..'", () => {
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "git@github.com:o/../etc", auth: "ssh" },
+				auth: { ssh: { privateKey: "k", knownHosts: "default" } },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
 	it("accepts https:// repo URLs", () => {
 		expect(
 			validateSessionConfig({
@@ -1006,5 +1038,13 @@ describe("encryptAuthCredentials / decryptStoredAuth / redactStoredAuth", () => 
 
 	it("redactStoredAuth returns undefined for undefined input", () => {
 		expect(redactStoredAuth(undefined)).toBeUndefined();
+	});
+
+	// PR #213 round 1 NIT: parity with `parseAuthColumn`. An `AuthStored`
+	// with neither `pat` nor `ssh` set must collapse to undefined so a
+	// future GET-config endpoint can use `auth !== undefined` as the
+	// "credentials configured?" predicate.
+	it("redactStoredAuth collapses an empty AuthStored to undefined", () => {
+		expect(redactStoredAuth({})).toBeUndefined();
 	});
 });

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -351,6 +351,19 @@ describe("validateSessionConfig", () => {
 		);
 	});
 
+	// PR #213 round 4 NIT: `repo: null` (explicit) and `repo` omitted
+	// are semantically distinct on the wire, but the cross-field guard's
+	// `if (result.data.repo)` predicate is falsy for both. Pin the
+	// behaviour with a separate test so a future edit that swaps the
+	// predicate for `if (result.data.repo !== undefined)` doesn't
+	// silently start persisting orphan credentials when the client
+	// sends `null` explicitly.
+	it("rejects explicit repo:null with credentials", () => {
+		expect(() => validateSessionConfig({ repo: null, auth: { pat: "ghp_x" } })).toThrowError(
+			SessionConfigValidationError,
+		);
+	});
+
 	it("accepts repo.auth='ssh' with matching git@ URL and ssh creds", () => {
 		expect(
 			validateSessionConfig({

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -12,11 +12,15 @@ const dbStubs = vi.hoisted(() => ({
 vi.mock("./db.js", () => dbStubs);
 
 import {
+	type AuthStored,
+	decryptStoredAuth,
 	decryptStoredEntries,
+	encryptAuthCredentials,
 	encryptSecretEntries,
 	getSessionConfig,
 	isEmptyConfig,
 	persistSessionConfig,
+	redactStoredAuth,
 	redactStoredEntries,
 	type SessionConfig,
 	SessionConfigSchema,
@@ -54,7 +58,13 @@ describe("validateSessionConfig", () => {
 			idleTtlSeconds: 3600,
 			postCreateCmd: "npm install",
 			postStartCmd: "npm run dev",
-			repos: [{ url: "https://github.com/example/repo", ref: "main" }],
+			repo: {
+				url: "https://github.com/example/repo",
+				ref: "main",
+				target: "frontend",
+				auth: "none",
+				depth: 1,
+			},
 			ports: [{ port: 3000, protocol: "http" }],
 			envVars: [{ name: "FOO", type: "plain", value: "bar" }],
 		};
@@ -113,13 +123,7 @@ describe("validateSessionConfig", () => {
 		);
 	});
 
-	it("caps the number of repos / ports", () => {
-		const tooManyRepos = Array.from({ length: 11 }, (_, i) => ({
-			url: `https://example.com/r${i}`,
-		}));
-		expect(() => validateSessionConfig({ repos: tooManyRepos })).toThrowError(
-			SessionConfigValidationError,
-		);
+	it("caps the number of ports", () => {
 		const tooManyPorts = Array.from({ length: 21 }, (_, i) => ({ port: 3000 + i }));
 		expect(() => validateSessionConfig({ ports: tooManyPorts })).toThrowError(
 			SessionConfigValidationError,
@@ -144,25 +148,35 @@ describe("validateSessionConfig", () => {
 		);
 	});
 
-	// Same reasoning as the empty-hook rule — stored "" ref would be
-	// indistinguishable from "no ref" and would push `git clone --branch ""`
-	// into PR 188's consumer.
-	it("rejects an empty repo ref", () => {
-		expect(() =>
-			validateSessionConfig({ repos: [{ url: "https://example.com/r", ref: "" }] }),
-		).toThrowError(SessionConfigValidationError);
+	// Empty `""` ref is now meaningful (= remote HEAD, no `--branch` flag).
+	// The clone runner uses presence + non-empty as the predicate for
+	// passing `--branch`, so an empty ref is a valid declarative value.
+	it("accepts an empty repo ref (= remote HEAD)", () => {
+		expect(
+			validateSessionConfig({
+				repo: { url: "https://example.com/r", ref: "", auth: "none" },
+			}),
+		).toBeDefined();
 	});
 
-	// Repo URL scheme allowlist — closes the file:// / ssh:// hole the
-	// review bot flagged. PR 188 will read these values straight into a
-	// git-clone consumer, so refusing them at ingest is the only place
-	// this can be blocked without a duplicate validator downstream.
-	it("rejects repo URLs with non-https schemes", () => {
-		// Allowlist is https:// only. http:// is rejected because a MITM
-		// on the path between the container and the public mirror can
-		// inject content which then runs as postCreate/postStart inside
-		// the container. ssh:// / git:// / file:// are rejected for the
-		// SSRF / arbitrary-path reasons documented on the regex.
+	// Refnames that fail `git check-ref-format` (or look like a CLI flag
+	// the runner could mis-interpret) are rejected — defence-in-depth
+	// alongside the runner's argv-only invocation.
+	it("rejects refs with traversal '..' or leading '-'", () => {
+		for (const ref of ["..", "main/..", "-fexec", "--upload-pack=evil"]) {
+			expect(() =>
+				validateSessionConfig({
+					repo: { url: "https://example.com/r", ref, auth: "none" },
+				}),
+			).toThrowError(SessionConfigValidationError);
+		}
+	});
+
+	// Repo URL scheme allowlist — closes the file:// / ssh://-scheme hole.
+	// The runner will hand these straight to `git clone`, so refusing them
+	// at ingest is the only place this can be blocked without a duplicate
+	// validator downstream.
+	it("rejects repo URLs with disallowed schemes", () => {
 		for (const url of [
 			"http://example.com/r",
 			"file:///etc/passwd",
@@ -170,24 +184,123 @@ describe("validateSessionConfig", () => {
 			"git://attacker.example:9418/r",
 			"javascript:alert(1)",
 		]) {
-			expect(() => validateSessionConfig({ repos: [{ url }] })).toThrowError(
+			expect(() => validateSessionConfig({ repo: { url, auth: "none" } })).toThrowError(
 				SessionConfigValidationError,
 			);
 		}
 	});
 
 	it("rejects repo URLs that are not URLs at all", () => {
-		expect(() => validateSessionConfig({ repos: [{ url: "just-a-name" }] })).toThrowError(
-			SessionConfigValidationError,
-		);
+		expect(() =>
+			validateSessionConfig({ repo: { url: "just-a-name", auth: "none" } }),
+		).toThrowError(SessionConfigValidationError);
 	});
 
 	it("accepts https:// repo URLs", () => {
 		expect(
 			validateSessionConfig({
-				repos: [{ url: "https://example.com/r" }, { url: "https://github.com/o/p" }],
+				repo: { url: "https://github.com/o/p", auth: "none" },
 			}),
 		).toBeDefined();
+	});
+
+	// #188: target validation — workspace-relative paths only. `..` and
+	// leading `/` would let a clone target escape the bind-mounted
+	// workspace; `//` is rejected as a defence-in-depth against a runner
+	// that doesn't normalise.
+	it("rejects target paths with '..' / leading '/' / '//'", () => {
+		for (const target of ["../escape", "/abs", "a//b", "../"]) {
+			expect(() =>
+				validateSessionConfig({
+					repo: { url: "https://example.com/r", target, auth: "none" },
+				}),
+			).toThrowError(SessionConfigValidationError);
+		}
+	});
+
+	it("accepts an empty target (= workspace root) and a clean subpath", () => {
+		for (const target of ["", "frontend", "services/api", "a/b/c.x"]) {
+			expect(
+				validateSessionConfig({
+					repo: { url: "https://example.com/r", target, auth: "none" },
+				}),
+			).toBeDefined();
+		}
+	});
+
+	// Cross-field repo↔auth consistency. The route reads these decisions
+	// directly: a `git@…` URL with `auth: "none"` would fail mysteriously
+	// inside the container, and PAT/SSH credentials with no matching
+	// `repo` block would silently never be used.
+	it("rejects repo.auth='pat' without auth.pat or with non-https URL", () => {
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "https://example.com/r", auth: "pat" },
+				// missing auth.pat
+			}),
+		).toThrowError(SessionConfigValidationError);
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "git@github.com:o/p", auth: "pat" },
+				auth: { pat: "ghp_xxx" },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
+	it("rejects repo.auth='ssh' without auth.ssh or with non-git@ URL", () => {
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "git@github.com:o/p", auth: "ssh" },
+				// missing auth.ssh
+			}),
+		).toThrowError(SessionConfigValidationError);
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "https://example.com/r", auth: "ssh" },
+				auth: { ssh: { privateKey: "k", knownHosts: "default" } },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
+	it("rejects credentials present when repo.auth='none'", () => {
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "https://example.com/r", auth: "none" },
+				auth: { pat: "ghp_orphan" },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
+	it("rejects orphan credentials with no repo block", () => {
+		expect(() => validateSessionConfig({ auth: { pat: "ghp_orphan" } })).toThrowError(
+			SessionConfigValidationError,
+		);
+	});
+
+	it("accepts repo.auth='ssh' with matching git@ URL and ssh creds", () => {
+		expect(
+			validateSessionConfig({
+				repo: { url: "git@github.com:o/p", auth: "ssh", target: "" },
+				auth: {
+					ssh: {
+						privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\n…",
+						knownHosts: "default",
+					},
+				},
+			}),
+		).toBeDefined();
+	});
+
+	// Depth bounds — out of [1, 10000]. A missing `depth` is allowed
+	// (full history), so the lower bound has to fire on `0` and `-1`.
+	it("rejects repo.depth out of bounds", () => {
+		for (const depth of [0, -1, 10_001]) {
+			expect(() =>
+				validateSessionConfig({
+					repo: { url: "https://example.com/r", auth: "none", depth },
+				}),
+			).toThrowError(SessionConfigValidationError);
+		}
 	});
 
 	// envVars contents flow through validateEnvVars per-entry — POSIX
@@ -343,7 +456,7 @@ describe("persistSessionConfig", () => {
 		const config: SessionConfig = {
 			cpuLimit: 1_000_000_000,
 			postCreateCmd: "echo hi",
-			repos: [{ url: "https://example.com/r" }],
+			repo: { url: "https://example.com/r", auth: "none" },
 		};
 		await persistSessionConfig("sess-1", config);
 		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
@@ -361,9 +474,10 @@ describe("persistSessionConfig", () => {
 			null, // idle_ttl_seconds
 			"echo hi", // post_create_cmd
 			null, // post_start_cmd
-			JSON.stringify([{ url: "https://example.com/r" }]),
+			JSON.stringify({ url: "https://example.com/r", auth: "none" }),
 			null, // ports_json
 			null, // env_vars_json
+			null, // auth_json
 		]);
 	});
 
@@ -379,20 +493,22 @@ describe("persistSessionConfig", () => {
 		// Defensive cross-check: the params length must match the column
 		// count, so a future caller adding bootstrapped_at to either side
 		// without updating the other trips this assertion immediately.
-		expect((params as unknown[]).length).toBe(10);
+		// 11 = sessionId + 10 column values (incl. auth_json added in 188b).
+		expect((params as unknown[]).length).toBe(11);
 	});
 
 	it("collapses empty array sub-records to NULL (no D1 row bloat)", async () => {
 		await persistSessionConfig("sess-empty", {
-			repos: [],
 			ports: [],
 			envVars: [],
 		});
 		const [, params] = dbStubs.d1Query.mock.calls[0]!;
-		// repos_json (param[7]), ports_json (param[8]), env_vars_json (param[9])
+		// repos_json (param[7]), ports_json (param[8]), env_vars_json (param[9]),
+		// auth_json (param[10])
 		expect(params?.[7]).toBeNull();
 		expect(params?.[8]).toBeNull();
 		expect(params?.[9]).toBeNull();
+		expect(params?.[10]).toBeNull();
 	});
 
 	it("serialises envVars + ports JSON columns (storage shape)", async () => {
@@ -449,9 +565,13 @@ describe("getSessionConfig", () => {
 					idle_ttl_seconds: null,
 					post_create_cmd: "npm i",
 					post_start_cmd: null,
-					repos_json: JSON.stringify([{ url: "https://example.com/r" }]),
+					repos_json: JSON.stringify({
+						url: "https://example.com/r",
+						auth: "none",
+					}),
 					ports_json: null,
 					env_vars_json: JSON.stringify([{ name: "FOO", type: "plain", value: "bar" }]),
+					auth_json: null,
 					bootstrapped_at: "2026-05-08 12:00:00",
 				},
 			],
@@ -462,10 +582,113 @@ describe("getSessionConfig", () => {
 		expect(got).not.toBeNull();
 		expect(got?.workspaceStrategy).toBe("preserve");
 		expect(got?.cpuLimit).toBe(2_000_000_000);
-		expect(got?.repos).toEqual([{ url: "https://example.com/r" }]);
+		expect(got?.repo).toEqual({ url: "https://example.com/r", auth: "none" });
 		expect(got?.envVars).toEqual([{ name: "FOO", type: "plain", value: "bar" }]);
+		expect(got?.auth).toBeUndefined();
 		// D1 returns suffix-less UTC; getter must not interpret as local.
 		expect(got?.bootstrappedAt?.toISOString()).toBe("2026-05-08T12:00:00.000Z");
+	});
+
+	// #188 PR 188b — backward compat. The pre-188 `repos_json` column
+	// stored an array placeholder; no production data uses it (no Repo
+	// tab UI ever shipped before #188), but the rehydrator promotes a
+	// legacy array to a single repo object so any pre-existing row from
+	// a dev DB stays usable.
+	it("promotes a legacy repos_json array to a single repo object", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [
+				{
+					session_id: "sess-legacy-repo",
+					workspace_strategy: null,
+					cpu_limit: null,
+					mem_limit: null,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: JSON.stringify([
+						{ url: "https://example.com/r", ref: "main" },
+						{ url: "https://example.com/second" },
+					]),
+					ports_json: null,
+					env_vars_json: null,
+					auth_json: null,
+					bootstrapped_at: null,
+				},
+			],
+			success: true as const,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const got = await getSessionConfig("sess-legacy-repo");
+		// First element wins; second is silently dropped (was a
+		// placeholder shape that never populated in production).
+		expect(got?.repo).toEqual({ url: "https://example.com/r", ref: "main" });
+	});
+
+	it("rehydrates auth_json with encrypted blobs intact", async () => {
+		const encrypted: AuthStored = {
+			pat: { ciphertext: "Y3Q=", iv: "MTIzNDU2Nzg5MDEy", tag: "MTIzNDU2Nzg5MDEyMzQ1Ng==" },
+			ssh: {
+				privateKey: {
+					ciphertext: "a2V5",
+					iv: "MTIzNDU2Nzg5MDEy",
+					tag: "MTIzNDU2Nzg5MDEyMzQ1Ng==",
+				},
+				knownHosts: "default",
+			},
+		};
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [
+				{
+					session_id: "sess-auth",
+					workspace_strategy: null,
+					cpu_limit: null,
+					mem_limit: null,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: null,
+					ports_json: null,
+					env_vars_json: null,
+					auth_json: JSON.stringify(encrypted),
+					bootstrapped_at: null,
+				},
+			],
+			success: true as const,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const got = await getSessionConfig("sess-auth");
+		expect(got?.auth).toEqual(encrypted);
+	});
+
+	// Defence-in-depth: a hand-edited D1 row that drops one of
+	// ciphertext/iv/tag must NOT reach the decrypt path — that would be
+	// an effective DoS for the session (every spawn throws). Drop the
+	// malformed credential with a logger warn instead.
+	it("drops auth_json entries with missing iv/tag fields", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [
+				{
+					session_id: "sess-auth-bad",
+					workspace_strategy: null,
+					cpu_limit: null,
+					mem_limit: null,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: null,
+					ports_json: null,
+					env_vars_json: null,
+					auth_json: JSON.stringify({
+						pat: { ciphertext: "Y3Q=" /* missing iv + tag */ },
+					}),
+					bootstrapped_at: null,
+				},
+			],
+			success: true as const,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const got = await getSessionConfig("sess-auth-bad");
+		expect(got?.auth).toBeUndefined();
 	});
 
 	// PR #210 round 2 fix: `session_configs.env_vars_json` had a
@@ -593,12 +816,13 @@ describe("getSessionConfig", () => {
 					idle_ttl_seconds: null,
 					post_create_cmd: null,
 					post_start_cmd: null,
-					// All three JSON columns deliberately broken — a direct
+					// All four JSON columns deliberately broken — a direct
 					// SQL write or migration corruption is the only way to
 					// reach this state, and the row should still be readable.
 					repos_json: "{not json",
 					ports_json: "[oh no",
 					env_vars_json: "definitely not",
+					auth_json: "}also broken",
 					bootstrapped_at: null,
 				},
 			],
@@ -607,9 +831,10 @@ describe("getSessionConfig", () => {
 		}));
 		const got = await getSessionConfig("sess-bad-json");
 		expect(got).not.toBeNull();
-		expect(got?.repos).toBeUndefined();
+		expect(got?.repo).toBeUndefined();
 		expect(got?.ports).toBeUndefined();
 		expect(got?.envVars).toBeUndefined();
+		expect(got?.auth).toBeUndefined();
 	});
 
 	it("treats unknown workspace_strategy values as undefined (defence-in-depth)", async () => {
@@ -626,6 +851,7 @@ describe("getSessionConfig", () => {
 					repos_json: null,
 					ports_json: null,
 					env_vars_json: null,
+					auth_json: null,
 					bootstrapped_at: null,
 				},
 			],
@@ -707,5 +933,78 @@ describe("encryptSecretEntries / decryptStoredEntries / redactStoredEntries", ()
 			return { ...e, tag: tagBytes.toString("base64") };
 		});
 		expect(() => decryptStoredEntries(tampered)).toThrow();
+	});
+});
+
+// ── Auth-blob encrypt / decrypt / redact round-trip (#188 PR 188b) ───────
+
+describe("encryptAuthCredentials / decryptStoredAuth / redactStoredAuth", () => {
+	it("returns undefined for an empty / absent input (column collapses to NULL)", () => {
+		expect(encryptAuthCredentials(undefined)).toBeUndefined();
+		expect(encryptAuthCredentials({})).toBeUndefined();
+	});
+
+	it("round-trips a PAT credential via real AES-GCM", () => {
+		const stored = encryptAuthCredentials({ pat: "ghp_secrettoken_1234567890" });
+		expect(stored).toBeDefined();
+		expect(stored?.pat).toBeDefined();
+		// Storage shape: only ciphertext + iv + tag — no plaintext.
+		expect(stored?.pat).not.toHaveProperty("value");
+		expect(stored?.pat?.ciphertext).toBeTruthy();
+		expect(stored?.pat?.iv).toBeTruthy();
+		expect(stored?.pat?.tag).toBeTruthy();
+		// Round-trip recovers the original plaintext.
+		const back = decryptStoredAuth(stored!);
+		expect(back.pat).toBe("ghp_secrettoken_1234567890");
+		expect(back.ssh).toBeUndefined();
+	});
+
+	it("round-trips an SSH credential and preserves knownHosts verbatim", () => {
+		const privateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nbase64bytes\n-----END\n";
+		const knownHosts = "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...";
+		const stored = encryptAuthCredentials({
+			ssh: { privateKey, knownHosts },
+		});
+		expect(stored?.ssh).toBeDefined();
+		// knownHosts is public — stored verbatim, NOT encrypted.
+		expect(stored?.ssh?.knownHosts).toBe(knownHosts);
+		// privateKey is encrypted: ciphertext envelope, no plaintext.
+		expect(stored?.ssh?.privateKey).toMatchObject({
+			ciphertext: expect.any(String),
+			iv: expect.any(String),
+			tag: expect.any(String),
+		});
+		const back = decryptStoredAuth(stored!);
+		expect(back.ssh?.privateKey).toBe(privateKey);
+		expect(back.ssh?.knownHosts).toBe(knownHosts);
+	});
+
+	it("decryptStoredAuth throws on a tampered ciphertext (GCM auth tag)", () => {
+		const stored = encryptAuthCredentials({ pat: "ghp_token" });
+		// Flip the last byte of the tag — auth check fails.
+		const tagBytes = Buffer.from(stored!.pat!.tag, "base64");
+		tagBytes[tagBytes.length - 1] ^= 0x01;
+		const tampered: AuthStored = {
+			pat: { ...stored!.pat!, tag: tagBytes.toString("base64") },
+		};
+		expect(() => decryptStoredAuth(tampered)).toThrow();
+	});
+
+	it("redactStoredAuth collapses pat / ssh.privateKey to { isSet: true } and keeps knownHosts visible", () => {
+		const stored = encryptAuthCredentials({
+			pat: "ghp_token",
+			ssh: { privateKey: "secretkey", knownHosts: "default" },
+		});
+		const redacted = redactStoredAuth(stored);
+		expect(redacted).toEqual({
+			pat: { isSet: true },
+			ssh: { isSet: true, knownHosts: "default" },
+		});
+		// Defensive: no encrypted material survives the redact.
+		expect(JSON.stringify(redacted)).not.toMatch(/ciphertext|iv|tag|secretkey/);
+	});
+
+	it("redactStoredAuth returns undefined for undefined input", () => {
+		expect(redactStoredAuth(undefined)).toBeUndefined();
 	});
 });

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -228,6 +228,20 @@ describe("validateSessionConfig", () => {
 		).toThrowError(SessionConfigValidationError);
 	});
 
+	// PR #213 round 3 NIT: `git@host:/abs/path` is an absolute-path
+	// SSH clone target. Against a self-hosted intranet Git server
+	// reachable from the container network, this is an SSRF widener
+	// the regex previously accepted. Standard SCP-form URLs use a
+	// relative path after the colon.
+	it("rejects SSH URLs with leading '/' in the path component", () => {
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "git@github.com:/etc/passwd", auth: "ssh" },
+				auth: { ssh: { privateKey: "k", knownHosts: "default" } },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
 	it("accepts https:// repo URLs", () => {
 		expect(
 			validateSessionConfig({
@@ -299,6 +313,34 @@ describe("validateSessionConfig", () => {
 			validateSessionConfig({
 				repo: { url: "https://example.com/r", auth: "none" },
 				auth: { pat: "ghp_orphan" },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
+	// PR #213 round 3 NIT: `repo.auth='pat'` with a co-present
+	// `auth.ssh` (or vice versa) would persist a stale credential
+	// the runner never uses. Reject so the operator gets a clear
+	// error instead of an undiagnosable encrypted blob.
+	it("rejects co-present auth.ssh when repo.auth='pat'", () => {
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "https://example.com/r", auth: "pat" },
+				auth: {
+					pat: "ghp_x",
+					ssh: { privateKey: "k", knownHosts: "default" },
+				},
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
+	it("rejects co-present auth.pat when repo.auth='ssh'", () => {
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "git@github.com:o/p", auth: "ssh" },
+				auth: {
+					pat: "ghp_x",
+					ssh: { privateKey: "k", knownHosts: "default" },
+				},
 			}),
 		).toThrowError(SessionConfigValidationError);
 	});
@@ -657,6 +699,39 @@ describe("getSessionConfig", () => {
 		// no auth field, and the runtime invariant on `RepoSpec` requires
 		// it to be set (PR #213 round 2 NIT).
 		expect(got?.repo).toEqual({ url: "https://example.com/r", ref: "main", auth: "none" });
+	});
+
+	// PR #213 round 3 NIT: `parseRepoColumn` blind-cast a single-object
+	// row even when it lacked the now-required `auth` field. Direct D1
+	// writes (e.g. incident response) are the realistic source of such
+	// rows. The runner would read `repo.auth: undefined` and silently
+	// fall through every credential branch. Drop with a logger.warn.
+	it("drops single-object repos_json missing the required 'auth' field", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [
+				{
+					session_id: "sess-repo-noauth",
+					workspace_strategy: null,
+					cpu_limit: null,
+					mem_limit: null,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					// Single-object shape but missing `auth` — could
+					// happen via direct D1 write or a partial-edit code
+					// path that doesn't go through validateSessionConfig.
+					repos_json: JSON.stringify({ url: "https://example.com/r" }),
+					ports_json: null,
+					env_vars_json: null,
+					auth_json: null,
+					bootstrapped_at: null,
+				},
+			],
+			success: true as const,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const got = await getSessionConfig("sess-repo-noauth");
+		expect(got?.repo).toBeUndefined();
 	});
 
 	it("rehydrates auth_json with encrypted blobs intact", async () => {

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -653,7 +653,10 @@ describe("getSessionConfig", () => {
 		const got = await getSessionConfig("sess-legacy-repo");
 		// First element wins; second is silently dropped (was a
 		// placeholder shape that never populated in production).
-		expect(got?.repo).toEqual({ url: "https://example.com/r", ref: "main" });
+		// `auth: "none"` is defaulted on promotion — pre-#188 rows had
+		// no auth field, and the runtime invariant on `RepoSpec` requires
+		// it to be set (PR #213 round 2 NIT).
+		expect(got?.repo).toEqual({ url: "https://example.com/r", ref: "main", auth: "none" });
 	});
 
 	it("rehydrates auth_json with encrypted blobs intact", async () => {

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -119,7 +119,13 @@ const MAX_ENV_NAME_LEN = 256;
 // invariant uniform across `repo.url` / `repo.ref` / `repo.target`
 // so the 188c author doesn't trip over an asymmetric foot-gun.
 const REPO_URL_HTTPS = /^https:\/\/[^@\s]+$/;
-const REPO_URL_SSH = /^git@[A-Za-z0-9.-]+:[A-Za-z0-9._/-]+$/;
+// First path char must be alphanumeric / `.` / `_` so `git@host:/etc/passwd`
+// (an absolute-path SSH clone target) doesn't slip through. Standard SCP-form
+// SSH URLs use a relative path after the colon — `git@github.com:owner/repo`
+// — and a leading `/` widens the SSRF surface against self-hosted intranet
+// Git servers reachable from the container network. Mirrors the
+// alphanumeric-leading rule already on `REPO_TARGET_PATTERN`. PR #213 round 3.
+const REPO_URL_SSH = /^git@[A-Za-z0-9.-]+:[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
 // Refnames: branches, tags, raw SHAs. Allow the standard refname
 // charset (per `git check-ref-format`) plus `/` for nested branches.
 // Reject `..` and leading `-` so the value can never be misinterpreted
@@ -537,6 +543,17 @@ export function validateSessionConfig(raw: unknown): SessionConfig | undefined {
 					"config.auth.pat: required when config.repo.auth is 'pat'",
 				);
 			}
+			// Reject a co-present SSH credential. Without this, the
+			// route encrypts and persists the SSH key into `auth_json`
+			// even though the runner ignores it, leaving a stale blob
+			// no operator can reason about post-rotation (PR #213
+			// round 3 NIT).
+			if (authBlob.ssh !== undefined) {
+				throw new SessionConfigValidationError(
+					"config.auth.ssh",
+					"config.auth.ssh: not valid when config.repo.auth is 'pat'",
+				);
+			}
 		} else if (repo.auth === "ssh") {
 			if (!isSsh) {
 				throw new SessionConfigValidationError(
@@ -548,6 +565,15 @@ export function validateSessionConfig(raw: unknown): SessionConfig | undefined {
 				throw new SessionConfigValidationError(
 					"config.auth.ssh",
 					"config.auth.ssh: required when config.repo.auth is 'ssh'",
+				);
+			}
+			// Mirror the `pat` branch: stale unused-credential blobs
+			// in D1 are credential confusion, not a security issue,
+			// but expensive to diagnose later (PR #213 round 3 NIT).
+			if (authBlob.pat !== undefined) {
+				throw new SessionConfigValidationError(
+					"config.auth.pat",
+					"config.auth.pat: not valid when config.repo.auth is 'ssh'",
 				);
 			}
 		}
@@ -943,6 +969,19 @@ function parseRepoColumn(sessionId: string, raw: string | null): SessionConfig["
 		return undefined;
 	}
 	if (typeof parsed === "object") {
+		// Defence-in-depth against a row written outside `persistSessionConfig`
+		// (direct D1 write during incident response, future code path that
+		// constructs the object partially). The legacy-array branch above
+		// already drops malformed rows with a `logger.warn`; the post-#188
+		// single-object branch should hold the same line. `auth` is the
+		// only field required by the new schema, so its presence is the
+		// minimal structural check (PR #213 round 3 NIT).
+		if (!("auth" in (parsed as object))) {
+			logger.warn(
+				`[sessionConfig] repos_json for session ${sessionId} missing required 'auth' field; dropping`,
+			);
+			return undefined;
+		}
 		return parsed as SessionConfig["repo"];
 	}
 	logger.warn(

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -101,7 +101,24 @@ const MAX_ENV_NAME_LEN = 256;
 // auth↔scheme pairing — a `git@…` URL with `auth: "none"` would clone
 // over a missing identity and fail mysteriously inside the container;
 // we reject it at the route boundary instead.
-const REPO_URL_HTTPS = /^https:\/\/[^\s]+$/;
+//
+// `[^@\s]` in REPO_URL_HTTPS is the round-1 SHOULD-FIX. Without it the
+// regex accepted `https://user:ghp_TOKEN@github.com/o/p`, which would
+// store the PAT verbatim in `repos_json` (the whole point of
+// `auth_json` / `encryptAuthCredentials` is that secrets never land
+// in plaintext anywhere on disk). The form forces credentials through
+// `auth.pat` instead, where the route encrypts before persist. The
+// SSH form's regex deliberately starts with the `git@` user prefix
+// — that's the canonical SSH-clone shape, not a credential — and
+// the host/path char class on the other side excludes `@` already.
+//
+// `..` in either side is rejected by the explicit `.includes("..")`
+// check below; the regex alone allows it because `.` and `/` are
+// valid path chars. The runner in 188c will pass the URL to `git
+// clone` via argv (no shell), but blocking `..` here keeps the
+// invariant uniform across `repo.url` / `repo.ref` / `repo.target`
+// so the 188c author doesn't trip over an asymmetric foot-gun.
+const REPO_URL_HTTPS = /^https:\/\/[^@\s]+$/;
 const REPO_URL_SSH = /^git@[A-Za-z0-9.-]+:[A-Za-z0-9._/-]+$/;
 // Refnames: branches, tags, raw SHAs. Allow the standard refname
 // charset (per `git check-ref-format`) plus `/` for nested branches.
@@ -123,6 +140,16 @@ const RepoSpec = z
 			.max(500)
 			.refine((u) => REPO_URL_HTTPS.test(u) || REPO_URL_SSH.test(u), {
 				message: "url must be https://… or git@host:path form",
+			})
+			// Belt-and-suspenders against `..` in either URL form. The
+			// HTTPS regex blocks `@` (creds-in-URL); the SSH path char
+			// class allows `.` and `/` (so `git@host:org/../etc` would
+			// otherwise pass shape validation). Argv-only invocation by
+			// the runner means this isn't a local RCE concern, but the
+			// uniform `..` rejection across url/ref/target keeps the
+			// invariant readable for the 188c author.
+			.refine((u) => !u.includes(".."), {
+				message: "url must not contain '..'",
 			}),
 		// Empty `""` = remote HEAD (no `--branch` flag). Non-empty is
 		// validated against the refname allowlist below. Stored as the
@@ -672,7 +699,14 @@ export function redactStoredAuth(stored: AuthStored | undefined): AuthPublic | u
 	if (stored.ssh !== undefined) {
 		out.ssh = { isSet: true, knownHosts: stored.ssh.knownHosts };
 	}
-	return out;
+	// Mirror `parseAuthColumn`: an `AuthStored` with neither field set
+	// collapses to undefined so listing-endpoint callers can rely on
+	// `auth !== undefined` as the "are credentials configured?"
+	// predicate (PR #213 round 1 NIT). `parseAuthColumn` already drops
+	// rows that come back as `{}`, but a future code path that
+	// constructs an `AuthStored` directly (e.g. a partial-edit endpoint)
+	// would otherwise leak `{}` here.
+	return out.pat === undefined && out.ssh === undefined ? undefined : out;
 }
 
 /**

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -39,8 +39,19 @@ const MAX_IDLE_TTL_S = 30 * 24 * 60 * 60; // 30 days
 // Cap repeating sub-records so a single create can't write a multi-MB
 // JSON blob into D1. Children may lower these when their forms cap by
 // product UX.
-const MAX_REPOS = 10;
 const MAX_PORTS = 20;
+// #188 — repo + auth bounds. Refs are git refnames (branch, tag, or
+// raw SHA). 200 chars covers any realistic name (Git itself imposes a
+// 255-byte filename cap on packed refs). Target is a workspace-
+// relative path; 256 chars matches the env-var name cap shape.
+// known_hosts is bundled-or-paste; 32 KiB lets a paranoid operator
+// drop in a corp-wide trust list without becoming a DoS surface.
+const MAX_REPO_REF_LEN = 200;
+const MAX_REPO_TARGET_LEN = 256;
+const MAX_REPO_DEPTH = 10_000;
+const MAX_PAT_LEN = 4 * 1024;
+const MAX_SSH_KEY_LEN = 16 * 1024;
+const MAX_KNOWN_HOSTS_LEN = 32 * 1024;
 // #186 env-var entry caps. Per-entry value at 16 KiB matches the
 // spec; aggregate budget below caps the whole serialised list so a
 // caller can't blow past D1-friendly sizes by stuffing 64 entries at
@@ -58,17 +69,17 @@ const MAX_ENV_NAME_LEN = 256;
 
 // ── Zod schemas ─────────────────────────────────────────────────────────────
 
-// Minimal placeholder for #188. Just shape today: the URL / ref pair.
-// Auth method, replace-workspace flag, etc. land with the repo-clone child.
-//
-// URL scheme allowlist is enforced at INGEST so a stored value can never
-// reach the #188 git-clone consumer with a problematic scheme:
+// #188 — repo specification. URL scheme allowlist is enforced at INGEST
+// so a stored value can never reach the git-clone consumer with a
+// problematic scheme:
 //   - `file://`              clone from arbitrary host paths (incl. the
-//                            bind-mounted workspace)
-//   - `ssh://attacker/`      SSRF / host-key confusion
+//                            bind-mounted workspace).
+//   - `ssh://attacker/`      SSRF / host-key confusion. The SSH auth
+//                            path uses the conventional `git@host:path`
+//                            URL form instead, NOT `ssh://`.
 //   - `git://attacker:9418/` unauthenticated git protocol; same SSRF
 //                            shape as ssh, GitHub deprecated/removed
-//                            support in 2021
+//                            support in 2021.
 //   - `http://`              cleartext: a MITM (corporate proxy, captive
 //                            portal, hostile WiFi) can inject repo
 //                            content which then executes inside the
@@ -82,22 +93,104 @@ const MAX_ENV_NAME_LEN = 256;
 // them. If a future deployment needs cleartext intranet mirrors, #188
 // can add an opt-in form affordance with a UI warning instead of
 // silently storing the URL.
-const REPO_URL_SCHEME = /^https:\/\//;
+//
+// Two URL forms are allowed:
+//   - `https://host/owner/repo[.git]`        — for `auth: "none"|"pat"`
+//   - `git@host:owner/repo[.git]`            — for `auth: "ssh"`
+// Cross-field validation in `validateSessionConfig` enforces the
+// auth↔scheme pairing — a `git@…` URL with `auth: "none"` would clone
+// over a missing identity and fail mysteriously inside the container;
+// we reject it at the route boundary instead.
+const REPO_URL_HTTPS = /^https:\/\/[^\s]+$/;
+const REPO_URL_SSH = /^git@[A-Za-z0-9.-]+:[A-Za-z0-9._/-]+$/;
+// Refnames: branches, tags, raw SHAs. Allow the standard refname
+// charset (per `git check-ref-format`) plus `/` for nested branches.
+// Reject `..` and leading `-` so the value can never be misinterpreted
+// as a `git clone` flag (e.g. `--upload-pack=…`) when the runner in
+// 188c shells out. The runner will pass `--branch <ref>` via argv (no
+// shell), but this is the cheap, declarative belt-and-suspenders.
+const REPO_REF_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._/+@-]*$/;
+// Target: workspace-relative path. Empty string = workspace root
+// (signals replace-workspace mode for 188c). Non-empty must be a
+// relative path with no `..` traversal segments and no leading `/`.
+// Same conservative charset as refnames, no spaces.
+const REPO_TARGET_PATTERN = /^(|[A-Za-z0-9_][A-Za-z0-9._/-]*)$/;
 const RepoSpec = z
 	.object({
 		url: z
 			.string()
 			.min(1)
 			.max(500)
-			.refine((u) => REPO_URL_SCHEME.test(u), {
-				message: "url must use https:// scheme",
+			.refine((u) => REPO_URL_HTTPS.test(u) || REPO_URL_SSH.test(u), {
+				message: "url must be https://… or git@host:path form",
 			}),
-		// `.min(1)` matches the postCreateCmd/postStartCmd rule: a stored
-		// empty string is indistinguishable from "no ref supplied" once
-		// it lands in D1, so refusing it at ingest lets the #188 git-
-		// clone consumer use a presence-only check instead of also
-		// defending against `git clone --branch ""`.
-		ref: z.string().min(1).max(200).optional(),
+		// Empty `""` = remote HEAD (no `--branch` flag). Non-empty is
+		// validated against the refname allowlist below. Stored as the
+		// literal user input; the runner decides whether to pass
+		// `--branch`.
+		ref: z
+			.string()
+			.max(MAX_REPO_REF_LEN)
+			.refine((r) => r === "" || (REPO_REF_PATTERN.test(r) && !r.includes("..")), {
+				message: "ref must match refname rules and not contain '..'",
+			})
+			.optional(),
+		// Empty `""` = workspace root (replace-workspace mode). Non-empty
+		// is a relative subpath validated below.
+		target: z
+			.string()
+			.max(MAX_REPO_TARGET_LEN)
+			.refine(
+				(t) =>
+					REPO_TARGET_PATTERN.test(t) &&
+					!t.includes("..") &&
+					!t.includes("//") &&
+					!t.startsWith("/"),
+				{
+					message:
+						"target must be empty or a workspace-relative path (no '..', no leading '/', no '//')",
+				},
+			)
+			.optional(),
+		// `"none"` = anonymous clone (must be https://). `"pat"` = HTTPS
+		// with a personal access token from `auth.pat`. `"ssh"` = SSH
+		// with private key + known_hosts from `auth.ssh`. Cross-field
+		// requirements enforced in `validateSessionConfig`.
+		auth: z.enum(["none", "pat", "ssh"]),
+		// Shallow clone depth. `null`/omitted = full history. Capped at
+		// MAX_REPO_DEPTH so a typo can't request a depth value that
+		// becomes effectively infinite in the runner.
+		depth: z.number().int().min(1).max(MAX_REPO_DEPTH).nullable().optional(),
+	})
+	.strict();
+// #188 — credential blob. Wire shape carries plaintext from the form;
+// the route encrypts before persistence (same boundary as envVars).
+// Fields are independently optional — a config with `auth.pat` set
+// but no `auth.ssh` (and vice-versa) is valid and common. The
+// cross-field check in `validateSessionConfig` requires the right
+// blob to be present given `repo.auth`.
+const KNOWN_HOSTS_DEFAULT_SENTINEL = "default";
+const WireAuthSpec = z
+	.object({
+		// PAT plaintext. AES-256-GCM encrypted before the row hits D1;
+		// the storage shape replaces this string with `{ ciphertext, iv,
+		// tag }` (see `encryptAuthCredentials`). 4 KiB ceiling is
+		// generous: GitHub fine-grained PATs are ~93 chars, classic ~40,
+		// GitLab/Bitbucket similar.
+		pat: z.string().min(1).max(MAX_PAT_LEN).optional(),
+		// SSH credentials: private key (encrypted at persistence) +
+		// known_hosts. `knownHosts === "default"` is a sentinel that
+		// 188d's runner will resolve to the bundled github/gitlab/
+		// bitbucket fingerprints; any other value is treated as a
+		// custom paste and stored verbatim (it's public information,
+		// no need to encrypt).
+		ssh: z
+			.object({
+				privateKey: z.string().min(1).max(MAX_SSH_KEY_LEN),
+				knownHosts: z.string().min(1).max(MAX_KNOWN_HOSTS_LEN),
+			})
+			.strict()
+			.optional(),
 	})
 	.strict();
 
@@ -183,9 +276,16 @@ export type EnvVarEntryPublic =
  */
 export const SessionConfigSchema = z
 	.object({
-		// #188 — populated by the repo-clone form
+		// #188 — populated by the repo-clone form. Single-repo today
+		// (multi-repo is deferred to #197). `repo: null` is wire-
+		// compatible with omitting the field entirely; both rehydrate
+		// to `undefined` and the bootstrap runner skips the clone step.
 		workspaceStrategy: z.enum(["preserve", "clone"]).optional(),
-		repos: z.array(RepoSpec).max(MAX_REPOS).optional(),
+		repo: RepoSpec.nullable().optional(),
+		// Credential blob for `repo.auth` ∈ {pat, ssh}. Omitted entirely
+		// for `auth: "none"`. The route encrypts before persistence —
+		// plaintext is in scope only inside the request handler.
+		auth: WireAuthSpec.optional(),
 		// #194 — populated by the resources form
 		cpuLimit: z.number().int().positive().max(MAX_CPU_NANO).optional(),
 		memLimit: z.number().int().positive().max(MAX_MEM_BYTES).optional(),
@@ -209,6 +309,32 @@ export const SessionConfigSchema = z
 	.strict();
 
 export type SessionConfig = z.infer<typeof SessionConfigSchema>;
+export type RepoSpecInput = z.infer<typeof RepoSpec>;
+export type AuthInput = z.infer<typeof WireAuthSpec>;
+
+/** Storage shape for the `auth` blob — same `{ ciphertext, iv, tag }`
+ *  envelope as encrypted env-var entries. Mirrors the wire shape's
+ *  optional fields exactly: `pat` is replaced by an envelope; `ssh`'s
+ *  private key is replaced by an envelope but `knownHosts` (public
+ *  information) stays plaintext. */
+export type AuthStored = {
+	pat?: { ciphertext: string; iv: string; tag: string };
+	ssh?: {
+		privateKey: { ciphertext: string; iv: string; tag: string };
+		knownHosts: string;
+	};
+};
+/** Public/redacted `auth` for listing endpoints — collapses any
+ *  encrypted credential to `{ isSet: true }`. `knownHosts` stays
+ *  visible (it's public). */
+export type AuthPublic = {
+	pat?: { isSet: true };
+	ssh?: { isSet: true; knownHosts: string };
+};
+/** Sentinel known_hosts value resolved by 188d's runner to the
+ *  bundled fingerprints. Exported so the runner and the frontend can
+ *  agree without copying the literal string. */
+export const KNOWN_HOSTS_DEFAULT = KNOWN_HOSTS_DEFAULT_SENTINEL;
 
 /**
  * Domain shape returned by `getSessionConfig`. Mirrors the schema above
@@ -216,13 +342,17 @@ export type SessionConfig = z.infer<typeof SessionConfigSchema>;
  * (PR 185b) writes once postCreate has succeeded — exposed here so the
  * runner can read it without going back through `d1Query` directly.
  */
-export interface SessionConfigRecord extends Omit<SessionConfig, "envVars"> {
+export interface SessionConfigRecord extends Omit<SessionConfig, "envVars" | "auth"> {
 	sessionId: string;
 	bootstrappedAt: Date | null;
 	// Storage-shape env vars: `secret` rows carry ciphertext + iv +
 	// tag (no plaintext value). DockerManager.spawn decrypts via
 	// `decryptStoredEntries` before handing them to `docker run`.
 	envVars?: EnvVarEntryStored[];
+	// Storage-shape auth credentials: `pat` and `ssh.privateKey` are
+	// encrypted envelopes. The 188c+ clone runner decrypts at use
+	// site via `decryptStoredAuth`.
+	auth?: AuthStored;
 }
 
 // ── Validation helper ──────────────────────────────────────────────────────
@@ -335,6 +465,77 @@ export function validateSessionConfig(raw: unknown): SessionConfig | undefined {
 			);
 		}
 	}
+	// #188 — repo↔auth cross-field consistency. Zod can't express these
+	// in a clean way (the `auth` blob is a sibling of `repo`, not nested
+	// inside it), so they're enforced here:
+	//   - `repo.auth: "pat"` ⇒ url MUST be https://, `auth.pat` MUST be set.
+	//     A `git@…` URL with PAT auth would fail mysteriously inside the
+	//     container; reject at the route boundary instead.
+	//   - `repo.auth: "ssh"` ⇒ url MUST be the `git@host:path` form,
+	//     `auth.ssh` MUST be set. The runner relies on the URL form to
+	//     pick the right `git clone` invocation.
+	//   - `repo.auth: "none"` ⇒ url MUST be https://. No credentials
+	//     allowed in `auth` for an anonymous clone — silently dropping
+	//     orphan credentials would leave the operator confused about
+	//     where their token "went".
+	// `repo === null` / undefined: skip — empty `auth` already meaningless.
+	if (result.data.repo) {
+		const repo = result.data.repo;
+		const authBlob = result.data.auth ?? {};
+		const isHttps = REPO_URL_HTTPS.test(repo.url);
+		const isSsh = REPO_URL_SSH.test(repo.url);
+		if (repo.auth === "none") {
+			if (!isHttps) {
+				throw new SessionConfigValidationError(
+					"config.repo.url",
+					"config.repo.url: anonymous clone requires an https:// URL",
+				);
+			}
+			if (authBlob.pat !== undefined || authBlob.ssh !== undefined) {
+				throw new SessionConfigValidationError(
+					"config.auth",
+					"config.auth: credentials must not be set when config.repo.auth is 'none'",
+				);
+			}
+		} else if (repo.auth === "pat") {
+			if (!isHttps) {
+				throw new SessionConfigValidationError(
+					"config.repo.url",
+					"config.repo.url: PAT auth requires an https:// URL",
+				);
+			}
+			if (authBlob.pat === undefined) {
+				throw new SessionConfigValidationError(
+					"config.auth.pat",
+					"config.auth.pat: required when config.repo.auth is 'pat'",
+				);
+			}
+		} else if (repo.auth === "ssh") {
+			if (!isSsh) {
+				throw new SessionConfigValidationError(
+					"config.repo.url",
+					"config.repo.url: SSH auth requires a git@host:path URL",
+				);
+			}
+			if (authBlob.ssh === undefined) {
+				throw new SessionConfigValidationError(
+					"config.auth.ssh",
+					"config.auth.ssh: required when config.repo.auth is 'ssh'",
+				);
+			}
+		}
+	} else if (result.data.auth !== undefined) {
+		// Orphan `auth` block with no `repo`. Same disposition as the
+		// `auth: "none"` + creds case — refuse rather than silently
+		// drop, so the operator gets a clear error message.
+		const a = result.data.auth;
+		if (a.pat !== undefined || a.ssh !== undefined) {
+			throw new SessionConfigValidationError(
+				"config.auth",
+				"config.auth: credentials require config.repo to be set",
+			);
+		}
+	}
 	return result.data;
 }
 
@@ -408,6 +609,73 @@ export function decryptStoredEntries(entries: EnvVarEntryStored[]): Record<strin
 }
 
 /**
+ * Encrypt the wire-shape `auth` blob into the storage shape the
+ * `session_configs.auth_json` column persists. Mirrors the env-vars
+ * pattern: plaintext credentials are in scope only inside the request
+ * handler. Returns `undefined` when the input has no credentials at
+ * all so the column collapses to NULL via `jsonOrNull`.
+ *
+ * `ssh.knownHosts` is NOT encrypted — known_hosts entries are public
+ * keys (the bundled-or-pasted equivalent of a published TLS root cert);
+ * encrypting them would be wasted CPU and would force the runner to
+ * decrypt before it knows whether to use the bundled defaults.
+ */
+export function encryptAuthCredentials(auth: AuthInput | undefined): AuthStored | undefined {
+	if (auth === undefined) return undefined;
+	if (auth.pat === undefined && auth.ssh === undefined) return undefined;
+	const out: AuthStored = {};
+	if (auth.pat !== undefined) {
+		out.pat = encryptSecret(auth.pat);
+	}
+	if (auth.ssh !== undefined) {
+		const keyBlob = encryptSecret(auth.ssh.privateKey);
+		out.ssh = {
+			privateKey: keyBlob,
+			knownHosts: auth.ssh.knownHosts,
+		};
+	}
+	return out;
+}
+
+/**
+ * Decrypt a stored auth blob into a wire-shape value the 188c+ clone
+ * runner can hand to `git clone`. `decryptSecret` throws on tag
+ * mismatch (tampered ciphertext, wrong key after rotation, D1
+ * corruption) — clone fails loudly rather than running with an empty
+ * credential string, which would silently fall back to anonymous and
+ * either leak the URL or 404 on a private repo.
+ */
+export function decryptStoredAuth(stored: AuthStored): AuthInput {
+	const out: AuthInput = {};
+	if (stored.pat !== undefined) {
+		out.pat = decryptSecret(stored.pat);
+	}
+	if (stored.ssh !== undefined) {
+		out.ssh = {
+			privateKey: decryptSecret(stored.ssh.privateKey),
+			knownHosts: stored.ssh.knownHosts,
+		};
+	}
+	return out;
+}
+
+/**
+ * Redact stored auth credentials for listing endpoints. Encrypted
+ * blobs collapse to `{ isSet: true }`; `knownHosts` (public) stays
+ * visible so a client showing the Repo tab can still display "using
+ * default known_hosts" vs "custom paste".
+ */
+export function redactStoredAuth(stored: AuthStored | undefined): AuthPublic | undefined {
+	if (stored === undefined) return undefined;
+	const out: AuthPublic = {};
+	if (stored.pat !== undefined) out.pat = { isSet: true };
+	if (stored.ssh !== undefined) {
+		out.ssh = { isSet: true, knownHosts: stored.ssh.knownHosts };
+	}
+	return out;
+}
+
+/**
  * Redact stored entries for listing endpoints. Plain entries pass
  * through; secret entries collapse to `{ name, type, isSet: true }`
  * so neither plaintext nor ciphertext leaks via `GET /api/sessions/:id`
@@ -435,6 +703,7 @@ interface SessionConfigRow {
 	repos_json: string | null;
 	ports_json: string | null;
 	env_vars_json: string | null;
+	auth_json: string | null;
 	bootstrapped_at: string | null;
 }
 
@@ -450,9 +719,10 @@ function rowToRecord(row: SessionConfigRow): SessionConfigRecord {
 		idleTtlSeconds: row.idle_ttl_seconds ?? undefined,
 		postCreateCmd: row.post_create_cmd ?? undefined,
 		postStartCmd: row.post_start_cmd ?? undefined,
-		repos: parseJsonColumn<SessionConfig["repos"]>(row.session_id, "repos_json", row.repos_json),
+		repo: parseRepoColumn(row.session_id, row.repos_json),
 		ports: parseJsonColumn<SessionConfig["ports"]>(row.session_id, "ports_json", row.ports_json),
 		envVars: parseEnvVarsColumn(row.session_id, row.env_vars_json),
+		auth: parseAuthColumn(row.session_id, row.auth_json),
 		bootstrappedAt: row.bootstrapped_at ? parseD1Utc(row.bootstrapped_at) : null,
 	};
 }
@@ -469,8 +739,17 @@ function rowToRecord(row: SessionConfigRow): SessionConfigRecord {
  * broken"). Degrade to `undefined` + a loud `logger.warn` so the rest of the
  * row stays usable and the operator sees the inconsistency.
  */
-function parseJsonColumn<T>(sessionId: string, column: string, raw: string | null): T | undefined {
-	if (raw === null) return undefined;
+function parseJsonColumn<T>(
+	sessionId: string,
+	column: string,
+	raw: string | null | undefined,
+): T | undefined {
+	// `undefined` shows up in tests whose mock rows omit a newly-added
+	// column (e.g. pre-#188 fixtures that don't set `auth_json`). Treat
+	// it the same as null — "column is absent" — rather than crashing
+	// the read with a `JSON.parse(undefined)` SyntaxError. Production
+	// rows always have the column after the ALTER TABLE migration runs.
+	if (raw === null || raw === undefined) return undefined;
 	try {
 		return JSON.parse(raw) as T;
 	} catch (err) {
@@ -585,6 +864,103 @@ function parseEnvVarsColumn(
 	return undefined;
 }
 
+/**
+ * Backward-compat repo-column rehydrator. The `repos_json` column was
+ * introduced in PR #205 (185a) for an array shape `[{url, ref?}, …]`
+ * but never populated by any frontend (no Repo tab UI shipped). #188
+ * narrows the data model to a single repo (multi-repo deferred to
+ * #197). Three shapes can be in the column at read time:
+ *
+ *   - `null`                          — no repo configured (common).
+ *   - `{url, ref?, target?, …}`       — current single-object shape.
+ *   - `[{url, ref?}, …]`              — legacy array placeholder. Take
+ *                                       the first element if it
+ *                                       conforms; otherwise drop.
+ *
+ * The single-object shape is NOT re-validated by Zod here — the row
+ * was written by `persistSessionConfig` after the route ran
+ * `validateSessionConfig`, so any object that landed in the column
+ * already passed validation at that time. A future schema tightening
+ * that invalidates an old row should ride a migration, not a silent
+ * read-side reject.
+ */
+function parseRepoColumn(sessionId: string, raw: string | null): SessionConfig["repo"] | undefined {
+	const parsed = parseJsonColumn<unknown>(sessionId, "repos_json", raw);
+	if (parsed === undefined || parsed === null) return undefined;
+	if (Array.isArray(parsed)) {
+		// Legacy array shape. The placeholder allowed multiple repos
+		// but no production data exercises it; promote first element
+		// or drop. Defensive: a non-object element should not crash.
+		const first = parsed[0];
+		if (first && typeof first === "object") {
+			return first as SessionConfig["repo"];
+		}
+		logger.warn(
+			`[sessionConfig] legacy repos_json array for session ${sessionId} has no usable first element; dropping`,
+		);
+		return undefined;
+	}
+	if (typeof parsed === "object") {
+		return parsed as SessionConfig["repo"];
+	}
+	logger.warn(
+		`[sessionConfig] repos_json for session ${sessionId} parsed to non-array, non-object value; skipping`,
+	);
+	return undefined;
+}
+
+/**
+ * Rehydrator for `auth_json`. Same defensive structural validation as
+ * `parseEnvVarsColumn`: a write-capable D1 attacker who could tamper
+ * with this column otherwise feeds garbage straight into
+ * `decryptSecret`, which would throw on every spawn (effective DoS for
+ * the session). Drop malformed entries with a logger warning instead.
+ */
+function parseAuthColumn(sessionId: string, raw: string | null): AuthStored | undefined {
+	const parsed = parseJsonColumn<unknown>(sessionId, "auth_json", raw);
+	if (parsed === undefined || parsed === null) return undefined;
+	if (typeof parsed !== "object") {
+		logger.warn(`[sessionConfig] auth_json for session ${sessionId} is not an object; skipping`);
+		return undefined;
+	}
+	const obj = parsed as { pat?: unknown; ssh?: unknown };
+	const out: AuthStored = {};
+	if (obj.pat !== undefined) {
+		if (isEncryptedBlob(obj.pat)) {
+			out.pat = obj.pat;
+		} else {
+			logger.warn(
+				`[sessionConfig] auth_json.pat for session ${sessionId} has wrong shape; dropping`,
+			);
+		}
+	}
+	if (obj.ssh !== undefined) {
+		const ssh = obj.ssh as { privateKey?: unknown; knownHosts?: unknown };
+		if (
+			ssh !== null &&
+			typeof ssh === "object" &&
+			isEncryptedBlob(ssh.privateKey) &&
+			typeof ssh.knownHosts === "string"
+		) {
+			out.ssh = {
+				privateKey: ssh.privateKey,
+				knownHosts: ssh.knownHosts,
+			};
+		} else {
+			logger.warn(
+				`[sessionConfig] auth_json.ssh for session ${sessionId} has wrong shape; dropping`,
+			);
+		}
+	}
+	return out.pat === undefined && out.ssh === undefined ? undefined : out;
+}
+
+function isEncryptedBlob(v: unknown): v is { ciphertext: string; iv: string; tag: string } {
+	if (v === null || typeof v !== "object") return false;
+	const o = v as { ciphertext?: unknown; iv?: unknown; tag?: unknown };
+	return typeof o.ciphertext === "string" && typeof o.iv === "string" && typeof o.tag === "string";
+}
+
 // Mirrors sessionManager.parseD1UtcTimestamp — D1's `datetime('now')` lacks
 // any timezone suffix and Node's Date treats suffix-less ISO strings as
 // LOCAL time. Append 'Z' unless the value already carries one (a future
@@ -604,8 +980,9 @@ function parseD1Utc(raw: string): Date {
  * is the only place plaintext lives. Callers MUST run `validateSessionConfig`
  * + `encryptSecretEntries` first; this module's serializer trusts both.
  */
-export type PersistableSessionConfig = Omit<SessionConfig, "envVars"> & {
+export type PersistableSessionConfig = Omit<SessionConfig, "envVars" | "auth"> & {
 	envVars?: EnvVarEntryStored[];
+	auth?: AuthStored;
 };
 
 /**
@@ -628,8 +1005,8 @@ export async function persistSessionConfig(
 		`INSERT INTO session_configs
                         (session_id, workspace_strategy, cpu_limit, mem_limit,
                          idle_ttl_seconds, post_create_cmd, post_start_cmd,
-                         repos_json, ports_json, env_vars_json)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         repos_json, ports_json, env_vars_json, auth_json)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON CONFLICT(session_id) DO UPDATE SET
                         workspace_strategy = excluded.workspace_strategy,
                         cpu_limit          = excluded.cpu_limit,
@@ -639,7 +1016,8 @@ export async function persistSessionConfig(
                         post_start_cmd     = excluded.post_start_cmd,
                         repos_json         = excluded.repos_json,
                         ports_json         = excluded.ports_json,
-                        env_vars_json      = excluded.env_vars_json`,
+                        env_vars_json      = excluded.env_vars_json,
+                        auth_json          = excluded.auth_json`,
 		[
 			sessionId,
 			config.workspaceStrategy ?? null,
@@ -653,9 +1031,14 @@ export async function persistSessionConfig(
 			// rehydrate them as undefined anyway, and PR 185b's runner
 			// uses `IS NOT NULL` semantics on these columns to decide
 			// whether the corresponding feature was configured.
-			jsonOrNull(config.repos),
+			//
+			// `repo` lands in the `repos_json` column (singular value in
+			// a column whose name pre-dates #188's data-model narrowing
+			// from array to single — column kept to avoid a migration).
+			jsonOrNull(config.repo),
 			jsonOrNull(config.ports),
 			jsonOrNull(config.envVars),
+			jsonOrNull(config.auth),
 		],
 	);
 }

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -943,6 +943,17 @@ function parseEnvVarsColumn(
  * already passed validation at that time. A future schema tightening
  * that invalidates an old row should ride a migration, not a silent
  * read-side reject.
+ *
+ * The `auth` presence check below is the only structural guard. It is
+ * deliberately MINIMAL — sufficient for 188c's branching to find a
+ * valid enum value, NOT sufficient to vouch for `url` / `target` /
+ * `ref` having survived the wire-path schema (a row injected by a
+ * direct D1 write or a partial-edit code path could carry e.g. a
+ * `file://` URL that the route would have rejected). Treat the shape
+ * returned here as "well-typed enough for the runner's switch
+ * statement"; do not pass `repo.url` to `git clone` without
+ * re-validating against `RepoSpec` if you are touching this on a path
+ * that bypasses `validateSessionConfig`. PR #213 round 4 NIT.
  */
 function parseRepoColumn(sessionId: string, raw: string | null): SessionConfig["repo"] | undefined {
 	const parsed = parseJsonColumn<unknown>(sessionId, "repos_json", raw);

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -927,7 +927,15 @@ function parseRepoColumn(sessionId: string, raw: string | null): SessionConfig["
 		// or drop. Defensive: a non-object element should not crash.
 		const first = parsed[0];
 		if (first && typeof first === "object") {
-			return first as SessionConfig["repo"];
+			// Default `auth: "none"` so the post-#188 RepoSpec invariant
+			// (auth is required) holds at runtime, not just at the
+			// type-checker layer. The legacy placeholder predates the
+			// auth field; the only URL form the old allowlist accepted
+			// was `https://` with no credentials, so `"none"` is the
+			// semantically correct default. Spread order lets a future
+			// migration that backfills `auth` win without further code
+			// changes (PR #213 round 2 NIT).
+			return { auth: "none", ...first } as SessionConfig["repo"];
 		}
 		logger.warn(
 			`[sessionConfig] legacy repos_json array for session ${sessionId} has no usable first element; dropping`,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -172,7 +172,20 @@ export interface SessionConfigPayload {
 	idleTtlSeconds?: number;
 	postCreateCmd?: string;
 	postStartCmd?: string;
-	repos?: Array<{ url: string; ref?: string }>;
+	// #188: single-repo today; multi-repo deferred to #197.
+	repo?: {
+		url: string;
+		ref?: string;
+		target?: string;
+		auth: "none" | "pat" | "ssh";
+		depth?: number | null;
+	} | null;
+	// Credential blob for `repo.auth` ∈ {pat, ssh}. Plaintext on the
+	// wire — the backend encrypts before persistence (#188 PR 188b).
+	auth?: {
+		pat?: string;
+		ssh?: { privateKey: string; knownHosts: string };
+	};
 	ports?: Array<{ port: number; protocol?: "http" | "tcp" }>;
 	envVars?: EnvVarEntryInput[];
 }


### PR DESCRIPTION
## Summary

First slice of #188's repo-clone work that touches the data model. Replaces the placeholder `repos: []` array with the proper #188 single-repo shape (url/ref/target/auth/depth) and adds the sibling `auth` blob carrying PAT / SSH credentials. The route encrypts credentials with AES-256-GCM before they hit D1 (mirrors PR #210's env-var secrets pattern); plaintext is in scope only inside the request handler. Cross-field validation enforces auth↔URL pairing so the 188c clone runner can trust the data.

This PR ships **schema + persistence + encryption helpers only**. The clone runner that consumes the decrypted credentials lands in 188c. No spawn-path changes.

## What changed

- `backend/src/sessionConfig.ts` — extended `RepoSpec` (target, auth, depth) + URL allowlist now covers both `https://…` and `git@host:path`. Added `WireAuthSpec` (plaintext) → `AuthStored` (encrypted envelope) types, `encryptAuthCredentials` / `decryptStoredAuth` / `redactStoredAuth` helpers, cross-field validation for repo↔auth consistency, `parseRepoColumn` (backward-compat shim for legacy array shape), `parseAuthColumn` (defensive structural validation against crafted D1 rows).
- `backend/src/db.ts` — `auth_json` column on `session_configs`. ALTER + duplicate-column swallow, same idiom as the existing migrations.
- `backend/src/routes.ts` — wires `encryptAuthCredentials` into the create path.
- `backend/src/sessionConfig.test.ts` — schema cross-validation tests (auth/url pairing, target traversal, ref refname rules, depth bounds), encrypt/decrypt round-trip for both PAT and SSH paths, redact shape, GCM tamper detection, legacy-array rehydration, missing-iv/tag rejection.
- `frontend/src/api.ts` — `SessionConfigPayload` shape updated to match (no UI changes; Repo tab lands in 188e).

## Test plan
- [x] `cd backend && npm test` — 330 passing
- [x] `cd backend && npm run build && npm run lint` — clean
- [x] `cd frontend && npm run build && npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)