### PR TITLE
perf(dispatcher): cache port-mapping lookups (#238)

### DIFF
--- a/backend/src/portMappings.test.ts
+++ b/backend/src/portMappings.test.ts
@@ -10,6 +10,7 @@ const dbStubs = vi.hoisted(() => ({
 vi.mock("./db.js", () => dbStubs);
 
 import {
+	__resetDispatchCacheForTests,
 	clearPortMappings,
 	getPortMappings,
 	lookupDispatchTarget,
@@ -25,6 +26,7 @@ beforeEach(() => {
 		success: true,
 		meta: { changes: 0, duration: 0, last_row_id: 0 },
 	}));
+	__resetDispatchCacheForTests();
 });
 
 // ── parseInspectPorts ────────────────────────────────────────────────────
@@ -194,7 +196,7 @@ describe("lookupDispatchTarget", () => {
 
 	it("returns the typed target when the session is running and the mapping exists", async () => {
 		dbStubs.d1Query.mockImplementationOnce(async () => ({
-			results: [{ host_port: 32768, is_public: 0, user_id: "u-owner" }],
+			results: [{ container_port: 3000, host_port: 32768, is_public: 0, user_id: "u-owner" }],
 			success: true,
 			meta: { changes: 0, duration: 0, last_row_id: 0 },
 		}));
@@ -207,7 +209,7 @@ describe("lookupDispatchTarget", () => {
 
 	it("coerces is_public: 1 → true (the public-port branch)", async () => {
 		dbStubs.d1Query.mockImplementationOnce(async () => ({
-			results: [{ host_port: 32769, is_public: 1, user_id: "u-owner" }],
+			results: [{ container_port: 3000, host_port: 32769, is_public: 1, user_id: "u-owner" }],
 			success: true,
 			meta: { changes: 0, duration: 0, last_row_id: 0 },
 		}));
@@ -221,29 +223,154 @@ describe("lookupDispatchTarget", () => {
 		// slipped past NOT NULL, a string from a hand-edit) must
 		// also rehydrate to false — never accidentally true.
 		dbStubs.d1Query.mockImplementationOnce(async () => ({
-			results: [{ host_port: 32770, is_public: 0, user_id: "u-owner" }],
+			results: [{ container_port: 3000, host_port: 32770, is_public: 0, user_id: "u-owner" }],
 			success: true,
 			meta: { changes: 0, duration: 0, last_row_id: 0 },
 		}));
 		expect((await lookupDispatchTarget("sess-zero", 3000))?.isPublic).toBe(false);
 
 		dbStubs.d1Query.mockImplementationOnce(async () => ({
-			results: [{ host_port: 32771, is_public: 2, user_id: "u-owner" }],
+			results: [{ container_port: 3000, host_port: 32771, is_public: 2, user_id: "u-owner" }],
 			success: true,
 			meta: { changes: 0, duration: 0, last_row_id: 0 },
 		}));
 		expect((await lookupDispatchTarget("sess-weird", 3000))?.isPublic).toBe(false);
 	});
 
-	it("issues the JOIN with the running-status filter and bound params", async () => {
+	it("issues the JOIN with the running-status filter, keyed on session only", async () => {
 		// Locks the SQL shape so a rename of the status column or a
 		// dropped filter is caught immediately. The `running` literal
 		// in the SQL is the security gate — losing it would let the
 		// dispatcher proxy stopped/terminated sessions.
+		//
+		// Per-port WHERE was REMOVED in #238 — the cache populates the
+		// full session-scoped set in one round-trip and serves
+		// subsequent per-port lookups from memory. The bound params
+		// list is now session-only.
 		await lookupDispatchTarget("sess-1", 3000);
 		const [sql, params] = dbStubs.d1Query.mock.calls[0]!;
 		expect(sql).toMatch(/JOIN\s+sessions\s+s\s+ON\s+s\.session_id\s*=\s*spm\.session_id/i);
 		expect(sql).toMatch(/s\.status\s*=\s*'running'/);
-		expect(params).toEqual(["sess-1", 3000]);
+		expect(params).toEqual(["sess-1"]);
+	});
+});
+
+// ── Dispatch cache (#238) ────────────────────────────────────────────────
+//
+// The cache layer is hot-path-critical: a wrong invalidation lets a
+// stopped session keep proxying (security regression) and a missed
+// invalidation lets a stale host_port keep flowing (correctness
+// regression). These tests pin the contract.
+
+describe("lookupDispatchTarget cache (#238)", () => {
+	const sessionRow = (containerPort: number, hostPort: number, isPublic = 0) => ({
+		container_port: containerPort,
+		host_port: hostPort,
+		is_public: isPublic,
+		user_id: "u-owner",
+	});
+
+	it("repeated lookups against the same session hit D1 exactly once", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [sessionRow(3000, 32768)],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		for (let i = 0; i < 100; i++) {
+			await lookupDispatchTarget("sess-hot", 3000);
+		}
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("different ports for the same session share one D1 round-trip", async () => {
+		// The whole point of populating the full session set on first
+		// miss: a typical dev session has app + WS + asset proxy on
+		// distinct ports, all hit in close succession.
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [sessionRow(3000, 32768), sessionRow(5173, 32769), sessionRow(8080, 32770)],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const a = await lookupDispatchTarget("sess-multi", 3000);
+		const b = await lookupDispatchTarget("sess-multi", 5173);
+		const c = await lookupDispatchTarget("sess-multi", 8080);
+		expect(a?.hostPort).toBe(32768);
+		expect(b?.hostPort).toBe(32769);
+		expect(c?.hostPort).toBe(32770);
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns null for a port that doesn't exist in the cached set without re-querying", async () => {
+		// Negative result for an unknown port on a session that's
+		// otherwise live must not invalidate the cache — the cache
+		// captures the FULL set, so a port that isn't in it truly
+		// doesn't exist for that session at this moment.
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [sessionRow(3000, 32768)],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await lookupDispatchTarget("sess-partial", 3000);
+		const missing = await lookupDispatchTarget("sess-partial", 9999);
+		expect(missing).toBeNull();
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT cache an empty result (session not running / no mapping)", async () => {
+		// Caching the miss would extend the "session is starting"
+		// race window into a 30-second 404 wall — see header comment.
+		dbStubs.d1Query.mockImplementation(async () => ({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await lookupDispatchTarget("sess-empty", 3000);
+		await lookupDispatchTarget("sess-empty", 3000);
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(2);
+	});
+
+	it("setPortMappings invalidates the cache so the next lookup re-fetches", async () => {
+		// First lookup populates cache.
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [sessionRow(3000, 32768)],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await lookupDispatchTarget("sess-w", 3000);
+		// setPortMappings: 1 DELETE + 1 INSERT. Then the next lookup
+		// should miss cache and re-query.
+		dbStubs.d1Query.mockImplementation(async () => ({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await setPortMappings("sess-w", [{ containerPort: 3000, hostPort: 32999, isPublic: false }]);
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [sessionRow(3000, 32999)],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const got = await lookupDispatchTarget("sess-w", 3000);
+		expect(got?.hostPort).toBe(32999);
+	});
+
+	it("clearPortMappings invalidates so the next lookup re-fetches and returns null", async () => {
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [sessionRow(3000, 32768)],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await lookupDispatchTarget("sess-cl", 3000);
+		// Drop mappings: 1 DELETE.
+		await clearPortMappings("sess-cl");
+		// Subsequent D1 returns no rows (mappings gone, or session no
+		// longer running — either collapses to null per the contract).
+		dbStubs.d1Query.mockImplementation(async () => ({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const got = await lookupDispatchTarget("sess-cl", 3000);
+		expect(got).toBeNull();
 	});
 });

--- a/backend/src/portMappings.test.ts
+++ b/backend/src/portMappings.test.ts
@@ -11,6 +11,7 @@ vi.mock("./db.js", () => dbStubs);
 
 import {
 	__resetDispatchCacheForTests,
+	CACHE_TTL_MS,
 	clearPortMappings,
 	getPortMappings,
 	lookupDispatchTarget,
@@ -352,6 +353,32 @@ describe("lookupDispatchTarget cache (#238)", () => {
 		}));
 		const got = await lookupDispatchTarget("sess-w", 3000);
 		expect(got?.hostPort).toBe(32999);
+	});
+
+	it("expired entry triggers a fresh D1 call and re-populates the cache", async () => {
+		// PR #242 round 2 SHOULD-FIX. Without this test the TTL-expiry
+		// branch was unreached: a regression that flipped `>` to `>=`
+		// or moved the pre-delete after the await would leave entries
+		// either never expiring or lingering as stale forever, and
+		// nothing would have caught it.
+		vi.useFakeTimers();
+		try {
+			dbStubs.d1Query.mockImplementation(async () => ({
+				results: [sessionRow(3000, 32768)],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			}));
+			await lookupDispatchTarget("sess-ttl", 3000);
+			expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+
+			// Advance past TTL — same shape `setTimeout` users would see.
+			vi.advanceTimersByTime(CACHE_TTL_MS + 1);
+
+			await lookupDispatchTarget("sess-ttl", 3000);
+			expect(dbStubs.d1Query).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("clearPortMappings invalidates so the next lookup re-fetches and returns null", async () => {

--- a/backend/src/portMappings.ts
+++ b/backend/src/portMappings.ts
@@ -58,7 +58,10 @@ import { d1Query } from "./db.js";
 // after a "miss". Caching the miss would amplify "session is starting"
 // race windows into a 30-second 404 wall.
 
-const CACHE_TTL_MS = 30_000;
+/** Exported for the test suite — the TTL-expiry test pins behaviour
+ *  against this value rather than a magic 30_001 literal that would
+ *  silently coast through a future TTL change. */
+export const CACHE_TTL_MS = 30_000;
 
 interface CacheEntry {
 	byContainerPort: Map<number, DispatchTarget>;

--- a/backend/src/portMappings.ts
+++ b/backend/src/portMappings.ts
@@ -185,8 +185,12 @@ export async function lookupDispatchTarget(
 		return cached.byContainerPort.get(containerPort) ?? null;
 	}
 	if (cached) {
-		// Expired entry — drop before re-fetch so a concurrent invalidate
-		// from `setPortMappings` doesn't race against our re-population.
+		// Expired entry — drop before the await so an empty D1 result
+		// (session stopped, no mappings) leaves a clean map. Without
+		// this, the empty-result branch below returns null without
+		// touching the cache, and the stale expired entry would
+		// linger forever for any session that's been stopped without
+		// a paired `clearPortMappings` invalidation having fired.
 		cache.delete(sessionId);
 	}
 	// Fetch the FULL set of dispatch targets for this session in one

--- a/backend/src/portMappings.ts
+++ b/backend/src/portMappings.ts
@@ -21,6 +21,65 @@
 
 import { d1Query } from "./db.js";
 
+// ── Dispatch-target cache (#238) ────────────────────────────────────────────
+//
+// The dispatcher's hot path is `lookupDispatchTarget(sessionId, port)` —
+// called per request to `https://p<port>-<sessionId>.<base>`. CLAUDE.md is
+// explicit that every `d1Query` is an HTTP round-trip to Cloudflare; without
+// a cache, hot-reload spam against a Vite dev server (~one request per file
+// edit, plus all the asset follow-ups) burns one D1 round-trip per asset
+// even though the row hasn't changed.
+//
+// Cache shape: `Map<sessionId, { byContainerPort, expiresAt }>` where
+// `byContainerPort` is the FULL set of dispatch targets for the running
+// session. We populate the whole set on first miss because:
+//   - the SELECT cost of `WHERE session_id = ?` (no port filter) is the
+//     same one round-trip as the per-port shape, and
+//   - typical dev-loop traffic hits 2–3 ports for the same session in
+//     close succession (app + WS + asset proxy), so per-port caching
+//     would still incur 2–3 D1 hits where per-session caching incurs 1.
+//
+// Invalidation is event-driven: `setPortMappings` and `clearPortMappings`
+// (the only writers, called from spawn / startContainer / reconcile / kill
+// / stopContainer) call `invalidateCache` before AND after their D1 work.
+// Before-and-after is belt-and-suspenders: a concurrent lookup that lands
+// between the DELETE and the first INSERT in `setPortMappings` would
+// otherwise re-populate the cache from the half-updated table; the
+// post-write invalidate clears that.
+//
+// TTL is the safety net for the unusual case where someone mutates the
+// table out-of-band (e.g. a manual SQL edit during debugging) — bounded
+// at 30 s so an operator running an experiment doesn't have to restart
+// the backend to see their change.
+//
+// Negative results (no row, or session not running) are NOT cached —
+// the dispatcher's per-IP rate limit is the throttle for probe traffic,
+// and a session that just spawned could land in the table milliseconds
+// after a "miss". Caching the miss would amplify "session is starting"
+// race windows into a 30-second 404 wall.
+
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+	byContainerPort: Map<number, DispatchTarget>;
+	expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function invalidateCache(sessionId: string): void {
+	cache.delete(sessionId);
+}
+
+/** Test seam: drop every cached entry. The dispatcher tests that swap
+ *  `lookupDispatchTarget` with a stub never go through the cache, but
+ *  unit tests that exercise the cache directly need a clean slate per
+ *  case. Not exported into the public API surface — only re-exported
+ *  via the named import path the test file uses. */
+export function __resetDispatchCacheForTests(): void {
+	cache.clear();
+}
+
 export interface PortMapping {
 	containerPort: number;
 	hostPort: number;
@@ -59,6 +118,9 @@ export interface DispatchTarget {
  * a torn read from proxying to a stale host port in the meantime.
  */
 export async function setPortMappings(sessionId: string, mappings: PortMapping[]): Promise<void> {
+	// Invalidate before AND after the D1 work — see the cache header
+	// comment for the concurrent-lookup race this defends against.
+	invalidateCache(sessionId);
 	await d1Query("DELETE FROM sessions_port_mappings WHERE session_id = ?", [sessionId]);
 	for (const m of mappings) {
 		await d1Query(
@@ -66,6 +128,7 @@ export async function setPortMappings(sessionId: string, mappings: PortMapping[]
 			[sessionId, m.containerPort, m.hostPort, m.isPublic ? 1 : 0],
 		);
 	}
+	invalidateCache(sessionId);
 }
 
 /**
@@ -93,7 +156,9 @@ export async function getPortMappings(sessionId: string): Promise<PortMapping[]>
 
 /** Drop all mappings for `sessionId`. Idempotent — no-op if none exist. */
 export async function clearPortMappings(sessionId: string): Promise<void> {
+	invalidateCache(sessionId);
 	await d1Query("DELETE FROM sessions_port_mappings WHERE session_id = ?", [sessionId]);
+	invalidateCache(sessionId);
 }
 
 /**
@@ -114,24 +179,50 @@ export async function lookupDispatchTarget(
 	sessionId: string,
 	containerPort: number,
 ): Promise<DispatchTarget | null> {
+	const now = Date.now();
+	const cached = cache.get(sessionId);
+	if (cached && cached.expiresAt > now) {
+		return cached.byContainerPort.get(containerPort) ?? null;
+	}
+	if (cached) {
+		// Expired entry — drop before re-fetch so a concurrent invalidate
+		// from `setPortMappings` doesn't race against our re-population.
+		cache.delete(sessionId);
+	}
+	// Fetch the FULL set of dispatch targets for this session in one
+	// round-trip. Same JOIN as before, minus the per-port WHERE clause —
+	// the per-port lookup is satisfied from the populated map below. This
+	// shape means a follow-up `lookupDispatchTarget(sessionId, otherPort)`
+	// hits the cache instead of issuing a second D1 call.
 	const result = await d1Query<{
+		container_port: number;
 		host_port: number;
 		is_public: number;
 		user_id: string;
 	}>(
-		`SELECT spm.host_port, spm.is_public, s.user_id
+		`SELECT spm.container_port, spm.host_port, spm.is_public, s.user_id
 		 FROM sessions_port_mappings spm
 		 JOIN sessions s ON s.session_id = spm.session_id
-		 WHERE spm.session_id = ? AND spm.container_port = ? AND s.status = 'running'`,
-		[sessionId, containerPort],
+		 WHERE spm.session_id = ? AND s.status = 'running'`,
+		[sessionId],
 	);
-	const row = result.results[0];
-	if (!row) return null;
-	return {
-		hostPort: row.host_port,
-		isPublic: row.is_public === 1,
-		ownerUserId: row.user_id,
-	};
+	if (result.results.length === 0) {
+		// Not cached — see header comment. A session that just spawned
+		// could land in the table milliseconds later; caching the miss
+		// would extend the "session is starting" race window into a
+		// 30-second wall.
+		return null;
+	}
+	const byContainerPort = new Map<number, DispatchTarget>();
+	for (const row of result.results) {
+		byContainerPort.set(row.container_port, {
+			hostPort: row.host_port,
+			isPublic: row.is_public === 1,
+			ownerUserId: row.user_id,
+		});
+	}
+	cache.set(sessionId, { byContainerPort, expiresAt: now + CACHE_TTL_MS });
+	return byContainerPort.get(containerPort) ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #238.

Adds an in-memory cache layer for `lookupDispatchTarget` so the dispatcher's hot path doesn't issue a D1 round-trip per request. CLAUDE.md is explicit that every `d1Query` is an HTTP round-trip to Cloudflare; without a cache, a Vite-style dev-server reload spam (one request per asset) burns one D1 call per asset even though the row hasn't changed.

## Cache shape

- `Map<sessionId, { byContainerPort, expiresAt }>` — keyed by session, populated with the FULL set of dispatch targets on first miss, so a follow-up lookup for a different port (app on 3000 + Vite HMR on 5173 + asset proxy on 8080 in close succession) hits memory.
- 30s TTL safety net for out-of-band SQL edits during operator experiments.
- **Negative results not cached** — caching the miss would extend the "session is starting" race window into a 30-second 404 wall. Per-IP rate limit on the dispatcher is the throttle for probe traffic.

## Invalidation

Event-driven, not TTL-only:

- `setPortMappings(sessionId, ...)` invalidates **before AND after** the D1 work. Post-write is the one that matters; pre-write is belt-and-suspenders against a concurrent lookup landing between the DELETE and the first INSERT in the multi-statement sequence.
- `clearPortMappings(sessionId)` invalidates with the same shape.
- Hard delete via FK CASCADE is covered because `kill()` calls `clearPortMappings` first.

## SQL shape change

The query moves from `WHERE spm.session_id = ? AND spm.container_port = ?` to `WHERE spm.session_id = ?` — the per-port filter is satisfied from the populated cache instead. The pinned `s.status = 'running'` security gate stays (a regression there would let the dispatcher proxy stopped sessions; the test suite locks the SQL shape so this can't drift unnoticed).

## Test plan

- [x] `npm run lint` clean (backend)
- [x] `npm test` — 609 tests pass (6 new cache-behaviour tests + 17 existing portMappings tests + 586 elsewhere)

New tests pin:

- 100 same-session lookups → 1 D1 call
- 3 different-port lookups on same session → 1 D1 call
- Unknown port returns null without re-query
- Empty result NOT cached (next call re-queries)
- `setPortMappings` invalidates
- `clearPortMappings` invalidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)