### PR TITLE
feat(repo): Repo tab UI for create-session modal (#188, PR 188e — closes #188)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -265,7 +265,111 @@
             role="tabpanel"
             aria-labelledby="session-tab-repo-tab"
             hidden
-          ></div>
+          >
+            <p class="modal-hint">
+              Clone a repo into the workspace before your postCreate
+              hook runs. Leave Target empty to clone into the workspace
+              root (replace mode). PAT and SSH credentials are
+              AES-GCM-encrypted at rest and never echoed back.
+            </p>
+            <label class="modal-field">
+              <span>Repository URL</span>
+              <input
+                type="text"
+                id="repo-url"
+                placeholder="https://github.com/owner/repo  or  git@github.com:owner/repo"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </label>
+            <div class="repo-fields-row">
+              <label class="modal-field">
+                <span>Ref (branch / tag / SHA)</span>
+                <input
+                  type="text"
+                  id="repo-ref"
+                  placeholder="main (empty = remote HEAD)"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </label>
+              <label class="modal-field">
+                <span>Target (workspace-relative)</span>
+                <input
+                  type="text"
+                  id="repo-target"
+                  placeholder="(empty = workspace root)"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </label>
+              <label class="modal-field">
+                <span>Shallow depth</span>
+                <input
+                  type="number"
+                  id="repo-depth"
+                  placeholder="(empty = full)"
+                  min="1"
+                  max="10000"
+                />
+              </label>
+            </div>
+            <label class="modal-field">
+              <span>Auth</span>
+              <select id="repo-auth">
+                <option value="none">None (public repo)</option>
+                <option value="pat">HTTPS Personal Access Token</option>
+                <option value="ssh">SSH key</option>
+              </select>
+            </label>
+            <div id="repo-auth-pat-panel" class="repo-auth-panel" hidden>
+              <label class="modal-field">
+                <span>Personal access token</span>
+                <input
+                  type="password"
+                  id="repo-auth-pat-token"
+                  placeholder="ghp_…"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </label>
+            </div>
+            <div id="repo-auth-ssh-panel" class="repo-auth-panel" hidden>
+              <label class="modal-field">
+                <span>Private key (OpenSSH format)</span>
+                <textarea
+                  id="repo-auth-ssh-key"
+                  rows="6"
+                  placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;…"
+                  autocomplete="off"
+                  spellcheck="false"
+                ></textarea>
+              </label>
+              <label class="modal-field">
+                <span>Known hosts</span>
+                <select id="repo-auth-ssh-known-hosts-mode">
+                  <option value="default">
+                    Bundled (github.com / gitlab.com / bitbucket.org)
+                  </option>
+                  <option value="custom">Custom paste</option>
+                </select>
+              </label>
+              <label
+                class="modal-field"
+                id="repo-auth-ssh-known-hosts-custom-wrap"
+                hidden
+              >
+                <span>Custom known_hosts</span>
+                <textarea
+                  id="repo-auth-ssh-known-hosts-custom"
+                  rows="4"
+                  placeholder="intranet.example.com ssh-ed25519 AAAA…"
+                  autocomplete="off"
+                  spellcheck="false"
+                ></textarea>
+              </label>
+            </div>
+          </div>
           <div
             class="session-tab-panel"
             id="session-tab-env"

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -571,6 +571,63 @@ main:not([data-sidebar-ready]) #sidebar {
 .session-field input[type="text"]:focus {
   border-color: #58a6ff;
 }
+/* #188 PR 188e — Repo tab. The form's field layout mirrors the
+ * existing modal-field shape used by the basics input; we add a
+ * flex row for the ref/target/depth triple so the three short fields
+ * fit on one line on a typical desktop viewport. The credential
+ * subpanels lift their inputs into a slightly tinted background so
+ * the user can see at a glance that they're entering secrets. */
+.modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: #8b949e;
+}
+.modal-field > span {
+  font-size: 0.78rem;
+}
+.modal-field input[type="text"],
+.modal-field input[type="password"],
+.modal-field input[type="number"],
+.modal-field select,
+.modal-field textarea {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.85rem;
+  color: #e6edf3;
+  outline: none;
+  font-family: inherit;
+}
+.modal-field input:focus,
+.modal-field select:focus,
+.modal-field textarea:focus {
+  border-color: #58a6ff;
+}
+.modal-field textarea {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  resize: vertical;
+}
+.repo-fields-row {
+  display: flex;
+  gap: 0.65rem;
+}
+.repo-fields-row .modal-field {
+  flex: 1 1 0;
+  min-width: 0;
+}
+.repo-auth-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  background: rgba(88, 166, 255, 0.04);
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+
 .session-placeholder {
   font-size: 0.82rem;
   color: #8b949e;

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -571,12 +571,14 @@ main:not([data-sidebar-ready]) #sidebar {
 .session-field input[type="text"]:focus {
   border-color: #58a6ff;
 }
-/* #188 PR 188e — Repo tab. The form's field layout mirrors the
- * existing modal-field shape used by the basics input; we add a
- * flex row for the ref/target/depth triple so the three short fields
- * fit on one line on a typical desktop viewport. The credential
- * subpanels lift their inputs into a slightly tinted background so
- * the user can see at a glance that they're entering secrets. */
+/* #188 PR 188e — Repo tab. `modal-field` is the new field-shape
+ * class introduced in this PR; the Basics tab's session-name input
+ * still uses the older `session-field` family, which is left
+ * unchanged. We add a flex row for the ref/target/depth triple so
+ * the three short fields fit on one line on a typical desktop
+ * viewport. The credential subpanels lift their inputs into a
+ * slightly tinted background so the user can see at a glance that
+ * they're entering secrets. */
 .modal-field {
   display: flex;
   flex-direction: column;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1318,10 +1318,10 @@ function resetRepoTab(): void {
  * `undefined` when no URL is set — that's the "no repo configured"
  * signal the bootstrap runner reads as a no-op.
  *
- * Trims input strings; empty `ref` / `target` are passed through as
- * empty strings (the backend interprets `ref: ""` as "remote HEAD"
- * and `target: ""` as "workspace root"). `depth` is parsed as int
- * if non-empty.
+ * Trims input strings; empty `ref` / `target` are omitted entirely
+ * from the payload (the backend's `.optional()` fields treat omission
+ * identically to `""` — "remote HEAD" and "workspace root"
+ * respectively). `depth` is parsed as int if non-empty.
  *
  * The collected shape is the `{ repo, auth }` pair the backend's
  * `validateSessionConfig` cross-field check expects. We do NOT

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -31,6 +31,7 @@ import {
 	register,
 	revokeInvite,
 	SESSION_EXPIRED_EVENT,
+	type SessionConfigPayload,
 	type SessionInfo,
 	startSession,
 	stopSession,
@@ -1052,11 +1053,6 @@ async function closeTab(tabId: string, triggeredBy?: HTMLButtonElement) {
 
 const SESSION_TAB_PLACEHOLDERS: Record<string, { title: string; body: string; issueUrl: string }> =
 	{
-		repo: {
-			title: "Clone a repo into the workspace",
-			body: "Public or private (PAT / SSH), pick a branch or ref, optionally replace the workspace.",
-			issueUrl: "https://github.com/gatof81/shared-terminal/issues/188",
-		},
 		ports: {
 			title: "Expose ports to the outside",
 			body: "Per-session subdomains, dynamic host ports, auth-gated by default (independent of session ownership).",
@@ -1224,6 +1220,10 @@ function closeNewSessionModal() {
 	// and re-open. The redundant reset on `openNewSessionModal` is
 	// gone — closing always leaves the array empty.
 	resetEnvTab();
+	// Reset Repo-tab state on close (#188 PR 188e). Critical for the
+	// credential fields (PAT, SSH key) — leaving them mounted would
+	// risk leaking a stale credential into the next session create.
+	resetRepoTab();
 	(newSessionOpener ?? newSessionBtn).focus();
 	newSessionOpener = null;
 }
@@ -1236,6 +1236,143 @@ newSessionModal.addEventListener("click", (e) => {
 	const tab = target.closest<HTMLButtonElement>("[data-session-tab]");
 	if (tab?.dataset.sessionTab) setActiveSessionTab(tab.dataset.sessionTab);
 });
+
+// ── Repo tab (#188 / PR 188e) ───────────────────────────────────────────────
+//
+// State + render + wiring for the repo-clone Repo tab. The tab is the
+// frontend half of #188; backend pieces shipped in 188a-188d.
+//
+// Three auth modes selected by the `Auth` dropdown:
+//   - `none` — anonymous HTTPS clone, no credentials.
+//   - `pat`  — HTTPS + personal access token. Token panel reveals.
+//   - `ssh`  — SSH clone (git@host:path). Key + known_hosts panel reveals.
+//
+// State here is read directly from the DOM at submit time
+// (`collectRepoForSubmit`) — no in-memory mirror. The form is small
+// enough that the env-tab's array-source-of-truth pattern would be
+// overkill, and a single-shot collect avoids needing to sync after
+// every keystroke.
+//
+// `resetRepoTab()` runs on modal close so a partially-typed PAT or
+// SSH key doesn't leak into the next session create.
+
+const repoUrl = document.getElementById("repo-url") as HTMLInputElement;
+const repoRef = document.getElementById("repo-ref") as HTMLInputElement;
+const repoTarget = document.getElementById("repo-target") as HTMLInputElement;
+const repoDepth = document.getElementById("repo-depth") as HTMLInputElement;
+const repoAuth = document.getElementById("repo-auth") as HTMLSelectElement;
+const repoAuthPatPanel = document.getElementById("repo-auth-pat-panel") as HTMLDivElement;
+const repoAuthPatToken = document.getElementById("repo-auth-pat-token") as HTMLInputElement;
+const repoAuthSshPanel = document.getElementById("repo-auth-ssh-panel") as HTMLDivElement;
+const repoAuthSshKey = document.getElementById("repo-auth-ssh-key") as HTMLTextAreaElement;
+const repoAuthSshKnownHostsMode = document.getElementById(
+	"repo-auth-ssh-known-hosts-mode",
+) as HTMLSelectElement;
+const repoAuthSshKnownHostsCustomWrap = document.getElementById(
+	"repo-auth-ssh-known-hosts-custom-wrap",
+) as HTMLLabelElement;
+const repoAuthSshKnownHostsCustom = document.getElementById(
+	"repo-auth-ssh-known-hosts-custom",
+) as HTMLTextAreaElement;
+
+/** Show/hide the auth subpanel based on the dropdown selection. */
+function syncRepoAuthPanels(): void {
+	const mode = repoAuth.value;
+	repoAuthPatPanel.toggleAttribute("hidden", mode !== "pat");
+	repoAuthSshPanel.toggleAttribute("hidden", mode !== "ssh");
+}
+
+/** Show/hide the custom-paste textarea based on the known_hosts mode. */
+function syncRepoSshKnownHostsCustom(): void {
+	const mode = repoAuthSshKnownHostsMode.value;
+	repoAuthSshKnownHostsCustomWrap.toggleAttribute("hidden", mode !== "custom");
+}
+
+repoAuth.addEventListener("change", syncRepoAuthPanels);
+repoAuthSshKnownHostsMode.addEventListener("change", syncRepoSshKnownHostsCustom);
+
+/**
+ * Wipe Repo-tab state on modal close. Critical for the credential
+ * fields (PAT, SSH private key) — leaving them in the DOM after a
+ * close would let the next session-create operator (or even the
+ * same user reopening for a different repo) accidentally submit a
+ * stale credential. Reset to the default "none" auth mode so the
+ * subpanels collapse too.
+ */
+function resetRepoTab(): void {
+	repoUrl.value = "";
+	repoRef.value = "";
+	repoTarget.value = "";
+	repoDepth.value = "";
+	repoAuth.value = "none";
+	repoAuthPatToken.value = "";
+	repoAuthSshKey.value = "";
+	repoAuthSshKnownHostsMode.value = "default";
+	repoAuthSshKnownHostsCustom.value = "";
+	syncRepoAuthPanels();
+	syncRepoSshKnownHostsCustom();
+}
+
+/**
+ * Read the Repo tab into the wire shape the backend accepts. Returns
+ * `undefined` when no URL is set — that's the "no repo configured"
+ * signal the bootstrap runner reads as a no-op.
+ *
+ * Trims input strings; empty `ref` / `target` are passed through as
+ * empty strings (the backend interprets `ref: ""` as "remote HEAD"
+ * and `target: ""` as "workspace root"). `depth` is parsed as int
+ * if non-empty.
+ *
+ * The collected shape is the `{ repo, auth }` pair the backend's
+ * `validateSessionConfig` cross-field check expects. We do NOT
+ * pre-validate URL scheme / refname rules here — the backend's Zod
+ * schema is the single source of truth; client-side mirroring would
+ * just be one more place to keep in sync. The user gets a 400 with
+ * a precise field path on submit.
+ *
+ * Exported for unit tests that pin the wire shape per (auth-mode)
+ * variant.
+ */
+export function collectRepoForSubmit(): {
+	repo: SessionConfigPayload["repo"];
+	auth: SessionConfigPayload["auth"];
+} {
+	const url = repoUrl.value.trim();
+	if (url === "") return { repo: undefined, auth: undefined };
+	const ref = repoRef.value.trim();
+	const target = repoTarget.value.trim();
+	const depthRaw = repoDepth.value.trim();
+	const depth = depthRaw === "" ? undefined : Number.parseInt(depthRaw, 10);
+	const auth = repoAuth.value as "none" | "pat" | "ssh";
+
+	const repo: NonNullable<SessionConfigPayload["repo"]> = {
+		url,
+		auth,
+	};
+	if (ref !== "") repo.ref = ref;
+	if (target !== "") repo.target = target;
+	if (depth !== undefined && Number.isFinite(depth)) repo.depth = depth;
+
+	if (auth === "none") {
+		return { repo, auth: undefined };
+	}
+	if (auth === "pat") {
+		const token = repoAuthPatToken.value;
+		// Plaintext token flows into the payload — sent over HTTPS,
+		// encrypted server-side at the route boundary before D1 write.
+		// Empty token is allowed through here; the backend will 400 on
+		// the cross-field check (`auth.pat required when repo.auth='pat'`).
+		return { repo, auth: { pat: token } };
+	}
+	// auth === "ssh"
+	const privateKey = repoAuthSshKey.value;
+	const knownHostsMode = repoAuthSshKnownHostsMode.value;
+	// "default" is the wire-shape sentinel the backend resolves to the
+	// bundled github/gitlab/bitbucket fingerprints (see 188d's
+	// knownHosts.ts). Custom mode passes the textarea content verbatim.
+	const knownHosts = knownHostsMode === "custom" ? repoAuthSshKnownHostsCustom.value : "default";
+	return { repo, auth: { ssh: { privateKey, knownHosts } } };
+}
 
 // ── Env tab (#186 / PR 186c) ────────────────────────────────────────────────
 //
@@ -1479,7 +1616,18 @@ newSessionForm.addEventListener("submit", async (e) => {
 	try {
 		showToast("Creating session…");
 		const envVars = collectEnvVarsForSubmit();
-		const config = envVars ? { envVars } : undefined;
+		const { repo, auth } = collectRepoForSubmit();
+		// Build the config payload only when something is actually
+		// configured. A bare `POST /sessions` (no config field) stays
+		// the steady-state for users not exercising any of the tabs.
+		const config: SessionConfigPayload | undefined =
+			envVars || repo
+				? {
+						...(envVars ? { envVars } : {}),
+						...(repo ? { repo } : {}),
+						...(auth ? { auth } : {}),
+					}
+				: undefined;
 		const session = await createSession(name, undefined, config);
 		sessions.unshift(session);
 		renderSessionList();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1357,7 +1357,14 @@ export function collectRepoForSubmit(): {
 		return { repo, auth: undefined };
 	}
 	if (auth === "pat") {
-		const token = repoAuthPatToken.value;
+		// Trim the PAT — clipboard sources (1Password, GitHub copy
+		// button) often append a trailing newline. A `\n`-suffixed
+		// token would pass Zod's `.min(1)` check, encrypt fine, and
+		// then fail with a cryptic git-auth error at clone time
+		// rather than a clean message here (PR #216 round 1 NIT).
+		// SSH keys below are deliberately NOT trimmed — they have
+		// load-bearing newlines.
+		const token = repoAuthPatToken.value.trim();
 		// Plaintext token flows into the payload — sent over HTTPS,
 		// encrypted server-side at the route boundary before D1 write.
 		// Empty token is allowed through here; the backend will 400 on

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1330,8 +1330,12 @@ function resetRepoTab(): void {
  * just be one more place to keep in sync. The user gets a 400 with
  * a precise field path on submit.
  *
- * Exported for unit tests that pin the wire shape per (auth-mode)
- * variant.
+ * Exported so a future test file (jsdom + DOM seed) can pin the
+ * wire shape per (auth-mode) variant without going through the
+ * full main.ts side-effect chain. None ship in this PR — the
+ * Env tab's equivalent (`collectEnvVarsForSubmit`) is also
+ * untested and the precedent is to add tests when the form is
+ * extracted into its own module.
  */
 export function collectRepoForSubmit(): {
 	repo: SessionConfigPayload["repo"];
@@ -1367,8 +1371,10 @@ export function collectRepoForSubmit(): {
 		const token = repoAuthPatToken.value.trim();
 		// Plaintext token flows into the payload — sent over HTTPS,
 		// encrypted server-side at the route boundary before D1 write.
-		// Empty token is allowed through here; the backend will 400 on
-		// the cross-field check (`auth.pat required when repo.auth='pat'`).
+		// Empty token is allowed through here; the backend rejects it
+		// in Zod's `.min(1)` check on `auth.pat` (the cross-field guard
+		// only fires when `auth.pat` is `undefined`, not `""` — PR #216
+		// round 2 NIT corrected the misstatement here).
 		return { repo, auth: { pat: token } };
 	}
 	// auth === "ssh"


### PR DESCRIPTION
## Summary

Frontend half of #188. Backend pieces shipped in 188a-188d; this PR is the visible surface that lets users actually configure a repo clone from the create-session modal.

## UI

- URL / ref / target / depth fields on the Repo tab.
- Auth dropdown (none / PAT / SSH) drives a conditional credential subpanel:
  - **PAT**: password-masked token input.
  - **SSH**: monospace textarea for the private key + a known_hosts mode dropdown (default = bundled github/gitlab/bitbucket fingerprints; custom = paste).

## Wiring

- \`collectRepoForSubmit\` reads the DOM at submit time into the wire shape the backend's \`validateSessionConfig\` accepts. Returns \`{ repo: undefined, auth: undefined }\` when URL is empty — that's the no-op case the bootstrap runner reads as \"skip\".
- \`resetRepoTab\` runs on modal close to wipe credential fields. Critical for PAT and SSH key — leaving them mounted between closes would leak a stale credential into a follow-on session create.
- Submit handler merges \`repo\` + \`auth\` into the existing config payload alongside \`envVars\`; the bare-POST path stays unchanged.

## Validation

Client-side mirroring of the backend Zod schema is intentionally NOT done — the backend is the single source of truth, and the user gets a 400 with a precise field path on submit. This matches the Env tab's approach.

## Closes

This closes #188 in conjunction with 188a-188d.

## Test plan
- [x] \`cd backend && npm test\` — 375 passing, no regressions
- [x] \`cd frontend && npm test\` — 47 passing
- [x] \`cd backend && npm run lint && npm run build\` — clean
- [x] \`cd frontend && npm run lint && npm run build\` — clean
- [ ] Manual: open the new-session modal, enter a public GitHub URL on the Repo tab, submit, confirm the bootstrap runner clones successfully.
- [ ] Manual: PAT mode against a private repo with a valid token; SSH mode against a private repo with a valid key + bundled known_hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)