### PR TITLE
feat(templates): Templates page + use-template flow (#195, PR 195c of 3 — closes #195)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -129,6 +129,7 @@
           <div id="session-list"></div>
           <div id="sidebar-footer">
             <span id="sidebar-user-display" aria-hidden="true"></span>
+            <button id="sidebar-templates-btn" type="button">Templates</button>
             <button id="sidebar-invites-btn" type="button">Invites</button>
             <button id="sidebar-logout-btn" type="button">Logout</button>
           </div>
@@ -725,6 +726,42 @@
           + Generate new invite
         </button>
         <div id="invite-list" class="invite-list"></div>
+      </div>
+    </div>
+
+    <!-- Templates page (#195 PR 195c). Lists the user's own
+         templates with Use / Delete actions. Click Use → closes
+         this modal and opens the create-session modal pre-filled
+         with the template's config. Click Delete → confirms then
+         removes the row. Edit + save-from-running-session are
+         deferred to follow-ups. -->
+    <div id="templates-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="templates-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="templates-modal-title">Templates</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint">
+          Reusable session-config presets. Use to pre-fill a new
+          session; secret values are stripped on save and re-prompted
+          on use.
+        </p>
+        <div id="templates-list">
+          <p class="modal-hint" id="templates-empty-hint">Loading templates…</p>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/api.templates.test.ts
+++ b/frontend/src/api.templates.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { type SessionConfigPayload, stripConfigForTemplate } from "./api.js";
+import {
+	idleSecondsToFormUnit,
+	memBytesToFormUnit,
+	type SessionConfigPayload,
+	stripConfigForTemplate,
+} from "./api.js";
 
 // `stripConfigForTemplate` is the client-side gate that prevents
 // plaintext secrets from reaching the unencrypted `templates.config`
@@ -98,5 +103,62 @@ describe("stripConfigForTemplate", () => {
 		const out = stripConfigForTemplate(input);
 		expect(out).toEqual(input);
 		expect(out.auth).toBeUndefined();
+	});
+});
+
+// `memBytesToFormUnit` and `idleSecondsToFormUnit` are the reverse-
+// direction helpers the use-template flow's pre-fill calls (the
+// inverse of what `collectAdvancedForSubmit` does). The boundary
+// branches (GiB vs MiB, hours vs minutes) are deterministic pure
+// math; pinning them here so a future regression in the divisibility
+// check trips a test rather than silently mis-populating a form.
+
+describe("memBytesToFormUnit", () => {
+	it("returns null for undefined / 0 / negative (form blank state)", () => {
+		expect(memBytesToFormUnit(undefined)).toBeNull();
+		expect(memBytesToFormUnit(0)).toBeNull();
+		expect(memBytesToFormUnit(-1)).toBeNull();
+	});
+
+	it("returns GiB when the byte count is an integer multiple of 1 GiB", () => {
+		expect(memBytesToFormUnit(1024 ** 3)).toEqual({ amount: 1, unit: "GiB" });
+		expect(memBytesToFormUnit(2 * 1024 ** 3)).toEqual({ amount: 2, unit: "GiB" });
+		expect(memBytesToFormUnit(16 * 1024 ** 3)).toEqual({ amount: 16, unit: "GiB" });
+	});
+
+	it("falls back to MiB when bytes don't divide evenly into GiB", () => {
+		// 1.5 GiB → 1536 MiB
+		expect(memBytesToFormUnit(1.5 * 1024 ** 3)).toEqual({ amount: 1536, unit: "MiB" });
+		// 256 MiB at the floor — under 1 GiB so the GiB branch is
+		// skipped (the `gib >= 1` guard).
+		expect(memBytesToFormUnit(256 * 1024 ** 2)).toEqual({ amount: 256, unit: "MiB" });
+	});
+
+	it("MiB rounds the boundary halfway case", () => {
+		// 1.5 MiB → 2 (Math.round rounds ties to even / up depending
+		// on the engine; pin that the round-up shape holds)
+		expect(memBytesToFormUnit(1.5 * 1024 ** 2)).toEqual({ amount: 2, unit: "MiB" });
+	});
+});
+
+describe("idleSecondsToFormUnit", () => {
+	it("returns null for undefined / 0 / negative (form blank state)", () => {
+		expect(idleSecondsToFormUnit(undefined)).toBeNull();
+		expect(idleSecondsToFormUnit(0)).toBeNull();
+		expect(idleSecondsToFormUnit(-60)).toBeNull();
+	});
+
+	it("returns hours when seconds divide evenly by 3600", () => {
+		expect(idleSecondsToFormUnit(3600)).toEqual({ amount: 1, unit: "hours" });
+		expect(idleSecondsToFormUnit(2 * 3600)).toEqual({ amount: 2, unit: "hours" });
+		expect(idleSecondsToFormUnit(24 * 3600)).toEqual({ amount: 24, unit: "hours" });
+	});
+
+	it("falls back to minutes when seconds don't divide evenly by 3600", () => {
+		expect(idleSecondsToFormUnit(60)).toEqual({ amount: 1, unit: "minutes" });
+		expect(idleSecondsToFormUnit(90)).toEqual({ amount: 2, unit: "minutes" }); // rounds
+		expect(idleSecondsToFormUnit(1800)).toEqual({ amount: 30, unit: "minutes" });
+		// 90 minutes (5400 seconds) — not divisible by 3600 → minutes
+		expect(idleSecondsToFormUnit(5400)).toEqual({ amount: 90, unit: "minutes" });
 	});
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -433,7 +433,10 @@ export async function deleteTemplate(id: string): Promise<void> {
 	const res = await apiFetch(`/templates/${encodeURIComponent(id)}`, {
 		method: "DELETE",
 	});
-	if (!res.ok && res.status !== 204) {
+	// 204 is in the 2xx range, so `res.ok` is already true. Earlier
+	// shape had a redundant `&& res.status !== 204` clause; dropped
+	// per PR #230 round 1 NIT.
+	if (!res.ok) {
 		throw new Error(`Failed to delete template (${res.status})`);
 	}
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -413,6 +413,38 @@ export async function createTemplate(input: {
 	return res.json();
 }
 
+/**
+ * Pure helpers for the use-template flow's reverse unit conversion
+ * (nano-CPUs → cores, bytes → GiB-or-MiB, seconds → hours-or-minutes).
+ * Extracted so the boundary cases the templates-page form pre-fill
+ * relies on can be unit-tested directly — `applyTemplateToForm` in
+ * `main.ts` is DOM-heavy and not easily exercised in jsdom.
+ *
+ * Each helper returns either a `{ amount, unit }` pair or `null`
+ * when the input is undefined / 0 / negative (the form's "leave
+ * the field blank" state). Picks the most natural unit for the
+ * common cases — integer GiB / divisible-by-3600 seconds — and
+ * falls back to MiB / minutes otherwise.
+ */
+export function memBytesToFormUnit(bytes: number | undefined): {
+	amount: number;
+	unit: "GiB" | "MiB";
+} | null {
+	if (bytes === undefined || bytes <= 0) return null;
+	const gib = bytes / 1024 ** 3;
+	if (Number.isInteger(gib) && gib >= 1) return { amount: gib, unit: "GiB" };
+	return { amount: Math.round(bytes / 1024 ** 2), unit: "MiB" };
+}
+
+export function idleSecondsToFormUnit(seconds: number | undefined): {
+	amount: number;
+	unit: "hours" | "minutes";
+} | null {
+	if (seconds === undefined || seconds <= 0) return null;
+	if (seconds % 3600 === 0) return { amount: seconds / 3600, unit: "hours" };
+	return { amount: Math.round(seconds / 60), unit: "minutes" };
+}
+
 export async function listTemplates(): Promise<TemplateSummary[]> {
 	const res = await apiFetch("/templates");
 	if (!res.ok) {
@@ -458,7 +490,10 @@ export async function getSession(id: string): Promise<SessionInfo> {
 export async function deleteSession(id: string, hard = false): Promise<void> {
 	const qs = hard ? "?hard=true" : "";
 	const res = await apiFetch(`/sessions/${id}${qs}`, { method: "DELETE" });
-	if (!res.ok && res.status !== 204) {
+	// 204 falls inside `res.ok`; the `&& res.status !== 204` clause
+	// the previous form had was dead code (mirrors the cleanup in
+	// `deleteTemplate` above).
+	if (!res.ok) {
 		throw new Error("Failed to delete session");
 	}
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -413,6 +413,31 @@ export async function createTemplate(input: {
 	return res.json();
 }
 
+export async function listTemplates(): Promise<TemplateSummary[]> {
+	const res = await apiFetch("/templates");
+	if (!res.ok) {
+		throw new Error(`Failed to list templates (${res.status})`);
+	}
+	return res.json();
+}
+
+export async function getTemplate(id: string): Promise<Template> {
+	const res = await apiFetch(`/templates/${encodeURIComponent(id)}`);
+	if (!res.ok) {
+		throw new Error(`Failed to load template (${res.status})`);
+	}
+	return res.json();
+}
+
+export async function deleteTemplate(id: string): Promise<void> {
+	const res = await apiFetch(`/templates/${encodeURIComponent(id)}`, {
+		method: "DELETE",
+	});
+	if (!res.ok && res.status !== 204) {
+		throw new Error(`Failed to delete template (${res.status})`);
+	}
+}
+
 export async function listSessions(includeTerminated = false): Promise<SessionInfo[]> {
 	const path = includeTerminated ? "/sessions?all=true" : "/sessions";
 	const res = await apiFetch(path);

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -934,6 +934,52 @@ main:not([data-sidebar-ready]) #sidebar {
 .resources-mem-row select {
   flex: 0 0 auto;
 }
+/* #195 PR 195c — Templates page (sidebar entry → modal listing
+   the user's own templates with Use / Delete actions). */
+.template-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  background: #0d1117;
+}
+.template-card-header strong {
+  font-size: 0.95rem;
+  color: #e6edf3;
+}
+.template-card-description {
+  font-size: 0.8rem;
+  color: #8b949e;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.template-card-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+.template-card-actions button {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.25rem 0.7rem;
+  color: #e6edf3;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.template-card-actions button:hover {
+  background: #30363d;
+}
+.template-card-delete:hover {
+  background: rgba(248, 81, 73, 0.12);
+  border-color: rgba(248, 81, 73, 0.45);
+  color: #ff8682;
+}
+
 .modal-field-checkbox {
   flex-direction: row;
   align-items: center;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,7 +18,9 @@ import {
 	createTemplate,
 	deleteSession,
 	deleteTab,
+	deleteTemplate,
 	type EnvVarEntryInput,
+	getTemplate,
 	type Invite,
 	InviteRequiredError,
 	isAdmin,
@@ -26,6 +28,7 @@ import {
 	listInvites,
 	listSessions,
 	listTabs,
+	listTemplates,
 	login,
 	logout,
 	openBootstrapWs,
@@ -39,6 +42,8 @@ import {
 	stripConfigForTemplate,
 	type Tab,
 	TabNotFoundError,
+	type Template,
+	type TemplateSummary,
 	uploadSessionFiles,
 } from "./api.js";
 import { parseDotEnv } from "./envParser.js";
@@ -1978,6 +1983,254 @@ saveTemplateForm.addEventListener("submit", async (e) => {
 	}
 });
 
+// ── Templates page (#195 / PR 195c) ─────────────────────────────────────────
+//
+// Sidebar entry → modal listing the user's own templates with Use /
+// Delete actions. Use opens the create-session modal pre-filled with
+// the template's config; secret-slot env entries collapse back to
+// type:"secret" with empty values so the user has to fill them in
+// before submit. Edit is deferred to a follow-up.
+
+const sidebarTemplatesBtn = document.getElementById("sidebar-templates-btn") as HTMLButtonElement;
+const templatesModal = document.getElementById("templates-modal")!;
+const templatesList = document.getElementById("templates-list") as HTMLDivElement;
+const templatesEmptyHint = document.getElementById("templates-empty-hint") as HTMLParagraphElement;
+
+let templatesOpener: HTMLElement | null = null;
+
+function openTemplatesModal(opener: HTMLElement) {
+	templatesOpener = opener;
+	templatesModal.classList.add("open");
+	templatesModal.setAttribute("aria-hidden", "false");
+	void refreshTemplatesList();
+}
+
+function closeTemplatesModal() {
+	templatesModal.classList.remove("open");
+	templatesModal.setAttribute("aria-hidden", "true");
+	(templatesOpener ?? sidebarTemplatesBtn).focus();
+	templatesOpener = null;
+}
+
+async function refreshTemplatesList() {
+	templatesList.textContent = "";
+	templatesEmptyHint.textContent = "Loading templates…";
+	templatesList.appendChild(templatesEmptyHint);
+	try {
+		const list = await listTemplates();
+		templatesList.textContent = "";
+		if (list.length === 0) {
+			templatesEmptyHint.textContent =
+				'No templates yet. Use "Save as template…" on the new-session modal to create one.';
+			templatesList.appendChild(templatesEmptyHint);
+			return;
+		}
+		for (const t of list) {
+			templatesList.appendChild(renderTemplateCard(t));
+		}
+	} catch (err) {
+		templatesEmptyHint.textContent = `Failed to load: ${(err as Error).message}`;
+		templatesList.appendChild(templatesEmptyHint);
+	}
+}
+
+function renderTemplateCard(t: TemplateSummary): HTMLElement {
+	const card = document.createElement("div");
+	card.className = "template-card";
+	card.dataset.templateId = t.id;
+
+	const header = document.createElement("div");
+	header.className = "template-card-header";
+	const nameEl = document.createElement("strong");
+	nameEl.textContent = t.name;
+	header.appendChild(nameEl);
+	card.appendChild(header);
+
+	if (t.description) {
+		const desc = document.createElement("p");
+		desc.className = "template-card-description";
+		desc.textContent = t.description;
+		card.appendChild(desc);
+	}
+
+	const actions = document.createElement("div");
+	actions.className = "template-card-actions";
+	const useBtn = document.createElement("button");
+	useBtn.type = "button";
+	useBtn.textContent = "Use";
+	useBtn.dataset.action = "use";
+	const delBtn = document.createElement("button");
+	delBtn.type = "button";
+	delBtn.textContent = "Delete";
+	delBtn.dataset.action = "delete";
+	delBtn.className = "template-card-delete";
+	actions.appendChild(useBtn);
+	actions.appendChild(delBtn);
+	card.appendChild(actions);
+
+	return card;
+}
+
+templatesList.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	const action = target.dataset.action;
+	if (action !== "use" && action !== "delete") return;
+	const card = target.closest<HTMLDivElement>(".template-card");
+	const id = card?.dataset.templateId;
+	if (!id) return;
+	if (action === "use") {
+		void useTemplate(id);
+	} else {
+		void deleteTemplateConfirmed(id, card!);
+	}
+});
+
+templatesModal.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeTemplatesModal();
+});
+
+sidebarTemplatesBtn.addEventListener("click", () => openTemplatesModal(sidebarTemplatesBtn));
+
+async function deleteTemplateConfirmed(id: string, card: HTMLDivElement) {
+	const name = card.querySelector("strong")?.textContent ?? "this template";
+	if (!confirm(`Delete template "${name}"? This cannot be undone.`)) return;
+	try {
+		await deleteTemplate(id);
+		showToast(`Template "${name}" deleted`);
+		void refreshTemplatesList();
+	} catch (err) {
+		showToast((err as Error).message, true);
+	}
+}
+
+/**
+ * Use template: closes the templates modal, opens the create-session
+ * modal, and pre-fills the form from the template's config. Secret
+ * values are placeholders the user fills in before submit.
+ */
+async function useTemplate(id: string) {
+	try {
+		const t = await getTemplate(id);
+		closeTemplatesModal();
+		openNewSessionModal(sidebarTemplatesBtn);
+		applyTemplateToForm(t);
+		showToast(`Loaded template "${t.name}". Fill in any required secrets, then Create.`);
+	} catch (err) {
+		showToast((err as Error).message, true);
+	}
+}
+
+/**
+ * Apply a template's stored config to the create-session form's
+ * in-memory state. Mirrors the collectors' field shapes in reverse —
+ * so a save-then-use round-trip ends up at the same form state the
+ * user originally typed (modulo stripped secrets).
+ *
+ * Secret-slot env entries collapse to `secret`-typed rows with empty
+ * values; the user has to type each one before submit. PAT / SSH
+ * "intent without credential" cases (config.repo.auth = pat/ssh with
+ * no auth.pat / auth.ssh) leave the credential fields empty for the
+ * user to fill in.
+ */
+function applyTemplateToForm(t: Template): void {
+	const cfg = t.config;
+	// Pre-fill the session name from the template name. The user
+	// can rename before submit; sessions and templates have
+	// independent name spaces (no uniqueness collision).
+	newSessionInput.value = t.name;
+
+	// Env vars — secret-slot becomes a `secret` row with empty
+	// value the user must fill in. Plain rows pass through.
+	envRows = (cfg.envVars ?? []).map((entry) => {
+		if (entry.type === "secret-slot") {
+			return { id: newEnvRowId(), name: entry.name, value: "", type: "secret" };
+		}
+		return {
+			id: newEnvRowId(),
+			name: entry.name,
+			value: entry.value,
+			type: entry.type,
+		};
+	});
+	renderEnvRows();
+
+	// Repo + auth. The credential fields stay empty if the
+	// template only carried the auth declaration (the strip
+	// helper drops auth.pat / auth.ssh.privateKey but keeps
+	// auth.ssh.knownHosts and the repo.auth flag).
+	if (cfg.repo) {
+		repoUrl.value = cfg.repo.url;
+		repoRef.value = cfg.repo.ref ?? "";
+		repoTarget.value = cfg.repo.target ?? "";
+		repoAuth.value = cfg.repo.auth;
+		repoDepth.value = cfg.repo.depth ? String(cfg.repo.depth) : "";
+		// Trigger the auth panel's render so PAT/SSH fields show
+		// or hide per the auth selector.
+		repoAuth.dispatchEvent(new Event("change"));
+		repoAuthPatToken.value = cfg.auth?.pat ?? "";
+		repoAuthSshKey.value = cfg.auth?.ssh?.privateKey ?? "";
+		// Leave the known-hosts mode/custom selector in its default
+		// state — known_hosts is a niche secondary field with its
+		// own mode-selector UX, and the strip helper preserves the
+		// public fingerprints anyway. Users who need a custom
+		// known_hosts after applying a template re-enter via the
+		// existing Repo-tab UI.
+	}
+
+	// Advanced — all the optional sub-sections.
+	gitIdentityName.value = cfg.gitIdentity?.name ?? "";
+	gitIdentityEmail.value = cfg.gitIdentity?.email ?? "";
+	dotfilesUrl.value = cfg.dotfiles?.url ?? "";
+	dotfilesRef.value = cfg.dotfiles?.ref ?? "";
+	dotfilesInstallScript.value = cfg.dotfiles?.installScript ?? "";
+	agentSeedSettings.value = cfg.agentSeed?.settings ?? "";
+	agentSeedClaudeMd.value = cfg.agentSeed?.claudeMd ?? "";
+	postCreateCmd.value = cfg.postCreateCmd ?? "";
+	postStartCmd.value = cfg.postStartCmd ?? "";
+
+	// Resources (cpu nano-CPUs → cores, mem bytes → GiB/MiB,
+	// idleTtl seconds → minutes/hours). Pick the most natural
+	// unit per field so the user sees the same values they would
+	// have typed.
+	resourcesCpuCores.value = cfg.cpuLimit ? String(cfg.cpuLimit / 1_000_000_000) : "";
+	if (cfg.memLimit) {
+		const gib = cfg.memLimit / 1024 ** 3;
+		if (Number.isInteger(gib) && gib >= 1) {
+			resourcesMemAmount.value = String(gib);
+			resourcesMemUnit.value = "GiB";
+		} else {
+			resourcesMemAmount.value = String(Math.round(cfg.memLimit / 1024 ** 2));
+			resourcesMemUnit.value = "MiB";
+		}
+	} else {
+		resourcesMemAmount.value = "";
+		resourcesMemUnit.value = "GiB";
+	}
+	if (cfg.idleTtlSeconds) {
+		if (cfg.idleTtlSeconds % 3600 === 0) {
+			resourcesIdleAmount.value = String(cfg.idleTtlSeconds / 3600);
+			resourcesIdleUnit.value = "hours";
+		} else {
+			resourcesIdleAmount.value = String(Math.round(cfg.idleTtlSeconds / 60));
+			resourcesIdleUnit.value = "minutes";
+		}
+	} else {
+		resourcesIdleAmount.value = "";
+		resourcesIdleUnit.value = "minutes";
+	}
+
+	// Ports — round-trip from the wire shape's `{container,public}`
+	// back to `PortRow` shape (string container for the input).
+	portRows = (cfg.ports ?? []).map((p) => ({
+		id: newPortRowId(),
+		container: String(p.container),
+		public: p.public,
+	}));
+	renderPortRows();
+	allowPrivilegedPortsCheckbox.checked = cfg.allowPrivilegedPorts === true;
+}
+
 // ── Ports tab (#190 / PR 190d) ──────────────────────────────────────────────
 //
 // Mirror of the env-tab pattern. Rows hold `{ container, public }` plus a
@@ -2581,6 +2834,8 @@ document.addEventListener("keydown", (e) => {
 		closeSaveTemplateModal();
 	} else if (newSessionModal.classList.contains("open")) {
 		closeNewSessionModal();
+	} else if (templatesModal.classList.contains("open")) {
+		closeTemplatesModal();
 	} else if (invitesModal.classList.contains("open")) {
 		closeInvitesModal();
 	} else if (pasteModal.classList.contains("open")) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2501,7 +2501,13 @@ document.addEventListener("keydown", (e) => {
 		invitesModal.classList.contains("open") ||
 		pasteModal.classList.contains("open") ||
 		actionsMenu.classList.contains("open") ||
-		newSessionModal.classList.contains("open")
+		newSessionModal.classList.contains("open") ||
+		// Both templates modals (the listing page and the
+		// save-as-template dialog) need the same guard or pressing
+		// Escape with one of them open AND the sidebar visible
+		// would close both at once. PR #230 round 1 NIT.
+		templatesModal.classList.contains("open") ||
+		saveTemplateModal.classList.contains("open")
 	)
 		return;
 	if (!mainEl.classList.contains("sidebar-open")) return;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -23,6 +23,7 @@ import {
 	getTemplate,
 	type Invite,
 	InviteRequiredError,
+	idleSecondsToFormUnit,
 	isAdmin,
 	isLoggedIn,
 	listInvites,
@@ -31,6 +32,7 @@ import {
 	listTemplates,
 	login,
 	logout,
+	memBytesToFormUnit,
 	openBootstrapWs,
 	register,
 	revokeInvite,
@@ -2079,7 +2081,16 @@ templatesList.addEventListener("click", (e) => {
 	const id = card?.dataset.templateId;
 	if (!id) return;
 	if (action === "use") {
-		void useTemplate(id);
+		// Disable the button before the in-flight `getTemplate` so a
+		// double-click can't fire two concurrent fetches that both
+		// race to apply config + close-and-open modals. Mirrors the
+		// `saveTemplateSubmit.disabled = true` shape on the save
+		// flow. PR #230 round 2 NIT.
+		const btn = target as HTMLButtonElement;
+		btn.disabled = true;
+		void useTemplate(id).finally(() => {
+			btn.disabled = false;
+		});
 	} else {
 		void deleteTemplateConfirmed(id, card!);
 	}
@@ -2194,27 +2205,18 @@ function applyTemplateToForm(t: Template): void {
 	// unit per field so the user sees the same values they would
 	// have typed.
 	resourcesCpuCores.value = cfg.cpuLimit ? String(cfg.cpuLimit / 1_000_000_000) : "";
-	if (cfg.memLimit) {
-		const gib = cfg.memLimit / 1024 ** 3;
-		if (Number.isInteger(gib) && gib >= 1) {
-			resourcesMemAmount.value = String(gib);
-			resourcesMemUnit.value = "GiB";
-		} else {
-			resourcesMemAmount.value = String(Math.round(cfg.memLimit / 1024 ** 2));
-			resourcesMemUnit.value = "MiB";
-		}
+	const mem = memBytesToFormUnit(cfg.memLimit);
+	if (mem) {
+		resourcesMemAmount.value = String(mem.amount);
+		resourcesMemUnit.value = mem.unit;
 	} else {
 		resourcesMemAmount.value = "";
 		resourcesMemUnit.value = "GiB";
 	}
-	if (cfg.idleTtlSeconds) {
-		if (cfg.idleTtlSeconds % 3600 === 0) {
-			resourcesIdleAmount.value = String(cfg.idleTtlSeconds / 3600);
-			resourcesIdleUnit.value = "hours";
-		} else {
-			resourcesIdleAmount.value = String(Math.round(cfg.idleTtlSeconds / 60));
-			resourcesIdleUnit.value = "minutes";
-		}
+	const idle = idleSecondsToFormUnit(cfg.idleTtlSeconds);
+	if (idle) {
+		resourcesIdleAmount.value = String(idle.amount);
+		resourcesIdleUnit.value = idle.unit;
 	} else {
 		resourcesIdleAmount.value = "";
 		resourcesIdleUnit.value = "minutes";


### PR DESCRIPTION
## Summary

Final PR for **#195 — Templates**. Adds the sidebar Templates entry, the listing modal, and the Use-template flow that pre-fills the create-session modal from a saved template.

## Changes

- **Sidebar:** new "Templates" button in the footer.
- **Templates modal:** lists the user's own templates via GET /api/templates (summary shape from 195a — no full config). Each card has Use + Delete.
- **Use flow:** fetches full template via GET /api/templates/:id, closes templates modal, opens create-session modal, and applies the config to the form via `applyTemplateToForm`. Toast prompts the user to fill in any required secrets.
- **Pre-fill helper** reverses each collector's field mapping:
  - `secret-slot` envVars collapse back to `type:"secret"` with empty values (user types each before submit; backend's `.min(1)` 400s on empty);
  - PAT / SSH-key fields stay empty when the template only carried the auth declaration (the strip helper drops the credential, the schema's `allowMissingAuth: true` accepts the declaration on its own);
  - advanced fields (gitIdentity, dotfiles, agentSeed, postCreate/postStart) round-trip directly;
  - resources: nano-CPUs → cores, bytes → GiB/MiB, seconds → hours/minutes (picking the most-natural unit);
  - ports + allowPrivilegedPorts round-trip via the existing PortRow shape.
- **Escape priority:** the topmost-first chain handles the templates modal.
- **CSS:** `.template-card` + actions, with the same red-on-hover delete treatment the Env tab uses.

## Out of scope (deferred)

- **Edit template** — would re-purpose the create-session modal as a template editor; non-trivial state-model change. Delete + re-create covers the immediate need; clean follow-up issue if it becomes a pain.
- **Save-from-running-session** — this app has no detail view (sessions are sidebar entries), so the issue's second entry point has no obvious UI surface in the current product.

## Test plan

- [x] `cd frontend && npm run lint / build / test` — 54 still pass (no new tests; the strip helper already has unit coverage in 195b, the pre-fill flow is interactive and tested by clicking through).
- [x] `cd backend && npm test` — 598 still pass (no backend source touched).

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)