### PR TITLE
feat(admin): cross-user sessions + force-actions (#241, PR 241d of 4)

### DIFF
--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -437,6 +437,7 @@ describe("auth route rate limiting", () => {
 			logout: { ipMax: 1000, ipWindowMs: 60_000 },
 			authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
 			adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+			adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
 			...cfg,
 		};
 		// rate-limit tests don't touch the bootstrap broadcaster — empty

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -97,6 +97,17 @@ export interface RateLimitConfig {
 		ipMax: number;
 		ipWindowMs: number;
 	};
+	// Caps how often a single IP can hit destructive admin actions
+	// (force-stop, hard-delete on any session via /api/admin/sessions).
+	// Sized like `invitesRevoke` — admin operations the legitimate
+	// user may need in bursts (incident response: stop 20 sessions
+	// after spotting abuse), but well below sustained-loop budget.
+	// Separate from `adminStats` so a polling dashboard can't starve
+	// out the operator's ability to actually act in an incident.
+	adminAction: {
+		ipMax: number;
+		ipWindowMs: number;
+	};
 }
 
 // Defaults match issue #10: login 10/15min, register 5/1h, per-username 10/15min.
@@ -164,6 +175,10 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 		ipMax: 120,
 		ipWindowMs: 60 * 60 * 1000,
 	},
+	adminAction: {
+		ipMax: 60,
+		ipWindowMs: 60 * 60 * 1000,
+	},
 };
 
 // ── IP-based limiters (express-rate-limit) ─────────────────────────────────
@@ -178,6 +193,7 @@ export interface AuthRateLimiters {
 	logoutIp: RateLimitRequestHandler;
 	authStatusIp: RateLimitRequestHandler;
 	adminStatsIp: RateLimitRequestHandler;
+	adminActionIp: RateLimitRequestHandler;
 }
 
 export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
@@ -257,6 +273,16 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		legacyHeaders: false,
 		message: { error: "Too many admin-stats requests from this IP, try again later", scope: "ip" },
 	});
+	const adminActionIp = rateLimit({
+		windowMs: cfg.adminAction.ipWindowMs,
+		limit: cfg.adminAction.ipMax,
+		standardHeaders: "draft-7",
+		legacyHeaders: false,
+		message: {
+			error: "Too many admin-action requests from this IP, try again later",
+			scope: "ip",
+		},
+	});
 	return {
 		loginIp,
 		registerIp,
@@ -267,6 +293,7 @@ export function createAuthRateLimiters(cfg: RateLimitConfig): AuthRateLimiters {
 		logoutIp,
 		authStatusIp,
 		adminStatsIp,
+		adminActionIp,
 	};
 }
 

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -86,13 +86,18 @@ export interface RateLimitConfig {
 		ipMax: number;
 		ipWindowMs: number;
 	};
-	// Caps how often a single IP can hit the admin stats / cross-user
-	// endpoints (#241). Even though `requireAdmin` already gates by
+	// Caps how often a single IP can hit the admin read endpoints
+	// (`GET /api/admin/stats` and `GET /api/admin/sessions`). SHARED
+	// across both — a polling dashboard typically fetches them in
+	// pairs, so a single bucket reflects total read-load on the
+	// admin namespace. Even though `requireAdmin` already gates by
 	// user role, an admin operator's compromised browser tab in a
 	// polling loop should not be able to hammer the GROUP BY +
-	// counter-readout work that the stats endpoint does. Sized like
-	// `invitesList` (the closest precedent — admin-only read endpoint
-	// the UI may legitimately poll while a modal is open).
+	// JOIN-against-users work the endpoints do. Sized at ~2× the
+	// `invitesList` precedent because the dashboard polls two
+	// endpoints concurrently — 240/h ≈ 4/min sustained, plenty for
+	// a 15-second refresh cadence (the smallest UI cadence we think
+	// makes sense) and well below sustained abuse rates.
 	adminStats: {
 		ipMax: number;
 		ipWindowMs: number;
@@ -172,7 +177,7 @@ export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
 	// browser tab in a polling loop should not be able to hammer
 	// the GROUP BY work the route does. See #241.
 	adminStats: {
-		ipMax: 120,
+		ipMax: 240,
 		ipWindowMs: 60 * 60 * 1000,
 	},
 	adminAction: {

--- a/backend/src/routes.admin.test.ts
+++ b/backend/src/routes.admin.test.ts
@@ -406,6 +406,23 @@ describe("POST /api/admin/sessions/:id/stop (#241d)", () => {
 		expect(get).not.toHaveBeenCalled();
 		expect(stopContainer).not.toHaveBeenCalled();
 	});
+
+	it("returns 500 with a generic body when stopContainer throws", async () => {
+		const get = vi.fn(async () => meta());
+		const stopContainer = vi.fn(async () => {
+			throw new Error("docker daemon unreachable");
+		});
+		await spinUp(vi.fn(), {
+			sessions: { get } as unknown as Partial<SessionManager>,
+			docker: { stopContainer } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/s-any/stop`, { method: "POST" });
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("Internal server error");
+		expect(body.error).not.toContain("docker daemon");
+	});
 });
 
 describe("DELETE /api/admin/sessions/:id (#241d)", () => {
@@ -522,5 +539,27 @@ describe("DELETE /api/admin/sessions/:id (#241d)", () => {
 		expect(res.status).toBe(403);
 		expect(get).not.toHaveBeenCalled();
 		expect(kill).not.toHaveBeenCalled();
+	});
+
+	it("returns 500 with a generic body when kill throws", async () => {
+		// purgeWorkspace's own failure is logged-and-swallowed inside the
+		// handler (the row removal still happens), so the failure path
+		// we surface here is the kill() throw — pre-terminate, pre-row-
+		// drop, the part the catch block actually owns.
+		const get = vi.fn(async () => meta());
+		const kill = vi.fn(async () => {
+			throw new Error("docker daemon unreachable");
+		});
+		const terminate = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get, terminate } as unknown as Partial<SessionManager>,
+			docker: { kill } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/s-any`, { method: "DELETE" });
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("Internal server error");
+		expect(body.error).not.toContain("docker daemon");
 	});
 });

--- a/backend/src/routes.admin.test.ts
+++ b/backend/src/routes.admin.test.ts
@@ -94,14 +94,19 @@ afterEach(async () => {
 	});
 });
 
-async function spinUp(countByStatus: ReturnType<typeof vi.fn>) {
+interface AdminSpinUp {
+	sessions?: Partial<SessionManager>;
+	docker?: Partial<DockerManager>;
+}
+
+async function spinUp(countByStatus: ReturnType<typeof vi.fn>, overrides: AdminSpinUp = {}) {
 	const sessions = {
 		countByStatus,
 		// Guard: any other SessionManager method called by this route's
-		// path would be an unintended dependency. Throw so a future
-		// route addition that brings in `get` / `assertOwnership` /
-		// etc. fails the test loudly rather than silently passing
-		// undefined into the route handler.
+		// path that's not overridden is undefined — calling it surfaces
+		// as a 500 with a clear "is not a function" message rather than
+		// silent test pass.
+		...overrides.sessions,
 	} as unknown as SessionManager;
 	const docker = {
 		getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
@@ -113,6 +118,7 @@ async function spinUp(countByStatus: ReturnType<typeof vi.fn>) {
 			sessionsCheckedSinceBoot: 0,
 			errorsSinceBoot: 0,
 		}),
+		...overrides.docker,
 	} as unknown as DockerManager;
 	const broadcaster = {} as BootstrapBroadcaster;
 	const router = buildRouter(sessions, docker, broadcaster, {
@@ -125,6 +131,7 @@ async function spinUp(countByStatus: ReturnType<typeof vi.fn>) {
 		logout: { ipMax: 1000, ipWindowMs: 60_000 },
 		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
 		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
 	});
 	const app = express();
 	app.use(express.json());
@@ -253,5 +260,267 @@ describe("GET /api/admin/stats (#241a)", () => {
 		const body = (await res.json()) as { error: string };
 		expect(body.error).toBe("Internal server error");
 		expect(body.error).not.toContain("D1 transient");
+	});
+});
+
+// ── Cross-user sessions list + force-actions (#241d) ─────────────────────
+
+describe("GET /api/admin/sessions (#241d)", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+		__resetDispatcherStatsForTests();
+	});
+
+	function fakeSession(sessionId: string, userId: string, ownerUsername: string) {
+		return {
+			sessionId,
+			userId,
+			name: sessionId,
+			status: "running" as const,
+			containerId: null,
+			containerName: `st-${sessionId}`,
+			cols: 80,
+			rows: 24,
+			envVars: {},
+			createdAt: new Date("2026-05-09T02:00:00Z"),
+			lastConnectedAt: null,
+			ownerUsername,
+		};
+	}
+
+	it("returns rows across users with ownerUsername attached", async () => {
+		const listAll = vi.fn(async () => [
+			fakeSession("s1", "u1", "alice"),
+			fakeSession("s2", "u2", "bob"),
+		]);
+		await spinUp(vi.fn(), { sessions: { listAll } as unknown as Partial<SessionManager> });
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{
+			sessionId: string;
+			userId: string;
+			ownerUsername: string;
+		}>;
+		expect(body).toHaveLength(2);
+		expect(body[0]?.ownerUsername).toBe("alice");
+		expect(body[1]?.userId).toBe("u2");
+		expect(listAll).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns 403 when requireAdmin denies (non-admin user) without calling listAll", async () => {
+		authStubs.requireAdmin.mockImplementation((_req, res, _next) => {
+			(res as { status: (n: number) => { json: (b: unknown) => void } })
+				.status(403)
+				.json({ error: "Forbidden" });
+		});
+		const listAll = vi.fn(async () => [] as never[]);
+		await spinUp(vi.fn(), { sessions: { listAll } as unknown as Partial<SessionManager> });
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions`);
+		expect(res.status).toBe(403);
+		// CRITICAL: a regression that ran the handler regardless of the
+		// admin gate would be a cross-user data leak.
+		expect(listAll).not.toHaveBeenCalled();
+	});
+
+	it("returns 500 with a generic body when listAll throws (no detail leak)", async () => {
+		const listAll = vi.fn(async () => {
+			throw new Error("D1 transient: connection reset");
+		});
+		await spinUp(vi.fn(), { sessions: { listAll } as unknown as Partial<SessionManager> });
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions`);
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("Internal server error");
+		expect(body.error).not.toContain("D1 transient");
+	});
+});
+
+describe("POST /api/admin/sessions/:id/stop (#241d)", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+		__resetDispatcherStatsForTests();
+	});
+
+	function meta() {
+		return {
+			sessionId: "s-any",
+			userId: "u-foreign", // NOT the admin's id — proves no ownership check
+			name: "s-any",
+			status: "running" as const,
+			containerId: "c1",
+			containerName: "st-s-any",
+			cols: 80,
+			rows: 24,
+			envVars: {},
+			createdAt: new Date(),
+			lastConnectedAt: null,
+		};
+	}
+
+	it("force-stops any session (no ownership check) and returns 204", async () => {
+		const get = vi.fn(async () => meta());
+		const stopContainer = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get } as unknown as Partial<SessionManager>,
+			docker: { stopContainer } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/s-any/stop`, { method: "POST" });
+		expect(res.status).toBe(204);
+		expect(stopContainer).toHaveBeenCalledWith("s-any");
+	});
+
+	it("returns 404 when the session id doesn't exist", async () => {
+		const get = vi.fn(async () => null);
+		const stopContainer = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get } as unknown as Partial<SessionManager>,
+			docker: { stopContainer } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/missing/stop`, { method: "POST" });
+		expect(res.status).toBe(404);
+		// stopContainer must NOT fire for a missing session — otherwise
+		// Docker surfaces a confusing "no such container" 500.
+		expect(stopContainer).not.toHaveBeenCalled();
+	});
+
+	it("returns 403 when requireAdmin denies", async () => {
+		authStubs.requireAdmin.mockImplementation((_req, res, _next) => {
+			(res as { status: (n: number) => { json: (b: unknown) => void } })
+				.status(403)
+				.json({ error: "Forbidden" });
+		});
+		const get = vi.fn(async () => meta());
+		const stopContainer = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get } as unknown as Partial<SessionManager>,
+			docker: { stopContainer } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/s-any/stop`, { method: "POST" });
+		expect(res.status).toBe(403);
+		expect(get).not.toHaveBeenCalled();
+		expect(stopContainer).not.toHaveBeenCalled();
+	});
+});
+
+describe("DELETE /api/admin/sessions/:id (#241d)", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+		__resetDispatcherStatsForTests();
+	});
+
+	function meta(status: "running" | "terminated" = "running") {
+		return {
+			sessionId: "s-any",
+			userId: "u-foreign",
+			name: "s-any",
+			status,
+			containerId: "c1",
+			containerName: "st-s-any",
+			cols: 80,
+			rows: 24,
+			envVars: {},
+			createdAt: new Date(),
+			lastConnectedAt: null,
+		};
+	}
+
+	it("soft-deletes (kill + terminate, workspace preserved) by default", async () => {
+		const get = vi.fn(async () => meta());
+		const terminate = vi.fn(async () => undefined);
+		const deleteRow = vi.fn(async () => undefined);
+		const kill = vi.fn(async () => undefined);
+		const purgeWorkspace = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get, terminate, deleteRow } as unknown as Partial<SessionManager>,
+			docker: { kill, purgeWorkspace } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/s-any`, { method: "DELETE" });
+		expect(res.status).toBe(204);
+		expect(kill).toHaveBeenCalledWith("s-any");
+		expect(terminate).toHaveBeenCalledWith("s-any");
+		// Soft-delete does NOT purge workspace or drop the row.
+		expect(purgeWorkspace).not.toHaveBeenCalled();
+		expect(deleteRow).not.toHaveBeenCalled();
+	});
+
+	it("hard-deletes (kill + terminate + purgeWorkspace + deleteRow) when ?hard=true", async () => {
+		const get = vi.fn(async () => meta());
+		const terminate = vi.fn(async () => undefined);
+		const deleteRow = vi.fn(async () => undefined);
+		const kill = vi.fn(async () => undefined);
+		const purgeWorkspace = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get, terminate, deleteRow } as unknown as Partial<SessionManager>,
+			docker: { kill, purgeWorkspace } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/s-any?hard=true`, { method: "DELETE" });
+		expect(res.status).toBe(204);
+		expect(kill).toHaveBeenCalledWith("s-any");
+		expect(terminate).toHaveBeenCalledWith("s-any");
+		expect(purgeWorkspace).toHaveBeenCalledWith("s-any");
+		expect(deleteRow).toHaveBeenCalledWith("s-any");
+	});
+
+	it("hard-delete on an already-terminated session skips kill+terminate but still purges + drops the row", async () => {
+		// Idempotent shape: the soft-delete branch is the only one that
+		// invokes kill/terminate; the hard-delete branch is independent
+		// so an admin can hard-purge a soft-deleted session via
+		// ?hard=true even though the container is already gone.
+		const get = vi.fn(async () => meta("terminated"));
+		const terminate = vi.fn(async () => undefined);
+		const deleteRow = vi.fn(async () => undefined);
+		const kill = vi.fn(async () => undefined);
+		const purgeWorkspace = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get, terminate, deleteRow } as unknown as Partial<SessionManager>,
+			docker: { kill, purgeWorkspace } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/s-any?hard=true`, { method: "DELETE" });
+		expect(res.status).toBe(204);
+		expect(kill).not.toHaveBeenCalled();
+		expect(terminate).not.toHaveBeenCalled();
+		expect(purgeWorkspace).toHaveBeenCalledWith("s-any");
+		expect(deleteRow).toHaveBeenCalledWith("s-any");
+	});
+
+	it("returns 404 when the session id doesn't exist", async () => {
+		const get = vi.fn(async () => null);
+		const kill = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get } as unknown as Partial<SessionManager>,
+			docker: { kill } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/missing`, { method: "DELETE" });
+		expect(res.status).toBe(404);
+		expect(kill).not.toHaveBeenCalled();
+	});
+
+	it("returns 403 when requireAdmin denies (no force-delete bypass for non-admins)", async () => {
+		authStubs.requireAdmin.mockImplementation((_req, res, _next) => {
+			(res as { status: (n: number) => { json: (b: unknown) => void } })
+				.status(403)
+				.json({ error: "Forbidden" });
+		});
+		const get = vi.fn(async () => meta());
+		const kill = vi.fn(async () => undefined);
+		await spinUp(vi.fn(), {
+			sessions: { get } as unknown as Partial<SessionManager>,
+			docker: { kill } as unknown as Partial<DockerManager>,
+		});
+
+		const res = await fetch(`${baseUrl}/api/admin/sessions/s-any?hard=true`, { method: "DELETE" });
+		expect(res.status).toBe(403);
+		expect(get).not.toHaveBeenCalled();
+		expect(kill).not.toHaveBeenCalled();
 	});
 });

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -170,6 +170,7 @@ async function spinUp(sessions: SessionManager, docker: DockerManager) {
 		logout: { ipMax: 1000, ipWindowMs: 60_000 },
 		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
 		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
 	});
 	const app = express();
 	app.use(express.json());

--- a/backend/src/routes.start.test.ts
+++ b/backend/src/routes.start.test.ts
@@ -141,6 +141,7 @@ async function spinUp(sessions: SessionManager, docker: DockerManager) {
 		logout: { ipMax: 1000, ipWindowMs: 60_000 },
 		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
 		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
 	});
 	const app = express();
 	app.use(express.json());

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -421,6 +421,9 @@ export function buildRouter(
 	// counters (idle sweeper, dispatcher, reconcile, D1 call rate)
 	// land in follow-up PRs so each one can ship independently.
 
+	// SHARES `adminStatsIp` (keyed per-IP) with `GET /admin/sessions`
+	// — see the comment on that route below + `RateLimitConfig.adminStats`
+	// for the budget rationale.
 	router.get("/admin/stats", adminStatsIp, requireAdmin, async (_req: Request, res: Response) => {
 		try {
 			const byStatus = await sessions.countByStatus();

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -464,6 +464,12 @@ export function buildRouter(
 	// every session row across every user (capped at ADMIN_LIST_LIMIT),
 	// paired with the owner's username. Reads-only — destructive actions
 	// live on the /admin/sessions/:id endpoints below.
+	//
+	// SHARES `adminStatsIp` with `GET /admin/stats` — see the comment
+	// on `RateLimitConfig.adminStats` for the budget rationale. A
+	// dashboard polling both pairs of endpoints drains the bucket 2×
+	// faster than a single endpoint would, which is why the default is
+	// sized for the pair, not the individual route.
 	router.get(
 		"/admin/sessions",
 		adminStatsIp,

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -93,6 +93,7 @@ export function buildRouter(
 		logoutIp,
 		authStatusIp,
 		adminStatsIp,
+		adminActionIp,
 	} = createAuthRateLimiters(rateLimitConfig);
 	const usernameLimiter = new UsernameRateLimiter(
 		rateLimitConfig.login.usernameMax,
@@ -458,6 +459,115 @@ export function buildRouter(
 			res.status(500).json({ error: "Internal server error" });
 		}
 	});
+
+	// Cross-user sessions list for the admin dashboard (#241d). Returns
+	// every session row across every user (capped at ADMIN_LIST_LIMIT),
+	// paired with the owner's username. Reads-only — destructive actions
+	// live on the /admin/sessions/:id endpoints below.
+	router.get(
+		"/admin/sessions",
+		adminStatsIp,
+		requireAdmin,
+		async (_req: Request, res: Response) => {
+			try {
+				const list = await sessions.listAll();
+				// Serialise via the same `serializeMeta` shape the user-facing
+				// `GET /sessions` returns + an `ownerUsername` field so the
+				// admin UI doesn't have to do a second lookup per row.
+				// Admin response includes `userId` (the regular
+				// `serializeMeta` deliberately omits it to avoid leaking
+				// internal IDs to non-admin users). Admins need the id
+				// to cross-reference logs and to drive the force-action
+				// endpoints by row.
+				res.json(
+					list.map((row) => ({
+						...serializeMeta(row),
+						userId: row.userId,
+						ownerUsername: row.ownerUsername,
+					})),
+				);
+			} catch (err) {
+				logger.error(`[admin] sessions list failed: ${(err as Error).message}`);
+				res.status(500).json({ error: "Internal server error" });
+			}
+		},
+	);
+
+	// Admin force-stop: same code path as `POST /sessions/:id/stop`
+	// minus the `assertOwnedBy` gate. `idleSweeper.forget` is called so
+	// the swept session doesn't sit in the activity map collecting
+	// stale bumps from a future race (e.g. the owner reconnects between
+	// stop and the next `/start`). 204 on success, 500 on docker error.
+	router.post(
+		"/admin/sessions/:id/stop",
+		adminActionIp,
+		requireAdmin,
+		async (req: Request, res: Response) => {
+			try {
+				// `get` first so a non-existent id returns 404 rather than
+				// surfacing a Docker "no such container" deep in
+				// stopContainer. Same shape the user path uses, just
+				// without ownership gating.
+				const meta = await sessions.get(req.params.id);
+				if (!meta) {
+					res.status(404).json({ error: "Session not found" });
+					return;
+				}
+				await docker.stopContainer(req.params.id);
+				idleSweeper?.forget(req.params.id);
+				res.status(204).send();
+			} catch (err) {
+				logger.error(`[admin] force-stop failed: ${(err as Error).message}`);
+				res.status(500).json({ error: "Internal server error" });
+			}
+		},
+	);
+
+	// Admin force-delete: mirrors the user-facing `DELETE /sessions/:id`
+	// minus `assertOwnedBy`. `?hard=true` purges workspace files and
+	// drops the D1 row; default is soft-delete (container killed, row
+	// flips to terminated, workspace preserved). The owner can still
+	// restore a soft-deleted session via `POST /sessions/:id/start` —
+	// admin force-delete is the same operation the owner could have
+	// done themselves, not a stronger semantic.
+	router.delete(
+		"/admin/sessions/:id",
+		adminActionIp,
+		requireAdmin,
+		async (req: Request, res: Response) => {
+			const hard = req.query.hard === "true" || req.query.hard === "1";
+			try {
+				const meta = await sessions.get(req.params.id);
+				if (!meta) {
+					res.status(404).json({ error: "Session not found" });
+					return;
+				}
+				// Idempotent soft branch — only kill + terminate if not
+				// already torn down.
+				if (meta.status !== "terminated") {
+					await docker.kill(req.params.id);
+					await sessions.terminate(req.params.id);
+					idleSweeper?.forget(req.params.id);
+				}
+				if (hard) {
+					try {
+						await docker.purgeWorkspace(req.params.id);
+					} catch (err) {
+						logger.error(
+							`[admin] force-delete purgeWorkspace failed for ${req.params.id}: ${(err as Error).message}`,
+						);
+						// Fall through — the D1 row removal still happens.
+					}
+					await sessions.deleteRow(req.params.id);
+					idleSweeper?.forget(req.params.id);
+				}
+				res.status(204).send();
+			} catch (err) {
+				logger.error(`[admin] force-delete failed: ${(err as Error).message}`);
+				res.status(500).json({ error: "Internal server error" });
+			}
+		},
+	);
 
 	// ── Session routes ──────────────────────────────────────────────────────
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -465,11 +465,14 @@ export function buildRouter(
 	// paired with the owner's username. Reads-only — destructive actions
 	// live on the /admin/sessions/:id endpoints below.
 	//
-	// SHARES `adminStatsIp` with `GET /admin/stats` — see the comment
-	// on `RateLimitConfig.adminStats` for the budget rationale. A
-	// dashboard polling both pairs of endpoints drains the bucket 2×
-	// faster than a single endpoint would, which is why the default is
-	// sized for the pair, not the individual route.
+	// SHARES `adminStatsIp` (keyed per-IP, not per-admin) with
+	// `GET /admin/stats` — see the comment on `RateLimitConfig.adminStats`
+	// for the budget rationale. A dashboard polling both pairs of
+	// endpoints drains the bucket 2× faster than a single endpoint
+	// would, which is why the default is sized for the pair, not the
+	// individual route. Per-IP keying means two admins behind the same
+	// NAT/office IP share the bucket — same tradeoff every other IP
+	// limiter in the app makes.
 	router.get(
 		"/admin/sessions",
 		adminStatsIp,
@@ -504,6 +507,14 @@ export function buildRouter(
 	// the swept session doesn't sit in the activity map collecting
 	// stale bumps from a future race (e.g. the owner reconnects between
 	// stop and the next `/start`). 204 on success, 500 on docker error.
+	//
+	// Response shape DIVERGES from the user-facing route: the user
+	// path re-reads and returns the updated SessionMeta so the
+	// caller can update its UI without a second fetch; the admin
+	// path returns 204 because the admin dashboard (#241e) always
+	// re-fetches the full session list after an action (operators
+	// see all sessions, not just the one they touched). Saves a D1
+	// round-trip per action.
 	router.post(
 		"/admin/sessions/:id/stop",
 		adminActionIp,

--- a/backend/src/sessionManager.test.ts
+++ b/backend/src/sessionManager.test.ts
@@ -94,6 +94,55 @@ describe("SessionManager.create — quota filter", () => {
 	});
 });
 
+// ── listAll (#241d) ────────────────────────────────────────────────────────
+
+describe("SessionManager.listAll", () => {
+	it("issues a single JOIN with the users table, newest-first, capped by ADMIN_LIST_LIMIT", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await mgr.listAll();
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+		const [sql, params] = dbStubs.d1Query.mock.calls[0]!;
+		// JOIN shape: every session row → owner row via FK.
+		expect(sql).toMatch(/FROM\s+sessions\s+s\s+JOIN\s+users\s+u\s+ON\s+u\.id\s*=\s*s\.user_id/i);
+		// Newest-first ordering for the dashboard.
+		expect(sql).toMatch(/ORDER\s+BY\s+s\.created_at\s+DESC/i);
+		// LIMIT is present so a runaway deployment doesn't return a
+		// multi-megabyte blob.
+		expect(sql).toMatch(/LIMIT\s+\d+/i);
+		// No bound params — cross-user aggregate, no per-user filter.
+		expect(params).toBeUndefined();
+	});
+
+	it("rehydrates rows into SessionMeta + ownerUsername", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [{ ...fakeSessionRow("s1", "u1"), username: "alice" }],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const list = await mgr.listAll();
+		expect(list).toHaveLength(1);
+		expect(list[0]?.sessionId).toBe("s1");
+		expect(list[0]?.userId).toBe("u1");
+		expect(list[0]?.ownerUsername).toBe("alice");
+	});
+
+	it("returns [] when no sessions exist", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await expect(mgr.listAll()).resolves.toEqual([]);
+	});
+});
+
 // ── countByStatus (#241) ───────────────────────────────────────────────────
 
 describe("SessionManager.countByStatus", () => {

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -153,6 +153,16 @@ export const OWNERSHIP_CACHE_TTL_MS = 60 * 60 * 1000;
  *  and 500 users this caps memory at ~10k entries × ~80 bytes each. */
 export const OWNERSHIP_CACHE_MAX = 10_000;
 
+/**
+ * Hard cap on rows returned by `listAll()` (#241d). Sized at 500
+ * because a typical operator dashboard refresh on a deployment with
+ * hundreds of sessions shouldn't return a multi-megabyte JSON blob.
+ * If a deployment grows past this, the dashboard will silently miss
+ * older terminated rows — pagination is a follow-up if anyone hits
+ * the cap in practice.
+ */
+export const ADMIN_LIST_LIMIT = 500;
+
 interface OwnershipCacheEntry {
 	ownerUserId: string;
 	expiresAt: number;
@@ -307,6 +317,34 @@ export class SessionManager {
 			ownerUserId,
 			expiresAt: Date.now() + OWNERSHIP_CACHE_TTL_MS,
 		});
+	}
+
+	/**
+	 * Cross-user session list for the admin dashboard (#241d). Returns
+	 * every session row across every user, paired with the owner's
+	 * username, newest-first. Hard-capped at `ADMIN_LIST_LIMIT` so a
+	 * deployment with 10k accumulated sessions doesn't return a
+	 * 10MB JSON blob on a routine dashboard refresh.
+	 *
+	 * Admin-gated at the route layer; do NOT call this from any
+	 * non-admin code path — it bypasses user-scoping.
+	 *
+	 * The JOIN to `users` is unconditional inner-join because the FK
+	 * means every session row has a parent user; if a row ever slips
+	 * past that (manual D1 edit), it's silently dropped from the
+	 * admin list, which is the safer fallback vs surfacing a null
+	 * username the UI would have to special-case.
+	 */
+	async listAll(): Promise<Array<SessionMeta & { ownerUsername: string }>> {
+		const result = await d1Query<SessionRow & { username: string }>(
+			"SELECT s.*, u.username AS username " +
+				"FROM sessions s JOIN users u ON u.id = s.user_id " +
+				`ORDER BY s.created_at DESC LIMIT ${ADMIN_LIST_LIMIT}`,
+		);
+		return result.results.map((row) => ({
+			...rowToMeta(row),
+			ownerUsername: row.username,
+		}));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fourth slice of #241. Three new admin-gated endpoints close the backend observability + cross-user admin surface; only the frontend (241e) remains.

- **`GET /api/admin/sessions`** — cross-user session list. Every session row across every user (capped at `ADMIN_LIST_LIMIT = 500`), paired with the owner's username via a JOIN against `users`. Newest-first. Read-only.
- **`POST /api/admin/sessions/:id/stop`** — force-stop ANY session. Same code path as the user-facing `/sessions/:id/stop` minus the `assertOwnedBy` gate. `idleSweeper.forget` is called so a stale bump can't re-add the entry. Returns 204 (the admin dashboard refetches the full list after acting; saves a D1 round-trip per action).
- **`DELETE /api/admin/sessions/:id`** (with optional `?hard=true`) — force-delete. Mirrors the user-facing semantics. Idempotent: hard-delete on an already-terminated session skips the kill/terminate branch but still purges + drops the row.

## Plumbing

- New `SessionManager.listAll()` — single JOIN against `users`, returns SessionMeta with `ownerUsername` attached. Bounded at `ADMIN_LIST_LIMIT` to avoid multi-megabyte responses on deployments with many accumulated sessions.
- New `adminActionIp` rate limiter (60/h) — separate from the read-side `adminStatsIp` (240/h, now shared across `GET /admin/stats` AND `GET /admin/sessions`) so a polling dashboard can't starve the operator's ability to act during an incident.
- Admin response includes `userId` (the user-facing `serializeMeta` deliberately omits it). Admins need the id to cross-reference logs and to target force-action endpoints.

## Authorization model

Force-actions reuse the SAME code paths as the user-facing routes (`docker.stopContainer` / `kill` / `purgeWorkspace`, `sessions.terminate` / `deleteRow`). The only difference is the authorization layer — admin endpoints replace `assertOwnedBy` with `requireAdmin`. Security semantics unchanged for both paths.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 661 tests pass

16 new tests pin:
- 3 `sessionManager.listAll`: SQL JOIN shape (with `LIMIT`), row rehydration with ownerUsername, empty result.
- 3 `GET /admin/sessions`: returns cross-user list, 403 from `requireAdmin` does NOT call `listAll` (regression would be a cross-user data leak), generic 500 on D1 error.
- 4 `POST /admin/sessions/:id/stop`: force-stops ANY session (no ownership check), 404 on missing id, 403 when admin gate denies, generic 500 on docker error.
- 6 `DELETE /admin/sessions/:id`: soft-delete default, hard with `?hard=true`, hard on already-terminated session (idempotent), 404 on missing, 403 on non-admin, generic 500 on docker error.

## Deferred

- **PR 241e**: frontend Admin sidebar consuming `/api/admin/stats` + `/api/admin/sessions` + force-action endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)