### PR TITLE
feat(resources): Advanced-tab Resources section (#194, PR 194c of 3 — closes #194)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -601,6 +601,73 @@
             </fieldset>
 
             <fieldset class="advanced-section">
+              <legend>Resources</legend>
+              <p class="modal-hint">
+                Per-session limits. Empty fields fall back to the
+                deployment defaults (2 cores / 2 GiB / no auto-stop).
+                Bounds: CPU 0.25–8 cores, memory 256 MiB–16 GiB,
+                idle TTL 1 minute–24 hours.
+              </p>
+              <div class="repo-fields-row">
+                <label class="modal-field">
+                  <span>CPU (cores)</span>
+                  <input
+                    type="number"
+                    id="resources-cpu-cores"
+                    inputmode="decimal"
+                    step="0.25"
+                    min="0.25"
+                    max="8"
+                    placeholder="2"
+                    autocomplete="off"
+                  />
+                </label>
+                <label class="modal-field">
+                  <span>Memory</span>
+                  <span class="resources-mem-row">
+                    <input
+                      type="number"
+                      id="resources-mem-amount"
+                      inputmode="numeric"
+                      step="1"
+                      min="1"
+                      placeholder="2"
+                      autocomplete="off"
+                    />
+                    <select id="resources-mem-unit">
+                      <option value="GiB" selected>GiB</option>
+                      <option value="MiB">MiB</option>
+                    </select>
+                  </span>
+                </label>
+              </div>
+              <p class="modal-hint">
+                Stops the container after N of inactivity. Workspace
+                files are preserved; opening a tab restarts it.
+              </p>
+              <div class="repo-fields-row">
+                <label class="modal-field">
+                  <span>Idle auto-stop</span>
+                  <span class="resources-mem-row">
+                    <input
+                      type="number"
+                      id="resources-idle-amount"
+                      inputmode="numeric"
+                      step="1"
+                      min="1"
+                      placeholder="Never"
+                      autocomplete="off"
+                    />
+                    <select id="resources-idle-unit">
+                      <option value="minutes" selected>minutes</option>
+                      <option value="hours">hours</option>
+                    </select>
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="advanced-section">
               <legend>Privileged ports</legend>
               <p class="modal-hint">
                 Container processes can't bind to ports below 1024

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -922,6 +922,18 @@ main:not([data-sidebar-ready]) #sidebar {
   font-family: -apple-system, sans-serif;
   white-space: nowrap;
 }
+.resources-mem-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.resources-mem-row input[type="number"] {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.resources-mem-row select {
+  flex: 0 0 auto;
+}
 .modal-field-checkbox {
   flex-direction: row;
   align-items: center;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1425,6 +1425,17 @@ const agentSeedSettingsError = document.getElementById(
 const agentSeedClaudeMd = document.getElementById("agent-seed-claude-md") as HTMLTextAreaElement;
 const postCreateCmd = document.getElementById("post-create-cmd") as HTMLTextAreaElement;
 const postStartCmd = document.getElementById("post-start-cmd") as HTMLTextAreaElement;
+// Resources sub-section. CPU is in cores → translated to nano-CPUs on
+// submit (Docker's HostConfig unit; matches the backend's wire shape).
+// Memory is amount + GiB/MiB → translated to bytes. Idle is amount +
+// minutes/hours → translated to seconds, OR omitted (undefined) for
+// "Never" — the schema is `.optional()` not `.nullable()`, so sending
+// `null` returns 400.
+const resourcesCpuCores = document.getElementById("resources-cpu-cores") as HTMLInputElement;
+const resourcesMemAmount = document.getElementById("resources-mem-amount") as HTMLInputElement;
+const resourcesMemUnit = document.getElementById("resources-mem-unit") as HTMLSelectElement;
+const resourcesIdleAmount = document.getElementById("resources-idle-amount") as HTMLInputElement;
+const resourcesIdleUnit = document.getElementById("resources-idle-unit") as HTMLSelectElement;
 
 /**
  * Validate `~/.claude/settings.json` content client-side. Backend's
@@ -1468,6 +1479,11 @@ function resetAdvancedTab(): void {
 	postCreateCmd.value = "";
 	postStartCmd.value = "";
 	agentSeedSettingsError.textContent = "";
+	resourcesCpuCores.value = "";
+	resourcesMemAmount.value = "";
+	resourcesMemUnit.value = "GiB";
+	resourcesIdleAmount.value = "";
+	resourcesIdleUnit.value = "minutes";
 }
 
 /**
@@ -1490,6 +1506,9 @@ export function collectAdvancedForSubmit(): {
 	agentSeed?: SessionConfigPayload["agentSeed"];
 	postCreateCmd?: string;
 	postStartCmd?: string;
+	cpuLimit?: number;
+	memLimit?: number;
+	idleTtlSeconds?: number;
 } {
 	const out: ReturnType<typeof collectAdvancedForSubmit> = {};
 
@@ -1533,6 +1552,44 @@ export function collectAdvancedForSubmit(): {
 	const ps = postStartCmd.value.trim();
 	if (pc !== "") out.postCreateCmd = pc;
 	if (ps !== "") out.postStartCmd = ps;
+
+	// Resources sub-section. Each field is optional and only emitted
+	// when it parses to a finite positive number — the backend's
+	// schema enforces the actual bounds (CPU 0.25–8 cores, memory
+	// 256 MiB–16 GiB, idle TTL 60 s–24 h), so a value at-or-near the
+	// edge gets a precise 400 with the field path. Empty / "Never" /
+	// non-numeric inputs drop through and the field is omitted —
+	// `.optional()` in the schema means an absent field falls back
+	// to the spawn-time default.
+	const cpuRaw = resourcesCpuCores.value.trim();
+	if (cpuRaw !== "") {
+		const cores = Number(cpuRaw);
+		// `Number.isFinite` (not `isInteger`) — the spec accepts
+		// fractional cores like 0.25 and 0.5; nano-CPU integer math
+		// happens at the multiplication step. Backend re-validates
+		// the integer result.
+		if (Number.isFinite(cores) && cores > 0) {
+			out.cpuLimit = Math.round(cores * 1_000_000_000);
+		}
+	}
+
+	const memRaw = resourcesMemAmount.value.trim();
+	if (memRaw !== "") {
+		const amount = Number(memRaw);
+		if (Number.isFinite(amount) && amount > 0) {
+			const unitFactor = resourcesMemUnit.value === "GiB" ? 1024 ** 3 : 1024 ** 2;
+			out.memLimit = Math.round(amount * unitFactor);
+		}
+	}
+
+	const idleRaw = resourcesIdleAmount.value.trim();
+	if (idleRaw !== "") {
+		const amount = Number(idleRaw);
+		if (Number.isFinite(amount) && amount > 0) {
+			const unitSeconds = resourcesIdleUnit.value === "hours" ? 3600 : 60;
+			out.idleTtlSeconds = Math.round(amount * unitSeconds);
+		}
+	}
 
 	return out;
 }
@@ -1790,7 +1847,10 @@ newSessionForm.addEventListener("submit", async (e) => {
 			advanced.dotfiles !== undefined ||
 			advanced.agentSeed !== undefined ||
 			advanced.postCreateCmd !== undefined ||
-			advanced.postStartCmd !== undefined;
+			advanced.postStartCmd !== undefined ||
+			advanced.cpuLimit !== undefined ||
+			advanced.memLimit !== undefined ||
+			advanced.idleTtlSeconds !== undefined;
 		const portsHasContent = ports !== undefined || allowPrivilegedPorts === true;
 		const config: SessionConfigPayload | undefined =
 			envVars || repo || advancedHasContent || portsHasContent


### PR DESCRIPTION
## Summary

Final PR for **#194 — Resource & lifecycle controls**. Frontend-only.

Adds a Resources fieldset to the Advanced tab with three optional inputs:

| Field | UI | Wire shape |
|---|---|---|
| CPU | number, cores, step=0.25, min=0.25, max=8 | `cpuLimit` (nano-CPUs) |
| Memory | number + GiB/MiB select (GiB default) | `memLimit` (bytes) |
| Idle auto-stop | number + minutes/hours select (placeholder "Never") | `idleTtlSeconds` (omitted if blank) |

## Decisions

- **Idle "Never" = omit the field**, not `null`. The schema is `.optional()` not `.nullable()`; a `null` value would 400. Leaving the input blank produces the right wire shape automatically.
- **Bounds enforced server-side, not client-side.** HTML `min`/`max`/`step` are hints; the backend's Zod schema (194a) is the single source of truth. A user typing `0.1` cores or `100` minutes-of-idle gets a precise 400 with the field path — same UX precedent as Repo / Env tabs.
- **`advancedHasContent` predicate** now also checks the three new fields so a user who only fills in a CPU cap (no other Advanced fields) still gets a `body.config` payload.

## Test plan

- [x] `cd frontend && npm run lint / build / test` — clean.
- [x] `cd backend && npm test` — 554 still pass (no source touched).

Closes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)