### PR TITLE
feat(repo): public-repo clone runner wired before postCreate (#188, PR 188c of 4)

### DIFF
--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -9,6 +9,25 @@ const dbStubs = vi.hoisted(() => ({
 }));
 vi.mock("./db.js", () => dbStubs);
 
+// `runAsyncBootstrap` calls `getSessionConfig` at the top to load the
+// repo + auth blob (#188 PR 188c). These tests target the orchestrator
+// behaviour, not the config rehydration, so mock it to return null by
+// default — that's the "no repo configured" branch, which is what
+// every existing test was implicitly relying on.
+const sessionConfigStubs = vi.hoisted(() => ({
+	getSessionConfig: vi.fn(async () => null),
+}));
+vi.mock("./sessionConfig.js", () => sessionConfigStubs);
+
+// `runCloneRepo` is the new step before postCreate. The default mock
+// returns success+exit 0; tests that target the clone step override
+// this per-case. Existing tests (postCreate-focused) inherit the
+// success default so the clone step is effectively a no-op for them.
+const cloneStubs = vi.hoisted(() => ({
+	runCloneRepo: vi.fn(async () => ({ exitCode: 0 })),
+}));
+vi.mock("./bootstrap/cloneRepo.js", () => cloneStubs);
+
 import {
 	BootstrapBroadcaster,
 	type BootstrapMessage,
@@ -20,6 +39,10 @@ import type { SessionManager } from "./sessionManager.js";
 
 beforeEach(() => {
 	dbStubs.d1Query.mockReset();
+	sessionConfigStubs.getSessionConfig.mockReset();
+	sessionConfigStubs.getSessionConfig.mockImplementation(async () => null);
+	cloneStubs.runCloneRepo.mockReset();
+	cloneStubs.runCloneRepo.mockImplementation(async () => ({ exitCode: 0 }));
 });
 
 describe("markBootstrapped", () => {
@@ -287,6 +310,126 @@ describe("runAsyncBootstrap", () => {
 		);
 		await settle();
 
+		expect(spies.runPostStart).toHaveBeenCalledWith("sess-1", "npm run dev");
+		expect(final).toEqual([{ type: "done", success: true }]);
+	});
+
+	// ── #188 PR 188c — clone step orchestration ─────────────────────────────
+
+	// Step ordering invariant. The runner must clone BEFORE postCreate so
+	// the user's hook can `cd` into the cloned repo or run `npm install`
+	// inside it. A swap would break the documented contract.
+	it("runs clone BEFORE postCreate when both are configured", async () => {
+		const { sessions, docker, broadcaster, spies } = makeFakes();
+		const order: string[] = [];
+		// Stub a config row so the clone runner is invoked. Shape
+		// matches SessionConfigRecord just enough — the runCloneRepo
+		// mock doesn't read it.
+		sessionConfigStubs.getSessionConfig.mockResolvedValueOnce({
+			sessionId: "sess-1",
+			repo: { url: "https://example.com/r", auth: "none" },
+			bootstrappedAt: null,
+		} as never);
+		cloneStubs.runCloneRepo.mockImplementation(async () => {
+			order.push("clone");
+			return { exitCode: 0 };
+		});
+		spies.runPostCreate.mockImplementation(async () => {
+			order.push("postCreate");
+			return { exitCode: 0 };
+		});
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(order).toEqual(["clone", "postCreate"]);
+	});
+
+	// A non-zero clone exit must hard-fail the session via the SAME
+	// status-flip-before-kill path that postCreate uses. Without this,
+	// a failed clone would leave a dangling container the reconcile
+	// loop would silently promote to stopped.
+	it("fail path: clone non-zero exit flips status, kills, broadcasts fail (postCreate not run)", async () => {
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		const order: string[] = [];
+		spies.updateStatus.mockImplementation(async () => {
+			order.push("updateStatus");
+		});
+		spies.kill.mockImplementation(async () => {
+			order.push("kill");
+		});
+		sessionConfigStubs.getSessionConfig.mockResolvedValueOnce({
+			sessionId: "sess-1",
+			repo: { url: "https://example.com/r", auth: "none" },
+			bootstrappedAt: null,
+		} as never);
+		cloneStubs.runCloneRepo.mockImplementation(async () => ({ exitCode: 128 }));
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+		expect(order).toEqual(["updateStatus", "kill"]);
+		expect(spies.runPostCreate).not.toHaveBeenCalled();
+		expect(final).toEqual([{ type: "fail", exitCode: 128 }]);
+	});
+
+	it("throw path: runCloneRepo throws → flip + kill + broadcast fail with error", async () => {
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		sessionConfigStubs.getSessionConfig.mockResolvedValueOnce({
+			sessionId: "sess-1",
+			repo: { url: "https://example.com/r", auth: "none" },
+			bootstrappedAt: null,
+		} as never);
+		cloneStubs.runCloneRepo.mockRejectedValueOnce(new Error("git not found"));
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+		expect(spies.runPostCreate).not.toHaveBeenCalled();
+		expect(final).toHaveLength(1);
+		expect(final[0]).toMatchObject({ type: "fail", exitCode: -1 });
+	});
+
+	// Repo-only sessions (clone configured, no postCreate) — bootstrap
+	// runs the clone, marks bootstrapped, broadcasts done.
+	it("repo-only path: no postCreateCmd → clone runs, gate marked, postStart fires, broadcast done", async () => {
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		sessionConfigStubs.getSessionConfig.mockResolvedValueOnce({
+			sessionId: "sess-1",
+			repo: { url: "https://example.com/r", auth: "none" },
+			bootstrappedAt: null,
+		} as never);
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 1, duration: 0, last_row_id: 0 },
+		});
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postStartCmd: "npm run dev" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(cloneStubs.runCloneRepo).toHaveBeenCalled();
+		expect(spies.runPostCreate).not.toHaveBeenCalled();
 		expect(spies.runPostStart).toHaveBeenCalledWith("sess-1", "npm run dev");
 		expect(final).toEqual([{ type: "done", success: true }]);
 	});

--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -341,12 +341,32 @@ describe("runAsyncBootstrap", () => {
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postCreateCmd: "npm install" },
+			{ postCreateCmd: "npm install", hasRepo: true },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();
 
 		expect(order).toEqual(["clone", "postCreate"]);
+	});
+
+	// PR #214 round 2 NIT: `hasRepo: false` (or omitted) gates the
+	// `getSessionConfig` D1 fetch. The pre-188c steady-state is
+	// postCreate-only; that path must not pay for a repo D1 round-trip
+	// every session create.
+	it("hasRepo=false skips the getSessionConfig D1 fetch (no extra round-trip)", async () => {
+		const { sessions, docker, broadcaster, spies } = makeFakes();
+		spies.runPostCreate.mockImplementation(async () => ({ exitCode: 0 }));
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install" /* hasRepo omitted = false */ },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(sessionConfigStubs.getSessionConfig).not.toHaveBeenCalled();
+		expect(cloneStubs.runCloneRepo).not.toHaveBeenCalled();
+		expect(spies.runPostCreate).toHaveBeenCalledWith("sess-1", "npm install", expect.any(Function));
 	});
 
 	// A non-zero clone exit must hard-fail the session via the SAME
@@ -371,7 +391,7 @@ describe("runAsyncBootstrap", () => {
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postCreateCmd: "npm install" },
+			{ postCreateCmd: "npm install", hasRepo: true },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();
@@ -394,7 +414,7 @@ describe("runAsyncBootstrap", () => {
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postCreateCmd: "npm install" },
+			{ postCreateCmd: "npm install", hasRepo: true },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();
@@ -423,7 +443,7 @@ describe("runAsyncBootstrap", () => {
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postStartCmd: "npm run dev" },
+			{ postStartCmd: "npm run dev", hasRepo: true },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -296,7 +296,7 @@ export class BootstrapBroadcaster {
  */
 export async function runAsyncBootstrap(
 	sessionId: string,
-	cfg: { postCreateCmd?: string; postStartCmd?: string },
+	cfg: { postCreateCmd?: string; postStartCmd?: string; hasRepo?: boolean },
 	deps: {
 		sessions: SessionManager;
 		docker: DockerManager;
@@ -306,18 +306,32 @@ export async function runAsyncBootstrap(
 	const { sessions, docker, broadcaster } = deps;
 	const onOutput = (chunk: string) => broadcaster.broadcast(sessionId, chunk);
 
-	// Step 1: repo clone. `runCloneRepo` is a no-op + exitCode=0 when
-	// no `repo` is configured, so this branch is free for sessions
-	// that only use postCreate. Load the full config here (one D1
-	// round-trip) — the route already persisted it before `spawn()`,
-	// so the row is guaranteed to exist when there's anything to
-	// clone or hook on.
+	// Step 1: repo clone. Skipped entirely when `cfg.hasRepo === false`
+	// — that's the steady-state for the existing postCreate-only
+	// population (everyone before #188's repo-clone landed). The hint
+	// is set by the route from `validatedConfig.repo`; gating on it
+	// avoids one D1 round-trip per session create on the hot path.
+	// CLAUDE.md flags D1 round-trip counts as performance-relevant,
+	// and a transient D1 failure on this fetch would also hard-fail
+	// the session before postCreate had a chance to run — we only
+	// take that risk when there's something to clone (PR #214 round 2).
 	let cloneExit: number;
 	try {
-		const config = await getSessionConfig(sessionId);
-		if (config) {
-			const result = await runCloneRepo({ sessionId, config, docker, onOutput });
-			cloneExit = result.exitCode;
+		if (cfg.hasRepo) {
+			const config = await getSessionConfig(sessionId);
+			if (config) {
+				const result = await runCloneRepo({ sessionId, config, docker, onOutput });
+				cloneExit = result.exitCode;
+			} else {
+				// Defensive: route guarantees the row exists when
+				// `hasRepo` is set, but a missing row shouldn't crash
+				// the runner. Treat as a no-op clone — markBootstrapped
+				// later will UPDATE 0 rows and log without failing.
+				logger.warn(
+					`[bootstrap] hasRepo=true but no session_configs row for ${sessionId}; skipping clone`,
+				);
+				cloneExit = 0;
+			}
 		} else {
 			cloneExit = 0;
 		}

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -19,9 +19,11 @@
  * the hook continues in the background.
  */
 
+import { runCloneRepo } from "./bootstrap/cloneRepo.js";
 import { d1Query } from "./db.js";
 import type { DockerManager } from "./dockerManager.js";
 import { logger } from "./logger.js";
+import { getSessionConfig } from "./sessionConfig.js";
 import type { SessionManager } from "./sessionManager.js";
 
 /**
@@ -266,28 +268,35 @@ export class BootstrapBroadcaster {
 // ── Async runner (PR 185b2b) ──────────────────────────────────────────────
 
 /**
- * Run postCreate (and on success, postStart) for a session out-of-band,
- * streaming output to the broadcaster as it arrives. Called from
- * `POST /api/sessions` AFTER the response has been sent (fire-and-forget),
- * so a long-running hook can't tie up the HTTP request and the modal
- * can subscribe to `/ws/bootstrap/<sessionId>` to see live output.
+ * Run repo-clone (#188) and postCreate (#185, on success postStart) for
+ * a session out-of-band, streaming output to the broadcaster as it
+ * arrives. Called from `POST /api/sessions` AFTER the response has
+ * been sent (fire-and-forget), so a long-running step can't tie up
+ * the HTTP request and the modal can subscribe to
+ * `/ws/bootstrap/<sessionId>` to see live output.
+ *
+ * Step order (188c): clone → postCreate → markBootstrapped → postStart.
+ * Clone runs FIRST so a configured repo is in place by the time the
+ * user's postCreate hook (or first interactive command) runs. A
+ * non-zero exit from any blocking step (clone, postCreate) hard-fails
+ * the session.
  *
  * Failure semantics match the synchronous flow that PR 185b2a shipped:
- *   - non-zero `postCreate` exit → flip status to `failed` BEFORE
- *     killing the container (so reconcile never sees a half-state row),
- *     then kill, then broadcast `{type: "fail"}` so the modal renders
- *     its inline error panel.
- *   - any unexpected throw inside the runner is logged + treated as a
- *     hard failure (same status flip + kill + broadcast).
+ *   - non-zero clone or postCreate exit → flip status to `failed`
+ *     BEFORE killing the container (so reconcile never sees a
+ *     half-state row), then kill, then broadcast `{type: "fail"}`
+ *     so the modal renders its inline error panel.
+ *   - any unexpected throw inside the runner is logged + treated as
+ *     a hard failure (same status flip + kill + broadcast).
  *
- * Caller: only invoke this if `postCreateCmd` is set. The
- * markBootstrapped gate is single-use, and the route already checks
- * `bootstrapped_at IS NULL` semantics by virtue of being on the
- * create path.
+ * Caller: only invoke this if SOMETHING is configured (postCreateCmd
+ * or repo). The markBootstrapped gate is single-use, and the route
+ * already checks `bootstrapped_at IS NULL` semantics by virtue of
+ * being on the create path.
  */
 export async function runAsyncBootstrap(
 	sessionId: string,
-	cfg: { postCreateCmd: string; postStartCmd?: string },
+	cfg: { postCreateCmd?: string; postStartCmd?: string },
 	deps: {
 		sessions: SessionManager;
 		docker: DockerManager;
@@ -297,14 +306,23 @@ export async function runAsyncBootstrap(
 	const { sessions, docker, broadcaster } = deps;
 	const onOutput = (chunk: string) => broadcaster.broadcast(sessionId, chunk);
 
-	let exitCode: number;
+	// Step 1: repo clone. `runCloneRepo` is a no-op + exitCode=0 when
+	// no `repo` is configured, so this branch is free for sessions
+	// that only use postCreate. Load the full config here (one D1
+	// round-trip) — the route already persisted it before `spawn()`,
+	// so the row is guaranteed to exist when there's anything to
+	// clone or hook on.
+	let cloneExit: number;
 	try {
-		const result = await docker.runPostCreate(sessionId, cfg.postCreateCmd, onOutput);
-		exitCode = result.exitCode;
+		const config = await getSessionConfig(sessionId);
+		if (config) {
+			const result = await runCloneRepo({ sessionId, config, docker, onOutput });
+			cloneExit = result.exitCode;
+		} else {
+			cloneExit = 0;
+		}
 	} catch (err) {
-		logger.error(
-			`[bootstrap] postCreate threw for session ${sessionId}: ${(err as Error).message}`,
-		);
+		logger.error(`[bootstrap] clone threw for session ${sessionId}: ${(err as Error).message}`);
 		await failSession(sessionId, sessions, docker);
 		broadcaster.finish(sessionId, {
 			type: "fail",
@@ -312,6 +330,35 @@ export async function runAsyncBootstrap(
 			error: (err as Error).message,
 		});
 		return;
+	}
+	if (cloneExit !== 0) {
+		await failSession(sessionId, sessions, docker);
+		broadcaster.finish(sessionId, { type: "fail", exitCode: cloneExit });
+		return;
+	}
+
+	// Step 2: postCreate. May be unset when only the repo step is
+	// configured — in that case skip straight to markBootstrapped +
+	// postStart. The bootstrap is still considered complete.
+	let exitCode: number;
+	if (cfg.postCreateCmd) {
+		try {
+			const result = await docker.runPostCreate(sessionId, cfg.postCreateCmd, onOutput);
+			exitCode = result.exitCode;
+		} catch (err) {
+			logger.error(
+				`[bootstrap] postCreate threw for session ${sessionId}: ${(err as Error).message}`,
+			);
+			await failSession(sessionId, sessions, docker);
+			broadcaster.finish(sessionId, {
+				type: "fail",
+				exitCode: -1,
+				error: (err as Error).message,
+			});
+			return;
+		}
+	} else {
+		exitCode = 0;
 	}
 
 	if (exitCode !== 0) {

--- a/backend/src/bootstrap/cloneRepo.test.ts
+++ b/backend/src/bootstrap/cloneRepo.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DockerManager } from "../dockerManager.js";
+import type { SessionConfigRecord } from "../sessionConfig.js";
+import {
+	buildCloneArgv,
+	CloneAuthNotImplementedError,
+	resolveTargetAbsPath,
+	runCloneRepo,
+} from "./cloneRepo.js";
+
+// ── buildCloneArgv ───────────────────────────────────────────────────────
+
+describe("buildCloneArgv", () => {
+	it("emits the minimal `git clone -- <url> <target>` form when no ref/depth", () => {
+		expect(
+			buildCloneArgv("https://example.com/r", undefined, undefined, "/home/developer/workspace"),
+		).toEqual(["git", "clone", "--", "https://example.com/r", "/home/developer/workspace"]);
+	});
+
+	it("appends --branch when ref is non-empty", () => {
+		expect(
+			buildCloneArgv("https://example.com/r", "main", undefined, "/home/developer/workspace/sub"),
+		).toEqual([
+			"git",
+			"clone",
+			"--branch",
+			"main",
+			"--",
+			"https://example.com/r",
+			"/home/developer/workspace/sub",
+		]);
+	});
+
+	// `ref === ""` is a wire-shape signal for "use remote HEAD". Must NOT
+	// produce `--branch ""` — that crashes git with "fatal: Remote branch
+	// not found". The runner reads the absent flag as "skip --branch",
+	// matching the schema's intent.
+	it("treats empty ref as 'use remote HEAD' (no --branch)", () => {
+		expect(
+			buildCloneArgv("https://example.com/r", "", undefined, "/home/developer/workspace"),
+		).toEqual(["git", "clone", "--", "https://example.com/r", "/home/developer/workspace"]);
+	});
+
+	it("appends --depth when depth is set", () => {
+		expect(
+			buildCloneArgv("https://example.com/r", undefined, 1, "/home/developer/workspace"),
+		).toEqual([
+			"git",
+			"clone",
+			"--depth",
+			"1",
+			"--",
+			"https://example.com/r",
+			"/home/developer/workspace",
+		]);
+	});
+
+	// `null` and `undefined` are both "no shallow"; both must skip the
+	// --depth flag. The schema models depth as `nullable().optional()`
+	// so both shapes can land in the runner.
+	it("skips --depth for both null and undefined", () => {
+		const noDepthForNull = buildCloneArgv(
+			"https://example.com/r",
+			undefined,
+			null,
+			"/home/developer/workspace",
+		);
+		const noDepthForUndef = buildCloneArgv(
+			"https://example.com/r",
+			undefined,
+			undefined,
+			"/home/developer/workspace",
+		);
+		expect(noDepthForNull).toEqual(noDepthForUndef);
+		expect(noDepthForNull).not.toContain("--depth");
+	});
+
+	// `--` separator must precede positional args so a future ref like
+	// `--evil` (already blocked at the schema layer with a leading `-`
+	// reject, but defence-in-depth) cannot be re-interpreted as a flag.
+	it("places '--' before the URL/target positional pair", () => {
+		const argv = buildCloneArgv("https://example.com/r", "main", 5, "/path");
+		const dashIdx = argv.indexOf("--");
+		const urlIdx = argv.indexOf("https://example.com/r");
+		expect(dashIdx).toBeGreaterThan(-1);
+		expect(urlIdx).toBeGreaterThan(dashIdx);
+	});
+});
+
+// ── resolveTargetAbsPath ─────────────────────────────────────────────────
+
+describe("resolveTargetAbsPath", () => {
+	it("maps undefined target to the workspace root", () => {
+		expect(resolveTargetAbsPath(undefined)).toBe("/home/developer/workspace");
+	});
+
+	it("maps empty target to the workspace root (replace-workspace mode)", () => {
+		expect(resolveTargetAbsPath("")).toBe("/home/developer/workspace");
+	});
+
+	it("appends a non-empty target to the workspace root", () => {
+		expect(resolveTargetAbsPath("frontend")).toBe("/home/developer/workspace/frontend");
+		expect(resolveTargetAbsPath("services/api")).toBe("/home/developer/workspace/services/api");
+	});
+});
+
+// ── runCloneRepo ─────────────────────────────────────────────────────────
+
+describe("runCloneRepo", () => {
+	let docker: { streamExec: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		docker = { streamExec: vi.fn(async () => ({ exitCode: 0 })) };
+	});
+
+	function makeConfig(overrides: Partial<SessionConfigRecord> = {}): SessionConfigRecord {
+		return {
+			sessionId: "sess-1",
+			bootstrappedAt: null,
+			...overrides,
+		};
+	}
+
+	it("returns exitCode 0 and never calls streamExec when no repo configured", async () => {
+		const result = await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig(),
+			docker: docker as unknown as DockerManager,
+		});
+		expect(result).toEqual({ exitCode: 0 });
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	it("invokes streamExec with the cloning argv for repo.auth='none'", async () => {
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "https://example.com/r", ref: "main", auth: "none", depth: 1 },
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		expect(docker.streamExec).toHaveBeenCalledTimes(1);
+		const [sessionId, opts] = docker.streamExec.mock.calls[0]!;
+		expect(sessionId).toBe("sess-1");
+		expect(opts.cmd).toEqual([
+			"git",
+			"clone",
+			"--branch",
+			"main",
+			"--depth",
+			"1",
+			"--",
+			"https://example.com/r",
+			"/home/developer/workspace",
+		]);
+		expect(opts.workingDir).toBe("/home/developer/workspace");
+	});
+
+	// The runner is argv-mode (no `bash -c`) so a hostile-but-schema-
+	// passing URL like one containing a literal `;` would reach git as a
+	// single positional argument, NOT as a shell command separator. The
+	// schema regex blocks `;` in URLs as of #213, but the argv-only
+	// invocation is the load-bearing layer that defangs values that slip
+	// past the regex.
+	it("never wraps the command in a shell layer", async () => {
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "https://example.com/r", auth: "none" },
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		// argv[0] must be `git`, not `bash` or `sh`.
+		expect(opts.cmd[0]).toBe("git");
+		expect(opts.cmd).not.toContain("bash");
+		expect(opts.cmd).not.toContain("-c");
+	});
+
+	it("clones into a subdir when target is set", async () => {
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: {
+					url: "https://example.com/r",
+					target: "services/api",
+					auth: "none",
+				},
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.cmd[opts.cmd.length - 1]).toBe("/home/developer/workspace/services/api");
+	});
+
+	// Empty target → workspace root. Documented as the replace-workspace
+	// mode signal. Test pins the resolution rather than the side-effects
+	// of git cloning into a non-empty workspace, which is git's job.
+	it("clones into the workspace root when target is empty", async () => {
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "https://example.com/r", target: "", auth: "none" },
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.cmd[opts.cmd.length - 1]).toBe("/home/developer/workspace");
+	});
+
+	// PAT/SSH paths land in 188d. Throwing rather than silently running
+	// an anonymous clone means a deploy that lands 188b+188c without
+	// 188d won't quietly fall back to anonymous against a private URL
+	// (which would 404 with no signal that the credential was ignored).
+	it("throws CloneAuthNotImplementedError for repo.auth='pat'", async () => {
+		await expect(
+			runCloneRepo({
+				sessionId: "sess-1",
+				config: makeConfig({
+					repo: { url: "https://example.com/r", auth: "pat" },
+				}),
+				docker: docker as unknown as DockerManager,
+			}),
+		).rejects.toBeInstanceOf(CloneAuthNotImplementedError);
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	it("throws CloneAuthNotImplementedError for repo.auth='ssh'", async () => {
+		await expect(
+			runCloneRepo({
+				sessionId: "sess-1",
+				config: makeConfig({
+					repo: { url: "git@github.com:o/p", auth: "ssh" },
+				}),
+				docker: docker as unknown as DockerManager,
+			}),
+		).rejects.toBeInstanceOf(CloneAuthNotImplementedError);
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	// Output streaming — the runner just forwards the callback. Pin the
+	// pass-through so a future refactor that adds intermediate
+	// processing (filtering, redaction) makes a deliberate choice.
+	it("forwards onOutput to streamExec verbatim", async () => {
+		const onOutput = vi.fn();
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "https://example.com/r", auth: "none" },
+			}),
+			docker: docker as unknown as DockerManager,
+			onOutput,
+		});
+		expect(docker.streamExec).toHaveBeenCalledTimes(1);
+		const [, , passedCallback] = docker.streamExec.mock.calls[0]!;
+		expect(passedCallback).toBe(onOutput);
+	});
+});

--- a/backend/src/bootstrap/cloneRepo.ts
+++ b/backend/src/bootstrap/cloneRepo.ts
@@ -1,0 +1,147 @@
+/**
+ * cloneRepo.ts — repo-clone bootstrap step (#188 PR 188c).
+ *
+ * Runs `git clone` inside the freshly-spawned session container BEFORE
+ * postCreate fires, so a configured `repo` is in place by the time
+ * the user's hook (or first interactive command) runs. Output streams
+ * to the same WS broadcaster as postCreate.
+ *
+ * Scope of THIS PR (188c):
+ *   - `repo.auth === "none"` only — anonymous HTTPS clone.
+ *   - PAT and SSH paths throw `CloneAuthNotImplementedError` so a
+ *     future PR (188d) wiring credentials wakes the runner up
+ *     loudly rather than silently misbehaving (e.g. running an
+ *     unauthenticated clone against a private URL and 404-ing).
+ *
+ * The clone runs argv-only (no shell). `--branch`, `--depth`, and the
+ * target dir are passed as separate arguments to defang any
+ * shell-meta in user-supplied values that slipped past the schema's
+ * regex allowlist.
+ */
+
+import type { DockerManager } from "../dockerManager.js";
+import { logger } from "../logger.js";
+import type { SessionConfigRecord } from "../sessionConfig.js";
+
+/**
+ * Path of the workspace bind mount inside the container. Mirrors the
+ * value DockerManager uses on the spawn side. Hard-coded here rather
+ * than imported because cloneRepo lives behind the streamExec
+ * primitive — the path needs to land in the runner's argv, not in
+ * the spawn config.
+ */
+const CONTAINER_WORKSPACE = "/home/developer/workspace";
+
+/** Thrown when `repo.auth !== "none"` lands here pre-188d. */
+export class CloneAuthNotImplementedError extends Error {
+	constructor(authMode: string) {
+		super(
+			`cloneRepo: auth='${authMode}' is not implemented in this PR (lands in 188d). ` +
+				"Reject the config at the route boundary or wait for the credential path to ship.",
+		);
+		this.name = "CloneAuthNotImplementedError";
+	}
+}
+
+interface RunCloneRepoArgs {
+	sessionId: string;
+	config: SessionConfigRecord;
+	docker: DockerManager;
+	onOutput?: (chunk: string) => void;
+}
+
+/**
+ * Run the configured clone for `sessionId` and return its exit code.
+ * Returns `{ exitCode: 0 }` and a no-op when no `repo` is configured —
+ * the caller treats that as "clone step succeeded" so a session with
+ * only a postCreate hook (no repo) is unaffected.
+ *
+ * `repo.target === ""` is a request to clone into the workspace root.
+ * `git clone` into a non-empty dir would fail, but a freshly-spawned
+ * session's bind-mounted workspace is empty (the `.uploads` dir lives
+ * outside the workspace tree as of PR 188a), so this is the
+ * straightforward path.
+ */
+export async function runCloneRepo(args: RunCloneRepoArgs): Promise<{ exitCode: number }> {
+	const { config, sessionId, docker, onOutput } = args;
+	const repo = config.repo;
+	if (!repo) {
+		// No repo configured — caller treats as success, postCreate
+		// fires next. This branch is the steady-state for sessions
+		// that don't use the repo-clone feature.
+		return { exitCode: 0 };
+	}
+
+	if (repo.auth !== "none") {
+		// Wire-shape `repo.auth` in {"pat", "ssh"} requires the
+		// credential path that lands in 188d. Throw rather than
+		// silently fall through to anonymous clone — anonymous clone
+		// against a private URL would 404 and the user would see
+		// "Repository not found", with no signal that their stored
+		// credential was ignored.
+		throw new CloneAuthNotImplementedError(repo.auth);
+	}
+
+	const targetAbs = resolveTargetAbsPath(repo.target);
+	const cloneArgv = buildCloneArgv(repo.url, repo.ref, repo.depth, targetAbs);
+
+	logger.info(
+		`[cloneRepo] session ${sessionId}: cloning ${repo.url} ` +
+			`(ref=${repo.ref ?? "<HEAD>"}, depth=${repo.depth ?? "full"}, target=${targetAbs})`,
+	);
+
+	// Run argv-style. `streamExec` shells out via Cmd: [argv0, argv1, …]
+	// (no `bash -c`) so user-controlled values can never break out into
+	// shell meta. The schema's regex allowlist is the primary defence;
+	// argv-only is belt-and-suspenders.
+	return docker.streamExec(
+		sessionId,
+		{ cmd: cloneArgv, workingDir: CONTAINER_WORKSPACE },
+		onOutput,
+	);
+}
+
+/**
+ * Resolve the in-container clone target. `target === ""` (or undefined)
+ * means clone into the workspace root (`/home/developer/workspace`).
+ * A non-empty `target` is a workspace-relative subpath validated by
+ * the schema (no `..`, no leading `/`). The runner trusts that
+ * validation: re-checking here would diverge if a future schema
+ * tightening changes the allowed shape.
+ *
+ * Exported for the unit-test that pins the mapping; not part of the
+ * public runtime API of the module.
+ */
+export function resolveTargetAbsPath(target: string | undefined): string {
+	if (target === undefined || target === "") return CONTAINER_WORKSPACE;
+	return `${CONTAINER_WORKSPACE}/${target}`;
+}
+
+/**
+ * Build the argv array for the clone. `--branch <ref>` and `--depth <N>`
+ * are conditionally appended based on the config; `--` separates flags
+ * from positional args so a future ref like `--evil` (already
+ * blocked by the schema's leading-`-` check, but defence-in-depth)
+ * can't be mis-parsed as a flag.
+ *
+ * Exported for the unit-test that pins the argv shape per
+ * (ref, depth, target) variant.
+ */
+export function buildCloneArgv(
+	url: string,
+	ref: string | undefined,
+	depth: number | null | undefined,
+	targetAbs: string,
+): string[] {
+	const argv: string[] = ["git", "clone"];
+	// Empty `ref` is the wire-shape signal for "use remote HEAD";
+	// only pass `--branch` when the user explicitly named one.
+	if (ref !== undefined && ref.length > 0) {
+		argv.push("--branch", ref);
+	}
+	if (depth !== null && depth !== undefined) {
+		argv.push("--depth", String(depth));
+	}
+	argv.push("--", url, targetAbs);
+	return argv;
+}

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -816,6 +816,41 @@ export class DockerManager {
 		cmd: string,
 		onOutput?: (chunk: string) => void,
 	): Promise<{ exitCode: number }> {
+		// Thin shim over `streamExec` — postCreate is shell-typed (the
+		// user wrote `npm install && npm test` etc.) so we wrap the
+		// command in `bash -c`. The clone runner (#188 PR 188c) calls
+		// `streamExec` directly with argv to avoid the shell layer.
+		return this.streamExec(
+			sessionId,
+			{
+				cmd: ["bash", "-c", cmd],
+				workingDir: "/home/developer/workspace",
+			},
+			onOutput,
+		);
+	}
+
+	/**
+	 * Run a one-off exec inside the session's container, streaming
+	 * stdout+stderr to `onOutput` as bytes arrive. Returns the exec's
+	 * exit code; throws if Docker can't determine it (indeterminate
+	 * outcome ≠ success — see the `info.ExitCode === null` branch
+	 * below).
+	 *
+	 * Exposed publicly for #188's clone runner, which needs argv-mode
+	 * invocation (not shell) so a malformed `repo.url` / `repo.ref`
+	 * can never become shell meta. `runPostCreate` is now a thin
+	 * shell-mode shim over this primitive.
+	 */
+	async streamExec(
+		sessionId: string,
+		opts: {
+			cmd: string[];
+			env?: Record<string, string>;
+			workingDir?: string;
+		},
+		onOutput?: (chunk: string) => void,
+	): Promise<{ exitCode: number }> {
 		const meta = await this.sessions.getOrThrow(sessionId);
 		if (!meta.containerId) throw new Error("No container for this session");
 		const container = this.docker.getContainer(meta.containerId);
@@ -826,12 +861,13 @@ export class DockerManager {
 		// the wire (Tty:false, multiplexed frames, WorkingDir pinned to
 		// the workspace) as #207 round 7 settled.
 		const exec = await container.exec({
-			Cmd: ["bash", "-c", cmd],
+			Cmd: opts.cmd,
+			Env: opts.env ? Object.entries(opts.env).map(([k, v]) => `${k}=${v}`) : undefined,
 			AttachStdin: false,
 			AttachStdout: true,
 			AttachStderr: true,
 			Tty: false,
-			WorkingDir: "/home/developer/workspace",
+			WorkingDir: opts.workingDir ?? "/home/developer/workspace",
 		});
 		const stream = await exec.start({ hijack: false, stdin: false });
 

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -214,6 +214,9 @@ describe("POST /sessions — async bootstrap dispatch (PR 185b2b)", () => {
 		expect(bootstrapStubs.runAsyncBootstrap.mock.calls[0]?.[1]).toEqual({
 			postCreateCmd: "npm install",
 			postStartCmd: "npm run dev",
+			// `hasRepo` lets the runner skip the getSessionConfig D1
+			// fetch on postCreate-only sessions (PR #214 round 2 NIT).
+			hasRepo: false,
 		});
 		expect(spies.runPostStart).not.toHaveBeenCalled();
 	});

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -501,6 +501,12 @@ export function buildRouter(
 				const cfg = {
 					postCreateCmd: validatedConfig.postCreateCmd,
 					postStartCmd: validatedConfig.postStartCmd,
+					// `hasRepo` lets the runner skip the `getSessionConfig`
+					// D1 fetch on postCreate-only sessions (PR #214 round 2
+					// NIT). The route already knows whether a repo was
+					// configured — passing the bit through avoids the
+					// runner having to fetch just to learn the answer.
+					hasRepo: validatedConfig.repo !== null && validatedConfig.repo !== undefined,
 				};
 				// Fire-and-forget; the runner internally catches every
 				// throw it can and translates them into broadcaster

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -489,9 +489,15 @@ export function buildRouter(
 			//
 			// postStart fires inside the runner on the success branch
 			// (after markBootstrapped). For sessions with postStart but
-			// NO postCreate, fire it directly here — the async runner
-			// only kicks off when there's a postCreateCmd to wait on.
-			if (validatedConfig?.postCreateCmd) {
+			// NO postCreate / repo, fire it directly here — the async
+			// runner only kicks off when there's something to block on.
+			//
+			// #188 PR 188c: the trigger now fires when EITHER a repo or
+			// a postCreateCmd is configured. The runner's clone step is
+			// a no-op when `repo` is absent, so this widening is safe
+			// for the postCreate-only path and lets repo-only sessions
+			// (no hook, just a clone) get their async-bootstrap modal.
+			if (validatedConfig?.postCreateCmd || validatedConfig?.repo) {
 				const cfg = {
 					postCreateCmd: validatedConfig.postCreateCmd,
 					postStartCmd: validatedConfig.postStartCmd,

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -364,8 +364,14 @@ describe("validateSessionConfig", () => {
 		);
 	});
 
-	it("accepts repo.auth='ssh' with matching git@ URL and ssh creds", () => {
-		expect(
+	// #188 PR 188c: PAT/SSH wire shapes are accepted by Zod (188b shipped
+	// the schema) but the clone runner only implements `auth: "none"`
+	// until 188d. The route-level guard rejects a structurally-valid
+	// SSH config so we don't burn a quota slot on a guaranteed-fail
+	// session. 188d removes this guard and the assertion flips back
+	// to `.toBeDefined()`.
+	it("rejects repo.auth='ssh' as not-yet-implemented (188c temporary guard)", () => {
+		expect(() =>
 			validateSessionConfig({
 				repo: { url: "git@github.com:o/p", auth: "ssh", target: "" },
 				auth: {
@@ -375,7 +381,16 @@ describe("validateSessionConfig", () => {
 					},
 				},
 			}),
-		).toBeDefined();
+		).toThrowError(/only 'none'.*supported in this version/);
+	});
+
+	it("rejects repo.auth='pat' with otherwise-valid config as not-yet-implemented (188c temporary guard)", () => {
+		expect(() =>
+			validateSessionConfig({
+				repo: { url: "https://example.com/r", auth: "pat" },
+				auth: { pat: "ghp_validtoken" },
+			}),
+		).toThrowError(/only 'none'.*supported in this version/);
 	});
 
 	// Depth bounds — out of [1, 10000]. A missing `depth` is allowed

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -589,6 +589,21 @@ export function validateSessionConfig(raw: unknown): SessionConfig | undefined {
 			);
 		}
 	}
+	// #188 PR 188c — schema accepts auth ∈ {"none","pat","ssh"} (188b
+	// shipped the wire shape) but the clone runner only implements
+	// "none" until 188d wires PAT and SSH. Without this guard the route
+	// would 201-return + spawn the container, then the bootstrap runner
+	// would throw `CloneAuthNotImplementedError` and broadcast a
+	// dev-facing failure message to the user's modal. Reject at the
+	// route boundary instead so the user sees a clean 400 with an
+	// actionable message and we don't burn a quota slot on a session
+	// that's guaranteed to fail. 188d removes this guard.
+	if (result.data.repo && result.data.repo.auth !== "none") {
+		throw new SessionConfigValidationError(
+			"config.repo.auth",
+			"config.repo.auth: only 'none' (anonymous HTTPS) is supported in this version; PAT and SSH support is in flight",
+		);
+	}
 	return result.data;
 }
 


### PR DESCRIPTION
## Summary

Adds the clone step that consumes the typed \`repo\` config landed in #213. Scope of THIS PR is \`repo.auth === \"none\"\` only — anonymous HTTPS clone — so the data path can land independently of the credential paths that come in 188d. The runner is argv-mode (no shell layer); a future schema-passing-but-hostile URL containing shell meta cannot reach \`bash -c\`.

## Architecture

- New \`backend/src/bootstrap/cloneRepo.ts\` builds the \`git clone\` argv from \`config.repo\` and hands it to a new \`DockerManager.streamExec\` primitive. PAT and SSH branches throw \`CloneAuthNotImplementedError\` so a deploy without 188d gets a loud failure rather than a silent fallback to anonymous (which would 404 against a private URL with no signal that the stored credential was ignored).
- \`DockerManager.runPostCreate\` is now a thin shell-mode shim over \`streamExec\`; the body that demuxes Docker frames and inspects the exit code moved up unchanged.
- \`runAsyncBootstrap\` runs clone → postCreate → markBootstrapped → postStart. A non-zero exit from EITHER step hard-fails the session via the same status-flip-before-kill path postCreate already used. Repo-only sessions (no postCreate) flow through the same pipeline and broadcast \`done\` after clone + markBootstrapped.
- Route trigger widens to fire async-bootstrap when EITHER \`repo\` or \`postCreateCmd\` is configured.

## Out of scope (lands in follow-ups)

- \`auth: \"pat\"\` credential path — 188d.
- \`auth: \"ssh\"\` credential path + bundled \`known_hosts\` — 188d.
- Frontend Repo tab UI — 188e.

## Test plan
- [x] cloneRepo unit tests pin argv shape, target resolution, and PAT/SSH throw
- [x] bootstrap orchestration tests pin clone-before-postCreate ordering, clone fail-path status-flip-before-kill, throw-path, and repo-only path
- [x] \`cd backend && npm test\` — 359 passing
- [x] \`cd backend && npm run lint && npm run build\` — clean
- [x] \`cd frontend && npm run lint && npm run build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)