### PR TITLE
feat(resources): idle-sweeper module + activity bumps (#194, PR 194b of 3)

### DIFF
--- a/backend/src/idleSweeper.test.ts
+++ b/backend/src/idleSweeper.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import { IdleSweeper, listRunningSessionIds } from "./idleSweeper.js";
+
+beforeEach(() => {
+	dbStubs.d1Query.mockReset();
+	dbStubs.d1Query.mockImplementation(async () => ({
+		results: [],
+		success: true,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	}));
+});
+
+function makeSweeper(opts?: {
+	stopContainer?: (sessionId: string) => Promise<void>;
+	startTime?: number;
+}): {
+	sweeper: IdleSweeper;
+	stopSpy: ReturnType<typeof vi.fn>;
+	advance: (ms: number) => void;
+} {
+	let mockNow = opts?.startTime ?? 1_000_000;
+	const stopSpy = vi.fn(opts?.stopContainer ?? (async () => {}));
+	const sweeper = new IdleSweeper({
+		stopContainer: stopSpy,
+		now: () => mockNow,
+		sweepIntervalMs: 60_000,
+	});
+	return {
+		sweeper,
+		stopSpy,
+		advance(ms) {
+			mockNow += ms;
+		},
+	};
+}
+
+function mockRunningWithTtl(rows: { session_id: string; idle_ttl_seconds: number }[]) {
+	dbStubs.d1Query.mockImplementationOnce(async () => ({
+		results: rows,
+		success: true,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	}));
+}
+
+// ── bump / forget / init ────────────────────────────────────────────────
+
+describe("IdleSweeper.bump / forget / init", () => {
+	it("bump records the current time as lastActivity", () => {
+		const { sweeper, advance } = makeSweeper({ startTime: 100 });
+		sweeper.bump("s1");
+		expect(sweeper.__peekActivity("s1")).toBe(100);
+		advance(5000);
+		sweeper.bump("s1");
+		expect(sweeper.__peekActivity("s1")).toBe(5100);
+	});
+
+	it("forget removes the entry", () => {
+		const { sweeper } = makeSweeper();
+		sweeper.bump("s1");
+		expect(sweeper.__peekActivity("s1")).toBeDefined();
+		sweeper.forget("s1");
+		expect(sweeper.__peekActivity("s1")).toBeUndefined();
+	});
+
+	it("init seeds `now()` for every passed session id", () => {
+		const { sweeper } = makeSweeper({ startTime: 9000 });
+		sweeper.init(["a", "b", "c"]);
+		expect(sweeper.__peekActivity("a")).toBe(9000);
+		expect(sweeper.__peekActivity("b")).toBe(9000);
+		expect(sweeper.__peekActivity("c")).toBe(9000);
+	});
+});
+
+// ── runSweep ────────────────────────────────────────────────────────────
+
+describe("IdleSweeper.runSweep", () => {
+	it("does nothing when no running sessions have idle_ttl_seconds set", async () => {
+		const { sweeper, stopSpy } = makeSweeper();
+		mockRunningWithTtl([]);
+		await sweeper.runSweep();
+		expect(stopSpy).not.toHaveBeenCalled();
+	});
+
+	it("seeds + skips a session it hasn't seen yet (race with /start)", async () => {
+		// A session that reached `running` between `init()` and the
+		// first sweep shouldn't be reaped on its first encounter —
+		// give it the full window.
+		const { sweeper, stopSpy } = makeSweeper({ startTime: 5_000 });
+		mockRunningWithTtl([{ session_id: "newcomer", idle_ttl_seconds: 60 }]);
+		await sweeper.runSweep();
+		expect(stopSpy).not.toHaveBeenCalled();
+		// It is now seeded.
+		expect(sweeper.__peekActivity("newcomer")).toBe(5_000);
+	});
+
+	it("does NOT stop a session whose idle is still under the TTL", async () => {
+		const { sweeper, stopSpy, advance } = makeSweeper({ startTime: 0 });
+		sweeper.bump("s-active");
+		advance(30_000); // 30 s elapsed; TTL is 60 s.
+		mockRunningWithTtl([{ session_id: "s-active", idle_ttl_seconds: 60 }]);
+		await sweeper.runSweep();
+		expect(stopSpy).not.toHaveBeenCalled();
+	});
+
+	it("stops a session whose idle exceeds the TTL", async () => {
+		const { sweeper, stopSpy, advance } = makeSweeper({ startTime: 0 });
+		sweeper.bump("s-stale");
+		advance(61_000); // 61 s; TTL 60 s.
+		mockRunningWithTtl([{ session_id: "s-stale", idle_ttl_seconds: 60 }]);
+		await sweeper.runSweep();
+		expect(stopSpy).toHaveBeenCalledWith("s-stale");
+	});
+
+	it("drops the activity entry after a successful auto-stop", async () => {
+		// Without this, a re-attach immediately after auto-stop would
+		// race against an already-decayed bucket; the next /start
+		// flow re-seeds when the session reappears in `running`.
+		const { sweeper, advance } = makeSweeper({ startTime: 0 });
+		sweeper.bump("s-stale");
+		advance(120_000);
+		mockRunningWithTtl([{ session_id: "s-stale", idle_ttl_seconds: 60 }]);
+		await sweeper.runSweep();
+		expect(sweeper.__peekActivity("s-stale")).toBeUndefined();
+	});
+
+	it("isolates per-row stop failures so one stuck container doesn't stall the sweep", async () => {
+		// `s-bad` throws on stop; the sweeper logs and keeps going.
+		// `s-good` is also stale and must still be stopped in the
+		// same pass.
+		let stopCalls = 0;
+		const stops: string[] = [];
+		const { sweeper, advance } = makeSweeper({
+			startTime: 0,
+			stopContainer: async (id) => {
+				stopCalls++;
+				stops.push(id);
+				if (id === "s-bad") throw new Error("docker down");
+			},
+		});
+		sweeper.bump("s-bad");
+		sweeper.bump("s-good");
+		advance(120_000);
+		mockRunningWithTtl([
+			{ session_id: "s-bad", idle_ttl_seconds: 60 },
+			{ session_id: "s-good", idle_ttl_seconds: 60 },
+		]);
+		await sweeper.runSweep();
+		expect(stopCalls).toBe(2);
+		expect(stops).toEqual(["s-bad", "s-good"]);
+	});
+
+	it("uses inclusive boundary — exactly the TTL is NOT a reap", async () => {
+		// Boundary pin: a session whose idle equals the TTL exactly
+		// stays alive for one more sweep window. Dropping `<=` to
+		// `<` would shave a window and make the cap behaviour
+		// surprising.
+		const { sweeper, stopSpy, advance } = makeSweeper({ startTime: 0 });
+		sweeper.bump("s-edge");
+		advance(60_000); // exactly 60 s; TTL 60 s
+		mockRunningWithTtl([{ session_id: "s-edge", idle_ttl_seconds: 60 }]);
+		await sweeper.runSweep();
+		expect(stopSpy).not.toHaveBeenCalled();
+	});
+
+	it("re-seeds an already-stopped session that re-appears in running", async () => {
+		// User auto-stopped, /started again. The earlier `delete`
+		// after the auto-stop dropped the entry; on the next sweep
+		// the session is back in `running` and gets re-seeded
+		// (skipped this round).
+		const { sweeper, stopSpy, advance } = makeSweeper({ startTime: 0 });
+		sweeper.bump("s-recurring");
+		advance(120_000);
+		mockRunningWithTtl([{ session_id: "s-recurring", idle_ttl_seconds: 60 }]);
+		await sweeper.runSweep();
+		expect(stopSpy).toHaveBeenCalledTimes(1);
+		// User restarts; sweep again — must not double-reap.
+		mockRunningWithTtl([{ session_id: "s-recurring", idle_ttl_seconds: 60 }]);
+		await sweeper.runSweep();
+		expect(stopSpy).toHaveBeenCalledTimes(1); // still 1 — re-seeded, not reaped
+	});
+});
+
+// ── start / stop lifecycle ──────────────────────────────────────────────
+
+describe("IdleSweeper.start / stop", () => {
+	it("start is idempotent (second call is a no-op)", () => {
+		// Use real timers but a fast cadence so the test is quick;
+		// don't actually wait — just verify start doesn't throw on
+		// double-call and stop cancels cleanly.
+		const sweeper = new IdleSweeper({
+			stopContainer: async () => {},
+			sweepIntervalMs: 60_000,
+		});
+		sweeper.start();
+		sweeper.start(); // second call → no-op, no second timer
+		sweeper.stop();
+	});
+
+	it("stop is idempotent (second call after stop is a no-op)", () => {
+		const sweeper = new IdleSweeper({
+			stopContainer: async () => {},
+			sweepIntervalMs: 60_000,
+		});
+		sweeper.start();
+		sweeper.stop();
+		sweeper.stop(); // double-stop → safe
+	});
+});
+
+// ── listRunningSessionIds (boot helper) ─────────────────────────────────
+
+describe("listRunningSessionIds", () => {
+	it("returns an empty array when no running sessions exist", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await expect(listRunningSessionIds()).resolves.toEqual([]);
+	});
+
+	it("returns the session_id column from the running rows", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [{ session_id: "a" }, { session_id: "b" }],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await expect(listRunningSessionIds()).resolves.toEqual(["a", "b"]);
+	});
+
+	it("queries with WHERE status = 'running'", async () => {
+		await listRunningSessionIds();
+		const [sql] = dbStubs.d1Query.mock.calls[0]!;
+		expect(sql).toMatch(/WHERE status = 'running'/);
+	});
+});

--- a/backend/src/idleSweeper.ts
+++ b/backend/src/idleSweeper.ts
@@ -1,0 +1,190 @@
+/**
+ * idleSweeper.ts — auto-stop sessions whose terminals have been idle
+ * past the configured `idle_ttl_seconds` (#194).
+ *
+ * Activity is tracked in-memory only — surviving a backend restart is
+ * not required because:
+ *
+ *   1. The sweeper re-seeds every running session to `now()` on
+ *      startup (`init`), so nobody gets reaped seconds after a
+ *      restart even if the previous backend's bumps are gone.
+ *   2. Idle auto-stop is a soft-stop (workspace preserved); a wrong
+ *      reap costs the user a re-attach, not data.
+ *
+ * Activity sources that bump the entry:
+ *   - WS data flow in either direction (bytes from tmux, bytes from
+ *     browser, resize events) — wired in wsHandler.
+ *   - REST handlers under `/api/sessions/:id` — wired as Express
+ *     middleware in routes.
+ *
+ * Sweep cadence: every 60 s. Per the issue spec, the actual idle
+ * time at stop can exceed the configured TTL by up to 60 s, which is
+ * acceptable.
+ */
+
+import { d1Query } from "./db.js";
+import { logger } from "./logger.js";
+
+export interface IdleSweeperDeps {
+	/** Stops a session's container — same code path as POST /stop. */
+	stopContainer: (sessionId: string) => Promise<void>;
+	/** Test seam — defaults to Date.now. */
+	now?: () => number;
+	/**
+	 * Sweep interval in milliseconds. Defaults to 60 s. Tests pass a
+	 * smaller value AND drive sweeps directly via `runSweep()`; the
+	 * timer is started by `start()` only when the caller wants the
+	 * production cadence.
+	 */
+	sweepIntervalMs?: number;
+}
+
+interface RunningWithTtlRow {
+	session_id: string;
+	idle_ttl_seconds: number;
+}
+
+/**
+ * Default sweep cadence. The longer-than-1-min ceiling-check error is
+ * deliberate — see the "Known wrinkles" note in the #194 issue body.
+ */
+const DEFAULT_SWEEP_INTERVAL_MS = 60_000;
+
+export class IdleSweeper {
+	private readonly stopContainer: (sessionId: string) => Promise<void>;
+	private readonly now: () => number;
+	private readonly sweepIntervalMs: number;
+
+	private readonly lastActivity = new Map<string, number>();
+	private timer: ReturnType<typeof setInterval> | null = null;
+
+	constructor(deps: IdleSweeperDeps) {
+		this.stopContainer = deps.stopContainer;
+		this.now = deps.now ?? Date.now;
+		this.sweepIntervalMs = deps.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
+	}
+
+	/**
+	 * Bump activity for `sessionId`. Called on every WS byte (either
+	 * direction), every resize event, and every REST hit under
+	 * `/api/sessions/:id`. Cheap (one Map.set), so it's safe to call
+	 * on the hot path.
+	 *
+	 * Calling this for a session that's not running is harmless — the
+	 * sweeper only acts on rows whose D1 status is `running`, and
+	 * stale Map entries are pruned by `forget()` callers.
+	 */
+	bump(sessionId: string): void {
+		this.lastActivity.set(sessionId, this.now());
+	}
+
+	/**
+	 * Drop the entry for `sessionId`. Called by `DockerManager.kill()`
+	 * and `stopContainer()` so a stopped/dead session doesn't sit in
+	 * the activity map forever (memory leak shape if not pruned).
+	 */
+	forget(sessionId: string): void {
+		this.lastActivity.delete(sessionId);
+	}
+
+	/**
+	 * Seed `lastActivity` to `now()` for each session id passed in.
+	 * Called once on backend boot with the list of currently-running
+	 * sessions so the first sweep doesn't reap a session whose users
+	 * haven't reconnected yet (the previous backend's bumps are gone).
+	 */
+	init(sessionIds: Iterable<string>): void {
+		const t = this.now();
+		for (const id of sessionIds) this.lastActivity.set(id, t);
+	}
+
+	/** Start the periodic sweep. Idempotent — a second call is a no-op. */
+	start(): void {
+		if (this.timer !== null) return;
+		this.timer = setInterval(() => {
+			void this.runSweep().catch((err) => {
+				// Sweep errors are logged-and-swallowed: a transient D1
+				// failure shouldn't kill the timer (which would silently
+				// disable auto-stop until the next backend restart).
+				logger.warn(`[idle-sweeper] sweep error: ${(err as Error).message}`);
+			});
+		}, this.sweepIntervalMs);
+		// `unref` so a long-lived sweeper doesn't keep the process
+		// alive past `wss.close()` during shutdown.
+		this.timer.unref?.();
+	}
+
+	/**
+	 * Stop the periodic sweep. Idempotent. Called from the shutdown
+	 * path before `wss.close()` so the timer doesn't fire during
+	 * teardown.
+	 */
+	stop(): void {
+		if (this.timer === null) return;
+		clearInterval(this.timer);
+		this.timer = null;
+	}
+
+	/**
+	 * One sweep pass. Exposed for tests so they can drive the loop
+	 * synchronously without waiting on real timers.
+	 */
+	async runSweep(): Promise<void> {
+		const result = await d1Query<RunningWithTtlRow>(
+			"SELECT s.session_id AS session_id, sc.idle_ttl_seconds AS idle_ttl_seconds " +
+				"FROM sessions s " +
+				"JOIN session_configs sc ON sc.session_id = s.session_id " +
+				"WHERE s.status = 'running' AND sc.idle_ttl_seconds IS NOT NULL",
+		);
+		const t = this.now();
+		for (const row of result.results) {
+			const last = this.lastActivity.get(row.session_id);
+			if (last === undefined) {
+				// Session reached `running` between init() and now (or a
+				// previous reap removed the entry). Seed and skip — gives
+				// the user a full window before we consider reaping.
+				this.lastActivity.set(row.session_id, t);
+				continue;
+			}
+			const idleMs = t - last;
+			const ttlMs = row.idle_ttl_seconds * 1000;
+			if (idleMs <= ttlMs) continue;
+			logger.info(
+				`[idle-sweeper] auto-stopping session ${row.session_id}: idle ${Math.round(idleMs / 1000)}s > ttl ${row.idle_ttl_seconds}s`,
+			);
+			try {
+				await this.stopContainer(row.session_id);
+				// Drop the entry; the next `/start` flow will re-seed.
+				this.lastActivity.delete(row.session_id);
+			} catch (err) {
+				// Per-row failure is isolated — log and keep iterating
+				// so one stuck container doesn't stall the whole sweep.
+				logger.warn(
+					`[idle-sweeper] stop failed for session ${row.session_id}: ${(err as Error).message}`,
+				);
+			}
+		}
+	}
+
+	/**
+	 * Test-only — peek at the in-memory map. Production code should
+	 * not depend on this; it exists so the test suite can assert
+	 * bookkeeping without adding non-test methods to the public
+	 * surface.
+	 */
+	__peekActivity(sessionId: string): number | undefined {
+		return this.lastActivity.get(sessionId);
+	}
+}
+
+/**
+ * Helper for the boot path: list every running session id (no JOIN
+ * needed since `init` doesn't care about idle_ttl). Exported so
+ * `index.ts` can seed the sweeper without duplicating the SQL.
+ */
+export async function listRunningSessionIds(): Promise<string[]> {
+	const result = await d1Query<{ session_id: string }>(
+		"SELECT session_id FROM sessions WHERE status = 'running'",
+	);
+	return result.results.map((r) => r.session_id);
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import {
 import { BootstrapBroadcaster } from "./bootstrap.js";
 import { migrateDb, validateD1Config } from "./db.js";
 import { DockerManager } from "./dockerManager.js";
+import { IdleSweeper, listRunningSessionIds } from "./idleSweeper.js";
 import { logger } from "./logger.js";
 import { createPortDispatcher, validatePortProxyBaseDomain } from "./portDispatcher.js";
 import { buildRouter } from "./routes.js";
@@ -95,6 +96,19 @@ const docker = new DockerManager(sessions);
 // than the one running the hook; that's documented as a single-replica
 // constraint of the hook runner, same as the terminal-attach path.
 const bootstrapBroadcaster = new BootstrapBroadcaster();
+
+// Idle-auto-stop sweeper. Bumped by every WS byte / resize and every
+// /api/sessions/:id REST hit; sweeps every 60 s and soft-stops sessions
+// whose `idle_ttl_seconds` has elapsed. In-memory state only — the
+// boot path seeds `now()` for each currently-running session below
+// so the first sweep doesn't reap a session whose users haven't
+// reconnected yet (the previous backend's bumps are gone). Process-
+// local — a load-balanced multi-backend deploy would lose the
+// activity signal when traffic lands on a different replica; that's
+// the same single-replica constraint the BootstrapBroadcaster has.
+const idleSweeper = new IdleSweeper({
+	stopContainer: (sessionId) => docker.stopContainer(sessionId),
+});
 
 // #190 PR 190c — port-exposure dispatcher. Resolves Host:
 // `p<container>-<sessionId>.<base>` to the runtime mapping in
@@ -265,7 +279,7 @@ app.use((_req, res, next) => {
 // (not optional) on buildRouter so a future caller that omits it
 // surfaces as a TypeScript error rather than a silently-dropped
 // postCreate hook (PR #208 round 1 review).
-app.use("/api", buildRouter(sessions, docker, bootstrapBroadcaster));
+app.use("/api", buildRouter(sessions, docker, bootstrapBroadcaster, undefined, idleSweeper));
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // ── HTTP + WebSocket server ───────────────────────────────────────────────────
@@ -382,7 +396,7 @@ server.on("upgrade", (req, socket, head) => {
 const stopHeartbeat = startWsHeartbeat(wss, 30_000);
 
 wss.on("connection", (ws, req) => {
-	handleWsConnection(ws, req, sessions, docker, bootstrapBroadcaster);
+	handleWsConnection(ws, req, sessions, docker, bootstrapBroadcaster, idleSweeper);
 });
 
 // ── Startup ───────────────────────────────────────────────────────────────────
@@ -397,6 +411,21 @@ async function start() {
 	// login (which short-circuits the dummy path) — exactly the
 	// timing leak the dummy is supposed to prevent.
 	await ensureAuthReady();
+
+	// Seed the idle sweeper with every running session so the first
+	// sweep doesn't reap sessions whose users haven't reconnected yet
+	// (the prior backend's bumps are gone). Failure here is non-fatal:
+	// log and continue; bumps will lazy-init the map on the next /api
+	// or WS hit, and the sweep's `last === undefined` branch seeds and
+	// skips.
+	try {
+		const ids = await listRunningSessionIds();
+		idleSweeper.init(ids);
+		logger.info(`[server] idle sweeper seeded ${ids.length} running session(s)`);
+	} catch (err) {
+		logger.warn(`[server] idle sweeper init failed: ${(err as Error).message}`);
+	}
+	idleSweeper.start();
 
 	server.listen(PORT, () => {
 		logger.info(`[server] listening on http://localhost:${PORT}`);
@@ -429,6 +458,11 @@ function shutdown() {
 	// Stop the heartbeat first so it doesn't try to ping a half-closed
 	// client during teardown (would race with the close calls below).
 	stopHeartbeat();
+	// Stop the idle sweeper so its 60-s timer doesn't fire mid-teardown
+	// and try to soft-stop a session via a Docker socket the shutdown
+	// path is about to close. Idempotent — `stop()` is safe to call
+	// even if `start()` never ran.
+	idleSweeper.stop();
 
 	// Actively close live WS clients. `wss.close()` alone only stops accepting
 	// new upgrades — existing connections stay open, which keeps `server.close()`

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -58,6 +58,10 @@ export function buildRouter(
 	docker: DockerManager,
 	broadcaster: BootstrapBroadcaster,
 	rateLimitConfig: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG,
+	// Optional so existing tests that build a router without a sweeper
+	// keep working. Production wires the singleton from index.ts; the
+	// absent-sweeper case is the pre-#194 behaviour.
+	idleSweeper?: { bump: (sessionId: string) => void },
 ): Router {
 	const router = Router();
 
@@ -283,6 +287,22 @@ export function buildRouter(
 
 	router.use("/invites", requireAuth);
 	router.use("/sessions", requireAuth);
+
+	// Idle-sweeper bumper. Mounted AFTER `requireAuth` so unauth
+	// requests don't reset the activity timer (an unauthenticated
+	// probe to /api/sessions/:id 401s without ever bumping). The
+	// `:id` capture is what the sweeper needs; static collection
+	// routes like `GET /sessions` (no id) are excluded by the
+	// pattern. Excluded by intent: nothing under /sessions today
+	// is a "health probe" or a `reconcile` read — `assertOwnership`
+	// gates user-driven traffic only, so every authed hit is a
+	// legitimate activity signal.
+	if (idleSweeper) {
+		router.use("/sessions/:id", (req, _res, next) => {
+			idleSweeper.bump(req.params.id);
+			next();
+		});
+	}
 
 	// ── Invite routes ───────────────────────────────────────────────────────
 	// All three routes are gated by `requireAdmin` (#50). Non-admins

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -60,8 +60,11 @@ export function buildRouter(
 	rateLimitConfig: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG,
 	// Optional so existing tests that build a router without a sweeper
 	// keep working. Production wires the singleton from index.ts; the
-	// absent-sweeper case is the pre-#194 behaviour.
-	idleSweeper?: { bump: (sessionId: string) => void },
+	// absent-sweeper case is the pre-#194 behaviour. `bump` is the hot
+	// path (every authed /sessions/:id hit); `forget` runs on stop /
+	// kill / hard-delete so the activity Map doesn't grow unboundedly
+	// across the backend's lifetime.
+	idleSweeper?: { bump: (sessionId: string) => void; forget: (sessionId: string) => void },
 ): Router {
 	const router = Router();
 
@@ -289,17 +292,26 @@ export function buildRouter(
 	router.use("/sessions", requireAuth);
 
 	// Idle-sweeper bumper. Mounted AFTER `requireAuth` so unauth
-	// requests don't reset the activity timer (an unauthenticated
-	// probe to /api/sessions/:id 401s without ever bumping). The
-	// `:id` capture is what the sweeper needs; static collection
-	// routes like `GET /sessions` (no id) are excluded by the
-	// pattern. Excluded by intent: nothing under /sessions today
-	// is a "health probe" or a `reconcile` read — `assertOwnership`
-	// gates user-driven traffic only, so every authed hit is a
-	// legitimate activity signal.
+	// requests don't reset the activity timer. The `:id` capture is
+	// what the sweeper needs; static collection routes like
+	// `GET /sessions` (no id) are excluded by the pattern.
+	//
+	// Bump is hooked on `res.on("finish")` and gated on a successful
+	// status (< 400) so a foreign-session probe (`GET /sessions/<not-mine>`)
+	// gets its 403 from the handler's `assertOwnership` BEFORE the
+	// bump fires — without this, any authed user could keep someone
+	// else's session alive indefinitely by hitting their session id
+	// in a loop, defeating the idle-TTL contract for the real owner.
+	// Status check covers the whole 4xx/5xx range (auth, ownership,
+	// rate-limit, 404, internal errors) so anything other than a
+	// healthy interaction stays out of the activity signal.
 	if (idleSweeper) {
-		router.use("/sessions/:id", (req, _res, next) => {
-			idleSweeper.bump(req.params.id);
+		router.use("/sessions/:id", (req, res, next) => {
+			res.on("finish", () => {
+				if (res.statusCode < 400) {
+					idleSweeper.bump(req.params.id);
+				}
+			});
 			next();
 		});
 	}
@@ -675,6 +687,12 @@ export function buildRouter(
 			if (meta.status !== "terminated") {
 				await docker.kill(req.params.id);
 				await sessions.terminate(req.params.id);
+				// Drop the idle-sweeper's lastActivity entry — without
+				// this the Map grows unboundedly across the backend's
+				// lifetime as soft-deleted sessions accumulate. Bump
+				// already needed an authed user; forget needs the same
+				// gate, which the assertOwnership above provides.
+				idleSweeper?.forget(req.params.id);
 			}
 
 			if (hard) {
@@ -688,6 +706,10 @@ export function buildRouter(
 					// Fall through — we still want to remove the row.
 				}
 				await sessions.deleteRow(req.params.id);
+				// Hard-delete also drops the activity entry — covers
+				// the path where a user goes straight to ?hard=true on
+				// an already-terminated session.
+				idleSweeper?.forget(req.params.id);
 			}
 
 			res.status(204).send();
@@ -701,6 +723,10 @@ export function buildRouter(
 		try {
 			await sessions.assertOwnership(req.params.id, userId);
 			await docker.stopContainer(req.params.id);
+			// Same `forget` rationale as DELETE above: a stopped
+			// session shouldn't sit in the activity map collecting
+			// stale bumps. The next /start re-seeds.
+			idleSweeper?.forget(req.params.id);
 			const updated = await sessions.get(req.params.id);
 			if (!updated) {
 				// Race: the session was deleted between assertOwnership

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -308,7 +308,15 @@ export function buildRouter(
 	if (idleSweeper) {
 		router.use("/sessions/:id", (req, res, next) => {
 			res.on("finish", () => {
-				if (res.statusCode < 400) {
+				// `res.locals.skipIdleBump` is the opt-out for routes
+				// that explicitly tore down the entry (DELETE / stop /
+				// hard-delete). Without this gate, the `finish`
+				// listener fires AFTER the handler's `res.send()` /
+				// `res.json()`, which means a `forget()` called inside
+				// the handler runs first, then the bump re-adds the
+				// entry milliseconds later — undoing the prune.
+				const skip = (res.locals as { skipIdleBump?: boolean }).skipIdleBump === true;
+				if (!skip && res.statusCode < 400) {
 					idleSweeper.bump(req.params.id);
 				}
 			});
@@ -689,9 +697,14 @@ export function buildRouter(
 				await sessions.terminate(req.params.id);
 				// Drop the idle-sweeper's lastActivity entry — without
 				// this the Map grows unboundedly across the backend's
-				// lifetime as soft-deleted sessions accumulate. Bump
+				// lifetime as soft-deleted sessions accumulate. The
+				// `skipIdleBump` flag suppresses the bump middleware's
+				// `finish` listener; without it, the success-status
+				// bump fires AFTER `forget` on the same response and
+				// re-adds the entry, making the prune a no-op. Bump
 				// already needed an authed user; forget needs the same
 				// gate, which the assertOwnership above provides.
+				res.locals.skipIdleBump = true;
 				idleSweeper?.forget(req.params.id);
 			}
 
@@ -708,7 +721,9 @@ export function buildRouter(
 				await sessions.deleteRow(req.params.id);
 				// Hard-delete also drops the activity entry — covers
 				// the path where a user goes straight to ?hard=true on
-				// an already-terminated session.
+				// an already-terminated session. Same `skipIdleBump`
+				// flag rationale as the soft-delete branch above.
+				res.locals.skipIdleBump = true;
 				idleSweeper?.forget(req.params.id);
 			}
 
@@ -725,7 +740,10 @@ export function buildRouter(
 			await docker.stopContainer(req.params.id);
 			// Same `forget` rationale as DELETE above: a stopped
 			// session shouldn't sit in the activity map collecting
-			// stale bumps. The next /start re-seeds.
+			// stale bumps. `skipIdleBump` blocks the bump middleware's
+			// success-status listener from re-adding the entry on
+			// the same response. The next /start re-seeds.
+			res.locals.skipIdleBump = true;
 			idleSweeper?.forget(req.params.id);
 			const updated = await sessions.get(req.params.id);
 			if (!updated) {

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -51,6 +51,12 @@ export function handleWsConnection(
 	sessions: SessionManager,
 	docker: DockerManager,
 	broadcaster: BootstrapBroadcaster,
+	// Optional so the existing test suite (which constructs WS handlers
+	// without the sweeper) keeps working unchanged. Production wires
+	// the singleton from index.ts; the absent-sweeper case just means
+	// auto-stop never fires for that handler invocation, which is the
+	// pre-#194 behaviour.
+	idleSweeper?: { bump: (sessionId: string) => void },
 ): void {
 	// Synchronous safety net registered BEFORE any await or sync ws.close().
 	// Node's EventEmitter routes an 'error' emission with no listener to
@@ -200,6 +206,13 @@ export function handleWsConnection(
 		// Attach to Docker container
 		const attachId = `${sessionId}:${uuidv4().slice(0, 8)}`;
 		const outputListener = (data: string) => {
+			// Bump the idle-sweeper on every byte from tmux. Cheap
+			// (single Map.set) so it's safe on the hot path. Pairs
+			// with the input/resize bumps in the message handler so
+			// "user is watching the terminal" counts as activity even
+			// when they're not typing — common case for a build that
+			// takes minutes and the user just wants to watch the log.
+			idleSweeper?.bump(sessionId);
 			sendMsg(ws, { type: "output", data });
 		};
 
@@ -243,10 +256,12 @@ export function handleWsConnection(
 
 			switch (msg.type) {
 				case "input":
+					idleSweeper?.bump(sessionId);
 					docker.write(attachId, msg.data);
 					break;
 				case "resize":
 					if (msg.cols > 0 && msg.rows > 0) {
+						idleSweeper?.bump(sessionId);
 						docker.resize(attachId, msg.cols, msg.rows).catch(() => {});
 					}
 					break;


### PR DESCRIPTION
## Summary

PR 2 of 3 for **#194 — Resource & lifecycle controls**. Adds the in-process idle-auto-stop sweeper.

- New `idleSweeper.ts` — `IdleSweeper` class with `bump`, `forget`, `init`, `start`, `stop`, `runSweep`. In-memory activity map per session; sweeps every 60 s; soft-stops sessions whose `idle_ttl_seconds` has elapsed.
- Activity sources wired:
  - `wsHandler.ts` — bumps on every tmux→WS byte (the `outputListener`), every WS input message, and every resize.
  - `routes.ts` — `router.use("/sessions/:id", bump)` middleware, mounted AFTER `requireAuth` so unauth probes don't reset the timer.
- Boot path (`index.ts`) — seeds the sweeper with every currently-running session id so the first sweep doesn't reap a session whose users haven't reconnected yet (prior backend's bumps are gone). Threads the singleton into `buildRouter` and `handleWsConnection` as optional args (pre-#194 tests work unchanged).
- Shutdown — calls `sweeper.stop()` before `wss.close()` so the 60-s timer doesn't fire mid-teardown against a closing Docker socket.

## Decisions

- **Per-row stop failures are isolated.** If `stopContainer(s-bad)` throws, the sweeper logs and keeps iterating, so one stuck container doesn't stall the whole pass.
- **Inclusive TTL boundary.** `idle <= ttl` stays alive — a session whose idle exactly matches the TTL gets one more window. Dropping `<=` to `<` would shave a window and surprise users.
- **Newcomer seed-and-skip.** A session that reaches `running` between `init()` and the first sweep would otherwise be reaped immediately. The `last === undefined` branch seeds the entry to `now()` and skips the row, giving the user a full window.
- **Sweep errors are log-and-continue at both layers.** `runSweep` catches per-row stop failures; `start()`'s timer wrapper catches whole-sweep failures (transient D1 hiccup) so a single bad sweep doesn't kill the timer.
- **`unref()` on the timer** — long-lived sweeper doesn't keep the process alive past `wss.close()`.
- **Optional dependencies** on the wired-in surfaces (`wsHandler`, `routes`) so the existing test suite, which builds those without a sweeper, keeps working unchanged.

## Test plan

- [x] `cd backend && npm run lint / build / test` — clean, 555 tests pass (was 539; +16 new in `idleSweeper.test.ts` covering bump/forget/init shape, runSweep paths, newcomer-seed, under/over/exact TTL, per-row failure isolation, recurring-session re-seed, start/stop idempotency, `listRunningSessionIds` shape and SQL).
- [x] `cd frontend && npm run lint / build / test` — clean (no source touched).

Refs #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)