### PR TITLE
feat(admin): frontend Admin dashboard view (#241, PR 241e of 4 — closes #241)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,6 +131,7 @@
             <span id="sidebar-user-display" aria-hidden="true"></span>
             <button id="sidebar-templates-btn" type="button">Templates</button>
             <button id="sidebar-invites-btn" type="button">Invites</button>
+            <button id="sidebar-admin-btn" type="button">Admin</button>
             <button id="sidebar-logout-btn" type="button">Logout</button>
           </div>
         </aside>
@@ -771,6 +772,52 @@
         </p>
         <div id="templates-list">
           <p class="modal-hint" id="templates-empty-hint">Loading templates…</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Admin dashboard (#241e). Visible only to is_admin=1 users via
+         applyAdminVisibility() — the sidebar button is .hidden for
+         non-admins, and every consumed endpoint is requireAdmin-gated
+         server-side so a leaked button reveal is harmless. -->
+    <div id="admin-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card admin-modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="admin-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="admin-modal-title">Admin dashboard</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint">
+          Process-local counters since the last backend restart. Refresh
+          manually after running force-actions — the dashboard doesn't
+          poll on its own (to keep the shared admin rate-limit headroom).
+        </p>
+        <div class="admin-controls">
+          <button id="admin-refresh-btn" type="button">Refresh</button>
+          <span id="admin-uptime" class="admin-uptime"></span>
+        </div>
+        <div id="admin-scroll-area">
+          <section class="admin-stats" id="admin-stats">
+            <p class="modal-hint">Loading stats…</p>
+          </section>
+          <section class="admin-sessions">
+            <h3 class="admin-section-title">Sessions (all users)</h3>
+            <div id="admin-sessions-list">
+              <p class="modal-hint">Loading sessions…</p>
+            </div>
+          </section>
         </div>
       </div>
     </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -639,6 +639,81 @@ export async function revokeInvite(codeHash: string): Promise<void> {
 	}
 }
 
+// ── Admin (#241) ────────────────────────────────────────────────────────────
+//
+// Shapes mirror the backend's `routes.ts` admin endpoints. All admin
+// surface is gated server-side by `requireAdmin` + `requireAuth`; the
+// client just calls and surfaces errors.
+
+export interface AdminStats {
+	bootedAt: string;
+	uptimeSeconds: number;
+	sessions: {
+		byStatus: { running: number; stopped: number; terminated: number; failed: number };
+	};
+	idleSweeper: {
+		lastSweepAt: number | null;
+		sweptSinceBoot: number;
+		currentMapSize: number;
+	} | null;
+	reconcile: {
+		lastRunAt: number | null;
+		sessionsCheckedSinceBoot: number;
+		errorsSinceBoot: number;
+	};
+	dispatcher: {
+		requestsSinceBoot: number;
+		responses2xxSinceBoot: number;
+		responses3xxSinceBoot: number;
+		responses4xxSinceBoot: number;
+		responses5xxSinceBoot: number;
+	};
+	d1: { callsSinceBoot: number };
+}
+
+/** Admin-visible session row — extends `SessionInfo` with the
+ *  cross-user identifiers the dashboard needs to attribute and
+ *  act on each row. */
+export interface AdminSession extends SessionInfo {
+	userId: string;
+	ownerUsername: string;
+}
+
+export async function fetchAdminStats(): Promise<AdminStats> {
+	const res = await apiFetch("/admin/stats");
+	if (!res.ok) throw new Error(`Failed to load admin stats (${res.status})`);
+	return res.json();
+}
+
+export async function fetchAdminSessions(): Promise<AdminSession[]> {
+	const res = await apiFetch("/admin/sessions");
+	if (!res.ok) throw new Error(`Failed to load admin sessions (${res.status})`);
+	return res.json();
+}
+
+export async function adminForceStop(sessionId: string): Promise<void> {
+	const res = await apiFetch(`/admin/sessions/${encodeURIComponent(sessionId)}/stop`, {
+		method: "POST",
+	});
+	if (res.status === 404) return; // race: session removed between list + action
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to force-stop session (${res.status})`);
+	}
+}
+
+export async function adminForceDelete(sessionId: string, hard: boolean): Promise<void> {
+	const path = hard
+		? `/admin/sessions/${encodeURIComponent(sessionId)}?hard=true`
+		: `/admin/sessions/${encodeURIComponent(sessionId)}`;
+	const res = await apiFetch(path, { method: "DELETE" });
+	if (res.status === 404) return;
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to force-delete session (${res.status})`);
+	}
+}
+
 // ── File uploads ────────────────────────────────────────────────────────────
 
 /**

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -969,6 +969,145 @@ main:not([data-sidebar-ready]) #sidebar {
 }
 /* #195 PR 195c — Templates page (sidebar entry → modal listing
    the user's own templates with Use / Delete actions). */
+/* ── Admin dashboard (#241e) ───────────────────────────────────
+   Wider modal card + scroll-aware inner layout. Stats live in a
+   responsive grid; session rows below. Same scroll-containment
+   shape as the new-session modal — header/controls anchored,
+   content scrolls inside the `.modal-card` clipping boundary. */
+.admin-modal-card {
+  width: 720px;
+  max-width: 96vw;
+}
+.admin-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+  flex-shrink: 0;
+}
+.admin-controls button {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.4rem 0.85rem;
+  color: #e6edf3;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.admin-controls button:hover {
+  background: #30363d;
+}
+.admin-controls button:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+.admin-uptime {
+  font-size: 0.78rem;
+  color: #8b949e;
+}
+#admin-scroll-area {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.admin-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.6rem;
+}
+.admin-stat-card {
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.admin-stat-card h4 {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8b949e;
+  margin-bottom: 0.2rem;
+}
+.admin-stat-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.82rem;
+}
+.admin-stat-key {
+  color: #c9d1d9;
+}
+.admin-stat-value {
+  color: #58a6ff;
+  font-variant-numeric: tabular-nums;
+}
+.admin-section-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #e6edf3;
+  margin-bottom: 0.5rem;
+}
+.admin-session-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  background: #0d1117;
+  margin-bottom: 0.4rem;
+}
+.admin-session-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+  flex: 1;
+}
+.admin-session-meta strong {
+  font-size: 0.88rem;
+  color: #e6edf3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.admin-session-sub {
+  font-size: 0.74rem;
+  color: #8b949e;
+}
+.admin-session-actions {
+  display: flex;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+.admin-session-actions button {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.75rem;
+  color: #c9d1d9;
+  cursor: pointer;
+}
+.admin-session-actions button:hover {
+  background: #30363d;
+  border-color: #58a6ff;
+}
+.admin-session-actions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.admin-session-actions button.admin-session-delete:hover {
+  border-color: #f85149;
+  color: #f85149;
+}
+
 /* The list scrolls inside the modal so a user with the maximum
    100 templates can reach every card on a short viewport — same
    inner-scroll shape as `.session-tab-panel.is-active` and

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2639,7 +2639,12 @@ document.addEventListener("keydown", (e) => {
 		// Escape with one of them open AND the sidebar visible
 		// would close both at once. PR #230 round 1 NIT.
 		templatesModal.classList.contains("open") ||
-		saveTemplateModal.classList.contains("open")
+		saveTemplateModal.classList.contains("open") ||
+		// adminModal joined the modal lineup in #241e; without this
+		// guard, Escape with the admin dashboard open AND the
+		// sidebar drawer visible would close the sidebar instead
+		// of the dialog.
+		adminModal.classList.contains("open")
 	)
 		return;
 	if (!mainEl.classList.contains("sidebar-open")) return;
@@ -2974,6 +2979,8 @@ document.addEventListener("keydown", (e) => {
 		closeNewSessionModal();
 	} else if (templatesModal.classList.contains("open")) {
 		closeTemplatesModal();
+	} else if (adminModal.classList.contains("open")) {
+		closeAdminModal();
 	} else if (invitesModal.classList.contains("open")) {
 		closeInvitesModal();
 	} else if (pasteModal.classList.contains("open")) {
@@ -3531,6 +3538,15 @@ async function confirmAndAct(
 		await refreshAdmin();
 	} catch (err) {
 		showToast((err as Error).message, true);
+	} finally {
+		// `refreshAdmin` swallows its own errors and toasts, so this
+		// `catch` only fires on `action()` itself throwing. If the
+		// action succeeded but refresh failed AFTER, the DOM hasn't
+		// been rebuilt and the original `btn` is still mounted —
+		// re-enable it unconditionally here so the operator isn't
+		// stuck with a permanently-disabled button until the next
+		// manual Refresh. (When refresh DID rebuild the rows, this
+		// runs on an orphaned button object — a harmless no-op.)
 		btn.disabled = false;
 	}
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3489,7 +3489,7 @@ function renderAdminSessions(sessions: AdminSession[]): void {
 		deleteBtn.className = "admin-session-delete";
 		deleteBtn.addEventListener("click", () =>
 			confirmAndAct(
-				`Force-delete "${s.name}" (${s.ownerUsername})?\n\nClick OK for soft-delete (workspace preserved), Cancel to skip.`,
+				`Soft-delete "${s.name}" (${s.ownerUsername})?\n\nContainer will be stopped and the row terminated; workspace is preserved.`,
 				deleteBtn,
 				async () => {
 					await adminForceDelete(s.sessionId, false);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,6 +11,10 @@
 import "./main.css";
 
 import {
+	type AdminSession,
+	type AdminStats,
+	adminForceDelete,
+	adminForceStop,
 	checkAuthStatus,
 	createInvite,
 	createSession,
@@ -20,6 +24,8 @@ import {
 	deleteTab,
 	deleteTemplate,
 	type EnvVarEntryInput,
+	fetchAdminSessions,
+	fetchAdminStats,
 	getTemplate,
 	type Invite,
 	InviteRequiredError,
@@ -91,6 +97,12 @@ const sidebarEl = document.getElementById("sidebar")!;
 const sidebarToggleBtn = document.getElementById("sidebar-toggle") as HTMLButtonElement;
 const sidebarBackdrop = document.getElementById("sidebar-backdrop")!;
 const sidebarInvitesBtn = document.getElementById("sidebar-invites-btn") as HTMLButtonElement;
+const sidebarAdminBtn = document.getElementById("sidebar-admin-btn") as HTMLButtonElement;
+const adminModal = document.getElementById("admin-modal")!;
+const adminStatsEl = document.getElementById("admin-stats")!;
+const adminSessionsListEl = document.getElementById("admin-sessions-list")!;
+const adminRefreshBtn = document.getElementById("admin-refresh-btn") as HTMLButtonElement;
+const adminUptimeEl = document.getElementById("admin-uptime")!;
 const sidebarLogoutBtn = document.getElementById("sidebar-logout-btn") as HTMLButtonElement;
 const chromeToggleBtn = document.getElementById("chrome-toggle") as HTMLButtonElement;
 const chromeToggleLabel = document.getElementById("chrome-toggle-label")!;
@@ -236,6 +248,7 @@ function applyAdminVisibility() {
 	const admin = isAdmin();
 	invitesBtn.classList.toggle("hidden", !admin);
 	sidebarInvitesBtn.classList.toggle("hidden", !admin);
+	sidebarAdminBtn.classList.toggle("hidden", !admin);
 }
 
 function updateAuthUI() {
@@ -3291,6 +3304,236 @@ fileInput.addEventListener("change", async () => {
 		attachInFlight = false;
 	}
 });
+
+// ── Admin dashboard (#241e) ─────────────────────────────────────────────────
+//
+// Visible only to is_admin=1 users via `applyAdminVisibility()`. Pulls
+// `/api/admin/stats` and `/api/admin/sessions` on open + on refresh.
+// No auto-polling — keeps the shared `adminStatsIp` (240/h) bucket
+// available for operator-initiated refreshes and pairs naturally with
+// the dashboard's "did my force-action take effect" mental model
+// (refresh, see new state, act, refresh).
+
+let adminOpener: HTMLButtonElement | null = null;
+
+function openAdminModal(opener: HTMLButtonElement) {
+	adminOpener = opener;
+	adminModal.classList.add("open");
+	adminModal.setAttribute("aria-hidden", "false");
+	adminRefreshBtn.focus();
+	void refreshAdmin();
+}
+
+function closeAdminModal() {
+	adminModal.classList.remove("open");
+	adminModal.setAttribute("aria-hidden", "true");
+	(adminOpener ?? sidebarAdminBtn).focus();
+	adminOpener = null;
+}
+
+adminModal.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeAdminModal();
+});
+
+sidebarAdminBtn.addEventListener("click", () => openAdminModal(sidebarAdminBtn));
+
+adminRefreshBtn.addEventListener("click", () => {
+	void refreshAdmin();
+});
+
+async function refreshAdmin(): Promise<void> {
+	// Fetch both endpoints in parallel — they're independent reads
+	// gated by the same admin token, and a sequential await would
+	// double the dashboard latency without any safety upside.
+	adminRefreshBtn.disabled = true;
+	try {
+		const [stats, sessions] = await Promise.all([fetchAdminStats(), fetchAdminSessions()]);
+		renderAdminStats(stats);
+		renderAdminSessions(sessions);
+	} catch (err) {
+		// Per-endpoint failure surfaces via the toast; the panels keep
+		// their previous state rather than wiping to a half-rendered
+		// shell.
+		showToast((err as Error).message, true);
+	} finally {
+		adminRefreshBtn.disabled = false;
+	}
+}
+
+function formatRelativeTime(ts: number | null): string {
+	if (ts === null) return "never";
+	const ageSec = Math.round((Date.now() - ts) / 1000);
+	if (ageSec < 60) return `${ageSec}s ago`;
+	if (ageSec < 3600) return `${Math.round(ageSec / 60)}m ago`;
+	return `${Math.round(ageSec / 3600)}h ago`;
+}
+
+function formatUptime(seconds: number): string {
+	if (seconds < 60) return `${seconds}s`;
+	if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+	if (seconds < 86_400) return `${Math.round(seconds / 3600)}h`;
+	return `${Math.round(seconds / 86_400)}d`;
+}
+
+function renderAdminStats(stats: AdminStats): void {
+	adminUptimeEl.textContent = `Uptime ${formatUptime(stats.uptimeSeconds)} · booted ${new Date(stats.bootedAt).toLocaleString()}`;
+	adminStatsEl.textContent = "";
+
+	const panel = (title: string, rows: Array<[string, string]>) => {
+		const card = document.createElement("div");
+		card.className = "admin-stat-card";
+		const h = document.createElement("h4");
+		h.textContent = title;
+		card.appendChild(h);
+		for (const [k, v] of rows) {
+			const row = document.createElement("div");
+			row.className = "admin-stat-row";
+			const ks = document.createElement("span");
+			ks.className = "admin-stat-key";
+			ks.textContent = k;
+			const vs = document.createElement("span");
+			vs.className = "admin-stat-value";
+			vs.textContent = v;
+			row.appendChild(ks);
+			row.appendChild(vs);
+			card.appendChild(row);
+		}
+		adminStatsEl.appendChild(card);
+	};
+
+	const s = stats.sessions.byStatus;
+	panel("Sessions", [
+		["Running", String(s.running)],
+		["Stopped", String(s.stopped)],
+		["Terminated", String(s.terminated)],
+		["Failed", String(s.failed)],
+	]);
+
+	const sw = stats.idleSweeper;
+	panel("Idle sweeper", [
+		["Last sweep", formatRelativeTime(sw?.lastSweepAt ?? null)],
+		["Reaped since boot", String(sw?.sweptSinceBoot ?? 0)],
+		["Tracked sessions", String(sw?.currentMapSize ?? 0)],
+	]);
+
+	const r = stats.reconcile;
+	panel("Reconcile", [
+		["Last run", formatRelativeTime(r.lastRunAt)],
+		["Sessions checked", String(r.sessionsCheckedSinceBoot)],
+		["Errors", String(r.errorsSinceBoot)],
+	]);
+
+	const d = stats.dispatcher;
+	panel("Dispatcher", [
+		["Requests", String(d.requestsSinceBoot)],
+		["2xx", String(d.responses2xxSinceBoot)],
+		["3xx", String(d.responses3xxSinceBoot)],
+		["4xx", String(d.responses4xxSinceBoot)],
+		["5xx", String(d.responses5xxSinceBoot)],
+	]);
+
+	panel("D1", [["Calls since boot", String(stats.d1.callsSinceBoot)]]);
+}
+
+function renderAdminSessions(sessions: AdminSession[]): void {
+	adminSessionsListEl.textContent = "";
+	if (sessions.length === 0) {
+		const empty = document.createElement("p");
+		empty.className = "modal-hint";
+		empty.textContent = "No sessions.";
+		adminSessionsListEl.appendChild(empty);
+		return;
+	}
+	for (const s of sessions) {
+		const row = document.createElement("div");
+		row.className = "admin-session-row";
+
+		const meta = document.createElement("div");
+		meta.className = "admin-session-meta";
+		const name = document.createElement("strong");
+		name.textContent = s.name;
+		const sub = document.createElement("span");
+		sub.className = "admin-session-sub";
+		sub.textContent = `${s.ownerUsername} · ${s.status} · ${new Date(s.createdAt).toLocaleString()}`;
+		meta.appendChild(name);
+		meta.appendChild(sub);
+
+		const actions = document.createElement("div");
+		actions.className = "admin-session-actions";
+
+		// Force-stop only enabled for running sessions — the backend
+		// returns 204 on a no-op stop, but the button label would be
+		// misleading on a stopped/terminated session.
+		const stopBtn = document.createElement("button");
+		stopBtn.type = "button";
+		stopBtn.textContent = "Stop";
+		stopBtn.disabled = s.status !== "running";
+		stopBtn.addEventListener("click", () =>
+			confirmAndAct(`Force-stop "${s.name}" (${s.ownerUsername})?`, stopBtn, async () => {
+				await adminForceStop(s.sessionId);
+				showToast(`Stopped ${s.name}`);
+			}),
+		);
+
+		const deleteBtn = document.createElement("button");
+		deleteBtn.type = "button";
+		deleteBtn.textContent = "Delete";
+		deleteBtn.className = "admin-session-delete";
+		deleteBtn.addEventListener("click", () =>
+			confirmAndAct(
+				`Force-delete "${s.name}" (${s.ownerUsername})?\n\nClick OK for soft-delete (workspace preserved), Cancel to skip.`,
+				deleteBtn,
+				async () => {
+					await adminForceDelete(s.sessionId, false);
+					showToast(`Soft-deleted ${s.name}`);
+				},
+			),
+		);
+
+		const hardBtn = document.createElement("button");
+		hardBtn.type = "button";
+		hardBtn.textContent = "Hard-delete";
+		hardBtn.className = "admin-session-delete";
+		hardBtn.addEventListener("click", () =>
+			confirmAndAct(
+				`HARD-DELETE "${s.name}" (${s.ownerUsername})?\n\nThis purges the workspace directory AND drops the D1 row. Unrecoverable.`,
+				hardBtn,
+				async () => {
+					await adminForceDelete(s.sessionId, true);
+					showToast(`Hard-deleted ${s.name}`);
+				},
+			),
+		);
+
+		actions.appendChild(stopBtn);
+		actions.appendChild(deleteBtn);
+		actions.appendChild(hardBtn);
+		row.appendChild(meta);
+		row.appendChild(actions);
+		adminSessionsListEl.appendChild(row);
+	}
+}
+
+/** Confirm + run an admin action. Disables the trigger button across
+ *  the in-flight window so a double-click can't fire two destructive
+ *  requests; refreshes the dashboard on success so the row reflects
+ *  the new state without the operator clicking Refresh. */
+async function confirmAndAct(
+	prompt: string,
+	btn: HTMLButtonElement,
+	action: () => Promise<void>,
+): Promise<void> {
+	if (!confirm(prompt)) return;
+	btn.disabled = true;
+	try {
+		await action();
+		await refreshAdmin();
+	} catch (err) {
+		showToast((err as Error).message, true);
+		btn.disabled = false;
+	}
+}
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Final slice of #241. The backend admin observability + force-action surface (241a/b/c/d) is now consumed by an admin-only dashboard modal accessible from the sidebar.

**Closes #241.**

## What lands

- New sidebar entry **"Admin"**, visible only when `isAdmin()` returns true (same `applyAdminVisibility()` helper that gates the existing invites button). Non-admins never see the entry, AND every consumed endpoint is `requireAdmin`-gated server-side so a leaked button reveal is harmless.
- Admin dashboard modal with two panes:
  - **Top**: stats grid showing sessions-by-status, idle sweeper, reconcile, dispatcher (HTTP request + 2xx/3xx/4xx/5xx breakdown), and D1 call rate. Uptime + boot timestamp at the top.
  - **Bottom**: cross-user sessions list with per-row **Stop / Delete / Hard-delete** buttons. Force-stop disabled for non-running sessions (the backend would 204 a no-op, but the button label would mislead).
- **Manual refresh only** — no auto-polling. Keeps the shared `adminStatsIp` (240/h) bucket available for operator-initiated refreshes and matches the dashboard's mental model: "refresh, see new state, act, refresh".
- Destructive actions confirm via `confirm()` before firing, disable the trigger button across the in-flight window (no double-fire on double-click), and refresh the dashboard on success.

## Frontend API client

- `AdminStats` / `AdminSession` types mirror the backend response shapes from #241a–d.
- `fetchAdminStats()` / `fetchAdminSessions()` / `adminForceStop()` / `adminForceDelete(id, hard)`.
- 404 on force-actions is silently swallowed — race between list refresh and action fire on a freshly-removed session; the operator-visible outcome is the same.

## CSS

- `.admin-modal-card` is 720px (capped at 96vw on mobile) vs the standard 480/540px to fit the stats grid.
- `#admin-scroll-area` is the inner scroll container, mirroring the `.session-tab-panel.is-active` shape from #247 so modal chrome stays anchored.
- Stats grid uses `repeat(auto-fit, minmax(200px, 1fr))` so it reflows from 4–5 columns on desktop to 1 column on mobile without media queries.

## Test plan

- [x] `npm run lint` clean (frontend)
- [x] `npm run build` clean (vite)
- [ ] Browser verification — this dev environment has no interactive browser. Reviewer should:
  - Confirm sidebar "Admin" entry visible for admin users, hidden for non-admins.
  - Open the modal; confirm stats panels render with the boot/uptime line at the top.
  - Confirm cross-user sessions list renders with `ownerUsername`; Stop disabled for non-running rows.
  - Force-stop a test session; confirm the row updates to `stopped` after the auto-refresh.
  - Hard-delete a test session; confirm it disappears from the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)