### PR TITLE
fix(bootstrap): clone-into-workspace-root via temp+move (#254)

### DIFF
--- a/backend/src/bootstrap/cloneRepo.test.ts
+++ b/backend/src/bootstrap/cloneRepo.test.ts
@@ -11,6 +11,7 @@ import { encryptAuthCredentials, type SessionConfigRecord } from "../sessionConf
 import {
 	buildCloneArgv,
 	CloneCredentialMissingError,
+	NOAUTH_CLONE_SCRIPT,
 	PAT_CLONE_SCRIPT,
 	patEnv,
 	resolveTargetAbsPath,
@@ -143,7 +144,7 @@ describe("runCloneRepo", () => {
 		expect(docker.streamExec).not.toHaveBeenCalled();
 	});
 
-	it("invokes streamExec with the cloning argv for repo.auth='none'", async () => {
+	it("invokes streamExec with the no-auth clone bash script and env-encoded values (#254)", async () => {
 		await runCloneRepo({
 			sessionId: "sess-1",
 			config: makeConfig({
@@ -154,27 +155,30 @@ describe("runCloneRepo", () => {
 		expect(docker.streamExec).toHaveBeenCalledTimes(1);
 		const [sessionId, opts] = docker.streamExec.mock.calls[0]!;
 		expect(sessionId).toBe("sess-1");
-		expect(opts.cmd).toEqual([
-			"git",
-			"clone",
-			"--branch",
-			"main",
-			"--depth",
-			"1",
-			"--",
-			"https://example.com/r",
-			"/home/developer/workspace",
-		]);
+		// Shell-mode (#254): no-auth now uses `bash -c <NOAUTH_CLONE_SCRIPT>`
+		// so the clone-into-temp + move-into-target flow works even when the
+		// workspace is non-empty (entrypoint.sh seeds .npm-global before
+		// bootstrap runs).
+		expect(opts.cmd[0]).toBe("bash");
+		expect(opts.cmd[1]).toBe("-c");
+		// User values reach git via env vars, NOT via shell-interpolated
+		// argv strings — same security model as PAT/SSH. A schema regex
+		// already blocks `;` in URLs (#213), but env-encoding is the
+		// load-bearing layer for any value that slips past the regex.
+		expect(opts.env).toEqual({
+			ST_URL: "https://example.com/r",
+			ST_REF: "main",
+			ST_DEPTH: "1",
+			ST_TARGET_ABS: "/home/developer/workspace",
+		});
 		expect(opts.workingDir).toBe("/home/developer/workspace");
 	});
 
-	// The runner is argv-mode (no `bash -c`) so a hostile-but-schema-
-	// passing URL like one containing a literal `;` would reach git as a
-	// single positional argument, NOT as a shell command separator. The
-	// schema regex blocks `;` in URLs as of #213, but the argv-only
-	// invocation is the load-bearing layer that defangs values that slip
-	// past the regex.
-	it("never wraps the command in a shell layer", async () => {
+	it("env-encodes user values (no shell-interpolation in argv)", async () => {
+		// Switched to shell-mode (#254) but the security model is the same:
+		// user values land in env, the script references them double-quoted,
+		// so shell-meta is inert. argv contains only `bash -c <script>` —
+		// no user-controlled strings.
 		await runCloneRepo({
 			sessionId: "sess-1",
 			config: makeConfig({
@@ -183,13 +187,17 @@ describe("runCloneRepo", () => {
 			docker: docker as unknown as DockerManager,
 		});
 		const [, opts] = docker.streamExec.mock.calls[0]!;
-		// argv[0] must be `git`, not `bash` or `sh`.
-		expect(opts.cmd[0]).toBe("git");
-		expect(opts.cmd).not.toContain("bash");
-		expect(opts.cmd).not.toContain("-c");
+		// argv has exactly 3 entries — bash, -c, the static script body.
+		// Anything else would indicate a regression that re-introduced
+		// shell-interpolated argv.
+		expect(opts.cmd).toHaveLength(3);
+		expect(opts.cmd[0]).toBe("bash");
+		expect(opts.cmd[1]).toBe("-c");
+		expect(opts.cmd[2]).not.toContain("https://example.com/r");
+		expect(opts.env?.ST_URL).toBe("https://example.com/r");
 	});
 
-	it("clones into a subdir when target is set", async () => {
+	it("env-encodes the target as a subdir when target is set", async () => {
 		await runCloneRepo({
 			sessionId: "sess-1",
 			config: makeConfig({
@@ -202,13 +210,13 @@ describe("runCloneRepo", () => {
 			docker: docker as unknown as DockerManager,
 		});
 		const [, opts] = docker.streamExec.mock.calls[0]!;
-		expect(opts.cmd[opts.cmd.length - 1]).toBe("/home/developer/workspace/services/api");
+		expect(opts.env?.ST_TARGET_ABS).toBe("/home/developer/workspace/services/api");
 	});
 
-	// Empty target → workspace root. Documented as the replace-workspace
-	// mode signal. Test pins the resolution rather than the side-effects
-	// of git cloning into a non-empty workspace, which is git's job.
-	it("clones into the workspace root when target is empty", async () => {
+	// Empty target → workspace root. The clone-then-move script (#254)
+	// makes this case work even though the workspace is non-empty due to
+	// the entrypoint-seeded .npm-global directory.
+	it("env-encodes the target as the workspace root when target is empty", async () => {
 		await runCloneRepo({
 			sessionId: "sess-1",
 			config: makeConfig({
@@ -217,7 +225,7 @@ describe("runCloneRepo", () => {
 			docker: docker as unknown as DockerManager,
 		});
 		const [, opts] = docker.streamExec.mock.calls[0]!;
-		expect(opts.cmd[opts.cmd.length - 1]).toBe("/home/developer/workspace");
+		expect(opts.env?.ST_TARGET_ABS).toBe("/home/developer/workspace");
 	});
 
 	// ── #188 PR 188d — PAT auth path ───────────────────────────────────────
@@ -325,6 +333,42 @@ describe("runCloneRepo", () => {
 		// hang the bootstrap on a stdin prompt. Pinning so the PR
 		// doesn't accidentally remove the env it sets.
 		expect(PAT_CLONE_SCRIPT).toContain("GIT_TERMINAL_PROMPT=0");
+	});
+
+	// ── #254 — clone-and-move shape on all three scripts ───────────────────
+	//
+	// The temp-clone + mv-into-target flow is what makes a clone-into-
+	// workspace-root succeed when entrypoint.sh has already seeded
+	// .npm-global. Pin the marker fragments so a future edit that drops
+	// the temp redirection (and re-introduces `git clone <url> $TARGET`
+	// against a non-empty workspace) trips this assertion immediately.
+
+	it("all three clone scripts use temp+move into target (#254)", () => {
+		for (const script of [NOAUTH_CLONE_SCRIPT, PAT_CLONE_SCRIPT, SSH_CLONE_SCRIPT]) {
+			// Clone destination is the temp dir, NOT the target — git
+			// can't refuse the temp because we just created it.
+			expect(script).toContain('"$TMP_CLONE/repo"');
+			// `mv` into the target rather than letting `git clone`
+			// write directly there.
+			expect(script).toContain('mv "$f" "$ST_TARGET_ABS/"');
+			// Skip-on-conflict so the entrypoint-seeded .npm-global
+			// survives. A regression that overwrote silently would
+			// drop this branch.
+			expect(script).toMatch(/already exists in target/);
+			// dotglob so .git, .gitignore, etc. are part of the move.
+			expect(script).toContain("shopt -s dotglob nullglob");
+		}
+	});
+
+	it("NOAUTH_CLONE_SCRIPT is the minimal temp+move shape (no auth setup)", () => {
+		// No askpass, no SSH key write — just temp + clone + move.
+		expect(NOAUTH_CLONE_SCRIPT).not.toContain("ASKPASS_PATH");
+		expect(NOAUTH_CLONE_SCRIPT).not.toContain("GIT_SSH_COMMAND");
+		expect(NOAUTH_CLONE_SCRIPT).not.toContain("ST_PAT");
+		expect(NOAUTH_CLONE_SCRIPT).not.toContain("ST_SSH_KEY");
+		// `set -e` so any step in the move loop hard-fails the bootstrap
+		// rather than silently producing a half-populated workspace.
+		expect(NOAUTH_CLONE_SCRIPT).toMatch(/^set -e/);
 	});
 
 	// ── #188 PR 188d — SSH auth path ───────────────────────────────────────

--- a/backend/src/bootstrap/cloneRepo.test.ts
+++ b/backend/src/bootstrap/cloneRepo.test.ts
@@ -510,6 +510,19 @@ describe("runCloneRepo", () => {
 		expect(r.stderr).toBe("");
 	});
 
+	it("NOAUTH_CLONE_SCRIPT parses cleanly under bash -n", () => {
+		// #254: the no-auth path is now shell-mode too. A future edit
+		// to CLONE_AND_MOVE_TAIL that breaks quoting would otherwise
+		// only surface for PAT/SSH; this test makes sure no-auth
+		// catches the same regression.
+		const r = spawnSync("bash", ["-n"], {
+			input: NOAUTH_CLONE_SCRIPT,
+			encoding: "utf8",
+		});
+		expect(r.status).toBe(0);
+		expect(r.stderr).toBe("");
+	});
+
 	// ── env helpers (PR 188d) ──────────────────────────────────────────────
 
 	// `patEnv` and `sshEnv` produce strings (not numbers / undefined)

--- a/backend/src/bootstrap/cloneRepo.ts
+++ b/backend/src/bootstrap/cloneRepo.ts
@@ -6,10 +6,13 @@
  * the user's hook (or first interactive command) runs. Output streams
  * to the same WS broadcaster as postCreate.
  *
- * Three auth modes (188d wires PAT and SSH on top of 188c's "none"):
+ * Three auth modes (188d wires PAT and SSH on top of 188c's "none";
+ * #254 unified all three on a shared clone-then-move shape):
  *
- *   - `auth: "none"` — anonymous HTTPS clone. Pure argv invocation
- *     (no shell), single `streamExec` call.
+ *   - `auth: "none"` — anonymous HTTPS clone. Shell-mode (since
+ *     #254): values are env-encoded (`ST_URL`, etc.) and the script
+ *     references them double-quoted, so shell-meta in any value
+ *     is inert.
  *
  *   - `auth: "pat"` — HTTPS clone authenticated by a personal access
  *     token. The PAT NEVER appears in argv (process listings) or in
@@ -30,11 +33,19 @@
  *     the user can subsequently `git pull` / `git push` from the
  *     interactive shell without further setup.
  *
- * The PAT/SSH paths are bash-script-mode (multi-step setup before
- * the clone). User-supplied values (URL, ref, target, depth) reach
- * `git` as positional argv inside the script — populated via env
- * vars and expanded with bash double-quoting — so a value that
- * slipped past the schema's regex still cannot become shell meta.
+ * All three paths are bash-script-mode (multi-step setup + the
+ * shared clone-into-temp + mv-into-target tail). User-supplied
+ * values (URL, ref, target, depth) reach `git` as positional argv
+ * inside the script — populated via env vars and expanded with bash
+ * double-quoting — so a value that slipped past the schema's regex
+ * still cannot become shell meta.
+ *
+ * The clone-then-move tail (#254) exists because entrypoint.sh
+ * pre-seeds `/home/developer/workspace/.npm-global/` so the
+ * workspace is non-empty by the time bootstrap runs; `git clone`
+ * refuses non-empty targets directly. We clone into a fresh temp
+ * dir, then move each entry into the workspace skip-on-conflict so
+ * the entrypoint-seeded `.npm-global` survives.
  */
 
 import type { DockerManager } from "../dockerManager.js";
@@ -258,23 +269,6 @@ export function sshEnv(
 }
 
 /**
- * Bash script for PAT clone. All user-controlled values are read from
- * env vars and double-quoted at use, so shell-meta in any of them is
- * inert. The askpass file is shredded on exit (success OR fail) via
- * `trap … EXIT` so a process snooping `/tmp` doesn't find the PAT.
- *
- * Note the conditional `--branch` / `--depth` handling: the variables
- * are empty strings when the user didn't configure them; the bash
- * `[ -n ]` guards skip the corresponding flag when so. Empty
- * positional values would NOT be safe — `git clone --branch ""`
- * crashes — and the empty-string convention is what `patEnv`
- * produces.
- *
- * Also exported for the unit-test that pins the script shape so a
- * future edit doesn't accidentally drop the `set -e`, the cleanup
- * trap, or the `--` separator.
- */
-/**
  * Shared bash fragment that performs the clone-into-temp + move-into-target
  * step (#254). All three modes (no-auth / PAT / SSH) append this AFTER
  * their auth-setup bytes. `mv`-into-target (not `git clone <target>`)
@@ -316,6 +310,23 @@ for f in "$TMP_CLONE/repo"/*; do
 done
 `;
 
+/**
+ * Bash script for PAT clone. All user-controlled values are read from
+ * env vars and double-quoted at use, so shell-meta in any of them is
+ * inert. The askpass file is shredded on exit (success OR fail) via
+ * `trap … EXIT` so a process snooping `/tmp` doesn't find the PAT.
+ *
+ * Note the conditional `--branch` / `--depth` handling inside the
+ * shared `CLONE_AND_MOVE_TAIL`: the variables are empty strings when
+ * the user didn't configure them; the bash `[ -n ]` guards skip the
+ * corresponding flag. Empty positional values would NOT be safe —
+ * `git clone --branch ""` crashes — and the empty-string convention
+ * is what `patEnv` produces.
+ *
+ * Also exported for the unit-test that pins the script shape so a
+ * future edit doesn't accidentally drop the `set -e`, the cleanup
+ * trap, or the temp+move tail.
+ */
 export const PAT_CLONE_SCRIPT = `set -e
 # Cleanup runs on EXIT (success or fail) so the askpass file never
 # survives the clone — the PAT it would print is gone with it. Same

--- a/backend/src/bootstrap/cloneRepo.ts
+++ b/backend/src/bootstrap/cloneRepo.ts
@@ -94,12 +94,23 @@ export async function runCloneRepo(args: RunCloneRepoArgs): Promise<{ exitCode: 
 	);
 
 	if (repo.auth === "none") {
-		const cloneArgv = buildCloneArgv(repo.url, repo.ref, repo.depth, targetAbs);
-		// argv-mode (no shell) — user-controlled values reach `git` as
-		// positional args, never as shell tokens.
+		// Switched from argv-mode to shell-mode (#254) so the clone path
+		// can do "clone to temp, then move into target" — required when
+		// the target is the workspace root, because entrypoint.sh
+		// pre-seeds `/home/developer/workspace/.npm-global/` and
+		// `git clone <url> /home/developer/workspace` refuses non-empty
+		// targets. User values are env-encoded (`ST_URL`, `ST_REF`,
+		// etc.) and the script references them quoted, so shell-meta
+		// in any of them is inert — same security model as PAT/SSH.
+		const env = noAuthEnv(repo);
 		return docker.streamExec(
 			sessionId,
-			{ cmd: cloneArgv, workingDir: CONTAINER_WORKSPACE, signal },
+			{
+				cmd: ["bash", "-c", NOAUTH_CLONE_SCRIPT],
+				env,
+				workingDir: CONTAINER_WORKSPACE,
+				signal,
+			},
 			onOutput,
 		);
 	}
@@ -159,6 +170,11 @@ export function resolveTargetAbsPath(target: string | undefined): string {
 
 /**
  * Build the argv array for an `auth: "none"` clone.
+ *
+ * No longer used by the runtime clone path (#254 switched no-auth to
+ * shell-mode for the temp+move flow); kept for the unit-test that
+ * pins the argv shape in case a future change adds an argv-mode
+ * entry point or rolls back the shell move.
  */
 export function buildCloneArgv(
 	url: string,
@@ -175,6 +191,26 @@ export function buildCloneArgv(
 	}
 	argv.push("--", url, targetAbs);
 	return argv;
+}
+
+/**
+ * Env block for the no-auth clone (#254). Mirrors `patEnv` / `sshEnv`
+ * minus the credential field — same env-encoded shape so a future
+ * edit to the shared `CLONE_AND_MOVE_TAIL` script template doesn't
+ * have to branch per auth mode.
+ */
+export function noAuthEnv(repo: {
+	url: string;
+	ref?: string;
+	depth?: number | null;
+	target?: string;
+}): Record<string, string> {
+	return {
+		ST_URL: repo.url,
+		ST_REF: repo.ref ?? "",
+		ST_DEPTH: repo.depth != null ? String(repo.depth) : "",
+		ST_TARGET_ABS: resolveTargetAbsPath(repo.target),
+	};
 }
 
 /**
@@ -238,11 +274,55 @@ export function sshEnv(
  * future edit doesn't accidentally drop the `set -e`, the cleanup
  * trap, or the `--` separator.
  */
+/**
+ * Shared bash fragment that performs the clone-into-temp + move-into-target
+ * step (#254). All three modes (no-auth / PAT / SSH) append this AFTER
+ * their auth-setup bytes. `mv`-into-target (not `git clone <target>`)
+ * because the entrypoint.sh pre-seeds .npm-global into the workspace,
+ * which makes the workspace non-empty, which makes git refuse to clone
+ * into it. Skip-on-conflict so any pre-existing entry (e.g. .npm-global)
+ * survives untouched — a future workspace-side file collision yields a
+ * warning + skipped move, not a hard fail.
+ *
+ * Caller MUST have already exported / set:
+ *   ST_URL, ST_REF, ST_DEPTH, ST_TARGET_ABS, TMP_CLONE
+ * and any auth-related env vars (GIT_ASKPASS, GIT_SSH_COMMAND, ...).
+ * Caller is also responsible for installing the EXIT trap that cleans
+ * up TMP_CLONE (and any auth temp files).
+ */
+const CLONE_AND_MOVE_TAIL = `ARGS=("git" "clone")
+[ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
+[ -n "$ST_DEPTH" ] && ARGS+=("--depth" "$ST_DEPTH")
+ARGS+=("--" "$ST_URL" "$TMP_CLONE/repo")
+"\${ARGS[@]}"
+mkdir -p "$ST_TARGET_ABS"
+# dotglob picks up dotfiles (e.g. .git, .gitignore) so the cloned
+# repo is complete inside the target. nullglob makes an empty
+# repo (no entries at all) a no-op instead of expanding to the
+# literal pattern.
+shopt -s dotglob nullglob
+for f in "$TMP_CLONE/repo"/*; do
+  name="$(basename "$f")"
+  if [ -e "$ST_TARGET_ABS/$name" ]; then
+    # Skip rather than overwrite. The workspace already has the
+    # entry (entrypoint-seeded .npm-global, or a future case where
+    # a user pre-populated something) and silently clobbering would
+    # destroy that data. Warn so the user sees it in the bootstrap
+    # log.
+    printf 'warning: skipping cloned entry %s — already exists in target\\n' "$name" >&2
+  else
+    mv "$f" "$ST_TARGET_ABS/"
+  fi
+done
+`;
+
 export const PAT_CLONE_SCRIPT = `set -e
 # Cleanup runs on EXIT (success or fail) so the askpass file never
-# survives the clone — the PAT it would print is gone with it.
+# survives the clone — the PAT it would print is gone with it. Same
+# cleanup also drops the temp-clone dir (#254).
 ASKPASS_PATH=$(mktemp /tmp/git-askpass-XXXXXXXX)
-cleanup() { rm -f "$ASKPASS_PATH"; }
+TMP_CLONE=$(mktemp -d /tmp/clone-XXXXXXXX)
+cleanup() { rm -f "$ASKPASS_PATH"; rm -rf "$TMP_CLONE"; }
 trap cleanup EXIT
 cat > "$ASKPASS_PATH" <<'ASKPASS_EOF'
 #!/bin/sh
@@ -257,12 +337,7 @@ export GIT_ASKPASS="$ASKPASS_PATH"
 # remote that doesn't accept the PAT would block the bootstrap on
 # stdin. We want a clean non-zero exit code instead.
 export GIT_TERMINAL_PROMPT=0
-ARGS=("git" "clone")
-[ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
-[ -n "$ST_DEPTH" ] && ARGS+=("--depth" "$ST_DEPTH")
-ARGS+=("--" "$ST_URL" "$ST_TARGET_ABS")
-"\${ARGS[@]}"
-# Defensive unset AFTER the clone (NOT before — git invokes the
+${CLONE_AND_MOVE_TAIL}# Defensive unset AFTER the clone (NOT before — git invokes the
 # askpass shim as a child process which reads $ST_PAT from its
 # inherited env; unsetting before would break auth). PR #218 round
 # 2 NIT — symmetry with SSH script's pre-clone unset (which is safe
@@ -280,6 +355,8 @@ unset ST_PAT
  * Also exported for the unit-test that pins the script shape.
  */
 export const SSH_CLONE_SCRIPT = `set -e
+TMP_CLONE=$(mktemp -d /tmp/clone-XXXXXXXX)
+trap 'rm -rf "$TMP_CLONE"' EXIT
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
 # printf '%s' (no trailing \\n) so a key that already ends in \\n
@@ -306,9 +383,16 @@ unset ST_SSH_KEY ST_KNOWN_HOSTS
 # hostile DNS / network can't substitute its own host key during
 # the clone.
 export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=yes"
-ARGS=("git" "clone")
-[ -n "$ST_REF" ] && ARGS+=("--branch" "$ST_REF")
-[ -n "$ST_DEPTH" ] && ARGS+=("--depth" "$ST_DEPTH")
-ARGS+=("--" "$ST_URL" "$ST_TARGET_ABS")
-"\${ARGS[@]}"
-`;
+${CLONE_AND_MOVE_TAIL}`;
+
+/**
+ * Bash script for the no-auth (public-repo) clone (#254). Same
+ * temp+move shape as PAT/SSH — uses the shared CLONE_AND_MOVE_TAIL
+ * so a future edit to the move logic propagates everywhere.
+ *
+ * Exported for the unit-test that pins the script shape.
+ */
+export const NOAUTH_CLONE_SCRIPT = `set -e
+TMP_CLONE=$(mktemp -d /tmp/clone-XXXXXXXX)
+trap 'rm -rf "$TMP_CLONE"' EXIT
+${CLONE_AND_MOVE_TAIL}`;

--- a/backend/src/bootstrap/cloneRepo.ts
+++ b/backend/src/bootstrap/cloneRepo.ts
@@ -406,4 +406,11 @@ ${CLONE_AND_MOVE_TAIL}`;
 export const NOAUTH_CLONE_SCRIPT = `set -e
 TMP_CLONE=$(mktemp -d /tmp/clone-XXXXXXXX)
 trap 'rm -rf "$TMP_CLONE"' EXIT
+# Same rationale as the PAT path: some "public" remotes still
+# present a credential challenge (corporate git hosts, HTTP
+# redirectors that wrap a private repo behind a public URL).
+# Without GIT_TERMINAL_PROMPT=0, git would block on stdin
+# indefinitely; the 10-minute bootstrap cap would be the only
+# backstop. Refuse the prompt so we get a clean non-zero exit.
+export GIT_TERMINAL_PROMPT=0
 ${CLONE_AND_MOVE_TAIL}`;


### PR DESCRIPTION
## Summary

Closes #254. **User-reported bug**: creating a session with a public repo URL and no other config fails 100% in the clone stage with `fatal: destination path '/home/developer/workspace' already exists and is not an empty directory`.

**Cause**: `session-image/entrypoint.sh` seeds `/home/developer/workspace/.npm-global/` from the image's claude install on first container boot (so claude survives container recreate via the bind-mounted workspace). The seeding lands BEFORE `runAsyncBootstrap` fires, so the workspace is non-empty by the time `runCloneRepo` issues `git clone <url> /home/developer/workspace` — git refuses non-empty targets.

All three auth modes (no-auth / PAT / SSH) had the same latent bug — the user only hit no-auth because public repos are the easiest path to try.

## Fix

Switch all three clone modes to a "clone into temp, then `mv` into target" pattern via a shared `CLONE_AND_MOVE_TAIL` bash fragment:

- `git clone` into `$TMP_CLONE/repo` (always empty — works fine)
- `mv` each cloned entry into `$ST_TARGET_ABS`, **skip-on-conflict** so pre-existing entries (entrypoint-seeded `.npm-global`, user-pre-populated files) survive untouched; warn on each skip so the user sees the conflict in the bootstrap log.
- `dotglob` / `nullglob` so `.git` and other dotfiles are part of the move and an empty repo is a no-op rather than a literal-glob error.

The no-auth path was previously argv-mode (`["git", "clone", ...]`); it's now shell-mode (`["bash", "-c", NOAUTH_CLONE_SCRIPT]`) with user values env-encoded as `ST_URL` / `ST_REF` / `ST_DEPTH` / `ST_TARGET_ABS` — same security model as PAT/SSH. The schema regex that blocks `;` in URLs (#213) is still the first line of defence; env-encoding is the load-bearing layer for any value that slips past.

`buildCloneArgv` is preserved (now unused by the runtime path) so its existing argv-shape test still pins what an argv-mode entry point would look like if a future change rolls back the shell move.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 663 tests pass (4 existing no-auth tests rewritten for shell-mode shape, 2 new structural tests pinning the temp+move shape across all three scripts)
- [ ] Browser verification — no interactive browser in this dev environment. Reviewer should:
  - Create a session with a public repo URL, nothing else configured → confirm it lands in `running`, not `failed`.
  - Confirm the cloned files are present in the workspace.
  - Confirm `.npm-global/` is still in the workspace (entrypoint-seeded survives the move).
  - Smoke-test PAT and SSH paths still work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)