### PR TITLE
fix(compose): quote SECRETS_ENCRYPTION_KEY env line so YAML doesn't parse it as a map

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,11 @@ services:
       # crash-loops. The `:?` guard here surfaces the failure to
       # `docker compose up` directly so the operator sees it without
       # tailing container logs. Generate with: openssl rand -base64 32
-      - SECRETS_ENCRYPTION_KEY=${SECRETS_ENCRYPTION_KEY:?SECRETS_ENCRYPTION_KEY must be set in .env — generate with: openssl rand -base64 32 (see .env.example)}
+      # Single-quoted so YAML doesn't try to parse the `with: openssl`
+      # colon-space inside the `:?` error message as a map key. The
+      # JWT_SECRET line above gets away without quotes because its
+      # error message has no `key: value`-shaped fragment.
+      - 'SECRETS_ENCRYPTION_KEY=${SECRETS_ENCRYPTION_KEY:?SECRETS_ENCRYPTION_KEY must be set in .env — generate with openssl rand -base64 32 (see .env.example)}'
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
       # Defaults to "0" (trust nothing) so a direct-connection dev setup
       # can't be XFF-spoofed. Set to "1" in your .env when deploying behind


### PR DESCRIPTION
## Summary

Operator-blocking bug. \`docker compose up\` fails with:

\`\`\`
services.app.environment.[4]: unexpected type map[string]interface {}
\`\`\`

The 5th env entry on the \`app\` service is the \`SECRETS_ENCRYPTION_KEY\` line. Its \`\${VAR:?msg}\` error message embeds \`with: openssl\` — an unquoted colon-space — which the Compose YAML parser interprets as a \`key: value\` map node rather than part of the surrounding string.

## Fix

Two layers, intentionally redundant:

- Single-quote the entire list item so YAML treats the whole value as a literal string regardless of internal punctuation.
- Drop the colon after \"with\" in the error message body so even a future copy-paste that loses the quotes parses cleanly.

The \`JWT_SECRET\` line above gets away without quotes because its error text has no \`key: value\` fragment.

## Test plan

- [x] \`python3 yaml.safe_load(open('docker-compose.yml'))\` round-trips all 12 environment list items as strings.
- Manual: \`docker compose config\` should now succeed (verified by YAML parse — Docker isn't installed in this dev environment).

Latent since PR #210 introduced the \`:?\` guard around the SECRETS_ENCRYPTION_KEY env line — only trips on first \`docker compose up\` after the required-key change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)