### PR TITLE
feat(hooks): gitIdentity / dotfiles / agentSeed schema (#191, PR 191a of 3)

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -199,6 +199,9 @@ export async function migrateDb(): Promise<void> {
                         ports_json          TEXT,
                         env_vars_json       TEXT,
                         auth_json           TEXT,
+                        git_identity_json   TEXT,
+                        dotfiles_json       TEXT,
+                        agent_seed_json     TEXT,
                         bootstrapped_at     TEXT,
                         created_at          TEXT NOT NULL DEFAULT (datetime('now')),
                         FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
@@ -234,6 +237,19 @@ export async function migrateDb(): Promise<void> {
 	} catch (err) {
 		if (!/duplicate column name|already exists/i.test((err as Error).message)) {
 			throw err;
+		}
+	}
+	// #191 PR 191a: lifecycle-hook columns on `session_configs` —
+	// gitIdentity / dotfiles / agentSeed JSON blobs. Same idiom as
+	// auth_json above. The bootstrap stages that consume these land
+	// in 191b; this PR only adds the schema + storage.
+	for (const column of ["git_identity_json", "dotfiles_json", "agent_seed_json"] as const) {
+		try {
+			await d1Query(`ALTER TABLE session_configs ADD COLUMN ${column} TEXT`);
+		} catch (err) {
+			if (!/duplicate column name|already exists/i.test((err as Error).message)) {
+				throw err;
+			}
 		}
 	}
 	// Auto-promote the earliest-created user when no admin exists yet.

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -419,6 +419,34 @@ describe("validateSessionConfig", () => {
 		).toThrowError(SessionConfigValidationError);
 	});
 
+	// PR #217 round 1 SHOULD-FIX: a `\n` in `name` would corrupt
+	// `~/.gitconfig` (INI format, newline-delimited records) when the
+	// 191b stage runs `git config --global user.name "<name>"`. Reject
+	// at the schema boundary so the runner doesn't need to defend at
+	// the write site.
+	it("rejects gitIdentity.name containing control characters", () => {
+		for (const name of ["Ada\nuser.email = evil@evil.com", "X\rY", "X\tY", "X Y", "XY"]) {
+			expect(() =>
+				validateSessionConfig({
+					gitIdentity: { name, email: "a@b.com" },
+				}),
+			).toThrowError(SessionConfigValidationError);
+		}
+	});
+
+	// Defence: regular space (0x20) and printable Unicode are NOT
+	// control chars. Names like "Ada Lovelace" or "François" must
+	// keep working past the new control-char regex.
+	it("accepts gitIdentity.name with spaces and printable Unicode", () => {
+		for (const name of ["Ada Lovelace", "François", "李雷"]) {
+			expect(
+				validateSessionConfig({
+					gitIdentity: { name, email: "a@b.com" },
+				}),
+			).toBeDefined();
+		}
+	});
+
 	it("accepts dotfiles with bare URL (clone-only, no install script)", () => {
 		expect(
 			validateSessionConfig({
@@ -503,6 +531,22 @@ describe("validateSessionConfig", () => {
 			SessionConfigValidationError,
 		);
 		expect(() => validateSessionConfig({ agentSeed: { claudeMd: big } })).toThrowError(
+			SessionConfigValidationError,
+		);
+	});
+
+	// PR #217 round 1 SHOULD-FIX: Zod's `.max()` counts UTF-16 code
+	// units, NOT UTF-8 bytes. A 4-byte-per-char string of 100 K
+	// codepoints (e.g. 💥) is 400 K UTF-8 bytes (over the 256 KiB
+	// cap) but only 200 K UTF-16 code units (under any naive
+	// char-count cap). The Buffer.byteLength refine catches this
+	// where `.max()` would have let it through.
+	it("rejects agentSeed bodies whose UTF-8 byte size exceeds the cap (4-byte chars)", () => {
+		const bigEmoji = "💥".repeat(100 * 1024); // 400 KiB UTF-8 bytes
+		expect(() => validateSessionConfig({ agentSeed: { claudeMd: bigEmoji } })).toThrowError(
+			SessionConfigValidationError,
+		);
+		expect(() => validateSessionConfig({ agentSeed: { settings: bigEmoji } })).toThrowError(
 			SessionConfigValidationError,
 		);
 	});
@@ -771,6 +815,38 @@ describe("persistSessionConfig", () => {
 		// ciphertext + iv + tag. A future serializer mistake that
 		// re-introduces plaintext would trip this.
 		expect(envJson[1]).not.toHaveProperty("value");
+	});
+
+	// PR #217 round 1 NIT: pin the wire shape of the three new
+	// 191a columns. Without this, a future rename of a TS field
+	// (`gitIdentity` → `identity`) would produce `jsonOrNull(undefined)
+	// → null` — silent data loss while every existing test passes
+	// because they all use null fixtures.
+	it("serialises gitIdentity / dotfiles / agentSeed JSON columns (191a)", async () => {
+		await persistSessionConfig("sess-191a", {
+			gitIdentity: { name: "Ada Lovelace", email: "ada@example.com" },
+			dotfiles: {
+				url: "https://github.com/u/dotfiles.git",
+				ref: "main",
+				installScript: "install.sh",
+			},
+			agentSeed: { settings: '{"theme":"dark"}', claudeMd: "# notes" },
+		});
+		const [, params] = dbStubs.d1Query.mock.calls[0]!;
+		// git_identity_json is param[11], dotfiles_json [12], agent_seed_json [13].
+		expect(JSON.parse(params?.[11] as string)).toEqual({
+			name: "Ada Lovelace",
+			email: "ada@example.com",
+		});
+		expect(JSON.parse(params?.[12] as string)).toEqual({
+			url: "https://github.com/u/dotfiles.git",
+			ref: "main",
+			installScript: "install.sh",
+		});
+		expect(JSON.parse(params?.[13] as string)).toEqual({
+			settings: '{"theme":"dark"}',
+			claudeMd: "# notes",
+		});
 	});
 });
 

--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -391,6 +391,132 @@ describe("validateSessionConfig", () => {
 		).toBeDefined();
 	});
 
+	// ── #191 — gitIdentity / dotfiles / agentSeed ────────────────────────
+
+	it("accepts gitIdentity with name + email", () => {
+		expect(
+			validateSessionConfig({
+				gitIdentity: { name: "Ada Lovelace", email: "ada@example.com" },
+			}),
+		).toBeDefined();
+	});
+
+	it("rejects gitIdentity with malformed email", () => {
+		for (const email of ["", "notanemail", "user@", "@host", "spaces in@email.com"]) {
+			expect(() =>
+				validateSessionConfig({
+					gitIdentity: { name: "X", email },
+				}),
+			).toThrowError(SessionConfigValidationError);
+		}
+	});
+
+	it("rejects gitIdentity with empty name", () => {
+		expect(() =>
+			validateSessionConfig({
+				gitIdentity: { name: "", email: "a@b.com" },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
+	it("accepts dotfiles with bare URL (clone-only, no install script)", () => {
+		expect(
+			validateSessionConfig({
+				dotfiles: { url: "https://github.com/user/dotfiles.git" },
+			}),
+		).toBeDefined();
+	});
+
+	it("accepts dotfiles with git@ URL + ref + installScript", () => {
+		expect(
+			validateSessionConfig({
+				dotfiles: {
+					url: "git@github.com:user/dotfiles.git",
+					ref: "main",
+					installScript: "install.sh",
+				},
+			}),
+		).toBeDefined();
+	});
+
+	it("rejects dotfiles URL with disallowed scheme", () => {
+		for (const url of ["http://example.com/r", "file:///etc", "ssh://attacker/r"]) {
+			expect(() => validateSessionConfig({ dotfiles: { url } })).toThrowError(
+				SessionConfigValidationError,
+			);
+		}
+	});
+
+	it("rejects dotfiles URL with embedded credentials (defends encryption boundary)", () => {
+		expect(() =>
+			validateSessionConfig({
+				dotfiles: { url: "https://user:token@github.com/user/dotfiles" },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
+	// Same path-traversal defence as `repo.target`. installScript ends
+	// up as `/home/developer/dotfiles/<installScript>` inside the
+	// container; `..` would let it escape the dotfiles tree.
+	it("rejects dotfiles installScript with '..' / leading '/' / '//'", () => {
+		for (const installScript of ["../escape", "/abs/path", "a//b", "../"]) {
+			expect(() =>
+				validateSessionConfig({
+					dotfiles: { url: "https://example.com/r", installScript },
+				}),
+			).toThrowError(SessionConfigValidationError);
+		}
+	});
+
+	it("accepts agentSeed with valid JSON settings + markdown CLAUDE.md", () => {
+		expect(
+			validateSessionConfig({
+				agentSeed: {
+					settings: '{"theme":"dark","editor":{"tabSize":2}}',
+					claudeMd: "# Project notes\n- Use TS strict mode.\n",
+				},
+			}),
+		).toBeDefined();
+	});
+
+	it("rejects agentSeed.settings that is not valid JSON", () => {
+		expect(() =>
+			validateSessionConfig({
+				agentSeed: { settings: "{not json" },
+			}),
+		).toThrowError(SessionConfigValidationError);
+	});
+
+	it("accepts agentSeed.settings that is an empty string (no file written)", () => {
+		// Empty string = wire-shape signal for "leave the file alone".
+		// The bootstrap stage's `if (settings)` guard skips the write.
+		expect(
+			validateSessionConfig({
+				agentSeed: { settings: "" },
+			}),
+		).toBeDefined();
+	});
+
+	it("rejects agentSeed bodies above the 256 KiB cap", () => {
+		const big = "x".repeat(257 * 1024);
+		expect(() => validateSessionConfig({ agentSeed: { settings: big } })).toThrowError(
+			SessionConfigValidationError,
+		);
+		expect(() => validateSessionConfig({ agentSeed: { claudeMd: big } })).toThrowError(
+			SessionConfigValidationError,
+		);
+	});
+
+	it("accepts null for gitIdentity / dotfiles / agentSeed (explicit-not-configured)", () => {
+		expect(
+			validateSessionConfig({
+				gitIdentity: null,
+				dotfiles: null,
+				agentSeed: null,
+			}),
+		).toBeDefined();
+	});
+
 	// Depth bounds — out of [1, 10000]. A missing `depth` is allowed
 	// (full history), so the lower bound has to fire on `0` and `-1`.
 	it("rejects repo.depth out of bounds", () => {
@@ -578,6 +704,9 @@ describe("persistSessionConfig", () => {
 			null, // ports_json
 			null, // env_vars_json
 			null, // auth_json
+			null, // git_identity_json
+			null, // dotfiles_json
+			null, // agent_seed_json
 		]);
 	});
 
@@ -593,8 +722,9 @@ describe("persistSessionConfig", () => {
 		// Defensive cross-check: the params length must match the column
 		// count, so a future caller adding bootstrapped_at to either side
 		// without updating the other trips this assertion immediately.
-		// 11 = sessionId + 10 column values (incl. auth_json added in 188b).
-		expect((params as unknown[]).length).toBe(11);
+		// 14 = sessionId + 13 column values (incl. git_identity_json /
+		// dotfiles_json / agent_seed_json added in 191a).
+		expect((params as unknown[]).length).toBe(14);
 	});
 
 	it("collapses empty array sub-records to NULL (no D1 row bloat)", async () => {
@@ -672,6 +802,9 @@ describe("getSessionConfig", () => {
 					ports_json: null,
 					env_vars_json: JSON.stringify([{ name: "FOO", type: "plain", value: "bar" }]),
 					auth_json: null,
+					git_identity_json: null,
+					dotfiles_json: null,
+					agent_seed_json: null,
 					bootstrapped_at: "2026-05-08 12:00:00",
 				},
 			],
@@ -712,6 +845,9 @@ describe("getSessionConfig", () => {
 					ports_json: null,
 					env_vars_json: null,
 					auth_json: null,
+					git_identity_json: null,
+					dotfiles_json: null,
+					agent_seed_json: null,
 					bootstrapped_at: null,
 				},
 			],
@@ -750,6 +886,9 @@ describe("getSessionConfig", () => {
 					ports_json: null,
 					env_vars_json: null,
 					auth_json: null,
+					git_identity_json: null,
+					dotfiles_json: null,
+					agent_seed_json: null,
 					bootstrapped_at: null,
 				},
 			],
@@ -825,6 +964,57 @@ describe("getSessionConfig", () => {
 		}));
 		const got = await getSessionConfig("sess-auth-bad");
 		expect(got?.auth).toBeUndefined();
+	});
+
+	// PR 191a — gitIdentity / dotfiles / agentSeed rehydrate via the
+	// generic `parseJsonColumn` (no special-case shim like repos_json
+	// / env_vars_json have). Pin the round-trip so a future column
+	// rename or schema-shape change can't silently drop them.
+	it("rehydrates gitIdentity / dotfiles / agentSeed JSON blobs", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [
+				{
+					session_id: "sess-191",
+					workspace_strategy: null,
+					cpu_limit: null,
+					mem_limit: null,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: null,
+					ports_json: null,
+					env_vars_json: null,
+					auth_json: null,
+					git_identity_json: JSON.stringify({
+						name: "Ada Lovelace",
+						email: "ada@example.com",
+					}),
+					dotfiles_json: JSON.stringify({
+						url: "https://github.com/u/dotfiles.git",
+						ref: "main",
+						installScript: "install.sh",
+					}),
+					agent_seed_json: JSON.stringify({
+						settings: '{"theme":"dark"}',
+						claudeMd: "# notes\n",
+					}),
+					bootstrapped_at: null,
+				},
+			],
+			success: true as const,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const got = await getSessionConfig("sess-191");
+		expect(got?.gitIdentity).toEqual({ name: "Ada Lovelace", email: "ada@example.com" });
+		expect(got?.dotfiles).toEqual({
+			url: "https://github.com/u/dotfiles.git",
+			ref: "main",
+			installScript: "install.sh",
+		});
+		expect(got?.agentSeed).toEqual({
+			settings: '{"theme":"dark"}',
+			claudeMd: "# notes\n",
+		});
 	});
 
 	// PR #210 round 2 fix: `session_configs.env_vars_json` had a
@@ -988,6 +1178,9 @@ describe("getSessionConfig", () => {
 					ports_json: null,
 					env_vars_json: null,
 					auth_json: null,
+					git_identity_json: null,
+					dotfiles_json: null,
+					agent_seed_json: null,
 					bootstrapped_at: null,
 				},
 			],

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -52,6 +52,16 @@ const MAX_REPO_DEPTH = 10_000;
 const MAX_PAT_LEN = 4 * 1024;
 const MAX_SSH_KEY_LEN = 16 * 1024;
 const MAX_KNOWN_HOSTS_LEN = 32 * 1024;
+// #191 lifecycle-hook bounds. Names + emails fit in 256 chars (RFC
+// 5321 caps the localpart at 64 + domain at 255 — 256 is comfortably
+// over the realistic max). Dotfiles install-script paths use the same
+// shape as repo target. Agent-seed file bodies are user-generated
+// content (settings.json, CLAUDE.md) — 256 KiB matches the env-vars
+// total cap so a single create can't push a multi-MB row to D1.
+const MAX_GIT_NAME_LEN = 256;
+const MAX_GIT_EMAIL_LEN = 256;
+const MAX_DOTFILES_INSTALL_SCRIPT_LEN = 256;
+const MAX_AGENT_SEED_BYTES = 256 * 1024;
 // #186 env-var entry caps. Per-entry value at 16 KiB matches the
 // spec; aggregate budget below caps the whole serialised list so a
 // caller can't blow past D1-friendly sizes by stuffing 64 entries at
@@ -227,6 +237,110 @@ const WireAuthSpec = z
 	})
 	.strict();
 
+// #191 — git identity. Used by the bootstrap stage to run
+// `git config --global user.{name,email}` inside the container BEFORE
+// any commit-producing operation (clone with rebase, dotfiles install
+// running git, postCreate scripts that auto-commit). Both fields
+// required when the block is set — a half-configured identity would
+// produce a less-helpful `git config` error at the wrong layer.
+//
+// Email validation is deliberately permissive: a single `@` with at
+// least one char on each side. RFC 5322's full grammar is overkill —
+// the bootstrap stage just hands the string to `git config`; git
+// itself accepts anything. The regex catches obvious typos
+// ("user@", "@example.com", whitespace-only) without the false
+// negatives a strict spec would produce.
+const GIT_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+$/;
+const GitIdentitySpec = z
+	.object({
+		name: z.string().min(1).max(MAX_GIT_NAME_LEN),
+		email: z
+			.string()
+			.min(1)
+			.max(MAX_GIT_EMAIL_LEN)
+			.refine((e) => GIT_EMAIL_PATTERN.test(e), {
+				message: "email must be of the form local@domain",
+			}),
+	})
+	.strict();
+
+// #191 — dotfiles repo. Same URL allowlist as the main repo (#188)
+// so the auth↔scheme pairing rules from `RepoSpec` carry over. Auth
+// is shared with the main repo by design (issue spec): the user has
+// one PAT / SSH identity per session; a per-repo identity is a
+// follow-up (#189). `installScript` is a path INSIDE the cloned
+// dotfiles repo; same path-traversal defence as `repo.target`.
+const DOTFILES_INSTALL_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._/-]*$/;
+const DotfilesSpec = z
+	.object({
+		url: z
+			.string()
+			.min(1)
+			.max(500)
+			.refine((u) => REPO_URL_HTTPS.test(u) || REPO_URL_SSH.test(u), {
+				message: "url must be https://… or git@host:path form",
+			})
+			.refine((u) => !u.includes(".."), {
+				message: "url must not contain '..'",
+			}),
+		// Empty/null = remote HEAD; same shape as `RepoSpec.ref`.
+		ref: z
+			.string()
+			.max(MAX_REPO_REF_LEN)
+			.refine((r) => r === "" || (REPO_REF_PATTERN.test(r) && !r.includes("..")), {
+				message: "ref must match refname rules and not contain '..'",
+			})
+			.nullable()
+			.optional(),
+		// Path inside the cloned dotfiles repo, e.g. "install.sh" or
+		// "scripts/setup". `null`/omitted = clone-only (no install
+		// script run). The pattern enforces no leading `/`, no `..`,
+		// and the leading-alnum/`_` rule from the target pattern so a
+		// future field never mis-resolves to "../etc/passwd".
+		installScript: z
+			.string()
+			.max(MAX_DOTFILES_INSTALL_SCRIPT_LEN)
+			.refine(
+				(s) =>
+					s === "" || (DOTFILES_INSTALL_PATTERN.test(s) && !s.includes("..") && !s.includes("//")),
+				{
+					message: "installScript must be a relative path with no '..', no leading '/', no '//'",
+				},
+			)
+			.nullable()
+			.optional(),
+	})
+	.strict();
+
+// #191 — agent config seed. Two optional file bodies that the
+// bootstrap stage writes verbatim into `~/.claude/`. Validation
+// is shape-only here: `settings`, when set, must parse as JSON
+// (Zod refine), since writing invalid JSON to settings.json would
+// crash the agent on next start with no signal that the operator
+// pasted invalid content. `claudeMd` is free markdown.
+const AgentSeedSpec = z
+	.object({
+		settings: z
+			.string()
+			.max(MAX_AGENT_SEED_BYTES)
+			.refine(
+				(s) => {
+					if (s === "") return true; // empty = "don't write the file"
+					try {
+						JSON.parse(s);
+						return true;
+					} catch {
+						return false;
+					}
+				},
+				{ message: "settings must be valid JSON" },
+			)
+			.nullable()
+			.optional(),
+		claudeMd: z.string().max(MAX_AGENT_SEED_BYTES).nullable().optional(),
+	})
+	.strict();
+
 // Minimal placeholder for #190. Topology (subdomain vs path, auth gate)
 // lands with the port-exposure child.
 const PortSpec = z
@@ -331,6 +445,15 @@ export const SessionConfigSchema = z
 		// having to also defend against `""`.
 		postCreateCmd: z.string().min(1).max(MAX_HOOK_LEN).optional(),
 		postStartCmd: z.string().min(1).max(MAX_HOOK_LEN).optional(),
+		// #191 — git identity / dotfiles / agent config seed. All three
+		// are independent and skippable; the bootstrap runner walks each
+		// stage in declared order and runs only the configured ones.
+		// `null` is the wire-shape signal for "explicitly not configured"
+		// and is treated identically to omission on persistence (both
+		// rehydrate to `undefined`).
+		gitIdentity: GitIdentitySpec.nullable().optional(),
+		dotfiles: DotfilesSpec.nullable().optional(),
+		agentSeed: AgentSeedSpec.nullable().optional(),
 		// #190 — populated by the ports form
 		ports: z.array(PortSpec).max(MAX_PORTS).optional(),
 		// #186 — typed entry list. `plain` values stored verbatim;
@@ -344,6 +467,9 @@ export const SessionConfigSchema = z
 export type SessionConfig = z.infer<typeof SessionConfigSchema>;
 export type RepoSpecInput = z.infer<typeof RepoSpec>;
 export type AuthInput = z.infer<typeof WireAuthSpec>;
+export type GitIdentityInput = z.infer<typeof GitIdentitySpec>;
+export type DotfilesInput = z.infer<typeof DotfilesSpec>;
+export type AgentSeedInput = z.infer<typeof AgentSeedSpec>;
 
 /** Storage shape for the `auth` blob — same `{ ciphertext, iv, tag }`
  *  envelope as encrypted env-var entries. Mirrors the wire shape's
@@ -764,6 +890,9 @@ interface SessionConfigRow {
 	ports_json: string | null;
 	env_vars_json: string | null;
 	auth_json: string | null;
+	git_identity_json: string | null;
+	dotfiles_json: string | null;
+	agent_seed_json: string | null;
 	bootstrapped_at: string | null;
 }
 
@@ -783,6 +912,21 @@ function rowToRecord(row: SessionConfigRow): SessionConfigRecord {
 		ports: parseJsonColumn<SessionConfig["ports"]>(row.session_id, "ports_json", row.ports_json),
 		envVars: parseEnvVarsColumn(row.session_id, row.env_vars_json),
 		auth: parseAuthColumn(row.session_id, row.auth_json),
+		gitIdentity: parseJsonColumn<SessionConfig["gitIdentity"]>(
+			row.session_id,
+			"git_identity_json",
+			row.git_identity_json,
+		),
+		dotfiles: parseJsonColumn<SessionConfig["dotfiles"]>(
+			row.session_id,
+			"dotfiles_json",
+			row.dotfiles_json,
+		),
+		agentSeed: parseJsonColumn<SessionConfig["agentSeed"]>(
+			row.session_id,
+			"agent_seed_json",
+			row.agent_seed_json,
+		),
 		bootstrappedAt: row.bootstrapped_at ? parseD1Utc(row.bootstrapped_at) : null,
 	};
 }
@@ -1097,8 +1241,9 @@ export async function persistSessionConfig(
 		`INSERT INTO session_configs
                         (session_id, workspace_strategy, cpu_limit, mem_limit,
                          idle_ttl_seconds, post_create_cmd, post_start_cmd,
-                         repos_json, ports_json, env_vars_json, auth_json)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         repos_json, ports_json, env_vars_json, auth_json,
+                         git_identity_json, dotfiles_json, agent_seed_json)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON CONFLICT(session_id) DO UPDATE SET
                         workspace_strategy = excluded.workspace_strategy,
                         cpu_limit          = excluded.cpu_limit,
@@ -1109,7 +1254,10 @@ export async function persistSessionConfig(
                         repos_json         = excluded.repos_json,
                         ports_json         = excluded.ports_json,
                         env_vars_json      = excluded.env_vars_json,
-                        auth_json          = excluded.auth_json`,
+                        auth_json          = excluded.auth_json,
+                        git_identity_json  = excluded.git_identity_json,
+                        dotfiles_json      = excluded.dotfiles_json,
+                        agent_seed_json    = excluded.agent_seed_json`,
 		[
 			sessionId,
 			config.workspaceStrategy ?? null,
@@ -1131,6 +1279,9 @@ export async function persistSessionConfig(
 			jsonOrNull(config.ports),
 			jsonOrNull(config.envVars),
 			jsonOrNull(config.auth),
+			jsonOrNull(config.gitIdentity),
+			jsonOrNull(config.dotfiles),
+			jsonOrNull(config.agentSeed),
 		],
 	);
 }

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -250,10 +250,27 @@ const WireAuthSpec = z
 // itself accepts anything. The regex catches obvious typos
 // ("user@", "@example.com", whitespace-only) without the false
 // negatives a strict spec would produce.
+//
+// `name` rejects control characters (PR #217 round 1 SHOULD-FIX).
+// `git config --global user.name "<name>"` writes the value into
+// `~/.gitconfig`, which is INI-format with newlines as record
+// separators. A `\n` in `name` would corrupt the file — even with
+// argv-only invocation, the bytes land in the INI verbatim and could
+// inject additional config keys (e.g. `\n[user]\nemail = evil@…`)
+// that subsequent git operations honor. Reject at the schema boundary
+// so the runner doesn't need to defend at the write site.
 const GIT_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+$/;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberate — the whole point of this regex is to reject control bytes that would corrupt INI-format git config when written by `git config --global`.
+const CONTROL_CHAR_PATTERN = /[\x00-\x1f\x7f]/;
 const GitIdentitySpec = z
 	.object({
-		name: z.string().min(1).max(MAX_GIT_NAME_LEN),
+		name: z
+			.string()
+			.min(1)
+			.max(MAX_GIT_NAME_LEN)
+			.refine((n) => !CONTROL_CHAR_PATTERN.test(n), {
+				message: "name must not contain control characters (would corrupt ~/.gitconfig)",
+			}),
 		email: z
 			.string()
 			.min(1)
@@ -270,6 +287,17 @@ const GitIdentitySpec = z
 // one PAT / SSH identity per session; a per-repo identity is a
 // follow-up (#189). `installScript` is a path INSIDE the cloned
 // dotfiles repo; same path-traversal defence as `repo.target`.
+//
+// NOTE: unlike `RepoSpec`, this schema has NO `auth` selector and
+// NO cross-field validation against `config.auth.ssh` / `config.auth.pat`.
+// The auth blob is shared with the main repo, so a `git@…` dotfiles
+// URL relies on `config.auth.ssh` being populated by the main-repo
+// path. 191b's bootstrap runner is the right place to enforce that
+// pairing — at validation time we'd need access to whichever of
+// `repo.auth: "ssh"` or a future "dotfiles only uses SSH" intent
+// signals it. Kept light here; the runner fails loudly if the auth
+// blob is missing when it tries to clone (PR #217 round 1 NIT
+// flagged the gap; this comment is the holding pattern until 191b).
 const DOTFILES_INSTALL_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._/-]*$/;
 const DotfilesSpec = z
 	.object({
@@ -318,11 +346,20 @@ const DotfilesSpec = z
 // (Zod refine), since writing invalid JSON to settings.json would
 // crash the agent on next start with no signal that the operator
 // pasted invalid content. `claudeMd` is free markdown.
+//
+// Byte-cap (NOT char-cap) on both fields. Zod's `.max()` counts
+// UTF-16 code units, NOT UTF-8 bytes — a 256K-codepoint string of
+// 4-byte chars (e.g. emoji) would be 1 MiB on disk, four times the
+// intended cap. Mirror the env-var pattern (`MAX_ENV_VALUE_BYTES`)
+// and use `Buffer.byteLength(v, "utf-8")` explicitly so the cap
+// matches the column-size budget. PR #217 round 1 SHOULD-FIX.
+const agentSeedByteCap = (label: string) =>
+	z.string().refine((s) => Buffer.byteLength(s, "utf-8") <= MAX_AGENT_SEED_BYTES, {
+		message: `${label} must not exceed ${MAX_AGENT_SEED_BYTES} bytes`,
+	});
 const AgentSeedSpec = z
 	.object({
-		settings: z
-			.string()
-			.max(MAX_AGENT_SEED_BYTES)
+		settings: agentSeedByteCap("settings")
 			.refine(
 				(s) => {
 					if (s === "") return true; // empty = "don't write the file"
@@ -337,7 +374,7 @@ const AgentSeedSpec = z
 			)
 			.nullable()
 			.optional(),
-		claudeMd: z.string().max(MAX_AGENT_SEED_BYTES).nullable().optional(),
+		claudeMd: agentSeedByteCap("claudeMd").nullable().optional(),
 	})
 	.strict();
 


### PR DESCRIPTION
## Summary

Schema foundation for #191's lifecycle-hook work. Adds three new optional fields to \`SessionConfigSchema\`, three D1 columns on \`session_configs\`, and the validation rules each stage needs. The bootstrap stages that consume these fields land in 191b; the Advanced-tab UI in 191c.

## What's new

- \`gitIdentity\` \`{ name, email }\` — both required when set; email matches a permissive \`local@domain\` regex (RFC 5322's full grammar would produce false negatives we don't want). The 191b stage will run \`git config --global user.{name,email}\` from this.
- \`dotfiles\` \`{ url, ref?, installScript? }\` — same URL allowlist as the main repo (#188): \`https://\` or \`git@host:path\`, no embedded creds, no \`..\`. \`installScript\` is a path inside the cloned tree; same path-traversal defence as \`repo.target\`. Auth is shared with the main repo (issue spec) so private dotfiles work without a second credential surface.
- \`agentSeed\` \`{ settings?, claudeMd? }\` — both optional bodies with 256 KiB caps. \`settings\`, when non-empty, must parse as JSON (a Zod refine catches it before write). \`claudeMd\` is free markdown.

## Persistence

Three TEXT columns (\`git_identity_json\`, \`dotfiles_json\`, \`agent_seed_json\`) added via the same ALTER-with-duplicate-swallow idiom used by \`auth_json\` in 188b. Rehydration goes through the generic \`parseJsonColumn\` — no migration shim needed since nothing wrote these columns before.

## Test plan
- [x] Schema validation: good email, bad email, URL schemes, path traversal in \`installScript\`, JSON parse on \`settings\`, 256 KiB cap on bodies, \`null\` = explicit-not-configured
- [x] Persistence: column count check (14 = sessionId + 13 columns), round-trip rehydration of all three fields
- [x] \`cd backend && npm test\` — 389 passing
- [x] \`cd backend && npm run lint && npm run build\` — clean
- [x] \`cd frontend && npm run lint && npm run build\` — clean (no frontend changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)