### PR TITLE
perf(auth): cache session ownership lookups (#239)

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -738,7 +738,7 @@ export function buildRouter(
 	router.post("/sessions/:id/stop", async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
 		try {
-			await sessions.assertOwnership(req.params.id, userId);
+			await sessions.assertOwnedBy(req.params.id, userId);
 			await docker.stopContainer(req.params.id);
 			// Same `forget` rationale as DELETE above: a stopped
 			// session shouldn't sit in the activity map collecting
@@ -817,7 +817,7 @@ export function buildRouter(
 			throw err;
 		}
 		try {
-			await sessions.assertOwnership(req.params.id, userId);
+			await sessions.assertOwnedBy(req.params.id, userId);
 			await sessions.updateEnvVars(req.params.id, validatedEnvVars);
 			const updated = await sessions.get(req.params.id);
 			if (!updated) {
@@ -840,7 +840,7 @@ export function buildRouter(
 	router.get("/sessions/:id/tabs", async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
 		try {
-			await sessions.assertOwnership(req.params.id, userId);
+			await sessions.assertOwnedBy(req.params.id, userId);
 			const tabs = await docker.listTabs(req.params.id);
 			res.json(tabs);
 		} catch (err) {
@@ -862,7 +862,7 @@ export function buildRouter(
 			return;
 		}
 		try {
-			await sessions.assertOwnership(req.params.id, userId);
+			await sessions.assertOwnedBy(req.params.id, userId);
 			const tab = await docker.createTab(req.params.id, label as string | undefined);
 			res.status(201).json(tab);
 		} catch (err) {
@@ -874,7 +874,7 @@ export function buildRouter(
 		const { userId } = req as AuthedRequest;
 		const { id, tabId } = req.params;
 		try {
-			await sessions.assertOwnership(id, userId);
+			await sessions.assertOwnedBy(id, userId);
 
 			// Closing all tabs is allowed — the container lifecycle is
 			// independent of tmux now, so a session with zero tabs is a
@@ -1018,7 +1018,7 @@ export function buildRouter(
 		next: NextFunction,
 	): Promise<void> => {
 		try {
-			await sessions.assertOwnership(req.params.id, (req as AuthedRequest).userId);
+			await sessions.assertOwnedBy(req.params.id, (req as AuthedRequest).userId);
 			next();
 		} catch (err) {
 			handleSessionError(err, res);

--- a/backend/src/sessionManager.test.ts
+++ b/backend/src/sessionManager.test.ts
@@ -18,11 +18,34 @@ const dbStubs = vi.hoisted(() => ({
 }));
 vi.mock("./db.js", () => dbStubs);
 
-import { SessionManager } from "./sessionManager.js";
+import {
+	ForbiddenError,
+	NotFoundError,
+	OWNERSHIP_CACHE_MAX,
+	OWNERSHIP_CACHE_TTL_MS,
+	SessionManager,
+} from "./sessionManager.js";
 
 beforeEach(() => {
 	dbStubs.d1Query.mockReset();
 });
+
+// Helper: a fully-formed `sessions` row that `rowToMeta` can handle.
+function fakeSessionRow(sessionId: string, userId: string) {
+	return {
+		session_id: sessionId,
+		user_id: userId,
+		name: "test",
+		status: "running",
+		container_id: null,
+		container_name: "st-test",
+		cols: 80,
+		rows: 24,
+		env_vars: "{}",
+		created_at: "2026-05-09 02:00:00",
+		last_connected_at: null,
+	};
+}
 
 describe("SessionManager.create — quota filter", () => {
 	it("excludes both 'terminated' and 'failed' rows from the quota count", async () => {
@@ -68,5 +91,163 @@ describe("SessionManager.create — quota filter", () => {
 		// `failed` exclusion).
 		expect(insertSql).toMatch(/'terminated'/);
 		expect(insertSql).toMatch(/'failed'/);
+	});
+});
+
+// ── Ownership cache (#239) ─────────────────────────────────────────────────
+
+describe("SessionManager.assertOwnedBy / assertOwnership cache", () => {
+	it("populates the cache on first assertOwnedBy and serves the second from memory", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+		// Second call hits cache — no new D1 round-trip.
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("assertOwnedBy short-circuits foreign-user requests via cache (negative fast path)", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		// Prime the cache with a successful assert.
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+		// Foreign user — should 403 from cache, no D1 call.
+		await expect(mgr.assertOwnedBy("s-1", "u-foreigner")).rejects.toBeInstanceOf(ForbiddenError);
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("assertOwnership populates the cache as a side effect", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const meta = await mgr.assertOwnership("s-1", "u-owner");
+		expect(meta.userId).toBe("u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+		// Now an assertOwnedBy for the same session is a cache hit.
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("assertOwnership short-circuits foreign-user requests via cache without fetching meta", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		// Foreign user via assertOwnership — short-circuits without
+		// the `getOrThrow` D1 call. (The positive case can't
+		// short-circuit — caller needs fresh meta — but the negative
+		// case absolutely can.)
+		await expect(mgr.assertOwnership("s-1", "u-foreigner")).rejects.toBeInstanceOf(ForbiddenError);
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT cache negative results (no row, session never existed)", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValue({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await expect(mgr.assertOwnedBy("s-missing", "u")).rejects.toBeInstanceOf(NotFoundError);
+		await expect(mgr.assertOwnedBy("s-missing", "u")).rejects.toBeInstanceOf(NotFoundError);
+		// Caching the miss would extend a "session is starting" race
+		// window (a session that just spawned would 404 from cache for
+		// the TTL). Both calls must hit D1.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(2);
+	});
+
+	it("deleteRow invalidates the cache so the next assert hits D1 with the fresh state", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		// deleteRow is the only mutator that affects ownership today.
+		// 1 D1 call for the DELETE.
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 1, duration: 0, last_row_id: 0 },
+		});
+		await mgr.deleteRow("s-1");
+		// Subsequent assert must re-fetch — and find no row.
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await expect(mgr.assertOwnedBy("s-1", "u-owner")).rejects.toBeInstanceOf(NotFoundError);
+		// 1 (initial) + 1 (DELETE) + 1 (re-fetch) = 3.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(3);
+	});
+
+	it("expired entry triggers a fresh D1 call and re-populates the cache", async () => {
+		const mgr = new SessionManager();
+		vi.useFakeTimers();
+		try {
+			dbStubs.d1Query.mockResolvedValue({
+				results: [fakeSessionRow("s-ttl", "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			});
+			await mgr.assertOwnedBy("s-ttl", "u-owner");
+			expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+			vi.advanceTimersByTime(OWNERSHIP_CACHE_TTL_MS + 1);
+			await mgr.assertOwnedBy("s-ttl", "u-owner");
+			expect(dbStubs.d1Query).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("evicts oldest entry when cap is reached so memory is bounded", async () => {
+		// Fill cache to OWNERSHIP_CACHE_MAX, then add one more — first
+		// inserted must be evicted. We test the eviction by seeing the
+		// evicted session re-issue a D1 call on next assert (i.e. it's
+		// no longer in cache).
+		const mgr = new SessionManager();
+		// Prime first session.
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-first", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await mgr.assertOwnedBy("s-first", "u-owner");
+
+		// Fill the rest with distinct ids; default mock returns the
+		// matching row so we don't need per-call mocks.
+		dbStubs.d1Query.mockImplementation(async (_sql, params) => {
+			const sid = (params as unknown[] | undefined)?.[0] as string;
+			return {
+				results: [fakeSessionRow(sid, "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			};
+		});
+		for (let i = 0; i < OWNERSHIP_CACHE_MAX; i++) {
+			await mgr.assertOwnedBy(`s-fill-${i}`, "u-owner");
+		}
+		// Initial s-first should now be evicted; assert re-issues a call.
+		const callsBefore = dbStubs.d1Query.mock.calls.length;
+		await mgr.assertOwnedBy("s-first", "u-owner");
+		expect(dbStubs.d1Query.mock.calls.length).toBeGreaterThan(callsBefore);
 	});
 });

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -277,6 +277,14 @@ export class SessionManager {
 		if (cached && cached.expiresAt > now && cached.ownerUserId !== userId) {
 			throw new ForbiddenError();
 		}
+		if (cached && cached.expiresAt <= now) {
+			// Mirror the `assertOwnedBy` cleanup: drop expired entries
+			// before the await so a `getOrThrow` that throws NotFoundError
+			// (session hard-deleted) leaves a clean map. Without this, a
+			// missed `deleteRow` invalidation would let a stale entry
+			// linger for the full eviction-cap rollover.
+			this.ownershipCache.delete(sessionId);
+		}
 		const meta = await this.getOrThrow(sessionId);
 		this.cacheOwnership(sessionId, meta.userId);
 		if (meta.userId !== userId) throw new ForbiddenError();
@@ -299,12 +307,6 @@ export class SessionManager {
 			ownerUserId,
 			expiresAt: Date.now() + OWNERSHIP_CACHE_TTL_MS,
 		});
-	}
-
-	/** Test seam: drop every cached entry. Production code never calls
-	 *  this — invalidation runs through `deleteRow`. */
-	__resetOwnershipCacheForTests(): void {
-		this.ownershipCache.clear();
 	}
 
 	async listForUser(userId: string): Promise<SessionMeta[]> {

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -114,6 +114,50 @@ function rowToMeta(row: SessionRow): SessionMeta {
 	};
 }
 
+// ── Ownership cache (#239) ──────────────────────────────────────────────────
+//
+// `assertOwnership` and its void-return sibling `assertOwnedBy` are called
+// on every authed REST hit under `/api/sessions/:id` and on every WS attach.
+// CLAUDE.md is explicit: every `d1Query` is an HTTP round-trip to Cloudflare,
+// so this is the hottest auth-check path in the app and the natural target
+// for caching after the dispatcher cache (#238) shipped.
+//
+// What we cache: `(sessionId → ownerUserId)` only. The full SessionMeta
+// has mutable fields (status, container_id, last_connected_at, env_vars),
+// and broadening the cache to those would mean wiring an invalidation hook
+// into every UPDATE in this class — high blast radius for a small win.
+// Ownership, by contrast, is immutable in v1: there is no transfer flow,
+// no admin-takeover, no merge. The only way `user_id` can change is a
+// future feature, so the only invalidation we need today is `deleteRow`
+// dropping the entry on hard delete.
+//
+// What we don't cache: negative results (no row, foreign user). A miss
+// hits D1; the caller gets `NotFoundError` / `ForbiddenError`. Caching
+// negative results would amplify the "session is starting" race window
+// (a session that just spawned would 404 from cache for the TTL), and
+// the per-IP rate limit on the auth-bearing routes is the throttle for
+// probe traffic.
+//
+// Bounded at OWNERSHIP_CACHE_MAX entries with insertion-order eviction
+// (delete-then-insert refreshes a hot session's position so it doesn't
+// roll out under cap pressure). 1-hour TTL is the safety net — if a
+// future feature lands a transfer/admin-takeover path WITHOUT updating
+// the invalidation point here, the staleness window is bounded at the
+// TTL rather than the lifetime of the backend process.
+
+/** Exported for the test suite — pin TTL behaviour against the constant
+ *  rather than a magic literal that wouldn't surface a future change. */
+export const OWNERSHIP_CACHE_TTL_MS = 60 * 60 * 1000;
+/** Exported for the test suite — same shape as TTL. The default is
+ *  conservative: with a `users.MAX_ACTIVE_SESSIONS_PER_USER = 20` cap
+ *  and 500 users this caps memory at ~10k entries × ~80 bytes each. */
+export const OWNERSHIP_CACHE_MAX = 10_000;
+
+interface OwnershipCacheEntry {
+	ownerUserId: string;
+	expiresAt: number;
+}
+
 // ── SessionManager ──────────────────────────────────────────────────────────
 
 export class SessionManager {
@@ -190,10 +234,77 @@ export class SessionManager {
 		return meta;
 	}
 
-	async assertOwnership(sessionId: string, userId: string): Promise<SessionMeta> {
+	private readonly ownershipCache = new Map<string, OwnershipCacheEntry>();
+
+	/**
+	 * Auth-only check that doesn't return SessionMeta. Use this at every
+	 * call site that discards the return value of `assertOwnership` — the
+	 * cache short-circuits the D1 round-trip on a hit, where
+	 * `assertOwnership` always has to fetch fresh meta for the caller.
+	 *
+	 * Throws `NotFoundError` if the session row is gone, `ForbiddenError`
+	 * if the row exists but `user_id` doesn't match.
+	 */
+	async assertOwnedBy(sessionId: string, userId: string): Promise<void> {
+		const cached = this.ownershipCache.get(sessionId);
+		const now = Date.now();
+		if (cached && cached.expiresAt > now) {
+			if (cached.ownerUserId !== userId) throw new ForbiddenError();
+			return;
+		}
+		if (cached) {
+			// Expired entry — drop before the await so an empty D1 result
+			// (session hard-deleted) leaves a clean map. Without this,
+			// `getOrThrow` throws NotFoundError without ever touching
+			// the cache, and the stale expired entry would linger forever
+			// for any session whose `deleteRow` invalidation was missed.
+			this.ownershipCache.delete(sessionId);
+		}
 		const meta = await this.getOrThrow(sessionId);
+		this.cacheOwnership(sessionId, meta.userId);
+		if (meta.userId !== userId) throw new ForbiddenError();
+	}
+
+	async assertOwnership(sessionId: string, userId: string): Promise<SessionMeta> {
+		// Negative-result fast path: a cached owner that doesn't match the
+		// requested user → 403 without a D1 round-trip. The positive case
+		// CAN'T short-circuit here because the caller may use the returned
+		// SessionMeta (status, last_connected_at, container_id, env_vars all
+		// mutate). Callers that don't need the meta should call
+		// `assertOwnedBy` instead — that one short-circuits both directions.
+		const cached = this.ownershipCache.get(sessionId);
+		const now = Date.now();
+		if (cached && cached.expiresAt > now && cached.ownerUserId !== userId) {
+			throw new ForbiddenError();
+		}
+		const meta = await this.getOrThrow(sessionId);
+		this.cacheOwnership(sessionId, meta.userId);
 		if (meta.userId !== userId) throw new ForbiddenError();
 		return meta;
+	}
+
+	private cacheOwnership(sessionId: string, ownerUserId: string): void {
+		// Delete-then-insert refreshes Map insertion order so frequently-
+		// asserted sessions stay near the back and don't get evicted under
+		// cap pressure. JS Map preserves insertion order; deleting the
+		// first key (`keys().next().value`) is the LRU-by-access
+		// approximation a Map gives us without an explicit doubly-linked-
+		// list — adequate for the bounded-cache use case here.
+		this.ownershipCache.delete(sessionId);
+		if (this.ownershipCache.size >= OWNERSHIP_CACHE_MAX) {
+			const oldestKey = this.ownershipCache.keys().next().value;
+			if (oldestKey !== undefined) this.ownershipCache.delete(oldestKey);
+		}
+		this.ownershipCache.set(sessionId, {
+			ownerUserId,
+			expiresAt: Date.now() + OWNERSHIP_CACHE_TTL_MS,
+		});
+	}
+
+	/** Test seam: drop every cached entry. Production code never calls
+	 *  this — invalidation runs through `deleteRow`. */
+	__resetOwnershipCacheForTests(): void {
+		this.ownershipCache.clear();
 	}
 
 	async listForUser(userId: string): Promise<SessionMeta[]> {
@@ -259,6 +370,13 @@ export class SessionManager {
 	 * workspace data on disk.
 	 */
 	async deleteRow(sessionId: string): Promise<void> {
+		// Invalidate before AND after to defend against a concurrent
+		// assertOwnership landing between the cache delete and the D1
+		// DELETE. Pre-delete prevents a stale cache hit from succeeding
+		// while the row is being torn down; post-delete clears any cache
+		// state a concurrent assert populated during the await window.
+		this.ownershipCache.delete(sessionId);
 		await d1Query("DELETE FROM sessions WHERE session_id = ?", [sessionId]);
+		this.ownershipCache.delete(sessionId);
 	}
 }

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -374,7 +374,7 @@ async function handleBootstrapWs(
 	broadcaster: BootstrapBroadcaster,
 ): Promise<void> {
 	try {
-		await sessions.assertOwnership(sessionId, userId);
+		await sessions.assertOwnedBy(sessionId, userId);
 	} catch (err) {
 		if (err instanceof NotFoundError) {
 			sendError(ws, "Session not found");


### PR DESCRIPTION
## Summary

Closes #239.

Adds an in-memory `Map<sessionId, ownerUserId>` cache to `SessionManager` so the hottest auth path in the app — `assertOwnership` on every authed REST hit + WS attach — doesn't issue a D1 round-trip per call.

## API split

- **New: `assertOwnedBy(sessionId, userId): Promise<void>`** — for callers that don't need the returned `SessionMeta`. Cache short-circuits both directions: positive match → returns without D1, positive mismatch → throws `ForbiddenError` without D1. The 7 void-discard call sites migrate to this method (`wsHandler` bootstrap, `/stop`, `/env`, tabs CRUD, file-upload guard).
- **Existing: `assertOwnership(sessionId, userId): Promise<SessionMeta>`** — signature unchanged. The positive case still has to fetch fresh meta because `status`, `container_id`, `last_connected_at`, and `env_vars` all mutate. The negative case short-circuits via cache (a probe attacker hitting a foreign id 100x in a row burns 1 D1 call instead of 100).

## What's cached, what's not

- **Cached**: only `(sessionId → ownerUserId)`. Ownership is immutable in v1 — no transfer flow, no admin takeover. Broadening to full `SessionMeta` would mean wiring invalidation into every UPDATE on the table; the win wasn't worth the blast radius.
- **Not cached**: negative results (no row, foreign user). A miss hits D1, the caller gets NotFound/Forbidden. Caching negatives would amplify the "session is starting" race window.

## Bounding

- `OWNERSHIP_CACHE_MAX = 10_000` entries with insertion-order eviction.
- `OWNERSHIP_CACHE_TTL_MS = 1 hour` safety net — bounds staleness if a future transfer/admin-takeover feature lands without updating the invalidation point here.
- Delete-then-insert refreshes hot-session position so they don't roll out under cap pressure.

## Invalidation

`deleteRow(sessionId)` invalidates **before AND after** the D1 DELETE. Pre-delete prevents a stale cache hit from succeeding while the row is being torn down; post-delete clears any cache state a concurrent assert populated during the await window.

## Test plan

- [x] `npm run lint` clean (backend)
- [x] `npm test` — 618 tests pass (8 new + 610 existing)

New tests pin:

- `assertOwnedBy` populates cache; second call serves from memory
- `assertOwnedBy` short-circuits foreign-user (negative) on cache hit
- `assertOwnership` populates cache as a side effect
- `assertOwnership` short-circuits foreign-user without fetching meta
- Empty / not-found result NOT cached
- `deleteRow` invalidates → next assert hits D1 + `NotFoundError`
- TTL expiry triggers re-fetch (fake timers)
- Cap eviction drops oldest entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)