### PR TITLE
feat(hooks): bootstrap stages + 10-min wall-clock cap (#191, PR 191b of 3)

### DIFF
--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -551,6 +551,64 @@ describe("runAsyncBootstrap", () => {
 		expect(final).toEqual([{ type: "fail", exitCode: 7 }]);
 	});
 
+	// PR #218 round 1 NIT: a stage that throws SYNCHRONOUSLY (before
+	// any await) AFTER the timer has fired must surface its OWN error
+	// message, not "bootstrap timeout". The discriminator now requires
+	// the error itself to be AbortError/TimeoutError — `signal.aborted`
+	// alone is not enough, since it stays true after the timer fires
+	// regardless of what later throws.
+	it("preserves stage-specific error message when timer fires before a sync throw", async () => {
+		vi.useFakeTimers();
+		try {
+			const { sessions, docker, broadcaster, final } = makeFakes();
+			sessionConfigStubs.getSessionConfig.mockResolvedValueOnce({
+				sessionId: "sess-1",
+				dotfiles: { url: "git@example.com:o/p.git" },
+				bootstrappedAt: null,
+			} as never);
+
+			// cloneRepo blocks on a manual resolver so the test can
+			// advance time externally between clone and dotfiles.
+			let cloneFinish: () => void = () => {};
+			cloneStubs.runCloneRepo.mockImplementationOnce(
+				() =>
+					new Promise<{ exitCode: number }>((resolve) => {
+						cloneFinish = () => resolve({ exitCode: 0 });
+					}),
+			);
+			// dotfiles throws SYNCHRONOUSLY (before any await) with a
+			// stage-specific error.
+			dotfilesStubs.runDotfiles.mockImplementationOnce(async () => {
+				throw new Error("dotfiles: SSH credential missing");
+			});
+
+			const runPromise = runAsyncBootstrap(
+				"sess-1",
+				{ postCreateCmd: "npm install", hasBootstrapConfig: true },
+				{ sessions, docker, broadcaster },
+			);
+			// Let the runner enter cloneRepo (which is now blocked on
+			// our manual resolver).
+			await Promise.resolve();
+			await Promise.resolve();
+			// Advance past the cap — timer fires, abortController
+			// aborts, signal.aborted flips true.
+			await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 100);
+			// Now release cloneRepo. Runner proceeds to dotfiles, which
+			// throws sync. The catch handler sees signal.aborted=true
+			// but the error name is "Error", NOT AbortError/TimeoutError.
+			cloneFinish();
+			await runPromise;
+
+			const failMsg = final.find((m) => m.type === "fail");
+			expect(failMsg).toMatchObject({ type: "fail", exitCode: -1 });
+			expect((failMsg as { error: string }).error).toBe("dotfiles: SSH credential missing");
+			expect((failMsg as { error: string }).error).not.toMatch(/bootstrap timeout/);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	// 10-minute wall-clock cap. A stage that hangs past the cap is
 	// aborted (the AbortError surfaces from streamExec via the
 	// stream-destroy mechanism), and the runner emits a clear

--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -28,6 +28,23 @@ const cloneStubs = vi.hoisted(() => ({
 }));
 vi.mock("./bootstrap/cloneRepo.js", () => cloneStubs);
 
+// #191 PR 191b — three new bootstrap stages. Same default-success
+// shape as runCloneRepo so existing tests don't have to opt out.
+const gitIdentityStubs = vi.hoisted(() => ({
+	runGitIdentity: vi.fn(async () => ({ exitCode: 0 })),
+}));
+vi.mock("./bootstrap/gitIdentity.js", () => gitIdentityStubs);
+
+const dotfilesStubs = vi.hoisted(() => ({
+	runDotfiles: vi.fn(async () => ({ exitCode: 0 })),
+}));
+vi.mock("./bootstrap/dotfiles.js", () => dotfilesStubs);
+
+const agentSeedStubs = vi.hoisted(() => ({
+	runAgentSeed: vi.fn(async () => ({ exitCode: 0 })),
+}));
+vi.mock("./bootstrap/agentSeed.js", () => agentSeedStubs);
+
 import {
 	BootstrapBroadcaster,
 	type BootstrapMessage,
@@ -43,6 +60,12 @@ beforeEach(() => {
 	sessionConfigStubs.getSessionConfig.mockImplementation(async () => null);
 	cloneStubs.runCloneRepo.mockReset();
 	cloneStubs.runCloneRepo.mockImplementation(async () => ({ exitCode: 0 }));
+	gitIdentityStubs.runGitIdentity.mockReset();
+	gitIdentityStubs.runGitIdentity.mockImplementation(async () => ({ exitCode: 0 }));
+	dotfilesStubs.runDotfiles.mockReset();
+	dotfilesStubs.runDotfiles.mockImplementation(async () => ({ exitCode: 0 }));
+	agentSeedStubs.runAgentSeed.mockReset();
+	agentSeedStubs.runAgentSeed.mockImplementation(async () => ({ exitCode: 0 }));
 });
 
 describe("markBootstrapped", () => {
@@ -341,7 +364,7 @@ describe("runAsyncBootstrap", () => {
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postCreateCmd: "npm install", hasRepo: true },
+			{ postCreateCmd: "npm install", hasBootstrapConfig: true },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();
@@ -349,17 +372,17 @@ describe("runAsyncBootstrap", () => {
 		expect(order).toEqual(["clone", "postCreate"]);
 	});
 
-	// PR #214 round 2 NIT: `hasRepo: false` (or omitted) gates the
+	// PR #214 round 2 NIT: `hasBootstrapConfig: false` (or omitted) gates the
 	// `getSessionConfig` D1 fetch. The pre-188c steady-state is
 	// postCreate-only; that path must not pay for a repo D1 round-trip
 	// every session create.
-	it("hasRepo=false skips the getSessionConfig D1 fetch (no extra round-trip)", async () => {
+	it("hasBootstrapConfig=false skips the getSessionConfig D1 fetch (no extra round-trip)", async () => {
 		const { sessions, docker, broadcaster, spies } = makeFakes();
 		spies.runPostCreate.mockImplementation(async () => ({ exitCode: 0 }));
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postCreateCmd: "npm install" /* hasRepo omitted = false */ },
+			{ postCreateCmd: "npm install" /* hasBootstrapConfig omitted = false */ },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();
@@ -391,7 +414,7 @@ describe("runAsyncBootstrap", () => {
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postCreateCmd: "npm install", hasRepo: true },
+			{ postCreateCmd: "npm install", hasBootstrapConfig: true },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();
@@ -414,7 +437,7 @@ describe("runAsyncBootstrap", () => {
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postCreateCmd: "npm install", hasRepo: true },
+			{ postCreateCmd: "npm install", hasBootstrapConfig: true },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();
@@ -443,7 +466,7 @@ describe("runAsyncBootstrap", () => {
 
 		await runAsyncBootstrap(
 			"sess-1",
-			{ postStartCmd: "npm run dev", hasRepo: true },
+			{ postStartCmd: "npm run dev", hasBootstrapConfig: true },
 			{ sessions, docker, broadcaster },
 		);
 		await settle();
@@ -452,5 +475,131 @@ describe("runAsyncBootstrap", () => {
 		expect(spies.runPostCreate).not.toHaveBeenCalled();
 		expect(spies.runPostStart).toHaveBeenCalledWith("sess-1", "npm run dev");
 		expect(final).toEqual([{ type: "done", success: true }]);
+	});
+
+	// ── #191 PR 191b — full stage pipeline + 10-min cap ────────────────────
+
+	// Issue spec order: gitIdentity → repo → dotfiles → agentSeed →
+	// postCreate. A swap would break the documented contract (e.g.
+	// dotfiles install scripts that need git config to commit).
+	it("runs stages in declared order (gitIdentity → clone → dotfiles → agentSeed → postCreate)", async () => {
+		const { sessions, docker, broadcaster, spies } = makeFakes();
+		const order: string[] = [];
+		sessionConfigStubs.getSessionConfig.mockResolvedValueOnce({
+			sessionId: "sess-1",
+			repo: { url: "https://example.com/r", auth: "none" },
+			gitIdentity: { name: "X", email: "x@y.com" },
+			dotfiles: { url: "https://example.com/d.git" },
+			agentSeed: { claudeMd: "# x" },
+			bootstrappedAt: null,
+		} as never);
+		gitIdentityStubs.runGitIdentity.mockImplementation(async () => {
+			order.push("gitIdentity");
+			return { exitCode: 0 };
+		});
+		cloneStubs.runCloneRepo.mockImplementation(async () => {
+			order.push("clone");
+			return { exitCode: 0 };
+		});
+		dotfilesStubs.runDotfiles.mockImplementation(async () => {
+			order.push("dotfiles");
+			return { exitCode: 0 };
+		});
+		agentSeedStubs.runAgentSeed.mockImplementation(async () => {
+			order.push("agentSeed");
+			return { exitCode: 0 };
+		});
+		spies.runPostCreate.mockImplementation(async () => {
+			order.push("postCreate");
+			return { exitCode: 0 };
+		});
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install", hasBootstrapConfig: true },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(order).toEqual(["gitIdentity", "clone", "dotfiles", "agentSeed", "postCreate"]);
+	});
+
+	// Each stage's non-zero exit must hard-fail via the same status-
+	// flip-before-kill teardown postCreate already used. Pin one stage
+	// (dotfiles) as the canonical example; the same code path serves
+	// all stages via the runStage helper.
+	it("dotfiles non-zero exit flips status, kills, broadcasts fail (later stages skipped)", async () => {
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		sessionConfigStubs.getSessionConfig.mockResolvedValueOnce({
+			sessionId: "sess-1",
+			dotfiles: { url: "https://example.com/d.git" },
+			bootstrappedAt: null,
+		} as never);
+		dotfilesStubs.runDotfiles.mockImplementationOnce(async () => ({ exitCode: 7 }));
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install", hasBootstrapConfig: true },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+		expect(spies.kill).toHaveBeenCalledWith("sess-1");
+		expect(agentSeedStubs.runAgentSeed).not.toHaveBeenCalled();
+		expect(spies.runPostCreate).not.toHaveBeenCalled();
+		expect(final).toEqual([{ type: "fail", exitCode: 7 }]);
+	});
+
+	// 10-minute wall-clock cap. A stage that hangs past the cap is
+	// aborted (the AbortError surfaces from streamExec via the
+	// stream-destroy mechanism), and the runner emits a clear
+	// "bootstrap timeout" message before the terminal fail.
+	it("aborts the in-flight stage and broadcasts a timeout message when the wall-clock cap fires", async () => {
+		vi.useFakeTimers();
+		try {
+			const { sessions, docker, broadcaster, final, spies } = makeFakes();
+			sessionConfigStubs.getSessionConfig.mockResolvedValueOnce({
+				sessionId: "sess-1",
+				dotfiles: { url: "https://example.com/d.git" },
+				bootstrappedAt: null,
+			} as never);
+			// dotfiles "stage" never resolves on its own — it'll only
+			// settle when the abort signal fires its `error` listener.
+			// Simulate by listening for abort and rejecting with an
+			// AbortError (matching what streamExec does in production).
+			dotfilesStubs.runDotfiles.mockImplementationOnce(async (args) => {
+				return new Promise((_resolve, reject) => {
+					args.signal?.addEventListener("abort", () => {
+						reject(new DOMException("aborted", "AbortError"));
+					});
+				});
+			});
+
+			const runPromise = runAsyncBootstrap(
+				"sess-1",
+				{ postCreateCmd: "npm install", hasBootstrapConfig: true },
+				{ sessions, docker, broadcaster },
+			);
+			// Advance past the 10-min cap — timer fires, abort
+			// propagates, dotfiles rejects, runner enters timeout
+			// handler.
+			await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 100);
+			await runPromise;
+
+			expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+			expect(spies.kill).toHaveBeenCalledWith("sess-1");
+			expect(spies.runPostCreate).not.toHaveBeenCalled();
+			// Final terminal message is `fail` with the timeout error
+			// string surfaced via the broadcaster.
+			const failMsg = final.find((m) => m.type === "fail");
+			expect(failMsg).toMatchObject({
+				type: "fail",
+				exitCode: -1,
+			});
+			expect((failMsg as { error: string }).error).toMatch(/bootstrap timeout/);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -19,12 +19,30 @@
  * the hook continues in the background.
  */
 
+import { runAgentSeed } from "./bootstrap/agentSeed.js";
 import { runCloneRepo } from "./bootstrap/cloneRepo.js";
+import { runDotfiles } from "./bootstrap/dotfiles.js";
+import { runGitIdentity } from "./bootstrap/gitIdentity.js";
 import { d1Query } from "./db.js";
 import type { DockerManager } from "./dockerManager.js";
 import { logger } from "./logger.js";
 import { getSessionConfig } from "./sessionConfig.js";
 import type { SessionManager } from "./sessionManager.js";
+
+/**
+ * Total bootstrap wall-clock cap. Beyond this, the in-flight stage
+ * is aborted (the stream destroy in `streamExec` unblocks the
+ * promise) and the session is hard-failed with a "bootstrap
+ * timeout" message in the WS stream. Sized per the issue spec
+ * (#191): generous enough for a chunky `npm install` plus dotfiles
+ * + repo clone, tight enough that a session stuck on a non-
+ * responsive remote doesn't pin a quota slot indefinitely.
+ *
+ * Note: aborting the streamExec only closes the host-side stream;
+ * the in-container process continues until `failSession` kills the
+ * container itself. Both happen on the timeout path, in that order.
+ */
+const BOOTSTRAP_WALL_CLOCK_CAP_MS = 10 * 60 * 1000;
 
 /**
  * Atomically mark `session_configs.bootstrapped_at` as set, but only
@@ -296,7 +314,16 @@ export class BootstrapBroadcaster {
  */
 export async function runAsyncBootstrap(
 	sessionId: string,
-	cfg: { postCreateCmd?: string; postStartCmd?: string; hasRepo?: boolean },
+	cfg: {
+		postCreateCmd?: string;
+		postStartCmd?: string;
+		/** True iff any of {repo, gitIdentity, dotfiles, agentSeed} is
+		 *  configured — the hint that gates the `getSessionConfig` D1
+		 *  fetch. Renamed from the older `hasRepo` (#214 round 2)
+		 *  because 191b adds three more stages that all need the
+		 *  config row. The route computes this from `validatedConfig`. */
+		hasBootstrapConfig?: boolean;
+	},
 	deps: {
 		sessions: SessionManager;
 		docker: DockerManager;
@@ -306,80 +333,164 @@ export async function runAsyncBootstrap(
 	const { sessions, docker, broadcaster } = deps;
 	const onOutput = (chunk: string) => broadcaster.broadcast(sessionId, chunk);
 
-	// Step 1: repo clone. Skipped entirely when `cfg.hasRepo === false`
-	// — that's the steady-state for the existing postCreate-only
-	// population (everyone before #188's repo-clone landed). The hint
-	// is set by the route from `validatedConfig.repo`; gating on it
-	// avoids one D1 round-trip per session create on the hot path.
-	// CLAUDE.md flags D1 round-trip counts as performance-relevant,
-	// and a transient D1 failure on this fetch would also hard-fail
-	// the session before postCreate had a chance to run — we only
-	// take that risk when there's something to clone (PR #214 round 2).
-	let cloneExit: number;
-	try {
-		if (cfg.hasRepo) {
-			const config = await getSessionConfig(sessionId);
-			if (config) {
-				const result = await runCloneRepo({ sessionId, config, docker, onOutput });
-				cloneExit = result.exitCode;
-			} else {
-				// Defensive: route guarantees the row exists when
-				// `hasRepo` is set, but a missing row shouldn't crash
-				// the runner. Treat as a no-op clone — markBootstrapped
-				// later will UPDATE 0 rows and log without failing.
-				logger.warn(
-					`[bootstrap] hasRepo=true but no session_configs row for ${sessionId}; skipping clone`,
-				);
-				cloneExit = 0;
-			}
-		} else {
-			cloneExit = 0;
-		}
-	} catch (err) {
-		logger.error(`[bootstrap] clone threw for session ${sessionId}: ${(err as Error).message}`);
-		await failSession(sessionId, sessions, docker);
-		broadcaster.finish(sessionId, {
-			type: "fail",
-			exitCode: -1,
-			error: (err as Error).message,
-		});
-		return;
-	}
-	if (cloneExit !== 0) {
-		await failSession(sessionId, sessions, docker);
-		broadcaster.finish(sessionId, { type: "fail", exitCode: cloneExit });
-		return;
-	}
+	// 10-min wall-clock cap (#191 PR 191b). The controller is aborted
+	// either by the timer or by a stage that wants to short-circuit
+	// the rest of the pipeline. `unref()` so the Node process can
+	// shut down cleanly even if a runaway timer is still pending.
+	const abortController = new AbortController();
+	const timer = setTimeout(() => {
+		abortController.abort(new DOMException("bootstrap timeout", "TimeoutError"));
+	}, BOOTSTRAP_WALL_CLOCK_CAP_MS);
+	timer.unref();
+	const signal = abortController.signal;
 
-	// Step 2: postCreate. May be unset when only the repo step is
-	// configured — in that case skip straight to markBootstrapped +
-	// postStart. The bootstrap is still considered complete.
-	let exitCode: number;
-	if (cfg.postCreateCmd) {
+	const finishWithFail = async (msg: BootstrapMessage): Promise<void> => {
+		clearTimeout(timer);
+		await failSession(sessionId, sessions, docker);
+		broadcaster.finish(sessionId, msg);
+	};
+
+	// Helper: run a stage and route any throw / non-zero exit through
+	// the same status-flip-before-kill teardown. Returns true on
+	// success (caller continues), false when the pipeline is done
+	// (caller returns). Centralised so adding a future stage doesn't
+	// require duplicating the four-line teardown block.
+	const runStage = async (
+		label: string,
+		run: () => Promise<{ exitCode: number }>,
+	): Promise<boolean> => {
 		try {
-			const result = await docker.runPostCreate(sessionId, cfg.postCreateCmd, onOutput);
-			exitCode = result.exitCode;
+			const { exitCode } = await run();
+			if (exitCode !== 0) {
+				await finishWithFail({ type: "fail", exitCode });
+				return false;
+			}
+			return true;
 		} catch (err) {
-			logger.error(
-				`[bootstrap] postCreate threw for session ${sessionId}: ${(err as Error).message}`,
-			);
-			await failSession(sessionId, sessions, docker);
-			broadcaster.finish(sessionId, {
+			// AbortError from the 10-min cap surfaces here. Distinguish
+			// the timeout failure from any other throw so the modal's
+			// rendered error tells the user the right thing.
+			const e = err as Error;
+			const isTimeout = e.name === "TimeoutError" || signal.aborted;
+			const message = isTimeout
+				? `bootstrap timeout: cumulative wall time exceeded ${BOOTSTRAP_WALL_CLOCK_CAP_MS / 1000}s during '${label}'`
+				: e.message;
+			logger.error(`[bootstrap] ${label} threw for session ${sessionId}: ${message}`);
+			// Surface the timeout reason in-stream so the user sees
+			// the cap, not just a generic fail. Goes through the
+			// broadcaster as a regular `output` chunk first; the
+			// terminal `fail` message has the exit code.
+			if (isTimeout) {
+				broadcaster.broadcast(sessionId, `\n${message}\n`);
+			}
+			await finishWithFail({
+				type: "fail",
+				exitCode: -1,
+				error: message,
+			});
+			return false;
+		}
+	};
+
+	// Load config once if any stage needs it. The hint gates this so
+	// postCreate-only sessions (the pre-#188 steady-state) don't pay
+	// for the D1 round-trip; it's only "free" for sessions that
+	// genuinely have config-driven bootstrap stages to run.
+	let config: Awaited<ReturnType<typeof getSessionConfig>> = null;
+	if (cfg.hasBootstrapConfig) {
+		try {
+			config = await getSessionConfig(sessionId);
+		} catch (err) {
+			await finishWithFail({
 				type: "fail",
 				exitCode: -1,
 				error: (err as Error).message,
 			});
 			return;
 		}
-	} else {
-		exitCode = 0;
+		if (!config) {
+			// Defensive: route guarantees the row exists when
+			// `hasBootstrapConfig` is set, but a missing row shouldn't
+			// crash the runner. Skip the config-driven stages and run
+			// only the cmd-driven postCreate/postStart.
+			logger.warn(
+				`[bootstrap] hasBootstrapConfig=true but no session_configs row for ${sessionId}; skipping config-driven stages`,
+			);
+		}
 	}
 
-	if (exitCode !== 0) {
-		await failSession(sessionId, sessions, docker);
-		broadcaster.finish(sessionId, { type: "fail", exitCode });
-		return;
+	// Stage order per #191 issue spec:
+	//   1. git identity (cheap; needed if later stages commit)
+	//   2. repo clone (#188)
+	//   3. dotfiles
+	//   4. agent seed (last so a cloned project's CLAUDE.md is in place first)
+	//   5. postCreate cmd
+	if (config) {
+		if (
+			!(await runStage("gitIdentity", () =>
+				runGitIdentity({
+					sessionId,
+					identity: config?.gitIdentity ?? null,
+					docker,
+					onOutput,
+					signal,
+				}),
+			))
+		)
+			return;
+		if (
+			!(await runStage("clone", () =>
+				runCloneRepo({ sessionId, config: config!, docker, onOutput, signal }),
+			))
+		)
+			return;
+		if (
+			!(await runStage("dotfiles", () =>
+				runDotfiles({
+					sessionId,
+					dotfiles: config?.dotfiles ?? null,
+					storedAuth: config?.auth ?? null,
+					docker,
+					onOutput,
+					signal,
+				}),
+			))
+		)
+			return;
+		if (
+			!(await runStage("agentSeed", () =>
+				runAgentSeed({
+					sessionId,
+					agentSeed: config?.agentSeed ?? null,
+					docker,
+					onOutput,
+					signal,
+				}),
+			))
+		)
+			return;
 	}
+
+	// postCreate. May be unset when only config-driven stages were
+	// configured (e.g. clone + agentSeed without a hook). The cap is
+	// still in force for postCreate; runPostCreate doesn't currently
+	// take a signal, but the timer can still abort the in-flight
+	// exec via the same destroy-the-stream mechanism if we extend
+	// the call. For now, postCreate's existing behaviour (no signal)
+	// means a runaway hook isn't aborted by the cap — same shape as
+	// before this PR.
+	if (cfg.postCreateCmd) {
+		const ok = await runStage("postCreate", () =>
+			docker.runPostCreate(sessionId, cfg.postCreateCmd!, onOutput),
+		);
+		if (!ok) return;
+	}
+
+	// All blocking stages succeeded — clear the wall-clock cap timer
+	// before markBootstrapped + postStart since those run after the
+	// success broadcast and can take their own time without the cap
+	// applying.
+	clearTimeout(timer);
 
 	// postCreate succeeded — mark the gate, then run postStart (if
 	// configured). markBootstrapped failure is logged but doesn't

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -370,8 +370,21 @@ export async function runAsyncBootstrap(
 			// AbortError from the 10-min cap surfaces here. Distinguish
 			// the timeout failure from any other throw so the modal's
 			// rendered error tells the user the right thing.
+			//
+			// PR #218 round 1 NIT: the discriminator must check that
+			// the thrown error itself came FROM the abort path
+			// (`AbortError` from streamExec, `TimeoutError` from the
+			// timer's `abort(reason)` call) — NOT just `signal.aborted`.
+			// Otherwise a stage that throws synchronously *after* the
+			// timer has already fired (e.g. `DotfilesAuthMismatchError`
+			// raised before the first await in `runDotfiles`) would be
+			// misreported as "bootstrap timeout" and the user would
+			// never see the actionable config error. `signal.aborted`
+			// is kept as a sanity guard so an unrelated future
+			// AbortError can't silently mark itself as a cap-fired
+			// timeout.
 			const e = err as Error;
-			const isTimeout = e.name === "TimeoutError" || signal.aborted;
+			const isTimeout = signal.aborted && (e.name === "AbortError" || e.name === "TimeoutError");
 			const message = isTimeout
 				? `bootstrap timeout: cumulative wall time exceeded ${BOOTSTRAP_WALL_CLOCK_CAP_MS / 1000}s during '${label}'`
 				: e.message;

--- a/backend/src/bootstrap/agentSeed.test.ts
+++ b/backend/src/bootstrap/agentSeed.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DockerManager } from "../dockerManager.js";
+import { AGENT_SEED_SCRIPT, runAgentSeed } from "./agentSeed.js";
+
+describe("runAgentSeed", () => {
+	let docker: { streamExec: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		docker = { streamExec: vi.fn(async () => ({ exitCode: 0 })) };
+	});
+
+	it("returns exitCode 0 and skips when agentSeed is null", async () => {
+		const result = await runAgentSeed({
+			sessionId: "sess-1",
+			agentSeed: null,
+			docker: docker as unknown as DockerManager,
+		});
+		expect(result).toEqual({ exitCode: 0 });
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	it("skips when both fields are absent (e.g. agentSeed: {})", async () => {
+		const result = await runAgentSeed({
+			sessionId: "sess-1",
+			agentSeed: {},
+			docker: docker as unknown as DockerManager,
+		});
+		expect(result).toEqual({ exitCode: 0 });
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	it("invokes bash with AGENT_SEED_SCRIPT when at least one field is set", async () => {
+		await runAgentSeed({
+			sessionId: "sess-1",
+			agentSeed: { settings: '{"theme":"dark"}' },
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.cmd[0]).toBe("bash");
+		expect(opts.cmd[1]).toBe("-c");
+		expect(opts.cmd[2]).toBe(AGENT_SEED_SCRIPT);
+	});
+
+	// Both file bodies travel via env vars, never argv. The schema's
+	// 256 KiB byte cap (PR 191a + #217 round 1) keeps the env block
+	// within kernel limits.
+	it("passes user content via env, never argv", async () => {
+		const settings = '{"secret_marker":"DO_NOT_LEAK"}';
+		const claudeMd = "# notes\nDO_NOT_LEAK\n";
+		await runAgentSeed({
+			sessionId: "sess-1",
+			agentSeed: { settings, claudeMd },
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		const argvJoined = (opts.cmd as string[]).join(" ");
+		expect(argvJoined).not.toContain("DO_NOT_LEAK");
+		expect(opts.env).toEqual({ ST_SETTINGS: settings, ST_CLAUDE_MD: claudeMd });
+	});
+
+	it("converts null fields to empty strings in the env block", async () => {
+		// `null` is the explicit-not-configured sentinel; the script's
+		// `[ -n "$VAR" ]` guards skip the corresponding write.
+		await runAgentSeed({
+			sessionId: "sess-1",
+			agentSeed: { settings: '{"a":1}', claudeMd: null },
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.env).toEqual({ ST_SETTINGS: '{"a":1}', ST_CLAUDE_MD: "" });
+	});
+
+	// Script integrity check: the `mkdir -p ~/.claude` is critical —
+	// without it the file write fails on a fresh container. Pin the
+	// script-shape markers so a future edit can't drop them.
+	it("AGENT_SEED_SCRIPT contains mkdir + conditional write guards + unset", () => {
+		expect(AGENT_SEED_SCRIPT).toContain("mkdir -p ~/.claude");
+		expect(AGENT_SEED_SCRIPT).toContain('[ -n "$ST_SETTINGS" ]');
+		expect(AGENT_SEED_SCRIPT).toContain('[ -n "$ST_CLAUDE_MD" ]');
+		expect(AGENT_SEED_SCRIPT).toContain("unset ST_SETTINGS ST_CLAUDE_MD");
+	});
+
+	it("forwards the abort signal to streamExec", async () => {
+		const ac = new AbortController();
+		await runAgentSeed({
+			sessionId: "sess-1",
+			agentSeed: { claudeMd: "# x" },
+			docker: docker as unknown as DockerManager,
+			signal: ac.signal,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.signal).toBe(ac.signal);
+	});
+});

--- a/backend/src/bootstrap/agentSeed.ts
+++ b/backend/src/bootstrap/agentSeed.ts
@@ -1,0 +1,89 @@
+/**
+ * agentSeed.ts — agent config seed bootstrap stage (#191 PR 191b).
+ *
+ * Writes the user's `settings.json` and/or `CLAUDE.md` content into
+ * `~/.claude/` inside the session container so the Claude CLI starts
+ * up with the operator's preferred config + project notes already in
+ * place.
+ *
+ * Both fields are independent — the user can configure either one,
+ * both, or neither. Empty / absent fields skip the corresponding
+ * file write (so an existing file in the bind-mounted workspace
+ * isn't clobbered with an empty body on a re-spawn).
+ *
+ * Both values reach the bash script via env vars, never argv. The
+ * 256 KiB byte cap (schema-enforced) keeps either body from ballooning
+ * the docker exec's env block beyond what the kernel accepts.
+ */
+
+import type { DockerManager } from "../dockerManager.js";
+import { logger } from "../logger.js";
+import type { AgentSeedInput } from "../sessionConfig.js";
+
+interface RunAgentSeedArgs {
+	sessionId: string;
+	agentSeed: AgentSeedInput | null | undefined;
+	docker: DockerManager;
+	onOutput?: (chunk: string) => void;
+	signal?: AbortSignal;
+}
+
+/**
+ * Returns `{ exitCode: 0 }` and skips when `agentSeed` is null /
+ * undefined / has neither field set. Otherwise writes the configured
+ * file(s) and returns the bash script's exit code.
+ */
+export async function runAgentSeed(args: RunAgentSeedArgs): Promise<{ exitCode: number }> {
+	const { agentSeed, sessionId, docker, onOutput, signal } = args;
+	if (!agentSeed) return { exitCode: 0 };
+	const settings = agentSeed.settings ?? "";
+	const claudeMd = agentSeed.claudeMd ?? "";
+	if (settings === "" && claudeMd === "") return { exitCode: 0 };
+
+	logger.info(
+		`[agentSeed] session ${sessionId}: settings=${settings.length > 0 ? "set" : "skip"} claudeMd=${claudeMd.length > 0 ? "set" : "skip"}`,
+	);
+
+	const env: Record<string, string> = {
+		ST_SETTINGS: settings,
+		ST_CLAUDE_MD: claudeMd,
+	};
+
+	return docker.streamExec(
+		sessionId,
+		{
+			cmd: ["bash", "-c", AGENT_SEED_SCRIPT],
+			env,
+			signal,
+		},
+		onOutput,
+	);
+}
+
+/**
+ * Bash script body. Both writes are conditional via `[ -n "$VAR" ]`
+ * so an unset field is a no-op, NOT an "empty file" overwrite of
+ * whatever was already there. `printf '%s' …` (no trailing `\n`)
+ * preserves the user's bytes exactly — they pasted the content,
+ * we trust it. After the writes, `unset` keeps the secrets out of
+ * any child process started later in the same exec context (lower
+ * blast radius even though these aren't strictly secrets).
+ *
+ * Exported for the unit-test that pins the script shape so a future
+ * edit can't drop the `mkdir -p ~/.claude` (which would let the
+ * write fail if `~/.claude` doesn't already exist) or the
+ * conditional guards.
+ */
+export const AGENT_SEED_SCRIPT = `set -e
+mkdir -p ~/.claude
+chmod 755 ~/.claude
+if [ -n "$ST_SETTINGS" ]; then
+  printf '%s' "$ST_SETTINGS" > ~/.claude/settings.json
+  chmod 644 ~/.claude/settings.json
+fi
+if [ -n "$ST_CLAUDE_MD" ]; then
+  printf '%s' "$ST_CLAUDE_MD" > ~/.claude/CLAUDE.md
+  chmod 644 ~/.claude/CLAUDE.md
+fi
+unset ST_SETTINGS ST_CLAUDE_MD
+`;

--- a/backend/src/bootstrap/cloneRepo.ts
+++ b/backend/src/bootstrap/cloneRepo.ts
@@ -70,6 +70,10 @@ interface RunCloneRepoArgs {
 	config: SessionConfigRecord;
 	docker: DockerManager;
 	onOutput?: (chunk: string) => void;
+	/** Abort signal threaded from the bootstrap runner's 10-min cap
+	 *  (#191 PR 191b). Forwarded to streamExec; an in-flight clone
+	 *  unblocks promptly when the timeout fires. */
+	signal?: AbortSignal;
 }
 
 /**
@@ -77,7 +81,7 @@ interface RunCloneRepoArgs {
  * Returns `{ exitCode: 0 }` and a no-op when no `repo` is configured.
  */
 export async function runCloneRepo(args: RunCloneRepoArgs): Promise<{ exitCode: number }> {
-	const { config, sessionId, docker, onOutput } = args;
+	const { config, sessionId, docker, onOutput, signal } = args;
 	const repo = config.repo;
 	if (!repo) return { exitCode: 0 };
 
@@ -95,7 +99,7 @@ export async function runCloneRepo(args: RunCloneRepoArgs): Promise<{ exitCode: 
 		// positional args, never as shell tokens.
 		return docker.streamExec(
 			sessionId,
-			{ cmd: cloneArgv, workingDir: CONTAINER_WORKSPACE },
+			{ cmd: cloneArgv, workingDir: CONTAINER_WORKSPACE, signal },
 			onOutput,
 		);
 	}
@@ -117,6 +121,7 @@ export async function runCloneRepo(args: RunCloneRepoArgs): Promise<{ exitCode: 
 				cmd: ["bash", "-c", PAT_CLONE_SCRIPT],
 				env,
 				workingDir: CONTAINER_WORKSPACE,
+				signal,
 			},
 			onOutput,
 		);
@@ -137,6 +142,7 @@ export async function runCloneRepo(args: RunCloneRepoArgs): Promise<{ exitCode: 
 			cmd: ["bash", "-c", SSH_CLONE_SCRIPT],
 			env,
 			workingDir: CONTAINER_WORKSPACE,
+			signal,
 		},
 		onOutput,
 	);

--- a/backend/src/bootstrap/cloneRepo.ts
+++ b/backend/src/bootstrap/cloneRepo.ts
@@ -262,6 +262,12 @@ ARGS=("git" "clone")
 [ -n "$ST_DEPTH" ] && ARGS+=("--depth" "$ST_DEPTH")
 ARGS+=("--" "$ST_URL" "$ST_TARGET_ABS")
 "\${ARGS[@]}"
+# Defensive unset AFTER the clone (NOT before — git invokes the
+# askpass shim as a child process which reads $ST_PAT from its
+# inherited env; unsetting before would break auth). PR #218 round
+# 2 NIT — symmetry with SSH script's pre-clone unset (which is safe
+# there because the key is already on disk by that point).
+unset ST_PAT
 `;
 
 /**

--- a/backend/src/bootstrap/dotfiles.test.ts
+++ b/backend/src/bootstrap/dotfiles.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Set the encryption key BEFORE importing the module — `decryptStoredAuth`
+// imports `secrets.js` at module-load time which reads the env var.
+process.env.SECRETS_ENCRYPTION_KEY = Buffer.alloc(32, 0x42).toString("base64");
+
+import type { DockerManager } from "../dockerManager.js";
+import { encryptAuthCredentials } from "../sessionConfig.js";
+import {
+	DOTFILES_NONE_SCRIPT,
+	DOTFILES_PAT_SCRIPT,
+	DOTFILES_SSH_SCRIPT,
+	DotfilesAuthMismatchError,
+	runDotfiles,
+} from "./dotfiles.js";
+
+describe("runDotfiles", () => {
+	let docker: { streamExec: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		docker = { streamExec: vi.fn(async () => ({ exitCode: 0 })) };
+	});
+
+	it("returns exitCode 0 and skips when dotfiles is null", async () => {
+		const result = await runDotfiles({
+			sessionId: "sess-1",
+			dotfiles: null,
+			storedAuth: null,
+			docker: docker as unknown as DockerManager,
+		});
+		expect(result).toEqual({ exitCode: 0 });
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	it("anonymous-https path: bash invokes DOTFILES_NONE_SCRIPT, env carries url+ref", async () => {
+		await runDotfiles({
+			sessionId: "sess-1",
+			dotfiles: { url: "https://github.com/u/d.git", ref: "main" },
+			storedAuth: null,
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.cmd[2]).toBe(DOTFILES_NONE_SCRIPT);
+		expect(opts.env).toEqual({
+			ST_URL: "https://github.com/u/d.git",
+			ST_REF: "main",
+			ST_TARGET_DIR: "/home/developer/dotfiles",
+		});
+	});
+
+	// PAT-https: token comes from the SHARED auth blob (auth.pat), not
+	// a dotfiles-specific field. Same encryption boundary as
+	// cloneRepo.PAT_CLONE_SCRIPT.
+	it("PAT-https path: token from shared auth.pat, never in argv", async () => {
+		const stored = encryptAuthCredentials({ pat: "ghp_dotfiles_TOKEN" });
+		await runDotfiles({
+			sessionId: "sess-1",
+			dotfiles: { url: "https://github.com/u/d.git" },
+			storedAuth: stored,
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.cmd[2]).toBe(DOTFILES_PAT_SCRIPT);
+		const argvJoined = (opts.cmd as string[]).join(" ");
+		expect(argvJoined).not.toContain("ghp_dotfiles_TOKEN");
+		expect(opts.env).toMatchObject({ ST_PAT: "ghp_dotfiles_TOKEN" });
+	});
+
+	// SSH: key + known_hosts come from auth.ssh. "default" knownHosts
+	// resolves to the bundled fingerprints; custom paste verbatim.
+	it("SSH path: key + known_hosts via env, NOT argv", async () => {
+		const stored = encryptAuthCredentials({
+			ssh: { privateKey: "SECRETKEY", knownHosts: "default" },
+		});
+		await runDotfiles({
+			sessionId: "sess-1",
+			dotfiles: { url: "git@github.com:u/d.git" },
+			storedAuth: stored,
+			docker: docker as unknown as DockerManager,
+		});
+		const [, opts] = docker.streamExec.mock.calls[0]!;
+		expect(opts.cmd[2]).toBe(DOTFILES_SSH_SCRIPT);
+		const argvJoined = (opts.cmd as string[]).join(" ");
+		expect(argvJoined).not.toContain("SECRETKEY");
+		expect(opts.env?.ST_SSH_KEY).toBe("SECRETKEY");
+	});
+
+	// Mismatched URL/auth: the schema doesn't cross-validate dotfiles
+	// against config.auth (per the DotfilesSpec note). The runner is
+	// the place that surfaces the mismatch with a loud throw rather
+	// than a silent fall-through to anonymous (which would 404 against
+	// a private repo with no signal).
+	it("throws DotfilesAuthMismatchError when git@ URL has no SSH credential available", async () => {
+		await expect(
+			runDotfiles({
+				sessionId: "sess-1",
+				dotfiles: { url: "git@github.com:u/d.git" },
+				storedAuth: null,
+				docker: docker as unknown as DockerManager,
+			}),
+		).rejects.toBeInstanceOf(DotfilesAuthMismatchError);
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	it("runs the install script after a successful clone", async () => {
+		await runDotfiles({
+			sessionId: "sess-1",
+			dotfiles: {
+				url: "https://github.com/u/d.git",
+				installScript: "install.sh",
+			},
+			storedAuth: null,
+			docker: docker as unknown as DockerManager,
+		});
+		expect(docker.streamExec).toHaveBeenCalledTimes(2);
+		const [, secondOpts] = docker.streamExec.mock.calls[1]!;
+		// argv-mode + workingDir pinned to the dotfiles tree so the
+		// installScript's relative paths resolve there.
+		expect(secondOpts.cmd).toEqual(["bash", "--", "install.sh"]);
+		expect(secondOpts.workingDir).toBe("/home/developer/dotfiles");
+	});
+
+	it("skips the install script when the clone fails", async () => {
+		docker.streamExec.mockImplementationOnce(async () => ({ exitCode: 128 }));
+		const result = await runDotfiles({
+			sessionId: "sess-1",
+			dotfiles: {
+				url: "https://github.com/u/d.git",
+				installScript: "install.sh",
+			},
+			storedAuth: null,
+			docker: docker as unknown as DockerManager,
+		});
+		expect(result).toEqual({ exitCode: 128 });
+		expect(docker.streamExec).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips the install script when installScript is omitted", async () => {
+		await runDotfiles({
+			sessionId: "sess-1",
+			dotfiles: { url: "https://github.com/u/d.git" },
+			storedAuth: null,
+			docker: docker as unknown as DockerManager,
+		});
+		expect(docker.streamExec).toHaveBeenCalledTimes(1);
+	});
+
+	it("forwards the abort signal to both clone + install streamExec calls", async () => {
+		const ac = new AbortController();
+		await runDotfiles({
+			sessionId: "sess-1",
+			dotfiles: {
+				url: "https://github.com/u/d.git",
+				installScript: "install.sh",
+			},
+			storedAuth: null,
+			docker: docker as unknown as DockerManager,
+			signal: ac.signal,
+		});
+		for (const call of docker.streamExec.mock.calls) {
+			const [, opts] = call;
+			expect(opts.signal).toBe(ac.signal);
+		}
+	});
+});

--- a/backend/src/bootstrap/dotfiles.ts
+++ b/backend/src/bootstrap/dotfiles.ts
@@ -145,7 +145,19 @@ ARGS+=("--" "$ST_URL" "$ST_TARGET_DIR")
 "\${ARGS[@]}"
 `;
 
-/** PAT-https clone via GIT_ASKPASS shim. Mirrors cloneRepo.PAT_CLONE_SCRIPT. */
+/** PAT-https clone via GIT_ASKPASS shim. Mirrors cloneRepo.PAT_CLONE_SCRIPT.
+ *
+ *  `unset ST_PAT` runs AFTER the clone, NOT before it. The askpass
+ *  shim is invoked as a child process by git and reads `$ST_PAT`
+ *  from its inherited environment; unsetting it before the clone
+ *  would make the shim print an empty token and break auth.
+ *  Placing the unset after clears the var from the bash process
+ *  for any subsequent operation in the same exec context (none in
+ *  this script today; defensive against a future edit that adds
+ *  one). PR #218 round 2 NIT flagged the inconsistency with
+ *  DOTFILES_SSH_SCRIPT (which can unset BEFORE git because the
+ *  key has already been written to disk by then and git reads
+ *  from the file, not the env). */
 export const DOTFILES_PAT_SCRIPT = `set -e
 ASKPASS_PATH=$(mktemp /tmp/git-askpass-XXXXXXXX)
 cleanup() { rm -f "$ASKPASS_PATH"; }
@@ -164,6 +176,7 @@ ARGS=("git" "clone")
 [ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
 ARGS+=("--" "$ST_URL" "$ST_TARGET_DIR")
 "\${ARGS[@]}"
+unset ST_PAT
 `;
 
 /** SSH clone. Reuses ~/.ssh/id_ed25519 and ~/.ssh/known_hosts the

--- a/backend/src/bootstrap/dotfiles.ts
+++ b/backend/src/bootstrap/dotfiles.ts
@@ -1,0 +1,189 @@
+/**
+ * dotfiles.ts — dotfiles bootstrap stage (#191 PR 191b).
+ *
+ * Clones a user-supplied dotfiles repo into `~/dotfiles` inside the
+ * session container, then optionally runs an install script from the
+ * cloned tree. Auth credentials are shared with the main repo
+ * (`config.auth`): the user has one identity per session, so a
+ * private dotfiles URL relies on the same PAT or SSH key the main
+ * repo uses. A per-repo identity is a follow-up (#189).
+ *
+ * The clone reuses the same three-mode logic as `cloneRepo.ts`:
+ *   - `auth.pat` set + https URL → GIT_ASKPASS-shimmed clone
+ *   - `auth.ssh` set + git@ URL  → key-on-disk + StrictHostKeyChecking=yes
+ *   - neither set + https URL    → anonymous clone
+ *
+ * Mismatched URL/auth combinations fail loudly inside the bash
+ * script — the schema-side cross-field validation that `repo` has
+ * deliberately doesn't apply here (DotfilesSpec note in
+ * sessionConfig.ts) because the auth blob is shared. The 191b
+ * runner is the right layer to surface the mismatch via a clear
+ * exit code + streamed error message.
+ *
+ * The install script (when set) runs from inside the cloned tree
+ * via `bash <installScript>`. A non-zero exit aborts the bootstrap.
+ */
+
+import type { DockerManager } from "../dockerManager.js";
+import { logger } from "../logger.js";
+import type { AuthInput, DotfilesInput } from "../sessionConfig.js";
+import { type AuthStored, decryptStoredAuth, KNOWN_HOSTS_DEFAULT } from "../sessionConfig.js";
+import { KNOWN_HOSTS_DEFAULT_BUNDLE } from "./knownHosts.js";
+
+const CONTAINER_DOTFILES_DIR = "/home/developer/dotfiles";
+
+interface RunDotfilesArgs {
+	sessionId: string;
+	dotfiles: DotfilesInput | null | undefined;
+	storedAuth: AuthStored | null | undefined;
+	docker: DockerManager;
+	onOutput?: (chunk: string) => void;
+	signal?: AbortSignal;
+}
+
+export class DotfilesAuthMismatchError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "DotfilesAuthMismatchError";
+	}
+}
+
+const HTTPS_URL = /^https:\/\/[^@\s]+$/;
+const SSH_URL = /^git@/;
+
+/**
+ * Returns `{ exitCode: 0 }` and skips when `dotfiles` is null /
+ * undefined. Otherwise: clone the repo, optionally run the install
+ * script. Returns the first non-zero exit code (or 0 on success).
+ */
+export async function runDotfiles(args: RunDotfilesArgs): Promise<{ exitCode: number }> {
+	const { dotfiles, storedAuth, sessionId, docker, onOutput, signal } = args;
+	if (!dotfiles) return { exitCode: 0 };
+
+	const decrypted: AuthInput = storedAuth ? decryptStoredAuth(storedAuth) : {};
+	const isHttps = HTTPS_URL.test(dotfiles.url);
+	const isSsh = SSH_URL.test(dotfiles.url);
+
+	logger.info(
+		`[dotfiles] session ${sessionId}: cloning ${dotfiles.url} (ref=${dotfiles.ref ?? "<HEAD>"}, install=${dotfiles.installScript ?? "<none>"})`,
+	);
+
+	// Pick the auth mode from the URL shape + what's available in the
+	// shared auth blob. The mode determines which bash script body to
+	// run. Mismatched URL/auth combinations are caught here as a
+	// loud throw — the schema's cross-field check doesn't fire for
+	// dotfiles because the auth blob is shared with the main repo.
+	const env: Record<string, string> = {
+		ST_URL: dotfiles.url,
+		ST_REF: dotfiles.ref ?? "",
+		ST_TARGET_DIR: CONTAINER_DOTFILES_DIR,
+	};
+	let script: string;
+	if (isSsh) {
+		if (!decrypted.ssh) {
+			throw new DotfilesAuthMismatchError(
+				"dotfiles: git@ URL requires config.auth.ssh (shared with main repo) to be set",
+			);
+		}
+		const knownHostsContent =
+			decrypted.ssh.knownHosts === KNOWN_HOSTS_DEFAULT
+				? KNOWN_HOSTS_DEFAULT_BUNDLE
+				: decrypted.ssh.knownHosts;
+		env.ST_SSH_KEY = decrypted.ssh.privateKey;
+		env.ST_KNOWN_HOSTS = knownHostsContent;
+		script = DOTFILES_SSH_SCRIPT;
+	} else if (isHttps) {
+		if (decrypted.pat !== undefined) {
+			env.ST_PAT = decrypted.pat;
+			script = DOTFILES_PAT_SCRIPT;
+		} else {
+			script = DOTFILES_NONE_SCRIPT;
+		}
+	} else {
+		throw new DotfilesAuthMismatchError("dotfiles: url must be https://… or git@host:path form");
+	}
+
+	const cloneResult = await docker.streamExec(
+		sessionId,
+		{
+			cmd: ["bash", "-c", script],
+			env,
+			signal,
+		},
+		onOutput,
+	);
+	if (cloneResult.exitCode !== 0) return cloneResult;
+
+	// Install script — optional. Run from inside the cloned tree so
+	// the script's relative paths resolve against the dotfiles root
+	// (e.g. `bash install.sh` referencing `./files/...`).
+	const installScript = dotfiles.installScript;
+	if (installScript === undefined || installScript === null || installScript === "") {
+		return { exitCode: 0 };
+	}
+	return docker.streamExec(
+		sessionId,
+		{
+			// argv-mode + workingDir pinned to the dotfiles tree.
+			// The schema's installScript regex blocks `..` and leading
+			// `/`, so the value is a clean relative path; we still pin
+			// the working dir defensively.
+			cmd: ["bash", "--", installScript],
+			workingDir: CONTAINER_DOTFILES_DIR,
+			signal,
+		},
+		onOutput,
+	);
+}
+
+/** Anonymous-https clone (no auth). Same shape as cloneRepo's argv
+ *  path but as a script for consistency with the auth'd variants. */
+export const DOTFILES_NONE_SCRIPT = `set -e
+ARGS=("git" "clone")
+[ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
+ARGS+=("--" "$ST_URL" "$ST_TARGET_DIR")
+"\${ARGS[@]}"
+`;
+
+/** PAT-https clone via GIT_ASKPASS shim. Mirrors cloneRepo.PAT_CLONE_SCRIPT. */
+export const DOTFILES_PAT_SCRIPT = `set -e
+ASKPASS_PATH=$(mktemp /tmp/git-askpass-XXXXXXXX)
+cleanup() { rm -f "$ASKPASS_PATH"; }
+trap cleanup EXIT
+cat > "$ASKPASS_PATH" <<'ASKPASS_EOF'
+#!/bin/sh
+case "$1" in
+  Username*) printf 'oauth2\\n' ;;
+  *) printf '%s\\n' "$ST_PAT" ;;
+esac
+ASKPASS_EOF
+chmod 700 "$ASKPASS_PATH"
+export GIT_ASKPASS="$ASKPASS_PATH"
+export GIT_TERMINAL_PROMPT=0
+ARGS=("git" "clone")
+[ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
+ARGS+=("--" "$ST_URL" "$ST_TARGET_DIR")
+"\${ARGS[@]}"
+`;
+
+/** SSH clone. Reuses ~/.ssh/id_ed25519 and ~/.ssh/known_hosts the
+ *  main repo's clone already wrote (shared per the issue spec) —
+ *  but we re-write them here too in case dotfiles runs BEFORE the
+ *  main repo clone in the pipeline. The order is currently
+ *  gitIdentity → repo → dotfiles, so the main clone has already
+ *  written the keys; the re-write is idempotent (same bytes).
+ *  StrictHostKeyChecking=yes mirrors cloneRepo.SSH_CLONE_SCRIPT. */
+export const DOTFILES_SSH_SCRIPT = `set -e
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+printf '%s' "$ST_SSH_KEY" > ~/.ssh/id_ed25519
+chmod 600 ~/.ssh/id_ed25519
+printf '%s\\n' "$ST_KNOWN_HOSTS" > ~/.ssh/known_hosts
+chmod 644 ~/.ssh/known_hosts
+unset ST_SSH_KEY ST_KNOWN_HOSTS
+export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=yes"
+ARGS=("git" "clone")
+[ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
+ARGS+=("--" "$ST_URL" "$ST_TARGET_DIR")
+"\${ARGS[@]}"
+`;

--- a/backend/src/bootstrap/gitIdentity.test.ts
+++ b/backend/src/bootstrap/gitIdentity.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DockerManager } from "../dockerManager.js";
+import { runGitIdentity } from "./gitIdentity.js";
+
+describe("runGitIdentity", () => {
+	let docker: { streamExec: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		docker = { streamExec: vi.fn(async () => ({ exitCode: 0 })) };
+	});
+
+	it("returns exitCode 0 and skips entirely when identity is null", async () => {
+		const result = await runGitIdentity({
+			sessionId: "sess-1",
+			identity: null,
+			docker: docker as unknown as DockerManager,
+		});
+		expect(result).toEqual({ exitCode: 0 });
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	it("returns exitCode 0 and skips when identity is undefined", async () => {
+		const result = await runGitIdentity({
+			sessionId: "sess-1",
+			identity: undefined,
+			docker: docker as unknown as DockerManager,
+		});
+		expect(result).toEqual({ exitCode: 0 });
+		expect(docker.streamExec).not.toHaveBeenCalled();
+	});
+
+	it("issues two argv-mode `git config --global` calls in name-then-email order", async () => {
+		await runGitIdentity({
+			sessionId: "sess-1",
+			identity: { name: "Ada Lovelace", email: "ada@example.com" },
+			docker: docker as unknown as DockerManager,
+		});
+		expect(docker.streamExec).toHaveBeenCalledTimes(2);
+		const [, firstOpts] = docker.streamExec.mock.calls[0]!;
+		const [, secondOpts] = docker.streamExec.mock.calls[1]!;
+		// argv-mode (no shell) so user-controlled values reach `git
+		// config` as positional args, not shell tokens.
+		expect(firstOpts.cmd).toEqual(["git", "config", "--global", "user.name", "Ada Lovelace"]);
+		expect(secondOpts.cmd).toEqual(["git", "config", "--global", "user.email", "ada@example.com"]);
+		// argv-only — no shell wrapping at all.
+		expect(firstOpts.cmd).not.toContain("bash");
+		expect(secondOpts.cmd).not.toContain("bash");
+	});
+
+	it("returns the first non-zero exit code without running the second call", async () => {
+		// `git config user.name` fails (e.g. read-only home) — we want
+		// the runner to surface that immediately and not paper over it
+		// with a successful user.email call.
+		docker.streamExec.mockResolvedValueOnce({ exitCode: 0 }).mockResolvedValueOnce({ exitCode: 0 });
+		// Override only the first call:
+		docker.streamExec.mockReset();
+		docker.streamExec.mockImplementationOnce(async () => ({ exitCode: 128 }));
+
+		const result = await runGitIdentity({
+			sessionId: "sess-1",
+			identity: { name: "X", email: "x@y.com" },
+			docker: docker as unknown as DockerManager,
+		});
+		expect(result).toEqual({ exitCode: 128 });
+		expect(docker.streamExec).toHaveBeenCalledTimes(1);
+	});
+
+	it("forwards the abort signal to streamExec on each call", async () => {
+		const ac = new AbortController();
+		await runGitIdentity({
+			sessionId: "sess-1",
+			identity: { name: "X", email: "x@y.com" },
+			docker: docker as unknown as DockerManager,
+			signal: ac.signal,
+		});
+		for (const call of docker.streamExec.mock.calls) {
+			const [, opts] = call;
+			expect(opts.signal).toBe(ac.signal);
+		}
+	});
+});

--- a/backend/src/bootstrap/gitIdentity.ts
+++ b/backend/src/bootstrap/gitIdentity.ts
@@ -1,0 +1,67 @@
+/**
+ * gitIdentity.ts — git identity bootstrap stage (#191 PR 191b).
+ *
+ * Runs `git config --global user.{name,email}` inside the session
+ * container BEFORE any commit-producing operation (clone-with-rebase,
+ * dotfiles install, postCreate scripts that auto-commit). Without
+ * this, those operations would fail with "Please tell me who you
+ * are" or commit under whatever default git picked.
+ *
+ * The values are user-supplied (validated by the schema's regex +
+ * control-char rejection) and reach `git config` as positional argv,
+ * NOT via shell interpolation. A `\n` in the value would still
+ * corrupt `~/.gitconfig` (INI uses newline as record separator), but
+ * the schema-side `CONTROL_CHAR_PATTERN` reject closes that path
+ * before the value reaches here.
+ */
+
+import type { DockerManager } from "../dockerManager.js";
+import { logger } from "../logger.js";
+import type { GitIdentityInput } from "../sessionConfig.js";
+
+interface RunGitIdentityArgs {
+	sessionId: string;
+	identity: GitIdentityInput | null | undefined;
+	docker: DockerManager;
+	onOutput?: (chunk: string) => void;
+	signal?: AbortSignal;
+}
+
+/**
+ * Returns `{ exitCode: 0 }` and skips the stage when `identity` is
+ * null/undefined. Otherwise runs two sequential `git config --global`
+ * invocations and returns the first non-zero exit (or 0 if both
+ * succeeded). The two-call shape matches what an interactive operator
+ * would type and produces clear streamed output for the modal.
+ */
+export async function runGitIdentity(args: RunGitIdentityArgs): Promise<{ exitCode: number }> {
+	const { identity, sessionId, docker, onOutput, signal } = args;
+	if (!identity) return { exitCode: 0 };
+
+	logger.info(
+		`[gitIdentity] session ${sessionId}: setting user.name=${identity.name} user.email=${identity.email}`,
+	);
+
+	// argv-mode (no shell). The schema's control-char reject keeps
+	// `\n` out, but argv-only is the load-bearing defence: any other
+	// shell-meta in the value reaches `git config` as a single
+	// positional argument.
+	const nameResult = await docker.streamExec(
+		sessionId,
+		{
+			cmd: ["git", "config", "--global", "user.name", identity.name],
+			signal,
+		},
+		onOutput,
+	);
+	if (nameResult.exitCode !== 0) return nameResult;
+
+	return docker.streamExec(
+		sessionId,
+		{
+			cmd: ["git", "config", "--global", "user.email", identity.email],
+			signal,
+		},
+		onOutput,
+	);
+}

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -848,9 +848,26 @@ export class DockerManager {
 			cmd: string[];
 			env?: Record<string, string>;
 			workingDir?: string;
+			/** Abort the in-flight exec by destroying the upstream
+			 *  stream. Used by #191 PR 191b's 10-min bootstrap cap.
+			 *  When the signal fires, the returned promise rejects
+			 *  with an `AbortError` so the runner routes the
+			 *  failure through its existing throw-path catch.
+			 *  Note: destroying the stream does NOT kill the
+			 *  in-container process — Docker has no "kill exec"
+			 *  API. The caller must kill the container itself in
+			 *  the timeout-failure path; the stream destroy here
+			 *  just lets the streamExec promise unblock quickly. */
+			signal?: AbortSignal;
 		},
 		onOutput?: (chunk: string) => void,
 	): Promise<{ exitCode: number }> {
+		// Pre-check: if already aborted, fail fast without burning a
+		// docker round-trip. Standard AbortSignal contract.
+		if (opts.signal?.aborted) {
+			throw new DOMException("aborted", "AbortError");
+		}
+
 		const meta = await this.sessions.getOrThrow(sessionId);
 		if (!meta.containerId) throw new Error("No container for this session");
 		const container = this.docker.getContainer(meta.containerId);
@@ -870,6 +887,16 @@ export class DockerManager {
 			WorkingDir: opts.workingDir ?? "/home/developer/workspace",
 		});
 		const stream = await exec.start({ hijack: false, stdin: false });
+
+		// Wire the abort signal: destroy the upstream stream when the
+		// signal fires so the resolve-on-end Promise below settles
+		// quickly. The stream emits `error` when destroyed, which
+		// rejects the promise; we then re-throw an AbortError so the
+		// caller's catch sees the standard contract.
+		const abortHandler = () => {
+			stream.destroy(new DOMException("aborted", "AbortError"));
+		};
+		opts.signal?.addEventListener("abort", abortHandler, { once: true });
 
 		// Demux frames as they arrive so `onOutput` fires per-chunk.
 		// `pending` accumulates across `data` events when a frame
@@ -901,11 +928,26 @@ export class DockerManager {
 		// `end` then `close`, but Dockerode streams can emit `close`
 		// without `end` on a dropped daemon connection. Promise spec
 		// silently drops the second resolve.
-		await new Promise<void>((resolve, reject) => {
-			stream.on("end", () => resolve());
-			stream.on("close", () => resolve());
-			stream.on("error", reject);
-		});
+		try {
+			await new Promise<void>((resolve, reject) => {
+				stream.on("end", () => resolve());
+				stream.on("close", () => resolve());
+				stream.on("error", reject);
+			});
+		} finally {
+			// Whether we resolved cleanly or threw, drop the abort
+			// listener so a late-firing signal doesn't try to destroy
+			// an already-closed stream.
+			opts.signal?.removeEventListener("abort", abortHandler);
+		}
+		// If the signal aborted mid-stream, surface AbortError up to
+		// the caller — don't pretend the exit code is meaningful.
+		// `info.ExitCode` would still be null here (process killed
+		// before docker recorded an exit) but the AbortError is the
+		// intent-carrying signal the runner needs.
+		if (opts.signal?.aborted) {
+			throw new DOMException("aborted", "AbortError");
+		}
 		const info = await exec.inspect();
 		// `info.ExitCode === null` is Docker's "the daemon hasn't
 		// recorded the process exit yet" state — a narrow window

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -214,9 +214,11 @@ describe("POST /sessions — async bootstrap dispatch (PR 185b2b)", () => {
 		expect(bootstrapStubs.runAsyncBootstrap.mock.calls[0]?.[1]).toEqual({
 			postCreateCmd: "npm install",
 			postStartCmd: "npm run dev",
-			// `hasRepo` lets the runner skip the getSessionConfig D1
-			// fetch on postCreate-only sessions (PR #214 round 2 NIT).
-			hasRepo: false,
+			// `hasBootstrapConfig` gates the getSessionConfig D1 fetch
+			// on postCreate-only sessions (PR #214 round 2 NIT,
+			// generalised in #191 PR 191b to cover all four
+			// config-driven stages).
+			hasBootstrapConfig: false,
 		});
 		expect(spies.runPostStart).not.toHaveBeenCalled();
 	});

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -223,6 +223,35 @@ describe("POST /sessions — async bootstrap dispatch (PR 185b2b)", () => {
 		expect(spies.runPostStart).not.toHaveBeenCalled();
 	});
 
+	// PR #218 round 2 NIT: pin `hasBootstrapConfig: true` for each of
+	// the new config-driven fields so a future route refactor (e.g. a
+	// `??` normalisation that maps undefined→null) can't silently
+	// break the gate.
+	it.each([
+		["repo", { url: "https://github.com/o/r", auth: "none" as const }],
+		["gitIdentity", { name: "Ada", email: "a@b.com" }],
+		["dotfiles", { url: "https://github.com/u/d.git" }],
+		["agentSeed", { claudeMd: "# notes" }],
+	])("computes hasBootstrapConfig=true when only %s is set", async (field, value) => {
+		const { sessions, docker } = makeFakes();
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "test",
+				config: { [field]: value },
+			}),
+		});
+		expect(res.status).toBe(201);
+		expect(bootstrapStubs.runAsyncBootstrap).toHaveBeenCalledTimes(1);
+		const cfgArg = bootstrapStubs.runAsyncBootstrap.mock.calls[0]?.[1] as {
+			hasBootstrapConfig?: boolean;
+		};
+		expect(cfgArg.hasBootstrapConfig).toBe(true);
+	});
+
 	it("returns 201 without bootstrapping flag and runs postStart inline when only postStartCmd is set", async () => {
 		// No postCreateCmd → no async bootstrap runner. postStart runs
 		// synchronously here because there's no hook to wait on, and

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -497,16 +497,25 @@ export function buildRouter(
 			// a no-op when `repo` is absent, so this widening is safe
 			// for the postCreate-only path and lets repo-only sessions
 			// (no hook, just a clone) get their async-bootstrap modal.
-			if (validatedConfig?.postCreateCmd || validatedConfig?.repo) {
+			// Fire async bootstrap when ANY config-driven stage or hook
+			// is set. #191 PR 191b widened from `repo || postCreateCmd`
+			// to also include the three new lifecycle-hook fields.
+			const hasBootstrapConfig =
+				(validatedConfig?.repo !== null && validatedConfig?.repo !== undefined) ||
+				(validatedConfig?.gitIdentity !== null && validatedConfig?.gitIdentity !== undefined) ||
+				(validatedConfig?.dotfiles !== null && validatedConfig?.dotfiles !== undefined) ||
+				(validatedConfig?.agentSeed !== null && validatedConfig?.agentSeed !== undefined);
+			if (validatedConfig?.postCreateCmd || hasBootstrapConfig) {
 				const cfg = {
-					postCreateCmd: validatedConfig.postCreateCmd,
-					postStartCmd: validatedConfig.postStartCmd,
-					// `hasRepo` lets the runner skip the `getSessionConfig`
-					// D1 fetch on postCreate-only sessions (PR #214 round 2
-					// NIT). The route already knows whether a repo was
-					// configured — passing the bit through avoids the
-					// runner having to fetch just to learn the answer.
-					hasRepo: validatedConfig.repo !== null && validatedConfig.repo !== undefined,
+					postCreateCmd: validatedConfig?.postCreateCmd,
+					postStartCmd: validatedConfig?.postStartCmd,
+					// `hasBootstrapConfig` gates the runner's
+					// `getSessionConfig` D1 fetch — skip the round-trip
+					// for postCreate-only sessions (PR #214 round 2 NIT,
+					// generalised in #191 PR 191b to cover all four
+					// config-driven stages: repo / gitIdentity / dotfiles
+					// / agentSeed).
+					hasBootstrapConfig,
 				};
 				// Fire-and-forget; the runner internally catches every
 				// throw it can and translates them into broadcaster


### PR DESCRIPTION
## Summary

Adds the three bootstrap stages that consume #191's typed config fields plus a 10-minute total bootstrap timeout. Pipeline order matches the issue spec.

## Pipeline

\`\`\`
  1. gitIdentity   — git config --global user.{name,email}
  2. clone         — #188's existing repo-clone runner
  3. dotfiles      — clone into ~/dotfiles + optional install script
  4. agentSeed     — write ~/.claude/{settings.json,CLAUDE.md}
  5. postCreate    — existing user hook
     ↓ markBootstrapped + postStart on success
\`\`\`

## New modules under bootstrap/

- **gitIdentity.ts** — two argv-mode \`git config\` calls, no shell.
- **dotfiles.ts** — three auth-mode bash scripts (none/PAT/SSH) that share env vars with cloneRepo. Auth comes from the **shared** \`config.auth\` blob (issue spec — one identity per session); a \`git@…\` URL with no SSH credential throws \`DotfilesAuthMismatchError\` rather than falling back to anonymous (which would 404 against private repos with no signal). Install script runs from inside the cloned tree.
- **agentSeed.ts** — bash script with conditional \`[ -n ]\` guards so a single configured field doesn't clobber the other with an empty file.

## 10-min wall-clock cap

\`BOOTSTRAP_WALL_CLOCK_CAP_MS\` wired via an \`AbortController\` whose signal threads through \`streamExec\` and into each stage. On timeout the in-flight stream is destroyed (unblocks the streamExec promise; doesn't kill the in-container process — Docker has no \"kill exec\" API), then the existing \`failSession\` path kills the container, and the broadcaster emits a clear \"bootstrap timeout\" line before the terminal \`fail\` message.

## Refactor

Bootstrap orchestration refactored: a \`runStage\` helper centralises the throw/non-zero-exit teardown so the timeout reason can be detected once and surfaced consistently. The \`hasRepo\` hint on \`runAsyncBootstrap\`'s cfg is renamed \`hasBootstrapConfig\` to cover all four config-driven stages (route updated to compute it from any of \`{repo, gitIdentity, dotfiles, agentSeed}\`). postCreate-only sessions still skip the \`getSessionConfig\` D1 fetch.

## Test plan
- [x] 24 new tests across the four stage modules + the orchestrator (stage isolation, argv shape, env-only secret routing for PAT/SSH, \`DotfilesAuthMismatchError\`, install-script gated on clone success, abort-signal forwarding, full pipeline order, mid-pipeline non-zero exit teardown, timeout-cap simulated via \`vi.useFakeTimers\`)
- [x] \`cd backend && npm test\` — 417 passing
- [x] \`cd backend && npm run lint && npm run build\` — clean
- [x] \`cd frontend && npm run lint && npm run build\` — clean (no frontend changes)

Frontend Advanced-tab UI lands in 191c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)