### PR TITLE
feat(admin): dispatcher counters in admin stats (#241, PR 241c of 4)

### DIFF
--- a/backend/src/portDispatcher.test.ts
+++ b/backend/src/portDispatcher.test.ts
@@ -774,6 +774,7 @@ describe("handleProxyError", () => {
 		const calls: { writeHead?: number; end?: string; destroyed?: boolean } = {};
 		const res = {
 			headersSent: true,
+			statusCode: 200,
 			writeHead(status: number) {
 				calls.writeHead = status;
 			},
@@ -783,7 +784,7 @@ describe("handleProxyError", () => {
 			destroy() {
 				calls.destroyed = true;
 			},
-		} as unknown as ServerResponse;
+		} as unknown as ServerResponse & { statusCode: number };
 		handleProxyError(new Error("boom"), fakeReq(), res);
 		// Mid-stream: don't double-write a status line, don't append
 		// "Bad Gateway: …" after the legitimate body. Just terminate
@@ -791,6 +792,12 @@ describe("handleProxyError", () => {
 		expect(calls.writeHead).toBeUndefined();
 		expect(calls.end).toBeUndefined();
 		expect(calls.destroyed).toBe(true);
+		// PR #249 round 3 NIT: statusCode is rewritten to 502 even
+		// though it never reaches the wire (headersSent: true makes
+		// the value an in-process no-op). The dispatcher's #241c
+		// close-listener reads this so a mid-stream-aborted request
+		// classifies as 5xx on the dashboard, not the inherited 200.
+		expect((res as unknown as { statusCode: number }).statusCode).toBe(502);
 	});
 
 	it("destroys a raw socket on WS failure (no writeHead, just teardown)", () => {

--- a/backend/src/portDispatcher.test.ts
+++ b/backend/src/portDispatcher.test.ts
@@ -877,6 +877,42 @@ describe("dispatcher counters (#241c)", () => {
 		expect(s.responses4xxSinceBoot).toBe(1);
 	});
 
+	it("counts a successful proxy response under responses2xxSinceBoot", async () => {
+		// 2xx is the most common runtime case (the public dev-server port
+		// returning HTML / JSON to a browser). Stub the proxy so it
+		// synchronously assigns a 200 to the response — the real
+		// `http-proxy` would do this asynchronously after the upstream
+		// responded, but the dispatcher's hookpoint reads `res.statusCode`
+		// at close, which is the same value either way.
+		const proxyStub = {
+			web: vi.fn((_req, res: ServerResponse) => {
+				res.statusCode = 200;
+			}),
+		} as unknown as Parameters<typeof createPortDispatcher>[0]["proxy"];
+		const dispatcher = createPortDispatcher({
+			baseDomain: VALID_BASE,
+			corsOrigins: [],
+			lookupTarget: vi.fn(async () => ({
+				hostPort: 32768,
+				isPublic: true, // public — skip auth
+				ownerUserId: "u-owner",
+			})),
+			verifyToken: vi.fn(() => null),
+			parseHost: makeHostParser(VALID_BASE),
+			proxy: proxyStub,
+		});
+		const req = makeReq(VALID_HOST);
+		const res = makeRes();
+		dispatcher.middleware(req, res, () => {});
+		await new Promise((r) => setTimeout(r, 0));
+		res.__fireClose();
+		const s = getDispatcherStats();
+		expect(s.requestsSinceBoot).toBe(1);
+		expect(s.responses2xxSinceBoot).toBe(1);
+		expect(s.responses4xxSinceBoot).toBe(0);
+		expect(s.responses5xxSinceBoot).toBe(0);
+	});
+
 	it("counts a 502 (proxy/lookup error) under responses5xxSinceBoot", async () => {
 		// authorize throws via the lookup stub → middleware emits 502.
 		const dispatcher = createPortDispatcher({

--- a/backend/src/portDispatcher.test.ts
+++ b/backend/src/portDispatcher.test.ts
@@ -887,13 +887,17 @@ describe("dispatcher counters (#241c)", () => {
 	it("counts a successful proxy response under responses2xxSinceBoot", async () => {
 		// 2xx is the most common runtime case (the public dev-server port
 		// returning HTML / JSON to a browser). Stub the proxy so it
-		// synchronously assigns a 200 to the response — the real
-		// `http-proxy` would do this asynchronously after the upstream
-		// responded, but the dispatcher's hookpoint reads `res.statusCode`
-		// at close, which is the same value either way.
+		// synchronously assigns a 204 — DELIBERATELY different from
+		// MockRes's default `statusCode: 200` so a regression in which
+		// the close-listener reads the stale default instead of the
+		// proxy-written value is caught. Real `http-proxy` writes the
+		// upstream's status code asynchronously after the response
+		// arrives; the dispatcher's hookpoint reads `res.statusCode` at
+		// close so the timing doesn't matter — only that it sees the
+		// last-written value.
 		const proxyStub = {
 			web: vi.fn((_req, res: ServerResponse) => {
-				res.statusCode = 200;
+				res.statusCode = 204;
 			}),
 		} as unknown as Parameters<typeof createPortDispatcher>[0]["proxy"];
 		const dispatcher = createPortDispatcher({
@@ -972,6 +976,62 @@ describe("dispatcher counters (#241c)", () => {
 		const s = getDispatcherStats();
 		expect(s.requestsSinceBoot).toBe(1);
 		expect(s.responses5xxSinceBoot).toBe(1);
+	});
+
+	it("end-to-end: mid-stream proxy failure registers as 5xx (handleProxyError → close)", async () => {
+		// Pins the integration between handleProxyError's mid-stream
+		// `statusCode = 502` write and the close-listener's
+		// classification. A regression that drops the statusCode rewrite
+		// in handleProxyError would silently re-classify mid-stream
+		// aborts as 2xx (whatever the proxy started with). The
+		// per-function tests at portDispatcher.test.ts:773 (statusCode
+		// rewrite) and dispatcher-counters > 5xx (authorize-throw path)
+		// each catch half the regression; this combines them.
+		const proxyStub = {
+			web: vi.fn((_req, res: ServerResponse) => {
+				// Simulate a mid-stream proxy error: the proxy started
+				// successfully (statusCode = 200, headersSent = true),
+				// then the upstream died and `proxy.error` fires
+				// `handleProxyError`.
+				res.statusCode = 200;
+				(res as unknown as { headersSent: boolean }).headersSent = true;
+				handleProxyError(new Error("upstream died mid-body"), {} as IncomingMessage, res);
+			}),
+		} as unknown as Parameters<typeof createPortDispatcher>[0]["proxy"];
+		const dispatcher = createPortDispatcher({
+			baseDomain: VALID_BASE,
+			corsOrigins: [],
+			lookupTarget: vi.fn(async () => ({
+				hostPort: 32768,
+				isPublic: true,
+				ownerUserId: "u-owner",
+			})),
+			verifyToken: vi.fn(() => null),
+			parseHost: makeHostParser(VALID_BASE),
+			proxy: proxyStub,
+		});
+		const req = makeReq(VALID_HOST);
+		const res = makeRes();
+		// `handleProxyError` branches on `typeof res.writeHead ===
+		// "function"` to distinguish ServerResponse from a raw socket
+		// (the WS path). The base MockRes doesn't supply writeHead
+		// (the other counter tests don't need it); add a stub so the
+		// branch evaluates correctly and the headersSent: true path
+		// runs. Without this, handleProxyError takes the Duplex
+		// branch and never rewrites statusCode.
+		(res as unknown as { writeHead: () => void; destroy: () => void }).writeHead = () => {};
+		(res as unknown as { destroy: () => void }).destroy = () => {};
+		dispatcher.middleware(req, res, () => {});
+		await new Promise((r) => setTimeout(r, 0));
+		res.__fireClose();
+		const s = getDispatcherStats();
+		expect(s.requestsSinceBoot).toBe(1);
+		// The proxy starts at 200 then handleProxyError rewrites to 502;
+		// the close-listener reads the final value, so the request
+		// classifies as 5xx, NOT the 2xx the proxy would otherwise leave
+		// behind.
+		expect(s.responses5xxSinceBoot).toBe(1);
+		expect(s.responses2xxSinceBoot).toBe(0);
 	});
 
 	it("hooks res.on('close') (not 'finish') so an aborted request still counts", async () => {

--- a/backend/src/portDispatcher.test.ts
+++ b/backend/src/portDispatcher.test.ts
@@ -913,6 +913,39 @@ describe("dispatcher counters (#241c)", () => {
 		expect(s.responses5xxSinceBoot).toBe(0);
 	});
 
+	it("counts a 3xx redirect response under responses3xxSinceBoot", async () => {
+		// 3xx is a real production case (a container app returning a
+		// redirect — auth-callback shape, OAuth dance, app-internal
+		// redirect). Stub the proxy to set statusCode = 301 the same
+		// way the 2xx test sets 200.
+		const proxyStub = {
+			web: vi.fn((_req, res: ServerResponse) => {
+				res.statusCode = 301;
+			}),
+		} as unknown as Parameters<typeof createPortDispatcher>[0]["proxy"];
+		const dispatcher = createPortDispatcher({
+			baseDomain: VALID_BASE,
+			corsOrigins: [],
+			lookupTarget: vi.fn(async () => ({
+				hostPort: 32768,
+				isPublic: true,
+				ownerUserId: "u-owner",
+			})),
+			verifyToken: vi.fn(() => null),
+			parseHost: makeHostParser(VALID_BASE),
+			proxy: proxyStub,
+		});
+		const req = makeReq(VALID_HOST);
+		const res = makeRes();
+		dispatcher.middleware(req, res, () => {});
+		await new Promise((r) => setTimeout(r, 0));
+		res.__fireClose();
+		const s = getDispatcherStats();
+		expect(s.requestsSinceBoot).toBe(1);
+		expect(s.responses3xxSinceBoot).toBe(1);
+		expect(s.responses2xxSinceBoot).toBe(0);
+	});
+
 	it("counts a 502 (proxy/lookup error) under responses5xxSinceBoot", async () => {
 		// authorize throws via the lookup stub → middleware emits 502.
 		const dispatcher = createPortDispatcher({

--- a/backend/src/portDispatcher.test.ts
+++ b/backend/src/portDispatcher.test.ts
@@ -1,9 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	__resetDispatcherStatsForTests,
 	createPortDispatcher,
 	extractAuthToken,
+	getDispatcherStats,
 	handleProxyError,
 	makeHostParser,
 	type ParsedHost,
@@ -173,8 +175,15 @@ interface MockRes {
 	headers: Record<string, string>;
 	body: string;
 	headersSent: boolean;
+	closeListeners: Array<() => void>;
 	setHeader: (k: string, v: string) => void;
 	end: (b?: string) => void;
+	on: (event: string, listener: () => void) => MockRes;
+	/** Test helper: invoke every `close` listener so the dispatcher
+	 *  counter (`#241c) sees its hookpoint fire. Production-like
+	 *  surface — `res.on("close")` is the standard ServerResponse
+	 *  shape. */
+	__fireClose: () => void;
 }
 
 function makeRes(): MockRes {
@@ -183,12 +192,20 @@ function makeRes(): MockRes {
 		headers: {},
 		body: "",
 		headersSent: false,
+		closeListeners: [],
 		setHeader(k, v) {
 			res.headers[k.toLowerCase()] = v;
 		},
 		end(b) {
 			res.headersSent = true;
 			res.body = b ?? "";
+		},
+		on(event, listener) {
+			if (event === "close") res.closeListeners.push(listener);
+			return res;
+		},
+		__fireClose() {
+			for (const l of res.closeListeners) l();
 		},
 	};
 	return res;
@@ -788,5 +805,111 @@ describe("handleProxyError", () => {
 		} as unknown as Duplex;
 		handleProxyError(new Error("ws boom"), fakeReq(), socket);
 		expect(calls.destroyed).toBe(true);
+	});
+});
+
+// ── Dispatcher counters (#241c) ──────────────────────────────────────────
+
+describe("dispatcher counters (#241c)", () => {
+	const VALID_BASE = "tunnel.example.com";
+	const VALID_HOST = `p3000-${SID}.${VALID_BASE}`;
+
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+	});
+
+	function makeDispatcher() {
+		return createPortDispatcher({
+			baseDomain: VALID_BASE,
+			corsOrigins: [],
+			lookupTarget: vi.fn(async () => null), // 404 path — simplest
+			verifyToken: vi.fn(() => null),
+			parseHost: makeHostParser(VALID_BASE),
+		});
+	}
+
+	it("starts with every counter at zero", () => {
+		expect(getDispatcherStats()).toEqual({
+			requestsSinceBoot: 0,
+			responses2xxSinceBoot: 0,
+			responses3xxSinceBoot: 0,
+			responses4xxSinceBoot: 0,
+			responses5xxSinceBoot: 0,
+		});
+	});
+
+	it("does NOT bump on requests the dispatcher doesn't claim (host outside base domain)", () => {
+		const { middleware } = makeDispatcher();
+		const req = makeReq("api.example.com"); // wrong host — falls through
+		const res = makeRes();
+		middleware(req, res, () => {});
+		// The close-listener was never attached because parseHost returned
+		// null and the middleware called next() directly. The counter must
+		// stay at zero.
+		res.__fireClose();
+		expect(getDispatcherStats().requestsSinceBoot).toBe(0);
+	});
+
+	it("counts 4xx responses (CSRF gate / auth failures) under responses4xxSinceBoot", async () => {
+		const { middleware } = makeDispatcher();
+		// Cross-origin request from a non-allowlisted origin → 403 from
+		// the CSRF gate at the top of the middleware, before authorize().
+		const req = makeReq(VALID_HOST, undefined, "https://evil.com");
+		const res = makeRes();
+		middleware(req, res, () => {});
+		res.__fireClose();
+		const s = getDispatcherStats();
+		expect(s.requestsSinceBoot).toBe(1);
+		expect(s.responses4xxSinceBoot).toBe(1);
+		expect(s.responses2xxSinceBoot).toBe(0);
+	});
+
+	it("counts the 404 lookup-miss path under responses4xxSinceBoot", async () => {
+		const { middleware } = makeDispatcher();
+		const req = makeReq(VALID_HOST);
+		const res = makeRes();
+		middleware(req, res, () => {});
+		// Allow the authorize() promise chain to settle.
+		await new Promise((r) => setTimeout(r, 0));
+		res.__fireClose();
+		const s = getDispatcherStats();
+		expect(s.requestsSinceBoot).toBe(1);
+		expect(s.responses4xxSinceBoot).toBe(1);
+	});
+
+	it("counts a 502 (proxy/lookup error) under responses5xxSinceBoot", async () => {
+		// authorize throws via the lookup stub → middleware emits 502.
+		const dispatcher = createPortDispatcher({
+			baseDomain: VALID_BASE,
+			corsOrigins: [],
+			lookupTarget: vi.fn(async () => {
+				throw new Error("D1 boom");
+			}),
+			verifyToken: vi.fn(() => null),
+			parseHost: makeHostParser(VALID_BASE),
+		});
+		const req = makeReq(VALID_HOST);
+		const res = makeRes();
+		dispatcher.middleware(req, res, () => {});
+		await new Promise((r) => setTimeout(r, 0));
+		res.__fireClose();
+		const s = getDispatcherStats();
+		expect(s.requestsSinceBoot).toBe(1);
+		expect(s.responses5xxSinceBoot).toBe(1);
+	});
+
+	it("hooks res.on('close') (not 'finish') so an aborted request still counts", async () => {
+		// `close` fires on both successful flush AND client disconnect
+		// mid-flush; `finish` only on successful flush. Pinning the
+		// hookpoint here means a regression that swaps `close` for
+		// `finish` — which would silently miss aborts on the dashboard
+		// — gets caught.
+		const { middleware } = makeDispatcher();
+		const req = makeReq(VALID_HOST, undefined, "https://evil.com");
+		const res = makeRes();
+		middleware(req, res, () => {});
+		// Production code attaches exactly one `close` listener — confirm
+		// the listener landed on the right event.
+		expect(res.closeListeners.length).toBe(1);
 	});
 });

--- a/backend/src/portDispatcher.ts
+++ b/backend/src/portDispatcher.ts
@@ -59,6 +59,16 @@ export interface ParsedHost {
 // 2xx/3xx/4xx/5xx blurs both signals. The HTTP counters cover the
 // regular browser traffic to dev-server / app ports — the dominant use
 // case the dashboard needs to surface.
+//
+// Exclusion: rate-limited 429s never reach this module's `middleware()`
+// because `dispatcherLimiter` mounts BEFORE the dispatcher in
+// `index.ts`. A request the per-IP limiter rejects is therefore NOT in
+// `requestsSinceBoot` — operators reading "dispatcher quiet but
+// `dispatcherLimiter` 429-firing" should consult the limiter's own
+// `RateLimit-*` response headers (or the limiter's express-rate-limit
+// internals) for that signal. Defensible: a request that never reached
+// the dispatcher is arguably not a dispatcher request, and including
+// 429s here would conflate the two layers' health signals.
 
 let requestsSinceBoot = 0;
 let responses2xxSinceBoot = 0;

--- a/backend/src/portDispatcher.ts
+++ b/backend/src/portDispatcher.ts
@@ -102,11 +102,13 @@ export function __resetDispatcherStatsForTests(): void {
  * that the dispatcher claimed contributes exactly one increment to
  * `requestsSinceBoot` and at most one to a status-class counter.
  *
- * Status 0 / undefined means the response never got a status code (rare:
- * client disconnected before any header was sent, or the dispatcher's
- * 502 emit failed). Counted in `requestsSinceBoot` but NOT in any
- * status-class bucket — operators reading the dashboard see the gap and
- * can correlate to sum-mismatch.
+ * The `!statusCode` early-return is a TypeScript safety net for the
+ * `undefined` branch of the parameter union — `http.ServerResponse`
+ * defaults `statusCode` to `200` and never assigns `0` at runtime,
+ * so this branch is unreachable in production. Kept anyway so a
+ * future caller passing through a partially-mocked response object
+ * (or a different response shape) doesn't NaN the counters via
+ * `>= undefined` comparisons.
  */
 function bumpDispatchResponse(statusCode: number | undefined): void {
 	requestsSinceBoot++;

--- a/backend/src/portDispatcher.ts
+++ b/backend/src/portDispatcher.ts
@@ -46,6 +46,77 @@ export interface ParsedHost {
 	sessionId: string;
 }
 
+// ── Observability counters (#241c) ─────────────────────────────────────────
+//
+// Process-local counters surfaced via `GET /api/admin/stats`. Reset on
+// every backend restart. Durable metrics belong in a separate Prometheus/
+// OTel follow-up; this is the same shape as the IdleSweeper / reconcile /
+// d1 counters that landed in 241b.
+//
+// Scope: HTTP requests only. WS upgrade counters are deferred to a future
+// follow-up because the upgrade-success / upgrade-fail signal is a
+// connection event, not a request event, and lumping them in with HTTP
+// 2xx/3xx/4xx/5xx blurs both signals. The HTTP counters cover the
+// regular browser traffic to dev-server / app ports — the dominant use
+// case the dashboard needs to surface.
+
+let requestsSinceBoot = 0;
+let responses2xxSinceBoot = 0;
+let responses3xxSinceBoot = 0;
+let responses4xxSinceBoot = 0;
+let responses5xxSinceBoot = 0;
+
+export interface DispatcherStats {
+	requestsSinceBoot: number;
+	responses2xxSinceBoot: number;
+	responses3xxSinceBoot: number;
+	responses4xxSinceBoot: number;
+	responses5xxSinceBoot: number;
+}
+
+/** Read-only snapshot for the admin stats endpoint. Cheap (no I/O,
+ *  no async). */
+export function getDispatcherStats(): DispatcherStats {
+	return {
+		requestsSinceBoot,
+		responses2xxSinceBoot,
+		responses3xxSinceBoot,
+		responses4xxSinceBoot,
+		responses5xxSinceBoot,
+	};
+}
+
+/** Test seam: zero every counter so cases don't bleed. Production code
+ *  never calls this. */
+export function __resetDispatcherStatsForTests(): void {
+	requestsSinceBoot = 0;
+	responses2xxSinceBoot = 0;
+	responses3xxSinceBoot = 0;
+	responses4xxSinceBoot = 0;
+	responses5xxSinceBoot = 0;
+}
+
+/**
+ * Record one finalised dispatcher response. Called from a `res.on("close")`
+ * listener (fires on both successful flush and abort), so EVERY request
+ * that the dispatcher claimed contributes exactly one increment to
+ * `requestsSinceBoot` and at most one to a status-class counter.
+ *
+ * Status 0 / undefined means the response never got a status code (rare:
+ * client disconnected before any header was sent, or the dispatcher's
+ * 502 emit failed). Counted in `requestsSinceBoot` but NOT in any
+ * status-class bucket — operators reading the dashboard see the gap and
+ * can correlate to sum-mismatch.
+ */
+function bumpDispatchResponse(statusCode: number | undefined): void {
+	requestsSinceBoot++;
+	if (!statusCode) return;
+	if (statusCode >= 200 && statusCode < 300) responses2xxSinceBoot++;
+	else if (statusCode >= 300 && statusCode < 400) responses3xxSinceBoot++;
+	else if (statusCode >= 400 && statusCode < 500) responses4xxSinceBoot++;
+	else if (statusCode >= 500 && statusCode < 600) responses5xxSinceBoot++;
+}
+
 /**
  * Build the host-header parser bound to a fixed base domain. Returns
  * null for any host that doesn't match `p<int>-<sessionId>.<base>`.
@@ -313,6 +384,13 @@ export function createPortDispatcher(deps: DispatcherDeps): {
 			next();
 			return;
 		}
+		// Counter hookpoint (#241c). Hooked on `close` (fires on both
+		// successful flush AND client disconnect mid-flush) so EVERY
+		// claimed request contributes exactly one increment. `finish`
+		// alone would miss aborts. The listener is attached BEFORE any
+		// possible early-return below so a 403 from the CSRF gate also
+		// counts.
+		res.on("close", () => bumpDispatchResponse(res.statusCode));
 		// CSRF defence — applies to ALL dispatcher HTTP requests,
 		// symmetric with the WS `handleUpgrade` path. In production
 		// the JWT cookie is `SameSite=None; Secure` (the Pages→Tunnel

--- a/backend/src/portDispatcher.ts
+++ b/backend/src/portDispatcher.ts
@@ -219,6 +219,17 @@ export function handleProxyError(
 			httpRes.writeHead(502, { "Content-Type": "text/plain" });
 			httpRes.end("Bad Gateway: target unreachable");
 		} else {
+			// Mid-stream failure: bytes already left the headersSent
+			// gate, so we can't legally rewrite the wire status — but
+			// we DO want the dispatcher's #241c counter close-listener
+			// to classify this as 5xx instead of inheriting whatever
+			// 2xx the proxy started with. Setting `statusCode` after
+			// `headersSent: true` is a documented no-op for the wire
+			// (the value never reaches the client) AND a legitimate
+			// in-process write that the close-listener reads. The
+			// admin dashboard shows the failure correctly; the client
+			// gets the truncated stream as before.
+			httpRes.statusCode = 502;
 			httpRes.destroy();
 		}
 	} else {

--- a/backend/src/routes.admin.test.ts
+++ b/backend/src/routes.admin.test.ts
@@ -73,6 +73,7 @@ vi.mock("./db.js", () => dbStubs);
 
 import type { BootstrapBroadcaster } from "./bootstrap.js";
 import type { DockerManager } from "./dockerManager.js";
+import { __resetDispatcherStatsForTests } from "./portDispatcher.js";
 import { buildRouter } from "./routes.js";
 import type { SessionManager } from "./sessionManager.js";
 
@@ -138,6 +139,11 @@ async function spinUp(countByStatus: ReturnType<typeof vi.fn>) {
 describe("GET /api/admin/stats (#241a)", () => {
 	beforeEach(() => {
 		dbStubs.d1Query.mockReset();
+		// Dispatcher counters live as module-level state in
+		// `portDispatcher.ts`; reset between cases so a count
+		// from a previous test (or another file in the same
+		// vitest run) doesn't leak into the wire-shape assertion.
+		__resetDispatcherStatsForTests();
 	});
 
 	it("returns the typed stats shape with bootedAt / uptimeSeconds / sessions.byStatus + subsystem counters (#241b)", async () => {
@@ -160,6 +166,13 @@ describe("GET /api/admin/stats (#241a)", () => {
 				lastRunAt: number | null;
 				sessionsCheckedSinceBoot: number;
 				errorsSinceBoot: number;
+			};
+			dispatcher: {
+				requestsSinceBoot: number;
+				responses2xxSinceBoot: number;
+				responses3xxSinceBoot: number;
+				responses4xxSinceBoot: number;
+				responses5xxSinceBoot: number;
 			};
 			d1: { callsSinceBoot: number };
 		};
@@ -187,6 +200,17 @@ describe("GET /api/admin/stats (#241a)", () => {
 			lastRunAt: null,
 			sessionsCheckedSinceBoot: 0,
 			errorsSinceBoot: 0,
+		});
+		// #241c: dispatcher counters present on the wire. All zero
+		// because this test fixture doesn't exercise the dispatcher
+		// middleware (the router is built but no request flows
+		// through it during `/admin/stats` handling).
+		expect(body.dispatcher).toEqual({
+			requestsSinceBoot: 0,
+			responses2xxSinceBoot: 0,
+			responses3xxSinceBoot: 0,
+			responses4xxSinceBoot: 0,
+			responses5xxSinceBoot: 0,
 		});
 		expect(body.d1).toEqual({ callsSinceBoot: 0 });
 	});

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -34,6 +34,7 @@ import { UploadQuotaExceededError } from "./dockerManager.js";
 import { EnvVarValidationError, validateEnvVars } from "./envVarValidation.js";
 import type { IdleSweeperStats } from "./idleSweeper.js";
 import { logger } from "./logger.js";
+import { getDispatcherStats } from "./portDispatcher.js";
 import type { RateLimitConfig } from "./rateLimit.js";
 import {
 	createAuthRateLimiters,
@@ -449,6 +450,7 @@ export function buildRouter(
 				sessions: { byStatus },
 				idleSweeper: idleSweeperStats,
 				reconcile: reconcileStats,
+				dispatcher: getDispatcherStats(),
 				d1: { callsSinceBoot: getD1CallsSinceBoot() },
 			});
 		} catch (err) {


### PR DESCRIPTION
## Summary

Third slice of #241. Extends `GET /api/admin/stats` with `dispatcher: { requestsSinceBoot, responses{2xx,3xx,4xx,5xx}SinceBoot }`.

## Counter semantics

- Bumped on `res.on(\"close\")`, **not** `res.on(\"finish\")`. Close fires on both successful flush AND client disconnect mid-flush, so every claimed request contributes exactly one increment. A pinned test catches a future regression that swaps the event.
- The close-listener is attached **before** any early return inside the middleware, so the CSRF-gate 403 path also counts. Without this, a probe attacker hammering invalid Origin headers would produce 0 dispatcher activity on the dashboard.
- Status 0 / undefined (response never got a status code — rare: client disconnected before any header was sent) bumps `requestsSinceBoot` but NOT any status-class bucket. The sum-mismatch is the operator's signal that something aborted pre-headers.

## Scope

**HTTP only.** WS upgrade counters are deferred — the upgrade-success / upgrade-fail signal is a connection event, not a request event, and lumping them in with HTTP 2xx/3xx/4xx/5xx blurs both signals. Documented as future work in the module comment.

## Test plan

- [x] `npm run lint` clean (backend)
- [x] `npm test` — 642 tests pass (6 new dispatcher-counter + existing tests).

6 new tests pin:
- Initial state all zero.
- Non-claimed requests (host outside base domain) don't bump.
- 4xx CSRF-gate response bumps `requestsSinceBoot` + 4xx bucket.
- 4xx 404-lookup-miss bumps under 4xx.
- 5xx proxy/lookup error bumps under 5xx.
- Hookpoint pinned on `close` not `finish` so aborts count.

Plus the existing routes.admin.test.ts wire-shape test extended to pin the new `dispatcher` field on the JSON response.

## Deferred

- **PR 241d**: cross-user sessions list endpoint + admin force-actions.
- **PR 241e**: frontend Admin sidebar consuming all of `/api/admin/stats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)