### PR TITLE
feat(ports): dynamic host-port allocation + CAP_NET_BIND_SERVICE (#190, PR 190b of 4)

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -187,6 +187,32 @@ export async function migrateDb(): Promise<void> {
 		// from its INSERT column list to preserve the NULL-on-create
 		// invariant; `sessionConfig.test.ts` locks this with an explicit
 		// SQL-shape assertion.
+		// #190 PR 190b — runtime port mappings, distinct from the
+		// declarative `session_configs.ports_json` config. The kernel
+		// hands Docker a random ephemeral host port at `container.start()`
+		// (we pass `-p 0:<container>`); we read it back via `inspect`
+		// and persist it here so the dispatcher (190c) can answer
+		// `Host: p<container>-<sessionId>.<base>` requests without
+		// re-inspecting on every hit.
+		//
+		// Rebuilt on every container start (including reconcile() after
+		// a backend restart — the host port is still bound by the
+		// running container, we just need to re-discover the mapping).
+		// ON DELETE CASCADE on the FK keeps the table garbage-free
+		// when a hard-delete drops the parent. Composite primary key
+		// (session_id, container_port) catches a duplicate container_port
+		// at the DB layer if validation ever lets one through (the
+		// schema's `superRefine` already rejects it at ingest, but
+		// defence-in-depth is cheap here).
+		`CREATE TABLE IF NOT EXISTS sessions_port_mappings (
+                        session_id      TEXT NOT NULL,
+                        container_port  INTEGER NOT NULL,
+                        host_port       INTEGER NOT NULL,
+                        PRIMARY KEY (session_id, container_port),
+                        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+                )`,
+		`CREATE INDEX IF NOT EXISTS idx_port_mappings_session
+                        ON sessions_port_mappings(session_id)`,
 		`CREATE TABLE IF NOT EXISTS session_configs (
                         session_id              TEXT PRIMARY KEY,
                         workspace_strategy      TEXT,

--- a/backend/src/dockerManager.spawnConfig.test.ts
+++ b/backend/src/dockerManager.spawnConfig.test.ts
@@ -70,7 +70,16 @@ interface CapturedCreate {
 	opts: Record<string, unknown>;
 }
 
-function makeDmWithCreateCapture(): { dm: DockerManager; captured: CapturedCreate } {
+function makeDmWithCreateCapture(
+	// #190 PR 190b — optional `inspectPorts` lets a test seed Docker's
+	// post-start `NetworkSettings.Ports` shape so we can assert that
+	// `setPortMappings` runs with the kernel-assigned host ports.
+	// Default is `{}` (no published ports), which matches today's
+	// non-port tests — they exercise the no-config / cpu+mem-only paths
+	// where `config?.ports` is undefined and the post-start inspect
+	// branch is short-circuited entirely.
+	inspectPorts?: Record<string, Array<{ HostIp?: string; HostPort: string }> | null>,
+): { dm: DockerManager; captured: CapturedCreate } {
 	const captured: CapturedCreate = { opts: {} };
 	const dm = new DockerManager(fakeSessions());
 	const fakeContainer = {
@@ -78,6 +87,9 @@ function makeDmWithCreateCapture(): { dm: DockerManager; captured: CapturedCreat
 		start: vi.fn(async () => {
 			/* noop */
 		}),
+		inspect: vi.fn(async () => ({
+			NetworkSettings: { Ports: inspectPorts ?? {} },
+		})),
 	};
 	const fakeDocker = {
 		createContainer: vi.fn(async (opts: Record<string, unknown>) => {
@@ -273,6 +285,7 @@ describe("DockerManager.spawn config-applied", () => {
 					post_start_cmd: null,
 					repos_json: null,
 					ports_json: null,
+					allow_privileged_ports: null,
 					// Storage shape (#186): typed entry list, plain rows have
 					// `{ name, type: "plain", value }`. The route encrypts
 					// secret entries before they land here.
@@ -322,6 +335,7 @@ describe("DockerManager.spawn config-applied", () => {
 					post_start_cmd: null,
 					repos_json: null,
 					ports_json: null,
+					allow_privileged_ports: null,
 					env_vars_json: JSON.stringify([
 						{
 							name: "API_KEY",
@@ -388,5 +402,173 @@ describe("DockerManager.spawn config-applied", () => {
 		const hc = captured.opts.HostConfig as { Memory: number; NanoCpus: number };
 		expect(hc.Memory).toBe(2 * 1024 * 1024 * 1024);
 		expect(hc.NanoCpus).toBe(2_000_000_000);
+	});
+
+	// ── #190 PR 190b — port wiring ──────────────────────────────────────
+
+	// Helper builds a session_configs row mock with ports + the
+	// privileged-toggle in one call so the per-test mocks stay short.
+	function mockConfigRow(opts: {
+		ports?: Array<{ container: number; public: boolean }>;
+		allowPrivilegedPorts?: boolean;
+	}): void {
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [
+				{
+					session_id: "sess-1",
+					workspace_strategy: null,
+					cpu_limit: null,
+					mem_limit: null,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: null,
+					ports_json: opts.ports ? JSON.stringify(opts.ports) : null,
+					allow_privileged_ports: opts.allowPrivilegedPorts ? 1 : null,
+					env_vars_json: null,
+					bootstrapped_at: null,
+				},
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+	}
+
+	it("emits ExposedPorts and PortBindings (HostPort=0) for each declared port", async () => {
+		mockConfigRow({
+			ports: [
+				{ container: 3000, public: false },
+				{ container: 5500, public: true },
+			],
+		});
+		const { dm, captured } = makeDmWithCreateCapture({
+			"3000/tcp": [{ HostIp: "0.0.0.0", HostPort: "32768" }],
+			"5500/tcp": [{ HostIp: "0.0.0.0", HostPort: "32769" }],
+		});
+		await dm.spawn("sess-1");
+		expect(captured.opts.ExposedPorts).toEqual({
+			"3000/tcp": {},
+			"5500/tcp": {},
+		});
+		const hc = captured.opts.HostConfig as {
+			PortBindings: Record<string, Array<{ HostPort: string }>>;
+		};
+		// HostPort: "0" tells Docker to pick a kernel-assigned ephemeral
+		// port at start time. The actual bound port comes back via
+		// inspect() and lands in `sessions_port_mappings`.
+		expect(hc.PortBindings).toEqual({
+			"3000/tcp": [{ HostPort: "0" }],
+			"5500/tcp": [{ HostPort: "0" }],
+		});
+	});
+
+	it("omits ExposedPorts/PortBindings entries when no ports are declared", async () => {
+		// Bare-create path (no config row): ExposedPorts and PortBindings
+		// must be empty objects, not undefined — Docker's createContainer
+		// rejects PortBindings if ExposedPorts is missing for any key,
+		// but accepts an empty pair.
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		expect(captured.opts.ExposedPorts).toEqual({});
+		expect((captured.opts.HostConfig as { PortBindings: object }).PortBindings).toEqual({});
+	});
+
+	it("adds CAP_NET_BIND_SERVICE only when allowPrivilegedPorts is true", async () => {
+		mockConfigRow({
+			ports: [{ container: 80, public: true }],
+			allowPrivilegedPorts: true,
+		});
+		const { dm, captured } = makeDmWithCreateCapture({
+			"80/tcp": [{ HostPort: "32768" }],
+		});
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as { CapAdd: string[] | undefined };
+		expect(hc.CapAdd).toEqual(["NET_BIND_SERVICE"]);
+	});
+
+	it("leaves CapAdd undefined when allowPrivilegedPorts is omitted", async () => {
+		mockConfigRow({ ports: [{ container: 3000, public: false }] });
+		const { dm, captured } = makeDmWithCreateCapture({
+			"3000/tcp": [{ HostPort: "32768" }],
+		});
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as { CapAdd: string[] | undefined };
+		expect(hc.CapAdd).toBeUndefined();
+	});
+
+	// CAP_NET_BIND_SERVICE is the ONLY capability we re-grant. A
+	// future refactor that accidentally widens CapAdd would defeat
+	// the whole point of `CapDrop: ["ALL"]`.
+	it("never adds any capability other than NET_BIND_SERVICE", async () => {
+		mockConfigRow({
+			ports: [{ container: 22, public: false }],
+			allowPrivilegedPorts: true,
+		});
+		const { dm, captured } = makeDmWithCreateCapture({
+			"22/tcp": [{ HostPort: "32768" }],
+		});
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as { CapAdd: string[] | undefined };
+		expect(hc.CapAdd).toEqual(["NET_BIND_SERVICE"]);
+		expect(hc.CapAdd?.length).toBe(1);
+	});
+
+	it("persists kernel-assigned host ports via setPortMappings after start", async () => {
+		mockConfigRow({
+			ports: [
+				{ container: 3000, public: false },
+				{ container: 5500, public: true },
+			],
+		});
+		const { dm } = makeDmWithCreateCapture({
+			"3000/tcp": [{ HostIp: "0.0.0.0", HostPort: "32768" }],
+			"5500/tcp": [{ HostIp: "0.0.0.0", HostPort: "32769" }],
+		});
+		await dm.spawn("sess-1");
+		// `setPortMappings` issues DELETE then one INSERT per mapping.
+		// Mock call sequence after the config-read at index 0:
+		//   [1] DELETE FROM sessions_port_mappings WHERE session_id = ?
+		//   [2] INSERT INTO sessions_port_mappings (..., 3000, 32768)
+		//   [3] INSERT INTO sessions_port_mappings (..., 5500, 32769)
+		const calls = dbStubs.d1Query.mock.calls;
+		const deleteIdx = calls.findIndex((c) =>
+			(c[0] as string).match(/DELETE FROM sessions_port_mappings/),
+		);
+		expect(deleteIdx).toBeGreaterThanOrEqual(0);
+		expect(calls[deleteIdx + 1]?.[0]).toMatch(/INSERT INTO sessions_port_mappings/);
+		expect(calls[deleteIdx + 1]?.[1]).toEqual(["sess-1", 3000, 32768]);
+		expect(calls[deleteIdx + 2]?.[1]).toEqual(["sess-1", 5500, 32769]);
+	});
+
+	it("does not call setPortMappings when no ports are declared (no DELETE on a clean spawn)", async () => {
+		// `config?.ports` is undefined here (no config row at all). The
+		// spawn path should skip the inspect+persist branch entirely so
+		// a session that never declares ports doesn't even touch the
+		// port-mappings table — no row writes, no D1 round-trips.
+		const { dm } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const portMappingCalls = dbStubs.d1Query.mock.calls.filter((c) =>
+			(c[0] as string).match(/sessions_port_mappings/),
+		);
+		expect(portMappingCalls).toEqual([]);
+	});
+
+	it("logs and continues when inspect() throws after start", async () => {
+		mockConfigRow({ ports: [{ container: 3000, public: false }] });
+		const { dm } = makeDmWithCreateCapture();
+		// Override inspect to throw, simulating a transient daemon
+		// hiccup right after start. The container itself is up, so
+		// killing it now would cost the user the bootstrap pipeline's
+		// progress over a recoverable error. Reconcile() resyncs on
+		// the next backend boot.
+		const docker = (dm as unknown as { docker: { getContainer: () => unknown } }).docker;
+		const fakeContainer = docker.getContainer() as {
+			start: ReturnType<typeof vi.fn>;
+			inspect: ReturnType<typeof vi.fn>;
+		};
+		fakeContainer.inspect = vi.fn(async () => {
+			throw new Error("daemon unreachable");
+		});
+		await expect(dm.spawn("sess-1")).resolves.toBeDefined();
 	});
 });

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -880,6 +880,120 @@ describe("DockerManager.reconcile", () => {
 		expect(warnSpy).not.toHaveBeenCalled();
 		warnSpy.mockRestore();
 	});
+
+	// ── #190 PR 190b — port-mapping resync ─────────────────────────────
+
+	function makeDockerWithInspectAndPorts(info: {
+		State: { Running: boolean };
+		HostConfig: { CapDrop?: string[]; SecurityOpt?: string[] };
+		NetworkSettings?: {
+			Ports?: Record<string, Array<{ HostPort: string }> | null>;
+		};
+	}): { dm: DockerManager; sessions: SessionManager } {
+		const sessions = makeFakeSessions();
+		const dm = new DockerManager(sessions);
+		(dm as unknown as { docker: unknown }).docker = {
+			getContainer: vi.fn(() => ({
+				inspect: vi.fn(async () => info),
+			})),
+		};
+		return { dm, sessions };
+	}
+
+	it("rewrites sessions_port_mappings from inspect on a still-running container", async () => {
+		const { dm } = makeDockerWithInspectAndPorts({
+			State: { Running: true },
+			HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
+			NetworkSettings: {
+				Ports: {
+					"3000/tcp": [{ HostPort: "32768" }],
+					"5500/tcp": [{ HostPort: "32769" }],
+				},
+			},
+		});
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ session_id: "s-running", container_id: "container-running" }],
+			meta: { changes: 0 },
+		});
+
+		await dm.reconcile();
+
+		// The reconcile path issues setPortMappings → DELETE + 2 INSERTs
+		// against sessions_port_mappings.
+		const portCalls = dbStubs.d1Query.mock.calls.filter((c) =>
+			(c[0] as string).match(/sessions_port_mappings/),
+		);
+		const deleteCall = portCalls.find((c) =>
+			(c[0] as string).match(/^DELETE FROM sessions_port_mappings/),
+		);
+		const insertCalls = portCalls.filter((c) =>
+			(c[0] as string).match(/^INSERT INTO sessions_port_mappings/),
+		);
+		expect(deleteCall?.[1]).toEqual(["s-running"]);
+		expect(insertCalls).toHaveLength(2);
+		expect(insertCalls[0]?.[1]).toEqual(["s-running", 3000, 32768]);
+		expect(insertCalls[1]?.[1]).toEqual(["s-running", 5500, 32769]);
+	});
+
+	it("clears port mappings when reconcile finds the container stopped", async () => {
+		const { dm, sessions } = makeDockerWithInspectAndPorts({
+			State: { Running: false },
+			HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
+			NetworkSettings: { Ports: {} },
+		});
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ session_id: "s-stopped", container_id: "container-stopped" }],
+			meta: { changes: 0 },
+		});
+
+		await dm.reconcile();
+
+		expect(sessions.updateStatus).toHaveBeenCalledWith("s-stopped", "stopped");
+		const deleteCall = dbStubs.d1Query.mock.calls.find(
+			(c) =>
+				(c[0] as string).match(/^DELETE FROM sessions_port_mappings/) &&
+				(c[1] as unknown[])?.[0] === "s-stopped",
+		);
+		expect(deleteCall).toBeDefined();
+	});
+
+	it("clears port mappings on the no-container_id branch", async () => {
+		const sessions = makeFakeSessions();
+		const dm = new DockerManager(sessions);
+		(dm as unknown as { docker: unknown }).docker = { getContainer: vi.fn() };
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ session_id: "s-noid", container_id: null }],
+			meta: { changes: 0 },
+		});
+
+		await dm.reconcile();
+
+		expect(sessions.updateStatus).toHaveBeenCalledWith("s-noid", "stopped");
+		const deleteCall = dbStubs.d1Query.mock.calls.find(
+			(c) =>
+				(c[0] as string).match(/^DELETE FROM sessions_port_mappings/) &&
+				(c[1] as unknown[])?.[0] === "s-noid",
+		);
+		expect(deleteCall).toBeDefined();
+	});
+
+	it("clears port mappings on the 404-container-gone branch", async () => {
+		const err = Object.assign(new Error("No such container"), { statusCode: 404 });
+		const { dm } = makeDockerWithInspectError(err);
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ session_id: "s-gone", container_id: "container-dead" }],
+			meta: { changes: 0 },
+		});
+
+		await dm.reconcile();
+
+		const deleteCall = dbStubs.d1Query.mock.calls.find(
+			(c) =>
+				(c[0] as string).match(/^DELETE FROM sessions_port_mappings/) &&
+				(c[1] as unknown[])?.[0] === "s-gone",
+		);
+		expect(deleteCall).toBeDefined();
+	});
 });
 
 describe("DockerManager.startContainer", () => {

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -1025,6 +1025,94 @@ describe("DockerManager.startContainer", () => {
 		expect(sessions.updateStatus).toHaveBeenCalledWith("s1", "running");
 		warnSpy.mockRestore();
 	});
+
+	// #190 PR 190b round 1 SHOULD-FIX. The Case-2 path restarts a stopped
+	// container, and Docker assigns a fresh ephemeral host port at every
+	// `start()`. `stopContainer` already cleared the mapping table, so
+	// without a post-start re-inspect the dispatcher (190c) would 404
+	// every proxied port until reconcile() runs — the most common
+	// lifecycle path for a session with declared ports.
+	it("refreshes sessions_port_mappings after restarting a stopped Case-2 container", async () => {
+		const sessions = makeFakeSessions();
+		const dm = new DockerManager(sessions);
+		// Two distinct inspect responses: (1) the pre-start snapshot
+		// reports State.Running=false with no Ports yet; (2) the
+		// post-start snapshot returns the freshly-bound host ports.
+		// Track call count so we can hand back the second shape only
+		// after start() has been invoked.
+		let inspectCalls = 0;
+		const inspect = vi.fn(async () => {
+			inspectCalls += 1;
+			if (inspectCalls === 1) {
+				return {
+					State: { Running: false },
+					HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
+					NetworkSettings: { Ports: {} },
+				};
+			}
+			return {
+				State: { Running: true },
+				HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
+				NetworkSettings: {
+					Ports: {
+						"3000/tcp": [{ HostPort: "32999" }],
+					},
+				},
+			};
+		});
+		const start = vi.fn(async () => {
+			/* started */
+		});
+		(dm as unknown as { docker: unknown }).docker = {
+			getContainer: vi.fn(() => ({ inspect, start })),
+		};
+
+		await dm.startContainer("s1");
+
+		expect(start).toHaveBeenCalledTimes(1);
+		expect(inspect).toHaveBeenCalledTimes(2);
+		// setPortMappings → DELETE then INSERT. The INSERT must hold
+		// the *post-start* host port (32999), not the empty pre-start
+		// snapshot.
+		const insertCall = dbStubs.d1Query.mock.calls.find((c) =>
+			(c[0] as string).match(/^INSERT INTO sessions_port_mappings/),
+		);
+		expect(insertCall?.[1]).toEqual(["s1", 3000, 32999]);
+	});
+
+	// Sub-branch: container was already running (e.g. operator did
+	// `docker start` out-of-band before the user clicked Start). The D1
+	// row from the original spawn / last reconcile is still valid;
+	// re-inspecting would be a wasted round-trip.
+	it("does NOT re-inspect when the Case-2 container was already running", async () => {
+		const sessions = makeFakeSessions();
+		const dm = new DockerManager(sessions);
+		const inspect = vi.fn(async () => ({
+			State: { Running: true },
+			HostConfig: { CapDrop: ["ALL"], SecurityOpt: ["no-new-privileges:true"] },
+			NetworkSettings: { Ports: {} },
+		}));
+		const start = vi.fn(async () => {
+			/* unused */
+		});
+		(dm as unknown as { docker: unknown }).docker = {
+			getContainer: vi.fn(() => ({ inspect, start })),
+		};
+
+		// Reset d1Query mock so any leftover reconcile-test calls don't
+		// poison the "no port-mapping calls for s1" assertion below.
+		dbStubs.d1Query.mockClear();
+
+		await dm.startContainer("s1");
+
+		expect(start).not.toHaveBeenCalled();
+		expect(inspect).toHaveBeenCalledTimes(1);
+		// No setPortMappings call — the existing D1 row stands.
+		const portMappingCalls = dbStubs.d1Query.mock.calls.filter((c) =>
+			(c[0] as string).match(/sessions_port_mappings/),
+		);
+		expect(portMappingCalls).toEqual([]);
+	});
 });
 
 describe("DockerManager constructor", () => {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -14,6 +14,7 @@ import { StringDecoder } from "node:string_decoder";
 import Dockerode from "dockerode";
 import { d1Query } from "./db.js";
 import { logger } from "./logger.js";
+import { clearPortMappings, parseInspectPorts, setPortMappings } from "./portMappings.js";
 import {
 	decryptStoredEntries,
 	getSessionConfig,
@@ -247,10 +248,35 @@ export class DockerManager {
 		// reads via the read-only mount; no need for it to own anything.
 
 		const hostname = sanitiseHostname(meta.name, sessionId);
+		// #190 PR 190b — `-p 0:<container>` per declared port. Docker
+		// resolves `HostPort: ""` (or `"0"`) to a kernel-assigned ephemeral
+		// host port, which we read back from `inspect()` after `start()`
+		// and persist to `sessions_port_mappings`. The dispatcher (190c)
+		// looks the host port up there to answer `Host: p<container>-
+		// <sessionId>.<base>` requests. The dual `ExposedPorts` shape is
+		// Docker-API-mandated: it documents the listening side of the
+		// container, separate from the host-binding side; createContainer
+		// rejects `PortBindings` for an undeclared `ExposedPorts` entry.
+		// v1 publishes TCP only — every port goes through the HTTP/WS
+		// dispatcher in 190c via http-proxy. UDP would need a different
+		// topology and is out of scope.
+		const exposedPorts: Record<string, Record<string, never>> = {};
+		const portBindings: Record<string, Array<{ HostPort: string }>> = {};
+		for (const p of config?.ports ?? []) {
+			const key = `${p.container}/tcp`;
+			exposedPorts[key] = {};
+			portBindings[key] = [{ HostPort: "0" }];
+		}
 		const container = await this.docker.createContainer({
 			Image: SESSION_IMAGE,
 			name: meta.containerName,
 			Hostname: hostname,
+			// `ExposedPorts` is on the top-level (Image-config layer);
+			// `PortBindings` is on `HostConfig` (host-binding layer).
+			// Both must be present together for createContainer to
+			// publish the port, even though the spawn path only ever
+			// sets the bindings to ephemeral.
+			ExposedPorts: exposedPorts,
 			// `buildContainerEnv` returns a deduplicated `KEY=VALUE[]` array
 			// so the precedence is unambiguous regardless of which reader
 			// resolves the var inside the container. Duplicates in
@@ -266,6 +292,7 @@ export class DockerManager {
 					`${WORKSPACE_ROOT}/${sessionId}:/home/developer/workspace`,
 					`${uploadsHostDir}:/home/developer/uploads:ro`,
 				],
+				PortBindings: portBindings,
 				// `mem_limit` / `cpu_limit` from session_configs override the
 				// hardcoded defaults. Docker pins HostConfig at create time,
 				// so a later config-row UPDATE wouldn't take effect on an
@@ -292,6 +319,21 @@ export class DockerManager {
 				// reintroduces a setuid binary it cannot raise
 				// effective UID/caps at exec time.
 				CapDrop: ["ALL"],
+				// #190 PR 190b — `allowPrivilegedPorts: true` re-grants
+				// exactly `CAP_NET_BIND_SERVICE` on the container so the
+				// in-container process can bind to ports < 1024. Nothing
+				// else from the default capability bag is restored —
+				// CAP_NET_RAW (raw sockets / ICMP), CAP_AUDIT_WRITE,
+				// CAP_MKNOD etc. stay dropped. The toggle is gated at the
+				// schema level: privileged ports without it are rejected
+				// at ingest, so a session reaching here with the toggle
+				// off has no privileged ports to bind regardless. We add
+				// the cap whenever the toggle is on (independent of
+				// whether any specific port is < 1024) — the user opted
+				// in at the form, and a future port edit shouldn't have
+				// to recycle the container to take effect (config is
+				// bound at create time per the umbrella non-goal).
+				CapAdd: config?.allowPrivilegedPorts === true ? ["NET_BIND_SERVICE"] : undefined,
 				SecurityOpt: ["no-new-privileges:true"],
 			},
 			OpenStdin: true,
@@ -301,6 +343,35 @@ export class DockerManager {
 		await container.start();
 		const containerId = container.id;
 		await this.sessions.setContainerId(sessionId, containerId);
+
+		// #190 PR 190b — read the kernel-assigned host ports back from
+		// inspect() and persist the mapping so the dispatcher (190c) can
+		// route inbound requests without re-inspecting on every hit.
+		// Best-effort: a failure here logs and lets the container run —
+		// reconcile() will resync on the next backend boot, and the
+		// dispatcher returns 404 for an unknown port until then. We do
+		// NOT roll back the spawn over a mapping-write failure: the
+		// container is up and the workspace is mounted, killing it now
+		// would lose the bootstrap pipeline's progress for what is
+		// likely a transient D1 hiccup.
+		const declaredPorts = config?.ports ?? [];
+		if (declaredPorts.length > 0) {
+			try {
+				const info = await container.inspect();
+				const mappings = parseInspectPorts(info.NetworkSettings?.Ports);
+				await setPortMappings(sessionId, mappings);
+				if (mappings.length !== declaredPorts.length) {
+					logger.warn(
+						`[docker] inspect returned ${mappings.length} mapping(s) for session ${sessionId}, ` +
+							`expected ${declaredPorts.length}; dispatcher will 404 the missing ports`,
+					);
+				}
+			} catch (err) {
+				logger.error(
+					`[docker] failed to persist port mappings for session ${sessionId}: ${(err as Error).message}`,
+				);
+			}
+		}
 
 		logger.info(
 			`[docker] spawned container ${meta.containerName} (${containerId.slice(0, 12)}) for session ${sessionId}`,
@@ -625,6 +696,19 @@ export class DockerManager {
 			} catch (err) {
 				logger.error(
 					`[docker] failed to null container_id for session ${sessionId}: ${(err as Error).message}`,
+				);
+			}
+			// #190 PR 190b — drop runtime port mappings: the host ports
+			// are about to be recycled by the kernel, and the dispatcher
+			// (190c) must NOT proxy a request to a port that's bound to
+			// some other tenant's container in the next moment. Best-
+			// effort because the container is already gone — failing to
+			// clear is a stale-row leak the next spawn / reconcile fixes.
+			try {
+				await clearPortMappings(sessionId);
+			} catch (err) {
+				logger.error(
+					`[docker] failed to clear port mappings for session ${sessionId}: ${(err as Error).message}`,
 				);
 			}
 		}
@@ -1021,6 +1105,19 @@ export class DockerManager {
 			/* already stopped */
 		}
 		await this.sessions.updateStatus(sessionId, "stopped");
+		// #190 PR 190b — clear port mappings: a stopped container's host
+		// port no longer reaches anything, and Docker may rebind the
+		// same ephemeral port to a different container on the next
+		// `start()`. Without this, the dispatcher would happily proxy a
+		// request to the previous tenant. Same best-effort logging
+		// shape as `kill()`.
+		try {
+			await clearPortMappings(sessionId);
+		} catch (err) {
+			logger.error(
+				`[docker] failed to clear port mappings for session ${sessionId}: ${(err as Error).message}`,
+			);
+		}
 		logger.info(`[docker] stopped container for session ${sessionId}`);
 	}
 
@@ -1704,6 +1801,16 @@ export class DockerManager {
 		for (const row of result.results) {
 			if (!row.container_id) {
 				await this.sessions.updateStatus(row.session_id, "stopped");
+				// Drop any leftover port mappings for the no-container
+				// case — same defensive intent as the running-but-
+				// stopped branch below.
+				try {
+					await clearPortMappings(row.session_id);
+				} catch (err) {
+					logger.warn(
+						`[docker] reconcile clearPortMappings failed for ${row.session_id}: ${(err as Error).message}`,
+					);
+				}
 				continue;
 			}
 			try {
@@ -1718,6 +1825,43 @@ export class DockerManager {
 				this.warnIfPreHardened(row.session_id, row.container_id, info.HostConfig);
 				if (!info.State.Running) {
 					await this.sessions.updateStatus(row.session_id, "stopped");
+					// Same rationale as `stopContainer()`: a container
+					// Docker reports as not-running has its host ports
+					// detached (or about to be), so the mapping table
+					// must not leave the dispatcher pointing at it.
+					try {
+						await clearPortMappings(row.session_id);
+					} catch (err) {
+						logger.warn(
+							`[docker] reconcile clearPortMappings failed for ${row.session_id}: ${(err as Error).message}`,
+						);
+					}
+				} else {
+					// #190 PR 190b — re-discover the host-port mappings
+					// for a still-running container after a backend
+					// restart. The kernel-bound host ports survive the
+					// backend dying (the container itself owns them),
+					// but the in-memory `sessions_port_mappings` row was
+					// just rewritten to an authoritative state on the
+					// last spawn — actually no, it's a D1 row, so it
+					// survives. Still, re-reading from inspect() guards
+					// against drift if a future code path ever wrote
+					// the table partially. Best-effort: a failure here
+					// logs and lets the rest of reconcile finish; the
+					// next /start writes a fresh row.
+					try {
+						const mappings = parseInspectPorts(info.NetworkSettings?.Ports);
+						if (mappings.length > 0) {
+							await setPortMappings(row.session_id, mappings);
+						} else {
+							// No published ports — clear any stale rows.
+							await clearPortMappings(row.session_id);
+						}
+					} catch (err) {
+						logger.warn(
+							`[docker] reconcile port-mapping resync failed for ${row.session_id}: ${(err as Error).message}`,
+						);
+					}
 				}
 			} catch (err) {
 				// Only 404 means container is actually gone (atomic null+stopped).
@@ -1726,11 +1870,31 @@ export class DockerManager {
 				const statusCode = (err as { statusCode?: number }).statusCode;
 				if (statusCode === 404) {
 					await this.sessions.recordContainerGone(row.session_id);
+					// Container is genuinely gone — its host ports are
+					// freed; the dispatcher must not retain mappings.
+					try {
+						await clearPortMappings(row.session_id);
+					} catch (clearErr) {
+						logger.warn(
+							`[docker] reconcile clearPortMappings (404 branch) failed for ${row.session_id}: ${(clearErr as Error).message}`,
+						);
+					}
 				} else {
 					logger.warn(
 						`[docker] reconcile inspect failed for session ${row.session_id}: ${(err as Error).message}`,
 					);
 					await this.sessions.updateStatus(row.session_id, "stopped");
+					// Daemon is unreachable, so we can't be sure of the
+					// container's state — the safe move is to drop the
+					// mappings (dispatcher 404s are recoverable; routing
+					// requests to a wrong tenant is not).
+					try {
+						await clearPortMappings(row.session_id);
+					} catch (clearErr) {
+						logger.warn(
+							`[docker] reconcile clearPortMappings (transient branch) failed for ${row.session_id}: ${(clearErr as Error).message}`,
+						);
+					}
 				}
 			}
 		}

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -1866,17 +1866,16 @@ export class DockerManager {
 					}
 				} else {
 					// #190 PR 190b — re-discover the host-port mappings
-					// for a still-running container after a backend
-					// restart. The kernel-bound host ports survive the
-					// backend dying (the container itself owns them),
-					// but the in-memory `sessions_port_mappings` row was
-					// just rewritten to an authoritative state on the
-					// last spawn — actually no, it's a D1 row, so it
-					// survives. Still, re-reading from inspect() guards
-					// against drift if a future code path ever wrote
-					// the table partially. Best-effort: a failure here
-					// logs and lets the rest of reconcile finish; the
-					// next /start writes a fresh row.
+					// for a still-running container. The kernel-bound
+					// host ports survive a backend restart (the
+					// container itself owns them) and the D1 row
+					// written by the last spawn / startContainer
+					// survives too — but re-reading from inspect()
+					// guards against drift if a prior `setPortMappings`
+					// crashed mid-sequence (DELETE without follow-up
+					// INSERTs is the practical worst case). Best-effort:
+					// a failure here logs and lets the rest of reconcile
+					// finish; the next /start writes a fresh row.
 					try {
 						const mappings = parseInspectPorts(info.NetworkSettings?.Ports);
 						if (mappings.length > 0) {

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -819,7 +819,35 @@ export class DockerManager {
 			this.warnIfPreHardened(sessionId, meta.containerId, info.HostConfig);
 			if (!info.State.Running) {
 				await this.docker.getContainer(meta.containerId).start();
+				// #190 PR 190b round 1 SHOULD-FIX — refresh port
+				// mappings after we restart a stopped container.
+				// `stopContainer()` clears the mapping table, and
+				// Docker assigns a fresh ephemeral host port at every
+				// start (the kernel pool isn't sticky), so the D1 row
+				// written by the original spawn is gone and the
+				// pre-start `info.NetworkSettings.Ports` snapshot is
+				// either empty or stale. Without re-inspecting here,
+				// the dispatcher (190c) would 404 every proxied port
+				// request on this session until the next reconcile()
+				// — which is the most common lifecycle path for any
+				// session with declared ports. Mirror spawn()'s
+				// best-effort pattern: a failure logs and lets the
+				// container keep running.
+				try {
+					const fresh = await this.docker.getContainer(meta.containerId).inspect();
+					const mappings = parseInspectPorts(fresh.NetworkSettings?.Ports);
+					if (mappings.length > 0) {
+						await setPortMappings(sessionId, mappings);
+					}
+				} catch (err) {
+					logger.warn(
+						`[docker] failed to refresh port mappings for session ${sessionId} after restart: ${(err as Error).message}`,
+					);
+				}
 			}
+			// When `info.State.Running` was already true (container was
+			// running before this call), the D1 row written by spawn()
+			// or the last reconcile() is still valid — no re-inspect.
 			await this.sessions.updateStatus(sessionId, "running");
 			logger.info(`[docker] restarted container for session ${sessionId}`);
 		} catch {

--- a/backend/src/portMappings.test.ts
+++ b/backend/src/portMappings.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import {
+	clearPortMappings,
+	getPortMappings,
+	type PortMapping,
+	parseInspectPorts,
+	setPortMappings,
+} from "./portMappings.js";
+
+beforeEach(() => {
+	dbStubs.d1Query.mockReset();
+	dbStubs.d1Query.mockImplementation(async () => ({
+		results: [],
+		success: true,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	}));
+});
+
+// ── parseInspectPorts ────────────────────────────────────────────────────
+
+describe("parseInspectPorts", () => {
+	it("returns [] for undefined / null / empty", () => {
+		expect(parseInspectPorts(undefined)).toEqual([]);
+		expect(parseInspectPorts(null)).toEqual([]);
+		expect(parseInspectPorts({})).toEqual([]);
+	});
+
+	it("extracts container_port:host_port from the standard tcp shape", () => {
+		const got = parseInspectPorts({
+			"3000/tcp": [{ HostIp: "0.0.0.0", HostPort: "32768" }],
+			"5500/tcp": [{ HostIp: "0.0.0.0", HostPort: "32769" }],
+		});
+		// Order is `Object.entries` order, which JS preserves for
+		// non-integer-string keys; `3000/tcp` comes before `5500/tcp`.
+		expect(got).toEqual([
+			{ containerPort: 3000, hostPort: 32768 },
+			{ containerPort: 5500, hostPort: 32769 },
+		]);
+	});
+
+	it("takes the FIRST binding when Docker emits IPv4 and IPv6 entries", () => {
+		// Real Docker output has two entries per port — same HostPort.
+		// Taking [0] is sufficient (we don't care which IP family bound).
+		const got = parseInspectPorts({
+			"3000/tcp": [
+				{ HostIp: "0.0.0.0", HostPort: "32768" },
+				{ HostIp: "::", HostPort: "32768" },
+			],
+		});
+		expect(got).toEqual([{ containerPort: 3000, hostPort: 32768 }]);
+	});
+
+	it("skips ports with null bindings (exposed but unpublished)", () => {
+		const got = parseInspectPorts({
+			"3000/tcp": [{ HostIp: "0.0.0.0", HostPort: "32768" }],
+			"5500/tcp": null,
+		});
+		expect(got).toEqual([{ containerPort: 3000, hostPort: 32768 }]);
+	});
+
+	it("skips ports with empty binding arrays", () => {
+		const got = parseInspectPorts({
+			"3000/tcp": [],
+			"5500/tcp": [{ HostIp: "0.0.0.0", HostPort: "32769" }],
+		});
+		expect(got).toEqual([{ containerPort: 5500, hostPort: 32769 }]);
+	});
+
+	it("accepts a key without the /proto suffix (defensive)", () => {
+		expect(parseInspectPorts({ "3000": [{ HostPort: "32768" }] })).toEqual([
+			{ containerPort: 3000, hostPort: 32768 },
+		]);
+	});
+
+	it("skips malformed entries without crashing the spawn path", () => {
+		// All four shapes are unreachable today (Docker's API enforces the
+		// shape) but a future API change shouldn't hard-fail the spawn.
+		const got = parseInspectPorts({
+			"not-a-port": [{ HostPort: "32768" }],
+			"3000/tcp": [{ HostPort: "not-a-number" }],
+			"-1/tcp": [{ HostPort: "32768" }],
+			"4000/tcp": [{ HostPort: "0" }],
+		});
+		expect(got).toEqual([]);
+	});
+});
+
+// ── setPortMappings ──────────────────────────────────────────────────────
+
+describe("setPortMappings", () => {
+	it("issues DELETE-then-INSERT in order, one INSERT per mapping", async () => {
+		const mappings: PortMapping[] = [
+			{ containerPort: 3000, hostPort: 32768 },
+			{ containerPort: 5500, hostPort: 32769 },
+		];
+		await setPortMappings("sess-1", mappings);
+
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(3);
+		expect(dbStubs.d1Query.mock.calls[0]?.[0]).toMatch(
+			/DELETE FROM sessions_port_mappings WHERE session_id/,
+		);
+		expect(dbStubs.d1Query.mock.calls[0]?.[1]).toEqual(["sess-1"]);
+		expect(dbStubs.d1Query.mock.calls[1]?.[0]).toMatch(/INSERT INTO sessions_port_mappings/);
+		expect(dbStubs.d1Query.mock.calls[1]?.[1]).toEqual(["sess-1", 3000, 32768]);
+		expect(dbStubs.d1Query.mock.calls[2]?.[1]).toEqual(["sess-1", 5500, 32769]);
+	});
+
+	it("issues only the DELETE when the mapping list is empty", async () => {
+		// Spawning with no declared ports must still clear any stale
+		// rows from a previous container life — `setPortMappings(s, [])`
+		// is the one-call entry point for that.
+		await setPortMappings("sess-empty", []);
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+		expect(dbStubs.d1Query.mock.calls[0]?.[0]).toMatch(/DELETE/);
+	});
+});
+
+// ── getPortMappings ──────────────────────────────────────────────────────
+
+describe("getPortMappings", () => {
+	it("returns [] when no rows exist for the session", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await expect(getPortMappings("sess-x")).resolves.toEqual([]);
+	});
+
+	it("rehydrates D1 rows into the typed shape", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [
+				{ container_port: 3000, host_port: 32768 },
+				{ container_port: 5500, host_port: 32769 },
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await expect(getPortMappings("sess-y")).resolves.toEqual([
+			{ containerPort: 3000, hostPort: 32768 },
+			{ containerPort: 5500, hostPort: 32769 },
+		]);
+	});
+});
+
+// ── clearPortMappings ────────────────────────────────────────────────────
+
+describe("clearPortMappings", () => {
+	it("issues a single DELETE bound to the session id", async () => {
+		await clearPortMappings("sess-z");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+		const [sql, params] = dbStubs.d1Query.mock.calls[0]!;
+		expect(sql).toMatch(/DELETE FROM sessions_port_mappings WHERE session_id/);
+		expect(params).toEqual(["sess-z"]);
+	});
+});

--- a/backend/src/portMappings.ts
+++ b/backend/src/portMappings.ts
@@ -1,0 +1,114 @@
+/**
+ * portMappings.ts — runtime container_port → host_port table for #190.
+ *
+ * The dispatcher (190c) parses an inbound `Host: p<container>-<sessionId>.<base>`
+ * header and looks the host port up here to decide where to reverse-proxy.
+ * Distinct from the *declarative* `session_configs.ports_json` (the user's
+ * configured list of ports to expose) — this table holds what Docker
+ * actually bound on the host after `container.start()` resolved the
+ * `-p 0:<container>` request to a concrete kernel-assigned ephemeral port.
+ *
+ * Lifecycle:
+ *   - Written by `DockerManager.spawn()` after `container.start()` (and
+ *     by `reconcile()` on backend restart — the running container's
+ *     bindings are still live; we just re-discover them).
+ *   - Cleared by `DockerManager.kill()` and `stopContainer()` so a
+ *     stopped/dead session doesn't leave the dispatcher pointing at
+ *     a host port the kernel is about to recycle.
+ *   - The FK ON DELETE CASCADE in `db.ts` cleans up automatically when
+ *     a hard-delete drops the session row.
+ */
+
+import { d1Query } from "./db.js";
+
+export interface PortMapping {
+	containerPort: number;
+	hostPort: number;
+}
+
+/**
+ * Replace all mappings for `sessionId` with `mappings` atomically (within
+ * a single D1 round-trip per statement; D1 has no multi-statement
+ * transaction primitive on the HTTP API, so we sequence DELETE then INSERTs
+ * and accept that a backend crash mid-rewrite leaves the table partially
+ * populated. The next spawn / reconcile rewrites it cleanly, and the
+ * dispatcher's "session must be running" gate stops a torn read from
+ * proxying to a stale host port).
+ */
+export async function setPortMappings(sessionId: string, mappings: PortMapping[]): Promise<void> {
+	await d1Query("DELETE FROM sessions_port_mappings WHERE session_id = ?", [sessionId]);
+	for (const m of mappings) {
+		await d1Query(
+			"INSERT INTO sessions_port_mappings (session_id, container_port, host_port) VALUES (?, ?, ?)",
+			[sessionId, m.containerPort, m.hostPort],
+		);
+	}
+}
+
+/** Read all mappings for `sessionId`. Empty array when no row exists. */
+export async function getPortMappings(sessionId: string): Promise<PortMapping[]> {
+	const result = await d1Query<{ container_port: number; host_port: number }>(
+		"SELECT container_port, host_port FROM sessions_port_mappings WHERE session_id = ? ORDER BY container_port",
+		[sessionId],
+	);
+	return result.results.map((r) => ({ containerPort: r.container_port, hostPort: r.host_port }));
+}
+
+/** Drop all mappings for `sessionId`. Idempotent — no-op if none exist. */
+export async function clearPortMappings(sessionId: string): Promise<void> {
+	await d1Query("DELETE FROM sessions_port_mappings WHERE session_id = ?", [sessionId]);
+}
+
+/**
+ * Parse Docker's `NetworkSettings.Ports` shape (as returned by
+ * `container.inspect()`) into the PortMapping[] this module persists.
+ *
+ * Docker shape (only the bits we care about):
+ *
+ *     {
+ *       "3000/tcp": [{ "HostIp": "0.0.0.0", "HostPort": "32768" }, ...],
+ *       "5500/tcp": null   // exposed but not bound (--publish-all=false)
+ *     }
+ *
+ * We take the FIRST non-null binding per container port — Docker can list
+ * multiple host bindings (IPv4 + IPv6 entries are common), and they
+ * always share the same kernel-assigned port number, so taking [0] is
+ * sufficient. `null` and empty arrays are filtered out (those container
+ * ports are exposed but unpublished, which would only happen if a
+ * future code path sets `ExposedPorts` without `PortBindings` — not the
+ * spawn path here, but the parser stays robust against it).
+ *
+ * The container-port half is `"<num>/<proto>"`; we only emit the int.
+ * v1 publishes TCP only (the dispatcher in 190c is HTTP/WS); a future
+ * UDP feature would extend this parser, not break it.
+ *
+ * Exported for the test suite.
+ */
+export function parseInspectPorts(
+	ports: Record<string, Array<{ HostPort: string; HostIp?: string }> | null> | undefined | null,
+): PortMapping[] {
+	if (!ports) return [];
+	const out: PortMapping[] = [];
+	for (const [key, bindings] of Object.entries(ports)) {
+		if (!bindings || bindings.length === 0) continue;
+		// Match `<port>` or `<port>/<proto>`. The proto half is informational
+		// only at this stage; we assume tcp.
+		const m = key.match(/^(\d+)(?:\/[a-z]+)?$/);
+		if (!m) continue;
+		const containerPort = Number(m[1]);
+		const hostPort = Number(bindings[0]!.HostPort);
+		// Defensive against a malformed inspect response: Docker's
+		// HostPort is always a stringified positive int, but a future
+		// API change shouldn't crash the spawn path.
+		if (
+			!Number.isInteger(containerPort) ||
+			containerPort <= 0 ||
+			!Number.isInteger(hostPort) ||
+			hostPort <= 0
+		) {
+			continue;
+		}
+		out.push({ containerPort, hostPort });
+	}
+	return out;
+}

--- a/backend/src/portMappings.ts
+++ b/backend/src/portMappings.ts
@@ -27,13 +27,13 @@ export interface PortMapping {
 }
 
 /**
- * Replace all mappings for `sessionId` with `mappings` atomically (within
- * a single D1 round-trip per statement; D1 has no multi-statement
- * transaction primitive on the HTTP API, so we sequence DELETE then INSERTs
- * and accept that a backend crash mid-rewrite leaves the table partially
- * populated. The next spawn / reconcile rewrites it cleanly, and the
- * dispatcher's "session must be running" gate stops a torn read from
- * proxying to a stale host port).
+ * Replace all mappings for `sessionId` with `mappings`. D1 has no
+ * multi-statement transaction primitive on the HTTP API, so this
+ * sequences DELETE then per-row INSERT — emphatically NOT atomic. A
+ * backend crash mid-sequence can leave the table empty (DELETE
+ * succeeded, INSERTs didn't); the next spawn / reconcile rewrites it
+ * cleanly, and the dispatcher's "session must be running" gate stops
+ * a torn read from proxying to a stale host port in the meantime.
  */
 export async function setPortMappings(sessionId: string, mappings: PortMapping[]): Promise<void> {
 	await d1Query("DELETE FROM sessions_port_mappings WHERE session_id = ?", [sessionId]);


### PR DESCRIPTION
## Summary

PR 2 of 4 for **#190 — Port exposure**. Wires the consumers of the schema 190a landed.

- Each declared port gets `-p 0:<container>` on `docker run`; Docker resolves `HostPort: "0"` to a kernel-assigned ephemeral host port.
- After `start()`, the spawn path inspects the container and persists `{ container, host }[]` to a new `sessions_port_mappings` table. The dispatcher (190c) will look the host port up there to answer `Host: p<container>-<sessionId>.<base>` requests without re-inspecting on every hit.
- `allowPrivilegedPorts: true` adds *exactly* `CAP_NET_BIND_SERVICE` on `docker run` — nothing else from the default capability bag is restored (CAP_NET_RAW, CAP_AUDIT_WRITE, CAP_MKNOD etc. stay dropped).
- `kill()`, `stopContainer()`, and `reconcile()` paths clear the mapping table appropriately — the dispatcher must NOT proxy a request to a host port that the kernel is about to recycle.

## Changes

### New
- `backend/src/portMappings.ts` — `setPortMappings` / `getPortMappings` / `clearPortMappings` / `parseInspectPorts`. Distinct from the *declarative* `session_configs.ports_json` (the user's configured list); this table holds what Docker *actually bound*.
- `backend/src/portMappings.test.ts` — 12 unit tests including `parseInspectPorts` IPv4+IPv6 dedupe, unpublished-binding skip, and malformed-row defence.
- `sessions_port_mappings` table — composite PK `(session_id, container_port)`, FK `ON DELETE CASCADE`, plus an index on `session_id`.

### Modified
- `dockerManager.ts` `spawn()`: builds `ExposedPorts` + `PortBindings`, adds `CapAdd: ["NET_BIND_SERVICE"]` when toggle is on, persists mappings post-start (best-effort).
- `dockerManager.ts` `kill()` / `stopContainer()` / `reconcile()`: clear or resync mappings.
- `dockerManager.test.ts` — 4 new reconcile tests covering all four mapping-clear branches.
- `dockerManager.spawnConfig.test.ts` — 8 new spawn tests (port wiring, cap-gating, post-start persist, port-less skip, inspect failure tolerance), plus the two remaining `allow_privileged_ports: null` mock rows the 190a partial `replace_all` missed.

### Decisions

- **TCP-only in v1.** The dispatcher in 190c is HTTP/WS via `http-proxy` (handles upgrades). UDP would need a different topology.
- **Cap-add fires whenever the toggle is on**, independent of whether any specific port is < 1024. The user opted in at the form; config is bound at create time per the umbrella non-goal.
- **Best-effort inspect → persist after `start()`**: a failure logs and lets the container run. Reconcile resyncs on the next boot; the dispatcher returns 404 for an unknown port until then. Killing the spawn over a D1 hiccup would lose bootstrap progress.

## Test plan

- [x] `cd backend && npm run lint` — clean.
- [x] `cd backend && npm run build` — clean.
- [x] `cd backend && npm test` — 455 tests pass (was 431; +24 new).
- [x] `cd frontend && npm run lint` / `build` / `test` — clean.

Refs #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)