### PR TITLE
feat(hooks): Advanced tab UI — closes #191 (PR 191c of 3)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -434,24 +434,151 @@
             aria-labelledby="session-tab-advanced-tab"
             hidden
           >
-            <p class="session-placeholder">
-              Lifecycle hooks (post-create / post-start commands), dotfiles,
-              git identity, agent config seed, and per-session resource caps
-              live here. Wired up in
-              <a
-                href="https://github.com/gatof81/shared-terminal/issues/191"
-                target="_blank"
-                rel="noopener"
-                >#191</a
-              >
-              and
-              <a
-                href="https://github.com/gatof81/shared-terminal/issues/194"
-                target="_blank"
-                rel="noopener"
-                >#194</a
-              >.
+            <p class="modal-hint">
+              These run during session bootstrap. Total wall-clock time
+              across all stages is capped at 10 minutes.
             </p>
+
+            <fieldset class="advanced-section">
+              <legend>Git identity</legend>
+              <p class="modal-hint">
+                Sets <code>user.name</code> /
+                <code>user.email</code> globally inside the session
+                container so commits land with the right identity.
+              </p>
+              <div class="repo-fields-row">
+                <label class="modal-field">
+                  <span>Name</span>
+                  <input
+                    type="text"
+                    id="git-identity-name"
+                    placeholder="Ada Lovelace"
+                    autocomplete="off"
+                    spellcheck="false"
+                  />
+                </label>
+                <label class="modal-field">
+                  <span>Email</span>
+                  <input
+                    type="email"
+                    id="git-identity-email"
+                    placeholder="ada@example.com"
+                    autocomplete="off"
+                    spellcheck="false"
+                  />
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="advanced-section">
+              <legend>Dotfiles</legend>
+              <p class="modal-hint">
+                Cloned into <code>~/dotfiles</code> before the
+                <code>postCreate</code> hook. Uses the same auth
+                credentials as the main repo above (PAT or SSH).
+                Optional install script runs from inside the cloned
+                tree on success.
+              </p>
+              <label class="modal-field">
+                <span>Repository URL</span>
+                <input
+                  type="text"
+                  id="dotfiles-url"
+                  placeholder="https://github.com/owner/dotfiles  or  git@github.com:owner/dotfiles"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </label>
+              <div class="repo-fields-row">
+                <label class="modal-field">
+                  <span>Ref (optional)</span>
+                  <input
+                    type="text"
+                    id="dotfiles-ref"
+                    placeholder="main (empty = remote HEAD)"
+                    autocomplete="off"
+                    spellcheck="false"
+                  />
+                </label>
+                <label class="modal-field">
+                  <span>Install script (optional)</span>
+                  <input
+                    type="text"
+                    id="dotfiles-install-script"
+                    placeholder="install.sh"
+                    autocomplete="off"
+                    spellcheck="false"
+                  />
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="advanced-section">
+              <legend>Agent config seed</legend>
+              <p class="modal-hint">
+                Both files are written verbatim into
+                <code>~/.claude/</code> so the Claude CLI starts
+                pre-configured. Settings must be valid JSON.
+              </p>
+              <label class="modal-field">
+                <span>~/.claude/settings.json</span>
+                <textarea
+                  id="agent-seed-settings"
+                  rows="6"
+                  placeholder='{"theme":"dark","editor":{"tabSize":2}}'
+                  autocomplete="off"
+                  spellcheck="false"
+                ></textarea>
+                <span
+                  id="agent-seed-settings-error"
+                  class="modal-field-error"
+                  aria-live="polite"
+                ></span>
+              </label>
+              <label class="modal-field">
+                <span>~/.claude/CLAUDE.md</span>
+                <textarea
+                  id="agent-seed-claude-md"
+                  rows="6"
+                  placeholder="# Project notes&#10;- Use TS strict mode."
+                  autocomplete="off"
+                  spellcheck="false"
+                ></textarea>
+              </label>
+            </fieldset>
+
+            <fieldset class="advanced-section">
+              <legend>Lifecycle commands</legend>
+              <label class="modal-field">
+                <span>postCreate command</span>
+                <textarea
+                  id="post-create-cmd"
+                  rows="3"
+                  placeholder="npm install"
+                  autocomplete="off"
+                  spellcheck="false"
+                ></textarea>
+                <span class="modal-hint-inline">
+                  Runs once on first creation, after clone + dotfiles +
+                  agent seed. Failure aborts session creation.
+                </span>
+              </label>
+              <label class="modal-field">
+                <span>postStart command</span>
+                <textarea
+                  id="post-start-cmd"
+                  rows="3"
+                  placeholder="npm run dev"
+                  autocomplete="off"
+                  spellcheck="false"
+                ></textarea>
+                <span class="modal-hint-inline">
+                  Runs every container start in tmux window
+                  <code>bootstrap</code>. For long-running daemons
+                  (e.g. <code>code tunnel</code>, <code>npm run dev</code>).
+                </span>
+              </label>
+            </fieldset>
           </div>
           <div class="session-modal-actions">
             <button type="button" data-close-modal>Cancel</button>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -186,6 +186,21 @@ export interface SessionConfigPayload {
 		pat?: string;
 		ssh?: { privateKey: string; knownHosts: string };
 	};
+	// #191 — git identity / dotfiles / agent config seed. All three
+	// are independent and skippable; the backend's bootstrap runner
+	// walks each stage in declared order and runs only the configured
+	// ones. `null` is the wire-shape signal for "explicitly not
+	// configured" (treated identically to omission).
+	gitIdentity?: { name: string; email: string } | null;
+	dotfiles?: {
+		url: string;
+		ref?: string | null;
+		installScript?: string | null;
+	} | null;
+	agentSeed?: {
+		settings?: string | null;
+		claudeMd?: string | null;
+	} | null;
 	ports?: Array<{ port: number; protocol?: "http" | "tcp" }>;
 	envVars?: EnvVarEntryInput[];
 }

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -630,6 +630,37 @@ main:not([data-sidebar-ready]) #sidebar {
   padding: 0.75rem;
 }
 
+/* #191 PR 191c — Advanced tab. Each section is a fieldset with a
+ * tinted background to visually group its fields. The agent-seed
+ * inline error sits beneath the textarea and goes red on parse
+ * failure (set via JS on blur). */
+.advanced-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  background: rgba(88, 166, 255, 0.04);
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  padding: 0.75rem 0.85rem;
+  margin: 0;
+}
+.advanced-section legend {
+  font-size: 0.82rem;
+  color: #e6edf3;
+  font-weight: 600;
+  padding: 0 0.4rem;
+}
+.modal-field-error {
+  color: #f85149;
+  font-size: 0.78rem;
+  min-height: 1.1em;
+}
+.modal-hint-inline {
+  color: #8b949e;
+  font-size: 0.75rem;
+  margin-top: 0.15rem;
+}
+
 .session-placeholder {
   font-size: 0.82rem;
   color: #8b949e;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1224,6 +1224,9 @@ function closeNewSessionModal() {
 	// credential fields (PAT, SSH key) — leaving them mounted would
 	// risk leaking a stale credential into the next session create.
 	resetRepoTab();
+	// Reset Advanced-tab state on close (#191 PR 191c). Same
+	// rationale plus the agent-seed bodies can be substantial.
+	resetAdvancedTab();
 	(newSessionOpener ?? newSessionBtn).focus();
 	newSessionOpener = null;
 }
@@ -1385,6 +1388,143 @@ export function collectRepoForSubmit(): {
 	// knownHosts.ts). Custom mode passes the textarea content verbatim.
 	const knownHosts = knownHostsMode === "custom" ? repoAuthSshKnownHostsCustom.value : "default";
 	return { repo, auth: { ssh: { privateKey, knownHosts } } };
+}
+
+// ── Advanced tab (#191 / PR 191c) ───────────────────────────────────────────
+//
+// Four sections: Git identity, Dotfiles, Agent config seed, and the
+// existing postCreate / postStart lifecycle commands. State is read
+// directly from the DOM at submit time (`collectAdvancedForSubmit`)
+// — same pattern as the Repo tab, no in-memory mirror needed.
+//
+// `resetAdvancedTab()` runs on modal close. Critical for the agent-
+// seed textareas in particular: those bodies can be substantial
+// (settings.json, CLAUDE.md), and leaving them mounted between
+// closes risks the next session-create operator submitting stale
+// content from a previous attempt.
+//
+// `validateAgentSeedSettings()` runs on blur of the settings.json
+// textarea: client-side JSON parse → red error message inline. The
+// backend's Zod refine is the source of truth (catches the same
+// case with a 400), but immediate feedback is much friendlier than
+// waiting for submit.
+
+const gitIdentityName = document.getElementById("git-identity-name") as HTMLInputElement;
+const gitIdentityEmail = document.getElementById("git-identity-email") as HTMLInputElement;
+const dotfilesUrl = document.getElementById("dotfiles-url") as HTMLInputElement;
+const dotfilesRef = document.getElementById("dotfiles-ref") as HTMLInputElement;
+const dotfilesInstallScript = document.getElementById(
+	"dotfiles-install-script",
+) as HTMLInputElement;
+const agentSeedSettings = document.getElementById("agent-seed-settings") as HTMLTextAreaElement;
+const agentSeedSettingsError = document.getElementById(
+	"agent-seed-settings-error",
+) as HTMLSpanElement;
+const agentSeedClaudeMd = document.getElementById("agent-seed-claude-md") as HTMLTextAreaElement;
+const postCreateCmd = document.getElementById("post-create-cmd") as HTMLTextAreaElement;
+const postStartCmd = document.getElementById("post-start-cmd") as HTMLTextAreaElement;
+
+/**
+ * Validate `~/.claude/settings.json` content client-side. Backend's
+ * Zod refine catches the same case with a precise 400, but inline
+ * feedback on blur is much friendlier than a server round-trip.
+ *
+ * Returns true when valid (or empty — empty is "don't write the
+ * file" per the schema). Sets the inline error message as a side
+ * effect.
+ */
+function validateAgentSeedSettings(): boolean {
+	const value = agentSeedSettings.value;
+	if (value.trim() === "") {
+		agentSeedSettingsError.textContent = "";
+		return true;
+	}
+	try {
+		JSON.parse(value);
+		agentSeedSettingsError.textContent = "";
+		return true;
+	} catch (err) {
+		agentSeedSettingsError.textContent = `Invalid JSON: ${(err as Error).message}`;
+		return false;
+	}
+}
+
+agentSeedSettings.addEventListener("blur", validateAgentSeedSettings);
+
+/** Wipe Advanced-tab state on modal close. Important for the agent-
+ *  seed textareas — leaving 256 KiB of pasted content mounted between
+ *  modal closes is bad UX (and a potential leak if the next operator
+ *  is a different user, though that's not the typical case here). */
+function resetAdvancedTab(): void {
+	gitIdentityName.value = "";
+	gitIdentityEmail.value = "";
+	dotfilesUrl.value = "";
+	dotfilesRef.value = "";
+	dotfilesInstallScript.value = "";
+	agentSeedSettings.value = "";
+	agentSeedClaudeMd.value = "";
+	postCreateCmd.value = "";
+	postStartCmd.value = "";
+	agentSeedSettingsError.textContent = "";
+}
+
+/**
+ * Read the Advanced tab into the wire shape the backend accepts under
+ * `body.config`. Returns the four optional fields plus the two cmd
+ * strings; `undefined` for any field whose inputs are empty.
+ *
+ * Trims trimmable values; keeps newlines in agent-seed bodies and the
+ * cmd textareas (those are content, not formatting). The backend's
+ * Zod schema is the single source of truth for shape validation —
+ * client-side mirroring would just be one more place to keep in
+ * sync. The user gets a 400 with a precise field path on submit.
+ *
+ * Exported so a future test file can pin the wire shape; matches the
+ * `collectRepoForSubmit` precedent.
+ */
+export function collectAdvancedForSubmit(): {
+	gitIdentity?: SessionConfigPayload["gitIdentity"];
+	dotfiles?: SessionConfigPayload["dotfiles"];
+	agentSeed?: SessionConfigPayload["agentSeed"];
+	postCreateCmd?: string;
+	postStartCmd?: string;
+} {
+	const out: ReturnType<typeof collectAdvancedForSubmit> = {};
+
+	const name = gitIdentityName.value.trim();
+	const email = gitIdentityEmail.value.trim();
+	if (name !== "" || email !== "") {
+		// Both required when either is set; backend cross-validates.
+		// We send what we have and let the 400 surface the missing
+		// half — same precedent as the Repo tab's PAT/SSH cases.
+		out.gitIdentity = { name, email };
+	}
+
+	const dotUrl = dotfilesUrl.value.trim();
+	if (dotUrl !== "") {
+		const dot: NonNullable<SessionConfigPayload["dotfiles"]> = { url: dotUrl };
+		const ref = dotfilesRef.value.trim();
+		const install = dotfilesInstallScript.value.trim();
+		if (ref !== "") dot.ref = ref;
+		if (install !== "") dot.installScript = install;
+		out.dotfiles = dot;
+	}
+
+	const settings = agentSeedSettings.value;
+	const claudeMd = agentSeedClaudeMd.value;
+	if (settings !== "" || claudeMd !== "") {
+		const seed: NonNullable<SessionConfigPayload["agentSeed"]> = {};
+		if (settings !== "") seed.settings = settings;
+		if (claudeMd !== "") seed.claudeMd = claudeMd;
+		out.agentSeed = seed;
+	}
+
+	const pc = postCreateCmd.value.trim();
+	const ps = postStartCmd.value.trim();
+	if (pc !== "") out.postCreateCmd = pc;
+	if (ps !== "") out.postStartCmd = ps;
+
+	return out;
 }
 
 // ── Env tab (#186 / PR 186c) ────────────────────────────────────────────────
@@ -1630,15 +1770,23 @@ newSessionForm.addEventListener("submit", async (e) => {
 		showToast("Creating session…");
 		const envVars = collectEnvVarsForSubmit();
 		const { repo, auth } = collectRepoForSubmit();
+		const advanced = collectAdvancedForSubmit();
 		// Build the config payload only when something is actually
 		// configured. A bare `POST /sessions` (no config field) stays
 		// the steady-state for users not exercising any of the tabs.
+		const advancedHasContent =
+			advanced.gitIdentity !== undefined ||
+			advanced.dotfiles !== undefined ||
+			advanced.agentSeed !== undefined ||
+			advanced.postCreateCmd !== undefined ||
+			advanced.postStartCmd !== undefined;
 		const config: SessionConfigPayload | undefined =
-			envVars || repo
+			envVars || repo || advancedHasContent
 				? {
 						...(envVars ? { envVars } : {}),
 						...(repo ? { repo } : {}),
 						...(auth ? { auth } : {}),
+						...advanced,
 					}
 				: undefined;
 		const session = await createSession(name, undefined, config);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1510,8 +1510,16 @@ export function collectAdvancedForSubmit(): {
 		out.dotfiles = dot;
 	}
 
-	const settings = agentSeedSettings.value;
-	const claudeMd = agentSeedClaudeMd.value;
+	// Trim BOTH fields before the empty check (PR #219 round 1
+	// SHOULD-FIX). A whitespace-only `settings` would otherwise pass
+	// the empty-check and reach the backend, where `JSON.parse("  ")`
+	// throws and Zod returns a 400 with no inline-error indication.
+	// Trimming JSON is safe — leading/trailing whitespace is
+	// insignificant per the spec. Trimming `claudeMd` is also fine
+	// here because the backend's bootstrap stage skips writing the
+	// file when the value is empty after the runner's own check.
+	const settings = agentSeedSettings.value.trim();
+	const claudeMd = agentSeedClaudeMd.value.trim();
 	if (settings !== "" || claudeMd !== "") {
 		const seed: NonNullable<SessionConfigPayload["agentSeed"]> = {};
 		if (settings !== "") seed.settings = settings;


### PR DESCRIPTION
## Summary

Frontend half of #191. Backend pieces shipped in 191a (schema) and 191b (bootstrap stages + 10-min cap); this PR is the visible surface for users to configure the four lifecycle-hook fields.

## UI

The Advanced tab now has four fieldsets, each with a tinted background + legend matching the existing \`repo-auth-panel\` style:

- **Git identity** — Name + Email side-by-side.
- **Dotfiles** — URL + Ref + Install script. Help text notes the auth credentials are shared with the main repo.
- **Agent config seed** — monospace textareas for \`settings.json\` + \`CLAUDE.md\`. Inline JSON validation on blur of the settings textarea (red error message if parse fails); backend Zod refine remains the source of truth.
- **Lifecycle commands** — \`postCreate\` + \`postStart\` textareas with help text explaining when each runs.

## Wiring

- \`collectAdvancedForSubmit\` reads the DOM at submit time into the wire shape the backend's \`validateSessionConfig\` accepts. Empty inputs map to \`undefined\` (the no-op signal — bootstrap runner skips the corresponding stage).
- \`resetAdvancedTab\` runs on modal close. Important for the agent-seed textareas (up to 256 KiB of content).
- Submit handler merges advanced fields alongside \`envVars\` + \`repo\` + \`auth\` into the existing config payload; bare-POST path stays unchanged.

## Closes

This closes #191 in conjunction with 191a + 191b.

## Test plan
- [x] \`cd backend && npm test\` — 422 passing, no regressions
- [x] \`cd backend && npm run lint && npm run build\` — clean
- [x] \`cd frontend && npm run lint && npm run build\` — clean
- [ ] Manual: open the new-session modal, fill each Advanced section in turn (alone and combined), confirm the bootstrap runner streams the corresponding stages.
- [ ] Manual: paste invalid JSON into settings.json textarea, blur, see red error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)