### PR TITLE
feat(repo): PAT + SSH credential paths + bundled known_hosts (#188, PR 188d of 4)

### DIFF
--- a/backend/src/bootstrap/cloneRepo.test.ts
+++ b/backend/src/bootstrap/cloneRepo.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Set the encryption key BEFORE importing the module — `decryptStoredAuth`
@@ -430,6 +431,39 @@ describe("runCloneRepo", () => {
 		// `unset` the secret env vars after the on-disk write so a
 		// child process started by git doesn't inherit them.
 		expect(SSH_CLONE_SCRIPT).toContain("unset ST_SSH_KEY ST_KNOWN_HOSTS");
+	});
+
+	// PR #215 round 1 SHOULD-FIX: the JSDoc claimed StrictHostKeyChecking=yes
+	// but the script body lacked the GIT_SSH_COMMAND that enforces it. Pin
+	// the explicit setting so a future edit can't silently revert to the
+	// 'ask' default and accept a swapped-in attacker host key.
+	it("SSH_CLONE_SCRIPT enforces StrictHostKeyChecking=yes via GIT_SSH_COMMAND", () => {
+		expect(SSH_CLONE_SCRIPT).toContain('export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=yes"');
+	});
+
+	// ── Bash syntax checks (PR #215 round 1 NIT) ───────────────────────────
+
+	// `bash -n` (parse-only) catches broken quoting, malformed heredoc
+	// delimiters, mismatched braces — exactly the class of breakage the
+	// string-presence tests above don't notice. `streamExec` is mocked
+	// in these tests, so a syntactically broken script body would
+	// otherwise reach production unblocked.
+	it("PAT_CLONE_SCRIPT parses cleanly under bash -n", () => {
+		const r = spawnSync("bash", ["-n"], {
+			input: PAT_CLONE_SCRIPT,
+			encoding: "utf8",
+		});
+		expect(r.status).toBe(0);
+		expect(r.stderr).toBe("");
+	});
+
+	it("SSH_CLONE_SCRIPT parses cleanly under bash -n", () => {
+		const r = spawnSync("bash", ["-n"], {
+			input: SSH_CLONE_SCRIPT,
+			encoding: "utf8",
+		});
+		expect(r.status).toBe(0);
+		expect(r.stderr).toBe("");
 	});
 
 	// ── env helpers (PR 188d) ──────────────────────────────────────────────

--- a/backend/src/bootstrap/cloneRepo.test.ts
+++ b/backend/src/bootstrap/cloneRepo.test.ts
@@ -1,13 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Set the encryption key BEFORE importing the module — `decryptStoredAuth`
+// (called transitively from runCloneRepo) imports `secrets.js` at module-
+// load time, and that module reads SECRETS_ENCRYPTION_KEY from env.
+process.env.SECRETS_ENCRYPTION_KEY = Buffer.alloc(32, 0x42).toString("base64");
+
 import type { DockerManager } from "../dockerManager.js";
-import type { SessionConfigRecord } from "../sessionConfig.js";
+import { encryptAuthCredentials, type SessionConfigRecord } from "../sessionConfig.js";
 import {
 	buildCloneArgv,
-	CloneAuthNotImplementedError,
+	CloneCredentialMissingError,
+	PAT_CLONE_SCRIPT,
+	patEnv,
 	resolveTargetAbsPath,
 	runCloneRepo,
+	SSH_CLONE_SCRIPT,
+	sshEnv,
 } from "./cloneRepo.js";
+import { KNOWN_HOSTS_DEFAULT_BUNDLE } from "./knownHosts.js";
 
 // ── buildCloneArgv ───────────────────────────────────────────────────────
 
@@ -209,34 +219,250 @@ describe("runCloneRepo", () => {
 		expect(opts.cmd[opts.cmd.length - 1]).toBe("/home/developer/workspace");
 	});
 
-	// PAT/SSH paths land in 188d. Throwing rather than silently running
-	// an anonymous clone means a deploy that lands 188b+188c without
-	// 188d won't quietly fall back to anonymous against a private URL
-	// (which would 404 with no signal that the credential was ignored).
-	it("throws CloneAuthNotImplementedError for repo.auth='pat'", async () => {
+	// ── #188 PR 188d — PAT auth path ───────────────────────────────────────
+
+	// PAT must NEVER appear in the bash command argv (process listings)
+	// or in the resulting `.git/config`. The runner uses a `GIT_ASKPASS`
+	// shim that reads the token from an env var; the env block is the
+	// ONLY place the plaintext is allowed.
+	it("PAT auth: token lands in env, never in argv", async () => {
+		const stored = encryptAuthCredentials({ pat: "ghp_test_TOKEN_DEADBEEF" });
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "https://example.com/r", auth: "pat" },
+				auth: stored,
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		expect(docker.streamExec).toHaveBeenCalledTimes(1);
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		// PAT must NOT appear in argv anywhere — argv is what shows up in
+		// host-side `ps` output via dockerd's exec subprocess.
+		const argvJoined = (opts.cmd as string[]).join(" ");
+		expect(argvJoined).not.toContain("ghp_test_TOKEN_DEADBEEF");
+		// PAT lives in env (visible to operators with `docker inspect`,
+		// not to host `ps`). This is the documented trade-off.
+		expect(opts.env).toMatchObject({ ST_PAT: "ghp_test_TOKEN_DEADBEEF" });
+	});
+
+	// argv shape: bash + script. The runner's PAT path is shell-mode
+	// (multi-step setup) but every user-controlled value reaches the
+	// shell via env var, NOT via shell-interpolation, so shell-meta
+	// in any of them is inert.
+	it("PAT auth: invokes bash with the canonical PAT_CLONE_SCRIPT", async () => {
+		const stored = encryptAuthCredentials({ pat: "ghp_x" });
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "https://example.com/r", auth: "pat" },
+				auth: stored,
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.cmd[0]).toBe("bash");
+		expect(opts.cmd[1]).toBe("-c");
+		expect(opts.cmd[2]).toBe(PAT_CLONE_SCRIPT);
+	});
+
+	// User values reach the bash script via env. The script reads each
+	// with `"$ST_*"` double-quoted, so even if a value contained shell
+	// meta the shell would treat it as a single argument.
+	it("PAT auth: env block contains all user values + target absolute path", async () => {
+		const stored = encryptAuthCredentials({ pat: "ghp_x" });
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: {
+					url: "https://example.com/r",
+					ref: "main",
+					depth: 1,
+					target: "frontend",
+					auth: "pat",
+				},
+				auth: stored,
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.env).toEqual({
+			ST_PAT: "ghp_x",
+			ST_URL: "https://example.com/r",
+			ST_REF: "main",
+			ST_DEPTH: "1",
+			ST_TARGET_ABS: "/home/developer/workspace/frontend",
+		});
+	});
+
+	// Defence-in-depth: a config where `repo.auth: "pat"` was persisted
+	// but `auth.pat` is missing (e.g. direct D1 write that bypassed the
+	// route's cross-field check) must throw rather than silently fall
+	// back to anonymous.
+	it("PAT auth: throws CloneCredentialMissingError when auth.pat absent", async () => {
 		await expect(
 			runCloneRepo({
 				sessionId: "sess-1",
 				config: makeConfig({
 					repo: { url: "https://example.com/r", auth: "pat" },
+					auth: undefined,
 				}),
 				docker: docker as unknown as DockerManager,
 			}),
-		).rejects.toBeInstanceOf(CloneAuthNotImplementedError);
+		).rejects.toBeInstanceOf(CloneCredentialMissingError);
 		expect(docker.streamExec).not.toHaveBeenCalled();
 	});
 
-	it("throws CloneAuthNotImplementedError for repo.auth='ssh'", async () => {
+	// Script integrity check: the PAT script must include the cleanup
+	// trap that shreds the askpass file on exit. Pinning the marker so a
+	// future edit that drops it (and lets the PAT-printing shim survive
+	// past the clone) trips this assertion immediately.
+	it("PAT_CLONE_SCRIPT contains the askpass-cleanup trap", () => {
+		expect(PAT_CLONE_SCRIPT).toContain("trap cleanup EXIT");
+		expect(PAT_CLONE_SCRIPT).toContain('rm -f "$ASKPASS_PATH"');
+		// `GIT_TERMINAL_PROMPT=0` so a remote that rejects the PAT can't
+		// hang the bootstrap on a stdin prompt. Pinning so the PR
+		// doesn't accidentally remove the env it sets.
+		expect(PAT_CLONE_SCRIPT).toContain("GIT_TERMINAL_PROMPT=0");
+	});
+
+	// ── #188 PR 188d — SSH auth path ───────────────────────────────────────
+
+	it("SSH auth: invokes bash with the canonical SSH_CLONE_SCRIPT", async () => {
+		const stored = encryptAuthCredentials({
+			ssh: { privateKey: "KEYDATA", knownHosts: "default" },
+		});
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "git@github.com:o/p", auth: "ssh" },
+				auth: stored,
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.cmd[0]).toBe("bash");
+		expect(opts.cmd[1]).toBe("-c");
+		expect(opts.cmd[2]).toBe(SSH_CLONE_SCRIPT);
+	});
+
+	// `knownHosts === "default"` → resolve to the bundled github/gitlab/
+	// bitbucket fingerprints. Any other string is a custom paste, used
+	// verbatim. The user's choice between these is captured in the
+	// schema; the runner just resolves the sentinel.
+	it("SSH auth: knownHosts='default' resolves to the bundled fingerprints", async () => {
+		const stored = encryptAuthCredentials({
+			ssh: { privateKey: "KEYDATA", knownHosts: "default" },
+		});
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "git@github.com:o/p", auth: "ssh" },
+				auth: stored,
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.env).toMatchObject({ ST_KNOWN_HOSTS: KNOWN_HOSTS_DEFAULT_BUNDLE });
+	});
+
+	it("SSH auth: knownHosts custom-paste is passed through verbatim", async () => {
+		const customHosts = "intranet.example.com ssh-ed25519 AAAA…";
+		const stored = encryptAuthCredentials({
+			ssh: { privateKey: "KEYDATA", knownHosts: customHosts },
+		});
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "git@intranet.example.com:o/p", auth: "ssh" },
+				auth: stored,
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.env).toMatchObject({ ST_KNOWN_HOSTS: customHosts });
+	});
+
+	// SSH key + known_hosts must NEVER appear in argv — same shape as
+	// the PAT defence. Both are env-only.
+	it("SSH auth: privateKey and knownHosts land in env, never in argv", async () => {
+		const stored = encryptAuthCredentials({
+			ssh: {
+				privateKey: "-----BEGIN OPENSSH KEY-----\nSECRETBYTES",
+				knownHosts: "github.com ssh-ed25519 PUBLICKEY",
+			},
+		});
+		await runCloneRepo({
+			sessionId: "sess-1",
+			config: makeConfig({
+				repo: { url: "git@github.com:o/p", auth: "ssh" },
+				auth: stored,
+			}),
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		const argvJoined = (opts.cmd as string[]).join(" ");
+		expect(argvJoined).not.toContain("SECRETBYTES");
+		expect(argvJoined).not.toContain("PUBLICKEY");
+	});
+
+	it("SSH auth: throws CloneCredentialMissingError when auth.ssh absent", async () => {
 		await expect(
 			runCloneRepo({
 				sessionId: "sess-1",
 				config: makeConfig({
 					repo: { url: "git@github.com:o/p", auth: "ssh" },
+					auth: undefined,
 				}),
 				docker: docker as unknown as DockerManager,
 			}),
-		).rejects.toBeInstanceOf(CloneAuthNotImplementedError);
+		).rejects.toBeInstanceOf(CloneCredentialMissingError);
 		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	// Script integrity check: the SSH script must chmod 600 the key file
+	// (ssh refuses keys with looser perms) and write known_hosts to the
+	// canonical path so subsequent `git pull` / `git push` work without
+	// further setup.
+	it("SSH_CLONE_SCRIPT chmods the key 600 and persists to canonical paths", () => {
+		expect(SSH_CLONE_SCRIPT).toContain("chmod 600 ~/.ssh/id_ed25519");
+		expect(SSH_CLONE_SCRIPT).toContain("~/.ssh/known_hosts");
+		// `unset` the secret env vars after the on-disk write so a
+		// child process started by git doesn't inherit them.
+		expect(SSH_CLONE_SCRIPT).toContain("unset ST_SSH_KEY ST_KNOWN_HOSTS");
+	});
+
+	// ── env helpers (PR 188d) ──────────────────────────────────────────────
+
+	// `patEnv` and `sshEnv` produce strings (not numbers / undefined)
+	// for every field — Docker's exec API only accepts string-valued
+	// env. The empty-string convention is what the bash script's
+	// `[ -n ]` guards check; a literal "undefined" would pass the
+	// guard and produce `git clone --branch undefined`.
+	it("patEnv produces string-only values, with empty strings for absent ref/depth", () => {
+		const env = patEnv("ghp_x", { url: "https://example.com/r" });
+		for (const v of Object.values(env)) {
+			expect(typeof v).toBe("string");
+		}
+		expect(env.ST_REF).toBe("");
+		expect(env.ST_DEPTH).toBe("");
+		expect(env.ST_TARGET_ABS).toBe("/home/developer/workspace");
+	});
+
+	it("sshEnv produces string-only values and resolves target", () => {
+		const env = sshEnv("KEYDATA", "HOSTSDATA", {
+			url: "git@github.com:o/p",
+			depth: 5,
+			target: "sub",
+		});
+		expect(env).toEqual({
+			ST_SSH_KEY: "KEYDATA",
+			ST_KNOWN_HOSTS: "HOSTSDATA",
+			ST_URL: "git@github.com:o/p",
+			ST_REF: "",
+			ST_DEPTH: "5",
+			ST_TARGET_ABS: "/home/developer/workspace/sub",
+		});
 	});
 
 	// Output streaming — the runner just forwards the callback. Pin the

--- a/backend/src/bootstrap/cloneRepo.ts
+++ b/backend/src/bootstrap/cloneRepo.ts
@@ -283,6 +283,17 @@ chmod 644 ~/.ssh/known_hosts
 # can't unset that, but we can keep them out of the post-write
 # scope.)
 unset ST_SSH_KEY ST_KNOWN_HOSTS
+# Enforce strict host-key checking explicitly. Without this, OpenSSH
+# falls back to its 'ask' default — which behaves like rejection in a
+# non-TTY context (\`Tty: false\` on the docker exec) but prompts in a
+# TTY. The bot review of PR #215 round 1 caught this: the SSH JSDoc
+# block claimed the protection without code-enforcing it. With the
+# known_hosts file populated above, \`StrictHostKeyChecking=yes\` means
+# "verify the server's host key against known_hosts; refuse on
+# mismatch or absence". That's exactly the protection we want — a
+# hostile DNS / network can't substitute its own host key during
+# the clone.
+export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=yes"
 ARGS=("git" "clone")
 [ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
 [ -n "$ST_DEPTH" ] && ARGS+=("--depth" "$ST_DEPTH")

--- a/backend/src/bootstrap/cloneRepo.ts
+++ b/backend/src/bootstrap/cloneRepo.ts
@@ -1,27 +1,47 @@
 /**
- * cloneRepo.ts — repo-clone bootstrap step (#188 PR 188c).
+ * cloneRepo.ts — repo-clone bootstrap step (#188 PR 188c + 188d).
  *
  * Runs `git clone` inside the freshly-spawned session container BEFORE
  * postCreate fires, so a configured `repo` is in place by the time
  * the user's hook (or first interactive command) runs. Output streams
  * to the same WS broadcaster as postCreate.
  *
- * Scope of THIS PR (188c):
- *   - `repo.auth === "none"` only — anonymous HTTPS clone.
- *   - PAT and SSH paths throw `CloneAuthNotImplementedError` so a
- *     future PR (188d) wiring credentials wakes the runner up
- *     loudly rather than silently misbehaving (e.g. running an
- *     unauthenticated clone against a private URL and 404-ing).
+ * Three auth modes (188d wires PAT and SSH on top of 188c's "none"):
  *
- * The clone runs argv-only (no shell). `--branch`, `--depth`, and the
- * target dir are passed as separate arguments to defang any
- * shell-meta in user-supplied values that slipped past the schema's
- * regex allowlist.
+ *   - `auth: "none"` — anonymous HTTPS clone. Pure argv invocation
+ *     (no shell), single `streamExec` call.
+ *
+ *   - `auth: "pat"` — HTTPS clone authenticated by a personal access
+ *     token. The PAT NEVER appears in argv (process listings) or in
+ *     the resulting `.git/config`. Implementation: write a small
+ *     `GIT_ASKPASS` shim to `/tmp`, point `GIT_ASKPASS` at it, pass
+ *     the PAT via env var (`ST_PAT`). Git invokes the askpass shim
+ *     when it needs credentials; the shim prints them, git uses
+ *     them, and the URL stored in `origin` is the public form. The
+ *     askpass file is shredded on exit so a process snooping the
+ *     filesystem after the clone finds nothing.
+ *
+ *   - `auth: "ssh"` — SSH clone with `git@host:path` URL. The user's
+ *     private key is written to `~/.ssh/id_ed25519` (mode 0600), the
+ *     known_hosts content (bundled defaults or a custom paste) is
+ *     written to `~/.ssh/known_hosts`. `StrictHostKeyChecking=yes`
+ *     is enforced so a hostile DNS / network can't trick the clone
+ *     into trusting an attacker's host key. Both files PERSIST so
+ *     the user can subsequently `git pull` / `git push` from the
+ *     interactive shell without further setup.
+ *
+ * The PAT/SSH paths are bash-script-mode (multi-step setup before
+ * the clone). User-supplied values (URL, ref, target, depth) reach
+ * `git` as positional argv inside the script — populated via env
+ * vars and expanded with bash double-quoting — so a value that
+ * slipped past the schema's regex still cannot become shell meta.
  */
 
 import type { DockerManager } from "../dockerManager.js";
 import { logger } from "../logger.js";
-import type { SessionConfigRecord } from "../sessionConfig.js";
+import type { AuthInput, SessionConfigRecord } from "../sessionConfig.js";
+import { decryptStoredAuth, KNOWN_HOSTS_DEFAULT } from "../sessionConfig.js";
+import { KNOWN_HOSTS_DEFAULT_BUNDLE } from "./knownHosts.js";
 
 /**
  * Path of the workspace bind mount inside the container. Mirrors the
@@ -32,14 +52,16 @@ import type { SessionConfigRecord } from "../sessionConfig.js";
  */
 const CONTAINER_WORKSPACE = "/home/developer/workspace";
 
-/** Thrown when `repo.auth !== "none"` lands here pre-188d. */
-export class CloneAuthNotImplementedError extends Error {
-	constructor(authMode: string) {
-		super(
-			`cloneRepo: auth='${authMode}' is not implemented in this PR (lands in 188d). ` +
-				"Reject the config at the route boundary or wait for the credential path to ship.",
-		);
-		this.name = "CloneAuthNotImplementedError";
+/** Thrown when the auth blob is missing required fields at runtime
+ *  (e.g. `repo.auth='pat'` but `auth.pat` not in the decrypted blob).
+ *  The route's cross-field validation already blocks this on the
+ *  wire, so seeing it here means a row landed via a path that
+ *  bypassed `validateSessionConfig` (direct D1 write, partial-edit
+ *  endpoint). */
+export class CloneCredentialMissingError extends Error {
+	constructor(authMode: string, missing: string) {
+		super(`cloneRepo: auth='${authMode}' configured but ${missing} is missing from the auth blob`);
+		this.name = "CloneCredentialMissingError";
 	}
 }
 
@@ -52,65 +74,77 @@ interface RunCloneRepoArgs {
 
 /**
  * Run the configured clone for `sessionId` and return its exit code.
- * Returns `{ exitCode: 0 }` and a no-op when no `repo` is configured —
- * the caller treats that as "clone step succeeded" so a session with
- * only a postCreate hook (no repo) is unaffected.
- *
- * `repo.target === ""` is a request to clone into the workspace root.
- * `git clone` into a non-empty dir would fail, but a freshly-spawned
- * session's bind-mounted workspace is empty (the `.uploads` dir lives
- * outside the workspace tree as of PR 188a), so this is the
- * straightforward path.
+ * Returns `{ exitCode: 0 }` and a no-op when no `repo` is configured.
  */
 export async function runCloneRepo(args: RunCloneRepoArgs): Promise<{ exitCode: number }> {
 	const { config, sessionId, docker, onOutput } = args;
 	const repo = config.repo;
-	if (!repo) {
-		// No repo configured — caller treats as success, postCreate
-		// fires next. This branch is the steady-state for sessions
-		// that don't use the repo-clone feature.
-		return { exitCode: 0 };
-	}
-
-	if (repo.auth !== "none") {
-		// Wire-shape `repo.auth` in {"pat", "ssh"} requires the
-		// credential path that lands in 188d. Throw rather than
-		// silently fall through to anonymous clone — anonymous clone
-		// against a private URL would 404 and the user would see
-		// "Repository not found", with no signal that their stored
-		// credential was ignored.
-		throw new CloneAuthNotImplementedError(repo.auth);
-	}
+	if (!repo) return { exitCode: 0 };
 
 	const targetAbs = resolveTargetAbsPath(repo.target);
-	const cloneArgv = buildCloneArgv(repo.url, repo.ref, repo.depth, targetAbs);
+	const decrypted: AuthInput = config.auth ? decryptStoredAuth(config.auth) : {};
 
 	logger.info(
 		`[cloneRepo] session ${sessionId}: cloning ${repo.url} ` +
-			`(ref=${repo.ref ?? "<HEAD>"}, depth=${repo.depth ?? "full"}, target=${targetAbs})`,
+			`(auth=${repo.auth}, ref=${repo.ref ?? "<HEAD>"}, depth=${repo.depth ?? "full"}, target=${targetAbs})`,
 	);
 
-	// Run argv-style. `streamExec` shells out via Cmd: [argv0, argv1, …]
-	// (no `bash -c`) so user-controlled values can never break out into
-	// shell meta. The schema's regex allowlist is the primary defence;
-	// argv-only is belt-and-suspenders.
+	if (repo.auth === "none") {
+		const cloneArgv = buildCloneArgv(repo.url, repo.ref, repo.depth, targetAbs);
+		// argv-mode (no shell) — user-controlled values reach `git` as
+		// positional args, never as shell tokens.
+		return docker.streamExec(
+			sessionId,
+			{ cmd: cloneArgv, workingDir: CONTAINER_WORKSPACE },
+			onOutput,
+		);
+	}
+
+	if (repo.auth === "pat") {
+		if (decrypted.pat === undefined) {
+			throw new CloneCredentialMissingError("pat", "auth.pat");
+		}
+		// User-supplied values land in env vars; the bash script
+		// references them with double-quotes so shell-meta would be
+		// inert even if it slipped past the schema's regex. The PAT
+		// itself is in the env block too — visible to operators with
+		// `docker inspect` but NOT in argv (host-side `ps`) or
+		// in `.git/config` (workspace bind mount).
+		const env = patEnv(decrypted.pat, repo);
+		return docker.streamExec(
+			sessionId,
+			{
+				cmd: ["bash", "-c", PAT_CLONE_SCRIPT],
+				env,
+				workingDir: CONTAINER_WORKSPACE,
+			},
+			onOutput,
+		);
+	}
+
+	// repo.auth === "ssh"
+	if (decrypted.ssh === undefined) {
+		throw new CloneCredentialMissingError("ssh", "auth.ssh");
+	}
+	const knownHostsContent =
+		decrypted.ssh.knownHosts === KNOWN_HOSTS_DEFAULT
+			? KNOWN_HOSTS_DEFAULT_BUNDLE
+			: decrypted.ssh.knownHosts;
+	const env = sshEnv(decrypted.ssh.privateKey, knownHostsContent, repo);
 	return docker.streamExec(
 		sessionId,
-		{ cmd: cloneArgv, workingDir: CONTAINER_WORKSPACE },
+		{
+			cmd: ["bash", "-c", SSH_CLONE_SCRIPT],
+			env,
+			workingDir: CONTAINER_WORKSPACE,
+		},
 		onOutput,
 	);
 }
 
 /**
  * Resolve the in-container clone target. `target === ""` (or undefined)
- * means clone into the workspace root (`/home/developer/workspace`).
- * A non-empty `target` is a workspace-relative subpath validated by
- * the schema (no `..`, no leading `/`). The runner trusts that
- * validation: re-checking here would diverge if a future schema
- * tightening changes the allowed shape.
- *
- * Exported for the unit-test that pins the mapping; not part of the
- * public runtime API of the module.
+ * means clone into the workspace root.
  */
 export function resolveTargetAbsPath(target: string | undefined): string {
 	if (target === undefined || target === "") return CONTAINER_WORKSPACE;
@@ -118,14 +152,7 @@ export function resolveTargetAbsPath(target: string | undefined): string {
 }
 
 /**
- * Build the argv array for the clone. `--branch <ref>` and `--depth <N>`
- * are conditionally appended based on the config; `--` separates flags
- * from positional args so a future ref like `--evil` (already
- * blocked by the schema's leading-`-` check, but defence-in-depth)
- * can't be mis-parsed as a flag.
- *
- * Exported for the unit-test that pins the argv shape per
- * (ref, depth, target) variant.
+ * Build the argv array for an `auth: "none"` clone.
  */
 export function buildCloneArgv(
 	url: string,
@@ -134,8 +161,6 @@ export function buildCloneArgv(
 	targetAbs: string,
 ): string[] {
 	const argv: string[] = ["git", "clone"];
-	// Empty `ref` is the wire-shape signal for "use remote HEAD";
-	// only pass `--branch` when the user explicitly named one.
 	if (ref !== undefined && ref.length > 0) {
 		argv.push("--branch", ref);
 	}
@@ -145,3 +170,122 @@ export function buildCloneArgv(
 	argv.push("--", url, targetAbs);
 	return argv;
 }
+
+/**
+ * Env block for the PAT clone. The script reads each of these from
+ * `$ST_*` so user-supplied values can never become shell tokens.
+ *
+ * Exported for the unit-test that pins the env shape — verifying the
+ * PAT lands in the env (not argv) and that user values are
+ * env-encoded rather than shell-interpolated.
+ */
+export function patEnv(
+	pat: string,
+	repo: { url: string; ref?: string; depth?: number | null; target?: string },
+): Record<string, string> {
+	return {
+		ST_PAT: pat,
+		ST_URL: repo.url,
+		ST_REF: repo.ref ?? "",
+		ST_DEPTH: repo.depth != null ? String(repo.depth) : "",
+		ST_TARGET_ABS: resolveTargetAbsPath(repo.target),
+	};
+}
+
+/**
+ * Env block for the SSH clone. Same env-only model as `patEnv`.
+ *
+ * `ST_SSH_KEY` is the plaintext private key (newline-terminated); the
+ * script writes it to `~/.ssh/id_ed25519` with mode 0600. `ST_KNOWN_HOSTS`
+ * is the resolved known_hosts content (bundle or paste); written to
+ * `~/.ssh/known_hosts`.
+ */
+export function sshEnv(
+	privateKey: string,
+	knownHosts: string,
+	repo: { url: string; ref?: string; depth?: number | null; target?: string },
+): Record<string, string> {
+	return {
+		ST_SSH_KEY: privateKey,
+		ST_KNOWN_HOSTS: knownHosts,
+		ST_URL: repo.url,
+		ST_REF: repo.ref ?? "",
+		ST_DEPTH: repo.depth != null ? String(repo.depth) : "",
+		ST_TARGET_ABS: resolveTargetAbsPath(repo.target),
+	};
+}
+
+/**
+ * Bash script for PAT clone. All user-controlled values are read from
+ * env vars and double-quoted at use, so shell-meta in any of them is
+ * inert. The askpass file is shredded on exit (success OR fail) via
+ * `trap … EXIT` so a process snooping `/tmp` doesn't find the PAT.
+ *
+ * Note the conditional `--branch` / `--depth` handling: the variables
+ * are empty strings when the user didn't configure them; the bash
+ * `[ -n ]` guards skip the corresponding flag when so. Empty
+ * positional values would NOT be safe — `git clone --branch ""`
+ * crashes — and the empty-string convention is what `patEnv`
+ * produces.
+ *
+ * Also exported for the unit-test that pins the script shape so a
+ * future edit doesn't accidentally drop the `set -e`, the cleanup
+ * trap, or the `--` separator.
+ */
+export const PAT_CLONE_SCRIPT = `set -e
+# Cleanup runs on EXIT (success or fail) so the askpass file never
+# survives the clone — the PAT it would print is gone with it.
+ASKPASS_PATH=$(mktemp /tmp/git-askpass-XXXXXXXX)
+cleanup() { rm -f "$ASKPASS_PATH"; }
+trap cleanup EXIT
+cat > "$ASKPASS_PATH" <<'ASKPASS_EOF'
+#!/bin/sh
+case "$1" in
+  Username*) printf 'oauth2\\n' ;;
+  *) printf '%s\\n' "$ST_PAT" ;;
+esac
+ASKPASS_EOF
+chmod 700 "$ASKPASS_PATH"
+export GIT_ASKPASS="$ASKPASS_PATH"
+# Refuse to ever drop into an interactive prompt — without this, a
+# remote that doesn't accept the PAT would block the bootstrap on
+# stdin. We want a clean non-zero exit code instead.
+export GIT_TERMINAL_PROMPT=0
+ARGS=("git" "clone")
+[ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
+[ -n "$ST_DEPTH" ] && ARGS+=("--depth" "$ST_DEPTH")
+ARGS+=("--" "$ST_URL" "$ST_TARGET_ABS")
+"\${ARGS[@]}"
+`;
+
+/**
+ * Bash script for SSH clone. Persists the key + known_hosts to
+ * `~/.ssh/` so the user can `git pull` / `git push` later without
+ * re-supplying credentials. `StrictHostKeyChecking=yes` (the default
+ * when known_hosts has matching entries) defends against a hostile
+ * network swapping in an attacker's host key during the clone.
+ *
+ * Also exported for the unit-test that pins the script shape.
+ */
+export const SSH_CLONE_SCRIPT = `set -e
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+# printf '%s' (no trailing \\n) so a key that already ends in \\n
+# isn't double-newlined; ssh-keygen tolerates either, but the
+# canonical form is exactly the bytes the user pasted.
+printf '%s' "$ST_SSH_KEY" > ~/.ssh/id_ed25519
+chmod 600 ~/.ssh/id_ed25519
+printf '%s\\n' "$ST_KNOWN_HOSTS" > ~/.ssh/known_hosts
+chmod 644 ~/.ssh/known_hosts
+# Drop the secret env vars from the bash environment as soon as they
+# land on disk so a child process started by git doesn't inherit
+# them. (The docker exec env is what initially carried them; we
+# can't unset that, but we can keep them out of the post-write
+# scope.)
+unset ST_SSH_KEY ST_KNOWN_HOSTS
+ARGS=("git" "clone")
+[ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
+[ -n "$ST_DEPTH" ] && ARGS+=("--depth" "$ST_DEPTH")
+ARGS+=("--" "$ST_URL" "$ST_TARGET_ABS")
+"\${ARGS[@]}"
+`;

--- a/backend/src/bootstrap/knownHosts.ts
+++ b/backend/src/bootstrap/knownHosts.ts
@@ -1,0 +1,40 @@
+/**
+ * knownHosts.ts — bundled SSH public-key fingerprints for #188's
+ * SSH-clone path (PR 188d).
+ *
+ * The user picks `knownHosts: "default"` in the Repo tab to opt into
+ * this bundle; any other value is treated as a custom paste and
+ * stored verbatim. The runner writes whichever string lands here
+ * to `~/.ssh/known_hosts` inside the container BEFORE calling
+ * `git clone`, so SSH's host-key check has something to compare
+ * against — `StrictHostKeyChecking=yes` would otherwise refuse the
+ * clone with "Host key verification failed."
+ *
+ * The set is the three providers most users will clone from. Public
+ * fingerprints, no secrets. Each line is a self-contained
+ * `<host> <key-type> <base64-key>` triple.
+ *
+ * Sourced from the providers' published meta-API endpoints:
+ *   - GitHub: https://api.github.com/meta (`ssh_keys`)
+ *   - GitLab: https://docs.gitlab.com/ee/user/gitlab_com/#ssh-host-keys-fingerprints
+ *   - Bitbucket: https://support.atlassian.com/bitbucket-cloud/docs/configure-ssh-and-two-step-verification/
+ *
+ * Last updated: 2026-05-09. A future schedule should re-pull these on
+ * a cadence; for v1 the bundle is a static constant and operators who
+ * need fresher keys paste their own.
+ */
+
+export const KNOWN_HOSTS_DEFAULT_BUNDLE: string = [
+	// GitHub
+	"github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl",
+	"github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=",
+	"github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=",
+	// GitLab
+	"gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf",
+	"gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=",
+	"gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9",
+	// Bitbucket
+	"bitbucket.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIazEu89wgQZ4bqs3d63QSMzYVa0MuJ2e2gKTKqu+UUO",
+	"bitbucket.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIQmuzMBuKdWeF4+a2sjSSpBK0iqitSQ+5BM9KhpexuGt20JpTVM7u5BDZngncgrqDMbWdxMWWOGtZ9UgbqgZE=",
+	"bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M=",
+].join("\n");

--- a/backend/src/bootstrap/knownHosts.ts
+++ b/backend/src/bootstrap/knownHosts.ts
@@ -7,8 +7,12 @@
  * stored verbatim. The runner writes whichever string lands here
  * to `~/.ssh/known_hosts` inside the container BEFORE calling
  * `git clone`, so SSH's host-key check has something to compare
- * against — `StrictHostKeyChecking=yes` would otherwise refuse the
- * clone with "Host key verification failed."
+ * against. Without a populated known_hosts entry for the remote,
+ * the script's `StrictHostKeyChecking=yes` would refuse the clone
+ * with "Host key verification failed"; with matching fingerprints
+ * `yes` verifies the server and proceeds — which is exactly the
+ * protection we want against a hostile network swapping in an
+ * attacker's host key.
  *
  * The set is the three providers most users will clone from. Public
  * fingerprints, no secrets. Each line is a self-contained

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -364,14 +364,12 @@ describe("validateSessionConfig", () => {
 		);
 	});
 
-	// #188 PR 188c: PAT/SSH wire shapes are accepted by Zod (188b shipped
-	// the schema) but the clone runner only implements `auth: "none"`
-	// until 188d. The route-level guard rejects a structurally-valid
-	// SSH config so we don't burn a quota slot on a guaranteed-fail
-	// session. 188d removes this guard and the assertion flips back
-	// to `.toBeDefined()`.
-	it("rejects repo.auth='ssh' as not-yet-implemented (188c temporary guard)", () => {
-		expect(() =>
+	// #188 PR 188d: PAT and SSH credential paths are now wired in the
+	// runner. The 188c temporary guard that rejected `auth !== "none"`
+	// at the route is removed; structurally-valid PAT/SSH configs flow
+	// through validation and into the clone runner.
+	it("accepts repo.auth='ssh' with matching git@ URL and ssh creds", () => {
+		expect(
 			validateSessionConfig({
 				repo: { url: "git@github.com:o/p", auth: "ssh", target: "" },
 				auth: {
@@ -381,16 +379,16 @@ describe("validateSessionConfig", () => {
 					},
 				},
 			}),
-		).toThrowError(/only 'none'.*supported in this version/);
+		).toBeDefined();
 	});
 
-	it("rejects repo.auth='pat' with otherwise-valid config as not-yet-implemented (188c temporary guard)", () => {
-		expect(() =>
+	it("accepts repo.auth='pat' with https:// URL and a PAT", () => {
+		expect(
 			validateSessionConfig({
 				repo: { url: "https://example.com/r", auth: "pat" },
 				auth: { pat: "ghp_validtoken" },
 			}),
-		).toThrowError(/only 'none'.*supported in this version/);
+		).toBeDefined();
 	});
 
 	// Depth bounds — out of [1, 10000]. A missing `depth` is allowed

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -589,21 +589,6 @@ export function validateSessionConfig(raw: unknown): SessionConfig | undefined {
 			);
 		}
 	}
-	// #188 PR 188c — schema accepts auth ∈ {"none","pat","ssh"} (188b
-	// shipped the wire shape) but the clone runner only implements
-	// "none" until 188d wires PAT and SSH. Without this guard the route
-	// would 201-return + spawn the container, then the bootstrap runner
-	// would throw `CloneAuthNotImplementedError` and broadcast a
-	// dev-facing failure message to the user's modal. Reject at the
-	// route boundary instead so the user sees a clean 400 with an
-	// actionable message and we don't burn a quota slot on a session
-	// that's guaranteed to fail. 188d removes this guard.
-	if (result.data.repo && result.data.repo.auth !== "none") {
-		throw new SessionConfigValidationError(
-			"config.repo.auth",
-			"config.repo.auth: only 'none' (anonymous HTTPS) is supported in this version; PAT and SSH support is in flight",
-		);
-	}
 	return result.data;
 }
 


### PR DESCRIPTION
## Summary

Wires the two credential auth modes that 188b/188c stubbed out and removes the 188c temporary route guard that rejected \`auth !== \"none\"\`.

## PAT path

- Plaintext token NEVER reaches argv (host-side \`ps\`) or \`.git/config\` (workspace bind mount). Implementation: write a small \`GIT_ASKPASS\` shim to \`/tmp\`, point \`GIT_ASKPASS\` at it, pass the PAT via env var (\`ST_PAT\`). Git invokes the shim when it needs creds; resulting \`origin\` URL is the public form.
- The askpass file is shredded on EXIT (success OR fail) via a bash trap so a process snooping \`/tmp\` post-clone finds nothing.
- \`GIT_TERMINAL_PROMPT=0\` so a remote that rejects the PAT fails fast with a non-zero exit instead of hanging on stdin.

## SSH path

- Private key written to \`~/.ssh/id_ed25519\` (mode 0600) and known_hosts to \`~/.ssh/known_hosts\` — the canonical paths, so the user can subsequently \`git pull\` / \`git push\` from the interactive shell without re-supplying creds.
- \`StrictHostKeyChecking=yes\` (default when known_hosts has matching entries) defends against a hostile network swapping in an attacker's host key during the clone.
- \`knownHosts: \"default\"\` resolves to a new bundle in \`bootstrap/knownHosts.ts\` covering github.com / gitlab.com / bitbucket.org. Custom-paste values are stored verbatim.
- \`ST_SSH_KEY\` / \`ST_KNOWN_HOSTS\` are \`unset\` after on-disk write so child processes started by git don't inherit the secrets.

## Argv-mode invariant

Both bash scripts pass user-controlled values (URL, ref, depth, target) via env vars expanded with double-quotes, so shell-meta in any of them is inert even if it slipped past the schema's regex. The credentials are in the exec env block (visible to operators with \`docker inspect\`, NOT to host \`ps\`) — the documented trade-off.

## Test plan
- [x] PAT/SSH never appear in argv (host-side \`ps\` defence)
- [x] bash invokes the canonical \`PAT_CLONE_SCRIPT\` / \`SSH_CLONE_SCRIPT\` bodies; env block is string-only with empty-string convention for absent ref/depth
- [x] \`CloneCredentialMissingError\` throws when \`auth.{pat,ssh}\` blob absent (defence against direct D1 writes that bypassed cross-field validation)
- [x] script-shape markers (askpass cleanup trap, \`GIT_TERMINAL_PROMPT=0\`, \`chmod 600\` on key, \`unset\` of secret env)
- [x] \`cd backend && npm test\` — 372 passing
- [x] \`cd backend && npm run lint && npm run build\` — clean
- [x] \`cd frontend && npm run lint && npm run build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)