### PR TITLE
feat(admin): GET /api/admin/stats with sessions-by-status (#241, PR 241a of 3)

### DIFF
--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -435,6 +435,7 @@ describe("auth route rate limiting", () => {
 			fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
 			logout: { ipMax: 1000, ipWindowMs: 60_000 },
 			authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+			adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
 			...cfg,
 		};
 		// rate-limit tests don't touch the bootstrap broadcaster — empty

--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -424,10 +424,11 @@ describe("auth route rate limiting", () => {
 		fileUpload?: { ipMax: number; ipWindowMs: number };
 		logout?: { ipMax: number; ipWindowMs: number };
 		authStatus?: { ipMax: number; ipWindowMs: number };
+		adminStats?: { ipMax: number; ipWindowMs: number };
 	}): Promise<void> {
-		// Invite + upload + logout + authStatus limiters were added later;
-		// default each to a permissive setting so tests that only exercise
-		// login/register don't trip them.
+		// Invite + upload + logout + authStatus + adminStats limiters were
+		// added later; default each to a permissive setting so tests that
+		// only exercise login/register don't trip them.
 		const fullCfg = {
 			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
 			invitesList: { ipMax: 1000, ipWindowMs: 60_000 },

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -150,13 +150,19 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 	// sustained — well above any realistic UI cadence (the frontend
 	// hits this once on first load), well below sustained abuse rates.
 	// See #148.
-	adminStats: {
-		ipMax: 120,
-		ipWindowMs: 60 * 60 * 1000,
-	},
 	authStatus: {
 		ipMax: 60,
 		ipWindowMs: 60 * 1000,
+	},
+	// 120/h per IP for /api/admin/stats. Sized like `invitesList`
+	// (the closest precedent — admin-only read endpoint that the
+	// UI may legitimately poll while a dashboard view is open).
+	// `requireAdmin` already gates by role, but a compromised admin
+	// browser tab in a polling loop should not be able to hammer
+	// the GROUP BY work the route does. See #241.
+	adminStats: {
+		ipMax: 120,
+		ipWindowMs: 60 * 60 * 1000,
 	},
 };
 

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -86,6 +86,17 @@ export interface RateLimitConfig {
 		ipMax: number;
 		ipWindowMs: number;
 	};
+	// Caps how often a single IP can hit the admin stats / cross-user
+	// endpoints (#241). Even though `requireAdmin` already gates by
+	// user role, an admin operator's compromised browser tab in a
+	// polling loop should not be able to hammer the GROUP BY +
+	// counter-readout work that the stats endpoint does. Sized like
+	// `invitesList` (the closest precedent — admin-only read endpoint
+	// the UI may legitimately poll while a modal is open).
+	adminStats: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
 }
 
 // Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
@@ -139,6 +150,10 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 	// sustained — well above any realistic UI cadence (the frontend
 	// hits this once on first load), well below sustained abuse rates.
 	// See #148.
+	adminStats: {
+		ipMax: 120,
+		ipWindowMs: 60 * 60 * 1000,
+	},
 	authStatus: {
 		ipMax: 60,
 		ipWindowMs: 60 * 1000,
@@ -156,6 +171,7 @@ export interface AuthRateLimiters {
 	fileUploadIp: RateLimitRequestHandler;
 	logoutIp: RateLimitRequestHandler;
 	authStatusIp: RateLimitRequestHandler;
+	adminStatsIp: RateLimitRequestHandler;
 }
 
 export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
@@ -228,6 +244,13 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many auth-status requests from this IP, try again later", scope: "ip" },
 	});
+	const adminStatsIp = rateLimit({
+		windowMs: cfg.adminStats.ipWindowMs,
+		limit: cfg.adminStats.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: { error: "Too many admin-stats requests from this IP, try again later", scope: "ip" },
+	});
 	return {
 		loginIp,
 		registerIp,
@@ -237,6 +260,7 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		fileUploadIp,
 		logoutIp,
 		authStatusIp,
+		adminStatsIp,
 	};
 }
 

--- a/backend/src/routes.admin.test.ts
+++ b/backend/src/routes.admin.test.ts
@@ -1,0 +1,203 @@
+/**
+ * routes.admin.test.ts — GET /api/admin/stats route tests for #241.
+ *
+ * Pins the wire shape (`bootedAt`, `uptimeSeconds`, `sessions.byStatus`)
+ * and the admin gate. The actual `countByStatus` SQL shape is pinned
+ * in `sessionManager.test.ts`; this file is the integration glue
+ * (rate limiter wiring, requireAdmin wiring, JSON shape contract).
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authStubs = vi.hoisted(() => ({
+	requireAuth: (req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	},
+	// vi.fn so tests can flip the admin gate per-case (the 403 path
+	// switches the impl to deny). Default is passthrough.
+	requireAdmin: vi.fn((req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	}),
+	AUTH_COOKIE_NAME: "st_token",
+	setAuthCookie: vi.fn(),
+	clearAuthCookie: vi.fn(),
+	extractTokenFromCookieHeader: vi.fn(() => null),
+	verifyJwt: vi.fn(() => null),
+	hasAnyUsers: vi.fn(async () => true),
+	registerUser: vi.fn(),
+	loginUser: vi.fn(),
+	listInvites: vi.fn(async () => [] as unknown[]),
+	createInvite: vi.fn(),
+	revokeInvite: vi.fn(),
+	InvalidCredentialsError: class extends Error {
+		constructor() {
+			super("invalid");
+		}
+	},
+	UsernameTakenError: class extends Error {
+		constructor() {
+			super("taken");
+		}
+	},
+	InviteRequiredError: class extends Error {
+		constructor() {
+			super("invite required");
+		}
+	},
+	InviteQuotaExceededError: class extends Error {
+		constructor() {
+			super("invite quota");
+		}
+	},
+}));
+vi.mock("./auth.js", () => authStubs);
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import type { BootstrapBroadcaster } from "./bootstrap.js";
+import type { DockerManager } from "./dockerManager.js";
+import { buildRouter } from "./routes.js";
+import type { SessionManager } from "./sessionManager.js";
+
+let server: http.Server | null = null;
+let baseUrl = "";
+
+afterEach(async () => {
+	if (server) {
+		await new Promise<void>((resolve, reject) => {
+			server?.close((e) => (e ? reject(e) : resolve()));
+		});
+		server = null;
+	}
+	authStubs.requireAdmin.mockReset();
+	authStubs.requireAdmin.mockImplementation((req, _res, next) => {
+		(req as { userId?: string }).userId = "u1";
+		next();
+	});
+});
+
+async function spinUp(countByStatus: ReturnType<typeof vi.fn>) {
+	const sessions = {
+		countByStatus,
+		// Guard: any other SessionManager method called by this route's
+		// path would be an unintended dependency. Throw so a future
+		// route addition that brings in `get` / `assertOwnership` /
+		// etc. fails the test loudly rather than silently passing
+		// undefined into the route handler.
+	} as unknown as SessionManager;
+	const docker = {
+		getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
+	} as unknown as DockerManager;
+	const broadcaster = {} as BootstrapBroadcaster;
+	const router = buildRouter(sessions, docker, broadcaster, {
+		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+		register: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+		logout: { ipMax: 1000, ipWindowMs: 60_000 },
+		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+	});
+	const app = express();
+	app.use(express.json());
+	app.use("/api", router);
+	const s = http.createServer(app);
+	server = s;
+	await new Promise<void>((resolve) => s.listen(0, "127.0.0.1", resolve));
+	const { port } = s.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+}
+
+describe("GET /api/admin/stats (#241a)", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+	});
+
+	it("returns the typed stats shape with bootedAt / uptimeSeconds / sessions.byStatus", async () => {
+		const countByStatus = vi.fn(async () => ({
+			running: 3,
+			stopped: 2,
+			terminated: 1,
+			failed: 0,
+		}));
+		await spinUp(countByStatus);
+
+		const res = await fetch(`${baseUrl}/api/admin/stats`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			bootedAt: string;
+			uptimeSeconds: number;
+			sessions: { byStatus: Record<string, number> };
+		};
+		// `bootedAt` is derived from process.uptime() — must be a parseable
+		// ISO string. The exact value depends on test-run timing, so we
+		// pin the type/parseability rather than a literal value.
+		expect(typeof body.bootedAt).toBe("string");
+		expect(Number.isNaN(Date.parse(body.bootedAt))).toBe(false);
+		// uptimeSeconds is a non-negative integer (rounded server-side).
+		expect(Number.isInteger(body.uptimeSeconds)).toBe(true);
+		expect(body.uptimeSeconds).toBeGreaterThanOrEqual(0);
+		// Counts pass through verbatim.
+		expect(body.sessions.byStatus).toEqual({
+			running: 3,
+			stopped: 2,
+			terminated: 1,
+			failed: 0,
+		});
+		expect(countByStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns 403 when requireAdmin denies the request (non-admin user)", async () => {
+		// Flip the admin gate to deny — mirrors the real `requireAdmin`
+		// behaviour for non-admin users.
+		authStubs.requireAdmin.mockImplementation((_req, res, _next) => {
+			(res as { status: (n: number) => { json: (body: unknown) => void } })
+				.status(403)
+				.json({ error: "Forbidden" });
+		});
+		const countByStatus = vi.fn(async () => ({
+			running: 0,
+			stopped: 0,
+			terminated: 0,
+			failed: 0,
+		}));
+		await spinUp(countByStatus);
+
+		const res = await fetch(`${baseUrl}/api/admin/stats`);
+		expect(res.status).toBe(403);
+		// Critical: countByStatus must NOT be invoked when the admin
+		// gate denies. A regression that ran the handler regardless
+		// would surface to a non-admin user as cross-user data leak.
+		expect(countByStatus).not.toHaveBeenCalled();
+	});
+
+	it("returns 500 with a generic error body when countByStatus throws", async () => {
+		// D1 transient error path. Don't leak the exception message
+		// (could include schema details) — generic body, full
+		// detail goes to logger.error.
+		const countByStatus = vi.fn(async () => {
+			throw new Error("D1 transient: connection reset");
+		});
+		await spinUp(countByStatus);
+
+		const res = await fetch(`${baseUrl}/api/admin/stats`);
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("Internal server error");
+		expect(body.error).not.toContain("D1 transient");
+	});
+});

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -165,11 +165,11 @@ async function spinUp(sessions: SessionManager, docker: DockerManager) {
 		register: { ipMax: 1000, ipWindowMs: 60_000 },
 		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
 		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
-		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
 		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
 		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
 		logout: { ipMax: 1000, ipWindowMs: 60_000 },
 		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
 	});
 	const app = express();
 	app.use(express.json());

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -165,6 +165,7 @@ async function spinUp(sessions: SessionManager, docker: DockerManager) {
 		register: { ipMax: 1000, ipWindowMs: 60_000 },
 		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
 		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
 		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
 		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
 		logout: { ipMax: 1000, ipWindowMs: 60_000 },

--- a/backend/src/routes.start.test.ts
+++ b/backend/src/routes.start.test.ts
@@ -140,6 +140,7 @@ async function spinUp(sessions: SessionManager, docker: DockerManager) {
 		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
 		logout: { ipMax: 1000, ipWindowMs: 60_000 },
 		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
 	});
 	const app = express();
 	app.use(express.json());

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -416,11 +416,18 @@ export function buildRouter(
 			// `Date.now()` at module load, so a long-running backend
 			// reports the actual boot wallclock even after monotonic
 			// clock skew has had time to drift from real time.
-			const uptimeSeconds = process.uptime();
+			//
+			// Round ONCE and reuse the same value for both fields so a
+			// client reconstructing `Date.now()` as
+			// `new Date(bootedAt).getTime() + uptimeSeconds * 1000`
+			// gets the same answer the server sees. Otherwise the
+			// rounded `uptimeSeconds` and the float-derived `bootedAt`
+			// disagree by up to 500 ms.
+			const uptimeSeconds = Math.round(process.uptime());
 			const bootedAt = new Date(Date.now() - uptimeSeconds * 1000).toISOString();
 			res.json({
 				bootedAt,
-				uptimeSeconds: Math.round(uptimeSeconds),
+				uptimeSeconds,
 				sessions: { byStatus },
 			});
 		} catch (err) {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -80,6 +80,7 @@ export function buildRouter(
 		fileUploadIp,
 		logoutIp,
 		authStatusIp,
+		adminStatsIp,
 	} = createAuthRateLimiters(rateLimitConfig);
 	const usernameLimiter = new UsernameRateLimiter(
 		rateLimitConfig.login.usernameMax,
@@ -292,6 +293,7 @@ export function buildRouter(
 	router.use("/invites", requireAuth);
 	router.use("/sessions", requireAuth);
 	router.use("/templates", requireAuth);
+	router.use("/admin", requireAuth);
 
 	// Idle-sweeper bumper. Mounted AFTER `requireAuth` so unauth
 	// requests don't reset the activity timer. The `:id` capture is
@@ -393,6 +395,39 @@ export function buildRouter(
 			}
 		},
 	);
+
+	// ── Admin routes (#241) ────────────────────────────────────────────────
+	// Cross-user observability for operators. Gated by `requireAdmin`
+	// (mirrors the invite-mint pattern from #50). `requireAuth` is
+	// provided by `router.use("/admin", requireAuth)` above —
+	// `requireAdmin` reads `req.userId` populated there.
+	//
+	// Counters reported here are in-memory / process-local: this PR
+	// surfaces only `sessions.byStatus` (a single GROUP BY against
+	// the `sessions` table, no boot-time counter wiring). Subsystem
+	// counters (idle sweeper, dispatcher, reconcile, D1 call rate)
+	// land in follow-up PRs so each one can ship independently.
+
+	router.get("/admin/stats", adminStatsIp, requireAdmin, async (_req: Request, res: Response) => {
+		try {
+			const byStatus = await sessions.countByStatus();
+			// `process.uptime()` returns seconds since process start
+			// — derive `bootedAt` from that rather than capturing
+			// `Date.now()` at module load, so a long-running backend
+			// reports the actual boot wallclock even after monotonic
+			// clock skew has had time to drift from real time.
+			const uptimeSeconds = process.uptime();
+			const bootedAt = new Date(Date.now() - uptimeSeconds * 1000).toISOString();
+			res.json({
+				bootedAt,
+				uptimeSeconds: Math.round(uptimeSeconds),
+				sessions: { byStatus },
+			});
+		} catch (err) {
+			logger.error(`[admin] stats failed: ${(err as Error).message}`);
+			res.status(500).json({ error: "Internal server error" });
+		}
+	});
 
 	// ── Session routes ──────────────────────────────────────────────────────
 

--- a/backend/src/sessionManager.test.ts
+++ b/backend/src/sessionManager.test.ts
@@ -94,6 +94,75 @@ describe("SessionManager.create — quota filter", () => {
 	});
 });
 
+// ── countByStatus (#241) ───────────────────────────────────────────────────
+
+describe("SessionManager.countByStatus", () => {
+	it("issues a single GROUP BY query with no parameters", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await mgr.countByStatus();
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+		const [sql, params] = dbStubs.d1Query.mock.calls[0]!;
+		expect(sql).toMatch(
+			/SELECT\s+status,\s+COUNT\(\*\)\s+AS\s+n\s+FROM\s+sessions\s+GROUP\s+BY\s+status/i,
+		);
+		// No bound params — admin-gated cross-user aggregate, no per-user filter.
+		expect(params).toBeUndefined();
+	});
+
+	it("returns zeros for every status the table has no rows for", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const counts = await mgr.countByStatus();
+		expect(counts).toEqual({ running: 0, stopped: 0, terminated: 0, failed: 0 });
+	});
+
+	it("rehydrates D1 rows into a fully-populated record", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [
+				{ status: "running", n: 12 },
+				{ status: "stopped", n: 4 },
+				// `terminated` and `failed` are absent — must default to 0.
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		expect(await mgr.countByStatus()).toEqual({
+			running: 12,
+			stopped: 4,
+			terminated: 0,
+			failed: 0,
+		});
+	});
+
+	it("silently drops rows with statuses outside the typed set (forward compat)", async () => {
+		// A future migration may add a status the type doesn't know about.
+		// Don't crash the admin dashboard — silently drop, route layer
+		// surfaces the typed shape.
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [
+				{ status: "running", n: 5 },
+				{ status: "creating", n: 2 }, // hypothetical future status
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const counts = await mgr.countByStatus();
+		expect(counts.running).toBe(5);
+		expect("creating" in counts).toBe(false);
+	});
+});
+
 // ── Ownership cache (#239) ─────────────────────────────────────────────────
 
 describe("SessionManager.assertOwnedBy / assertOwnership cache", () => {

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -309,6 +309,36 @@ export class SessionManager {
 		});
 	}
 
+	/**
+	 * Counts of sessions across the whole table, grouped by status.
+	 * Surfaced via `GET /api/admin/stats` (#241). Cross-user aggregate
+	 * — admin-gated at the route layer; do NOT call this from any
+	 * non-admin code path.
+	 *
+	 * Returns a record keyed by every valid `SessionStatus` so callers
+	 * can render zero-counts without per-key existence checks. Statuses
+	 * the database doesn't know about (a future migration adds one,
+	 * GROUP BY emits it before the type is updated) are silently
+	 * dropped — the route's serializer handles the typed surface.
+	 */
+	async countByStatus(): Promise<Record<SessionStatus, number>> {
+		const result = await d1Query<{ status: string; n: number }>(
+			"SELECT status, COUNT(*) AS n FROM sessions GROUP BY status",
+		);
+		const out: Record<SessionStatus, number> = {
+			running: 0,
+			stopped: 0,
+			terminated: 0,
+			failed: 0,
+		};
+		for (const row of result.results) {
+			if (row.status in out) {
+				out[row.status as SessionStatus] = row.n;
+			}
+		}
+		return out;
+	}
+
 	async listForUser(userId: string): Promise<SessionMeta[]> {
 		const result = await d1Query<SessionRow>(
 			"SELECT * FROM sessions WHERE user_id = ? AND status != 'terminated' ORDER BY created_at DESC",


### PR DESCRIPTION
## Summary

First slice of #241. Three-PR split since the issue's scope (stats + cross-user listing + force actions + frontend) is too cross-cutting for one PR (per the lessons from #228's 9-round review).

This PR (**241a**): minimal admin stats endpoint.

- New `GET /api/admin/stats` admin-gated route returning `{ bootedAt, uptimeSeconds, sessions: { byStatus } }`.
- `bootedAt` derived from `process.uptime()` rather than a module-load `Date.now()` snapshot so the reported wallclock stays anchored to real time even after monotonic-clock skew on a long-running backend.

Deferred:
- **PR 241b**: subsystem counters (idle sweeper, dispatcher, reconcile, D1 call rate).
- **PR 241c**: cross-user sessions list endpoint + admin force-actions.
- **PR 241d**: frontend Admin sidebar consuming the endpoints.

## Backend plumbing

- `SessionManager.countByStatus()`: a single GROUP BY against the `sessions` table that returns a fully-populated record keyed by every valid `SessionStatus` (zero-defaulted for missing rows). Forward-compatible: a future migration that adds a status the type doesn't know about is silently dropped at the route layer rather than crashing the dashboard.
- New `adminStatsIp` rate limiter sized like `invitesList` (admin-only read endpoint that may be polled while a UI modal is open). Even though `requireAdmin` already gates by role, an admin's compromised browser tab in a polling loop should not be able to hammer the GROUP BY work.

## Test plan

- [x] `npm run lint` clean (backend)
- [x] `npm test` — 625 tests pass (7 new + 618 existing)

New tests pin:

- 4 `countByStatus` unit tests: SQL shape, zero-default surface, partial-row rehydration, forward-compat silent drop of unknown statuses.
- 3 `routes.admin.test.ts` integration tests: typed JSON shape, `requireAdmin` denial returns 403 WITHOUT calling `countByStatus` (a regression here would be a cross-user data leak), transient D1 error returns 500 with a generic body (no leak of exception detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)