### PR TITLE
feat(templates): save-as-template flow (#195, PR 195b of 3)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -688,6 +688,9 @@
           </div>
           <div class="session-modal-actions">
             <button type="button" data-close-modal>Cancel</button>
+            <button type="button" id="save-as-template-btn" class="modal-secondary-action">
+              Save as template…
+            </button>
             <button type="submit" id="new-session-submit">Create session</button>
           </div>
         </form>
@@ -722,6 +725,65 @@
           + Generate new invite
         </button>
         <div id="invite-list" class="invite-list"></div>
+      </div>
+    </div>
+
+    <!-- Save-as-template dialog (#195 PR 195b). Surfaces from the
+         create-session modal's "Save as template…" button. The
+         create-session modal stays open underneath; submitting this
+         dialog just POSTs to /api/templates and toasts on success. -->
+    <div id="save-template-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="save-template-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="save-template-modal-title">Save as template</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint">
+          Saves the current form as a reusable preset. Secret values
+          (env vars marked secret, PAT, SSH private key) are stripped
+          before storage; the recipient re-supplies them when using
+          the template.
+        </p>
+        <form id="save-template-form" novalidate>
+          <label class="modal-field">
+            <span>Template name</span>
+            <input
+              id="save-template-name"
+              type="text"
+              placeholder="my-stack"
+              maxlength="64"
+              autocomplete="off"
+              required
+            />
+          </label>
+          <label class="modal-field">
+            <span>Description (optional)</span>
+            <input
+              id="save-template-description"
+              type="text"
+              placeholder="What this template configures"
+              maxlength="512"
+              autocomplete="off"
+            />
+          </label>
+          <div class="session-modal-actions">
+            <button type="button" data-close-modal>Cancel</button>
+            <button type="submit" id="save-template-submit">Save template</button>
+          </div>
+        </form>
       </div>
     </div>
 

--- a/frontend/src/api.templates.test.ts
+++ b/frontend/src/api.templates.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { type SessionConfigPayload, stripConfigForTemplate } from "./api.js";
+
+// `stripConfigForTemplate` is the client-side gate that prevents
+// plaintext secrets from reaching the unencrypted `templates.config`
+// column. The backend's `assertTemplateConfigShape` (195a, round 3
+// BLOCKER) is the regression guard if this function ever ships a
+// regression, but the client-side strip is the source of truth for
+// what we send — these tests pin every branch.
+
+describe("stripConfigForTemplate", () => {
+	it("returns the same shape for a config with no secrets", () => {
+		const input: SessionConfigPayload = {
+			cpuLimit: 1_000_000_000,
+			postCreateCmd: "npm install",
+			envVars: [{ name: "FOO", type: "plain", value: "bar" }],
+		};
+		expect(stripConfigForTemplate(input)).toEqual(input);
+	});
+
+	it("collapses secret envVars to secret-slot (no value)", () => {
+		const input: SessionConfigPayload = {
+			envVars: [
+				{ name: "FOO", type: "plain", value: "bar" },
+				{ name: "API_KEY", type: "secret", value: "sk-test-1234" },
+			],
+		};
+		const out = stripConfigForTemplate(input);
+		expect(out.envVars).toEqual([
+			{ name: "FOO", type: "plain", value: "bar" },
+			{ name: "API_KEY", type: "secret-slot" },
+		]);
+		// Belt-and-braces: the slot row must NOT carry a value.
+		const slot = out.envVars?.find((e) => e.type === "secret-slot");
+		expect(slot).not.toHaveProperty("value");
+	});
+
+	it("drops auth.pat entirely (PAT material must not persist)", () => {
+		const input: SessionConfigPayload = {
+			repo: { url: "https://github.com/u/r", auth: "pat" },
+			auth: { pat: "ghp_leakedtokenvalue" },
+		};
+		const out = stripConfigForTemplate(input);
+		// The repo's auth: "pat" declaration stays — the recipient
+		// re-supplies the PAT via the Use-template re-prompt.
+		expect(out.repo?.auth).toBe("pat");
+		// `auth.pat` is gone; `auth` itself is dropped because there's
+		// nothing else in it.
+		expect(out.auth).toBeUndefined();
+	});
+
+	it("drops auth.ssh.privateKey but keeps knownHosts (public)", () => {
+		const input: SessionConfigPayload = {
+			repo: { url: "git@github.com:u/r", auth: "ssh" },
+			auth: {
+				ssh: {
+					privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----…",
+					knownHosts: "github.com ssh-ed25519 …",
+				},
+			},
+		};
+		const out = stripConfigForTemplate(input);
+		expect(out.repo?.auth).toBe("ssh");
+		// privateKey is gone; knownHosts (public fingerprints) stays
+		// so the recipient doesn't have to re-paste them.
+		expect(out.auth?.ssh).not.toHaveProperty("privateKey");
+		expect(out.auth?.ssh?.knownHosts).toBe("github.com ssh-ed25519 …");
+	});
+
+	it("drops `auth` entirely when SSH had only a privateKey (no knownHosts)", () => {
+		const input: SessionConfigPayload = {
+			repo: { url: "git@github.com:u/r", auth: "ssh" },
+			auth: { ssh: { privateKey: "secret", knownHosts: "" } },
+		};
+		const out = stripConfigForTemplate(input);
+		// No knownHosts → nothing left in `auth.ssh` after the strip.
+		// Whole `auth` collapses out so the wire shape matches what
+		// the backend's `allowMissingAuth: true` accepts.
+		expect(out.auth).toBeUndefined();
+	});
+
+	it("does not mutate the input config (non-destructive)", () => {
+		const input: SessionConfigPayload = {
+			envVars: [{ name: "API_KEY", type: "secret", value: "sk-test-1234" }],
+			auth: { pat: "ghp_x" },
+		};
+		const snapshot = JSON.parse(JSON.stringify(input));
+		stripConfigForTemplate(input);
+		// Caller's `input` must be unchanged — prevents a
+		// future-form-resubmit-after-save-as-template from accidentally
+		// sending a stripped config with a secret-slot to POST /sessions
+		// (which 400s on slots).
+		expect(input).toEqual(snapshot);
+	});
+
+	it("leaves a no-auth / no-envVars config untouched", () => {
+		const input: SessionConfigPayload = { cpuLimit: 1_000_000_000 };
+		const out = stripConfigForTemplate(input);
+		expect(out).toEqual(input);
+		expect(out.auth).toBeUndefined();
+	});
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -329,6 +329,90 @@ export async function createSession(
 	return res.json();
 }
 
+// ── Templates (#195) ────────────────────────────────────────────────────────
+
+/**
+ * Strip a SessionConfigPayload down to a template-safe shape:
+ *   - `secret`-typed envVars collapse to `secret-slot` (no value);
+ *   - `auth.pat` is dropped entirely (PAT material must not land in
+ *     the unencrypted `templates.config` column);
+ *   - `auth.ssh.privateKey` is dropped, but `knownHosts` (public
+ *     fingerprints) stays — the recipient re-supplies the key on
+ *     `Use template`.
+ *
+ * Pure function, exported so `main.ts` can call it before the API
+ * request and a test can pin the contract. The backend's
+ * `assertTemplateConfigShape` is the regression guard if a
+ * misbehaving client tries to skip this strip — it 400s a config
+ * with live credentials. Same shape the issue spec calls out.
+ */
+export function stripConfigForTemplate(config: SessionConfigPayload): SessionConfigPayload {
+	const out: SessionConfigPayload = { ...config };
+	if (config.envVars) {
+		out.envVars = config.envVars.map((entry) =>
+			entry.type === "secret" ? ({ name: entry.name, type: "secret-slot" } as const) : entry,
+		);
+	}
+	if (config.auth) {
+		const stripped: NonNullable<SessionConfigPayload["auth"]> = {};
+		// `auth.pat` is the entire PAT credential — drop it. The
+		// `repo.auth: "pat"` declaration on `config.repo` stays
+		// (preserves intent for the Use-template re-prompt). The
+		// schema's `allowMissingAuth: true` flag in 195a tolerates
+		// the missing credential.
+		if (config.auth.ssh) {
+			// SSH: keep knownHosts (public), drop privateKey.
+			if (config.auth.ssh.knownHosts) {
+				stripped.ssh = { knownHosts: config.auth.ssh.knownHosts } as {
+					privateKey: string;
+					knownHosts: string;
+				};
+				// Type cheat: the wire type's `ssh.privateKey` is
+				// declared required, but the backend accepts the
+				// shape with `privateKey` absent under
+				// `allowMissingAuth: true`. The cast keeps us
+				// honest about the runtime shape we're sending.
+				delete (stripped.ssh as { privateKey?: string }).privateKey;
+			}
+		}
+		// Only attach `auth` if there's anything left after stripping.
+		if (Object.keys(stripped).length > 0) {
+			out.auth = stripped;
+		} else {
+			delete out.auth;
+		}
+	}
+	return out;
+}
+
+export interface TemplateSummary {
+	id: string;
+	name: string;
+	description: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface Template extends TemplateSummary {
+	config: SessionConfigPayload;
+}
+
+export async function createTemplate(input: {
+	name: string;
+	description?: string;
+	config: SessionConfigPayload;
+}): Promise<Template> {
+	const res = await apiFetch("/templates", {
+		method: "POST",
+		body: JSON.stringify(input),
+	});
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string; path?: string };
+		throw new Error(body.error ?? `Failed to create template (${res.status})`);
+	}
+	return res.json();
+}
+
 export async function listSessions(includeTerminated = false): Promise<SessionInfo[]> {
 	const path = includeTerminated ? "/sessions?all=true" : "/sessions";
 	const res = await apiFetch(path);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1916,6 +1916,10 @@ function openSaveTemplateModal() {
 function closeSaveTemplateModal() {
 	saveTemplateModal.classList.remove("open");
 	saveTemplateModal.setAttribute("aria-hidden", "true");
+	// Return focus to the trigger button so keyboard users don't lose
+	// their tab-order position. Same shape as `closeInvitesModal` /
+	// `closePasteModal`. PR #229 round 1 NIT.
+	saveTemplateBtn.focus();
 }
 
 saveTemplateBtn.addEventListener("click", () => {
@@ -2565,7 +2569,17 @@ invitesModal.addEventListener("click", (e) => {
 
 document.addEventListener("keydown", (e) => {
 	if (e.key !== "Escape") return;
-	if (newSessionModal.classList.contains("open")) {
+	// Topmost-first: WAI-ARIA 1.2 §6.2 says Escape dismisses the
+	// dialog the user is currently focused on, not the parent it
+	// floats above. The save-template dialog opens ON TOP of the
+	// create-session modal; without this priority, Escape would
+	// close the parent and leave the save-template dialog
+	// orphaned (and the parent's reset would wipe the form
+	// underneath, so confirming the save would persist a stripped
+	// template from default values). PR #229 round 1 SHOULD-FIX.
+	if (saveTemplateModal.classList.contains("open")) {
+		closeSaveTemplateModal();
+	} else if (newSessionModal.classList.contains("open")) {
 		closeNewSessionModal();
 	} else if (invitesModal.classList.contains("open")) {
 		closeInvitesModal();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -15,6 +15,7 @@ import {
 	createInvite,
 	createSession,
 	createTab,
+	createTemplate,
 	deleteSession,
 	deleteTab,
 	type EnvVarEntryInput,
@@ -35,6 +36,7 @@ import {
 	type SessionInfo,
 	startSession,
 	stopSession,
+	stripConfigForTemplate,
 	type Tab,
 	TabNotFoundError,
 	uploadSessionFiles,
@@ -1880,6 +1882,95 @@ newSessionForm.addEventListener("submit", async (e) => {
 	} catch (err) {
 		showToast((err as Error).message, true);
 		newSessionSubmitBtn.disabled = false;
+	}
+});
+
+// ── Save-as-template flow (#195 / PR 195b) ──────────────────────────────────
+//
+// "Save as template…" button on the create-session modal opens a tiny
+// dialog (name + optional description), strips secrets from the
+// current form state via `stripConfigForTemplate`, and POSTs to
+// `/api/templates`. The create-session modal stays open underneath so
+// the user can still create the session after saving the template, or
+// dismiss both. The Templates *page* (list / use / delete) lands in
+// the next sub-PR; this PR is "save only".
+
+const saveTemplateBtn = document.getElementById("save-as-template-btn") as HTMLButtonElement;
+const saveTemplateModal = document.getElementById("save-template-modal")!;
+const saveTemplateForm = document.getElementById("save-template-form") as HTMLFormElement;
+const saveTemplateNameInput = document.getElementById("save-template-name") as HTMLInputElement;
+const saveTemplateDescriptionInput = document.getElementById(
+	"save-template-description",
+) as HTMLInputElement;
+const saveTemplateSubmit = document.getElementById("save-template-submit") as HTMLButtonElement;
+
+function openSaveTemplateModal() {
+	saveTemplateNameInput.value = "";
+	saveTemplateDescriptionInput.value = "";
+	saveTemplateSubmit.disabled = false;
+	saveTemplateModal.classList.add("open");
+	saveTemplateModal.setAttribute("aria-hidden", "false");
+	requestAnimationFrame(() => saveTemplateNameInput.focus());
+}
+
+function closeSaveTemplateModal() {
+	saveTemplateModal.classList.remove("open");
+	saveTemplateModal.setAttribute("aria-hidden", "true");
+}
+
+saveTemplateBtn.addEventListener("click", () => {
+	openSaveTemplateModal();
+});
+
+saveTemplateModal.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeSaveTemplateModal();
+});
+
+/**
+ * Build the same `body.config` payload `createSession` would send,
+ * then strip secrets before handing it to `createTemplate`. Reuses
+ * the four collectors so the template captures EXACTLY what the
+ * user sees in the form — no drift between "what would I create"
+ * and "what would I save".
+ */
+function buildTemplateConfigFromForm(): SessionConfigPayload {
+	const envVars = collectEnvVarsForSubmit();
+	const { repo, auth } = collectRepoForSubmit();
+	const advanced = collectAdvancedForSubmit();
+	const { ports, allowPrivilegedPorts } = collectPortsForSubmit();
+	const config: SessionConfigPayload = {
+		...(envVars ? { envVars } : {}),
+		...(repo ? { repo } : {}),
+		...(auth ? { auth } : {}),
+		...advanced,
+		...(ports ? { ports } : {}),
+		...(allowPrivilegedPorts ? { allowPrivilegedPorts } : {}),
+	};
+	return stripConfigForTemplate(config);
+}
+
+saveTemplateForm.addEventListener("submit", async (e) => {
+	e.preventDefault();
+	const name = saveTemplateNameInput.value.trim();
+	if (!name) {
+		saveTemplateNameInput.focus();
+		return;
+	}
+	const description = saveTemplateDescriptionInput.value.trim();
+	saveTemplateSubmit.disabled = true;
+	try {
+		const config = buildTemplateConfigFromForm();
+		await createTemplate({
+			name,
+			...(description !== "" ? { description } : {}),
+			config,
+		});
+		closeSaveTemplateModal();
+		showToast(`Template "${name}" saved`);
+	} catch (err) {
+		showToast((err as Error).message, true);
+		saveTemplateSubmit.disabled = false;
 	}
 });
 


### PR DESCRIPTION
## Summary

PR 2 of 3 for **#195 — Templates**. Adds the "Save as template…" button on the create-session modal, a small dialog (name + description), the client-side secret-strip helper, and the `createTemplate` API call. The Templates *page* (list / use / delete) lands in 195c.

## Changes

- `frontend/src/api.ts`:
  - `stripConfigForTemplate(config)` — pure, non-destructive helper. Collapses `secret`-typed envVars to `secret-slot`, drops `auth.pat`, drops `auth.ssh.privateKey` (keeps `knownHosts`), drops `auth` entirely if nothing's left.
  - `createTemplate({ name, description?, config })` POSTs to `/api/templates`.
  - `Template` / `TemplateSummary` types matching 195a's wire shapes.
- `frontend/index.html`:
  - "Save as template…" button next to "Create session" in the modal footer.
  - New `<div id="save-template-modal">` dialog with name + description fields.
- `frontend/src/main.ts`:
  - Wire-up: open/close the dialog, build the config from existing collectors (`collectEnvVarsForSubmit` / `collectRepoForSubmit` / `collectAdvancedForSubmit` / `collectPortsForSubmit`), strip via `stripConfigForTemplate`, POST, toast.

## Decisions

- **Reuse the existing collectors.** The template captures EXACTLY what the user sees in the form — no drift between "what would I create" and "what would I save".
- **Strip helper is pure / non-destructive.** Caller's input is unchanged so a save-then-create flow doesn't accidentally send the stripped config (with `secret-slot` rows that POST `/sessions` rejects) on the actual session create.
- **Modal stays open underneath.** The user can save the template AND then create the session, or dismiss both — matches the issue's "Save as template… button next to the primary action" intent.
- **Bounds match the backend.** Name ≤64, description ≤512 — same caps as 195a's `parseTemplateBody`. No parallel source of truth.

## Test plan

- [x] `cd frontend && npm run lint / build / test` — 54 tests pass (was 47; +7 in `api.templates.test.ts` covering the strip helper's every branch + non-mutation invariant).
- [x] `cd backend && npm test` — 598 still pass (no backend source touched).

Refs #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)