### PR TITLE
refactor(backend): consolidate parseD1Utc into shared module

### DIFF
--- a/backend/src/d1Time.test.ts
+++ b/backend/src/d1Time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseD1Utc } from "./d1Time";
+import { parseD1Utc } from "./d1Time.js";
 
 describe("parseD1Utc", () => {
 	it("treats suffix-less D1 timestamp as UTC, not local time", () => {

--- a/backend/src/d1Time.test.ts
+++ b/backend/src/d1Time.test.ts
@@ -3,8 +3,8 @@ import { parseD1Utc } from "./d1Time";
 
 describe("parseD1Utc", () => {
 	it("treats suffix-less D1 timestamp as UTC, not local time", () => {
-		// 2024-01-01 10:00:00 — D1's exact wire shape. We assert via
-		// `getTime()` because the test must be timezone-independent.
+		// 2024-01-01 10:00:00 — D1's exact wire shape. Assert via
+		// `toISOString()` (always UTC) so the test is timezone-independent.
 		const d = parseD1Utc("2024-01-01 10:00:00");
 		expect(d.toISOString()).toBe("2024-01-01T10:00:00.000Z");
 	});

--- a/backend/src/d1Time.test.ts
+++ b/backend/src/d1Time.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseD1Utc } from "./d1Time";
+
+describe("parseD1Utc", () => {
+	it("treats suffix-less D1 timestamp as UTC, not local time", () => {
+		// 2024-01-01 10:00:00 — D1's exact wire shape. We assert via
+		// `getTime()` because the test must be timezone-independent.
+		const d = parseD1Utc("2024-01-01 10:00:00");
+		expect(d.toISOString()).toBe("2024-01-01T10:00:00.000Z");
+	});
+
+	it("preserves an explicit Z suffix without doubling", () => {
+		const d = parseD1Utc("2024-01-01T10:00:00Z");
+		expect(d.toISOString()).toBe("2024-01-01T10:00:00.000Z");
+	});
+
+	it("preserves an explicit offset suffix", () => {
+		const d = parseD1Utc("2024-01-01T10:00:00+00:00");
+		expect(d.toISOString()).toBe("2024-01-01T10:00:00.000Z");
+	});
+
+	it("throws on garbage input", () => {
+		expect(() => parseD1Utc("not-a-date")).toThrow(/D1: unparseable timestamp/);
+	});
+
+	it("includes the caller-supplied context in the error", () => {
+		expect(() => parseD1Utc("not-a-date", "templates")).toThrow(/templates: unparseable timestamp/);
+	});
+});

--- a/backend/src/d1Time.ts
+++ b/backend/src/d1Time.ts
@@ -1,0 +1,24 @@
+// ── d1Time ──────────────────────────────────────────────────────────────────
+//
+// D1's `datetime('now')` returns SQLite's canonical UTC format
+// (`YYYY-MM-DD HH:MM:SS`) with no `Z`, no offset, nothing. Node's `new Date()`
+// treats suffix-less ISO strings as LOCAL time on every engine — so a row
+// written at `2024-01-01 10:00:00` (UTC, from D1) becomes a `Date` three
+// hours off on a UTC-3 machine. Append `Z` unless the value already carries
+// a suffix; double-`Z` parses as `Invalid Date` and silently `NaN`s.
+//
+// Three modules independently grew this same helper (sessionManager,
+// sessionConfig, templates) — consolidate so a future migration that
+// changes D1's timestamp shape is a one-file fix.
+
+export function parseD1Utc(raw: string, context = "D1"): Date {
+	const hasSuffix = /[zZ]$/.test(raw) || /[+-]\d{2}:?\d{2}$/.test(raw);
+	const d = new Date(hasSuffix ? raw : `${raw}Z`);
+	if (Number.isNaN(d.getTime())) {
+		// Crash loudly here rather than letting an `Invalid Date` propagate
+		// — once it serialises through `toJSON()` it becomes `null` and the
+		// failure shows up far away from this module.
+		throw new Error(`${context}: unparseable timestamp ${raw}`);
+	}
+	return d;
+}

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -19,6 +19,7 @@
  */
 
 import { z } from "zod";
+import { parseD1Utc } from "./d1Time.js";
 import { d1Query } from "./db.js";
 import { checkEnvVarSafety, EnvVarValidationError } from "./envVarValidation.js";
 import { logger } from "./logger.js";
@@ -1106,7 +1107,7 @@ function rowToRecord(row: SessionConfigRow): SessionConfigRecord {
 			"agent_seed_json",
 			row.agent_seed_json,
 		),
-		bootstrappedAt: row.bootstrapped_at ? parseD1Utc(row.bootstrapped_at) : null,
+		bootstrappedAt: row.bootstrapped_at ? parseD1Utc(row.bootstrapped_at, "session_configs") : null,
 	};
 }
 
@@ -1374,19 +1375,6 @@ function isEncryptedBlob(v: unknown): v is { ciphertext: string; iv: string; tag
 	if (v === null || typeof v !== "object") return false;
 	const o = v as { ciphertext?: unknown; iv?: unknown; tag?: unknown };
 	return typeof o.ciphertext === "string" && typeof o.iv === "string" && typeof o.tag === "string";
-}
-
-// Mirrors sessionManager.parseD1UtcTimestamp — D1's `datetime('now')` lacks
-// any timezone suffix and Node's Date treats suffix-less ISO strings as
-// LOCAL time. Append 'Z' unless the value already carries one (a future
-// migration could add it explicitly).
-function parseD1Utc(raw: string): Date {
-	const hasSuffix = /[zZ]$/.test(raw) || /[+-]\d{2}:?\d{2}$/.test(raw);
-	const d = new Date(hasSuffix ? raw : `${raw}Z`);
-	if (Number.isNaN(d.getTime())) {
-		throw new Error(`session_configs returned unparseable timestamp: ${raw}`);
-	}
-	return d;
 }
 
 /**

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -5,6 +5,7 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
+import { parseD1Utc } from "./d1Time.js";
 import { d1Query } from "./db.js";
 import { logger } from "./logger.js";
 import type { CreateSessionOpts, SessionMeta, SessionStatus } from "./types.js";
@@ -97,24 +98,6 @@ interface SessionRow {
 	last_connected_at: string | null;
 }
 
-// D1's `datetime('now')` returns SQLite's canonical UTC format — no 'Z' or
-// other timezone suffix. Node's Date parses that as LOCAL time, which is
-// wrong: a row written at 2024-01-01T10:00:00 (UTC, from D1) becomes a Date
-// 3h off on a UTC-3 machine. We append 'Z' to force UTC interpretation.
-// Guard the append in case D1 (or a future migration) ever returns a suffix
-// already — double-Z is an invalid date and silently NaNs. Also catch full
-// ISO 8601 offsets like `+00:00`.
-function parseD1UtcTimestamp(raw: string): Date {
-	const hasSuffix = /[zZ]$/.test(raw) || /[+-]\d{2}:?\d{2}$/.test(raw);
-	const d = new Date(hasSuffix ? raw : `${raw}Z`);
-	if (Number.isNaN(d.getTime())) {
-		// Better to crash loudly here than return "Invalid Date" that
-		// would later serialize to null in JSON.
-		throw new Error(`D1 returned unparseable timestamp: ${raw}`);
-	}
-	return d;
-}
-
 function rowToMeta(row: SessionRow): SessionMeta {
 	return {
 		sessionId: row.session_id,
@@ -126,8 +109,8 @@ function rowToMeta(row: SessionRow): SessionMeta {
 		cols: row.cols,
 		rows: row.rows,
 		envVars: JSON.parse(row.env_vars),
-		createdAt: parseD1UtcTimestamp(row.created_at),
-		lastConnectedAt: row.last_connected_at ? parseD1UtcTimestamp(row.last_connected_at) : null,
+		createdAt: parseD1Utc(row.created_at, "sessions"),
+		lastConnectedAt: row.last_connected_at ? parseD1Utc(row.last_connected_at, "sessions") : null,
 	};
 }
 

--- a/backend/src/templates.ts
+++ b/backend/src/templates.ts
@@ -17,6 +17,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { parseD1Utc } from "./d1Time.js";
 import { d1Query } from "./db.js";
 import { ForbiddenError, NotFoundError } from "./sessionManager.js";
 
@@ -100,23 +101,9 @@ function rowToTemplate(row: TemplateRow): Template {
 		name: row.name,
 		description: row.description,
 		config,
-		// `datetime('now')` produces SQLite's `YYYY-MM-DD HH:MM:SS`
-		// (UTC, no timezone suffix). `new Date()` interprets that as
-		// LOCAL time on most engines — the same trap `sessionConfig`
-		// works around with `parseD1Utc`. Mirror the fix here so
-		// timestamps stay UTC end-to-end.
-		createdAt: parseD1Utc(row.created_at),
-		updatedAt: parseD1Utc(row.updated_at),
+		createdAt: parseD1Utc(row.created_at, "templates"),
+		updatedAt: parseD1Utc(row.updated_at, "templates"),
 	};
-}
-
-function parseD1Utc(raw: string): Date {
-	const hasSuffix = /[zZ]$/.test(raw) || /[+-]\d{2}:?\d{2}$/.test(raw);
-	const d = new Date(hasSuffix ? raw : `${raw}Z`);
-	if (Number.isNaN(d.getTime())) {
-		throw new Error(`templates: unparseable timestamp ${raw}`);
-	}
-	return d;
 }
 
 /**
@@ -199,8 +186,8 @@ export async function listForUser(userId: string): Promise<TemplateSummary[]> {
 		ownerUserId: row.owner_user_id,
 		name: row.name,
 		description: row.description,
-		createdAt: parseD1Utc(row.created_at),
-		updatedAt: parseD1Utc(row.updated_at),
+		createdAt: parseD1Utc(row.created_at, "templates"),
+		updatedAt: parseD1Utc(row.updated_at, "templates"),
 	}));
 }
 


### PR DESCRIPTION
## Summary

Closes #232.

Three backend modules independently grew the same `parseD1Utc` helper to fix Node's local-time interpretation of D1's suffix-less `datetime('now')` output (`YYYY-MM-DD HH:MM:SS` is treated as local time, off by hours on non-UTC machines). Consolidate into `backend/src/d1Time.ts` with a single tested implementation; replace the three copies.

The helper accepts an optional `context` string (defaults to `"D1"`) so a corrupt-timestamp error still names the owning table — preserves the per-caller diagnostics each copy had.

## Test plan

- [x] `npm run lint` clean (backend)
- [x] `npm test` — 603 tests pass (5 new in `d1Time.test.ts`, 598 pre-existing)
- [x] `npm run build` — tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)