### PR TITLE
fix(frontend): surface Templates + Admin buttons on desktop

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -97,7 +97,9 @@
         </button>
         <div class="header-right">
           <span id="user-display"></span>
+          <button id="templates-btn" type="button" title="Session templates">Templates</button>
           <button id="invites-btn" title="Manage invite codes">Invites</button>
+          <button id="admin-btn" type="button" title="Admin dashboard">Admin</button>
           <button id="logout-btn">Logout</button>
         </div>
         <button

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -98,9 +98,9 @@
         <div class="header-right">
           <span id="user-display"></span>
           <button id="templates-btn" type="button" title="Session templates">Templates</button>
-          <button id="invites-btn" title="Manage invite codes">Invites</button>
+          <button id="invites-btn" type="button" title="Manage invite codes">Invites</button>
           <button id="admin-btn" type="button" title="Admin dashboard">Admin</button>
-          <button id="logout-btn">Logout</button>
+          <button id="logout-btn" type="button">Logout</button>
         </div>
         <button
           id="actions-btn"

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -200,7 +200,9 @@ main.chrome-open #chrome-toggle-icon {
   border-color: #f85149;
   color: #f85149;
 }
-#invites-btn {
+#templates-btn,
+#invites-btn,
+#admin-btn {
   background: transparent;
   border: 1px solid #30363d;
   border-radius: 6px;
@@ -209,7 +211,9 @@ main.chrome-open #chrome-toggle-icon {
   padding: 0.25rem 0.6rem;
   cursor: pointer;
 }
-#invites-btn:hover {
+#templates-btn:hover,
+#invites-btn:hover,
+#admin-btn:hover {
   border-color: #58a6ff;
   color: #58a6ff;
 }
@@ -1260,7 +1264,9 @@ main:not([data-sidebar-ready]) #sidebar {
   color: #3fb950;
   margin-right: auto;
 }
+#sidebar-templates-btn,
 #sidebar-invites-btn,
+#sidebar-admin-btn,
 #sidebar-logout-btn {
   background: transparent;
   border: 1px solid #30363d;
@@ -1270,7 +1276,9 @@ main:not([data-sidebar-ready]) #sidebar {
   padding: 0.35rem 0.7rem;
   cursor: pointer;
 }
-#sidebar-invites-btn:hover {
+#sidebar-templates-btn:hover,
+#sidebar-invites-btn:hover,
+#sidebar-admin-btn:hover {
   border-color: #58a6ff;
   color: #58a6ff;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -98,6 +98,8 @@ const sidebarToggleBtn = document.getElementById("sidebar-toggle") as HTMLButton
 const sidebarBackdrop = document.getElementById("sidebar-backdrop")!;
 const sidebarInvitesBtn = document.getElementById("sidebar-invites-btn") as HTMLButtonElement;
 const sidebarAdminBtn = document.getElementById("sidebar-admin-btn") as HTMLButtonElement;
+const templatesBtn = document.getElementById("templates-btn") as HTMLButtonElement;
+const adminBtn = document.getElementById("admin-btn") as HTMLButtonElement;
 const adminModal = document.getElementById("admin-modal")!;
 const adminStatsEl = document.getElementById("admin-stats")!;
 const adminSessionsListEl = document.getElementById("admin-sessions-list")!;
@@ -248,6 +250,7 @@ function applyAdminVisibility() {
 	const admin = isAdmin();
 	invitesBtn.classList.toggle("hidden", !admin);
 	sidebarInvitesBtn.classList.toggle("hidden", !admin);
+	adminBtn.classList.toggle("hidden", !admin);
 	sidebarAdminBtn.classList.toggle("hidden", !admin);
 }
 
@@ -2124,7 +2127,12 @@ function openTemplatesModal(opener: HTMLElement) {
 function closeTemplatesModal() {
 	templatesModal.classList.remove("open");
 	templatesModal.setAttribute("aria-hidden", "true");
-	(templatesOpener ?? sidebarTemplatesBtn).focus();
+	// Fall back to the desktop button if the opener is missing (legacy
+	// path or a future caller that forgot to set it). Matches the
+	// Invites convention — on mobile the desktop button is hidden, so a
+	// missing opener still drops focus, but that's a regression to flag
+	// in code review, not something to silently paper over here.
+	(templatesOpener ?? templatesBtn).focus();
 	templatesOpener = null;
 }
 
@@ -2221,6 +2229,7 @@ templatesModal.addEventListener("click", (e) => {
 	if (target.hasAttribute("data-close-modal")) closeTemplatesModal();
 });
 
+templatesBtn.addEventListener("click", () => openTemplatesModal(templatesBtn));
 sidebarTemplatesBtn.addEventListener("click", () => openTemplatesModal(sidebarTemplatesBtn));
 
 async function deleteTemplateConfirmed(id: string, card: HTMLDivElement) {
@@ -3348,7 +3357,9 @@ function openAdminModal(opener: HTMLButtonElement) {
 function closeAdminModal() {
 	adminModal.classList.remove("open");
 	adminModal.setAttribute("aria-hidden", "true");
-	(adminOpener ?? sidebarAdminBtn).focus();
+	// Fall back to the desktop button if the opener is missing — same
+	// rationale as closeTemplatesModal / closeInvitesModal.
+	(adminOpener ?? adminBtn).focus();
 	adminOpener = null;
 }
 
@@ -3357,6 +3368,7 @@ adminModal.addEventListener("click", (e) => {
 	if (target.hasAttribute("data-close-modal")) closeAdminModal();
 });
 
+adminBtn.addEventListener("click", () => openAdminModal(adminBtn));
 sidebarAdminBtn.addEventListener("click", () => openAdminModal(sidebarAdminBtn));
 
 adminRefreshBtn.addEventListener("click", () => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2145,12 +2145,12 @@ function openTemplatesModal(opener: HTMLElement) {
 function closeTemplatesModal() {
 	templatesModal.classList.remove("open");
 	templatesModal.setAttribute("aria-hidden", "true");
-	// Fall back to the desktop button if the opener is missing (legacy
-	// path or a future caller that forgot to set it). Matches the
-	// Invites convention — on mobile the desktop button is hidden, so a
-	// missing opener still drops focus, but that's a regression to flag
-	// in code review, not something to silently paper over here.
-	(templatesOpener ?? templatesBtn).focus();
+	// Fall back to whichever button is rendered for the current
+	// viewport if the opener is missing (legacy path or a future
+	// caller that forgot to set it). The resolver covers both
+	// desktop and mobile — `templatesBtn` is `display:none` on
+	// mobile and would silently drop focus there otherwise.
+	(templatesOpener ?? resolveTemplatesOpener()).focus();
 	templatesOpener = null;
 }
 
@@ -3364,6 +3364,15 @@ fileInput.addEventListener("change", async () => {
 
 let adminOpener: HTMLButtonElement | null = null;
 
+/** Symmetric with `resolveTemplatesOpener` — see that helper for the
+ *  rationale. Admin is opened from a single click site per surface,
+ *  so the resolver is currently only consumed by the close fallback,
+ *  but keeping it parallel to Templates makes the pattern uniform if
+ *  a future caller opens the admin modal from a third place. */
+function resolveAdminOpener(): HTMLButtonElement {
+	return adminBtn.offsetParent !== null ? adminBtn : sidebarAdminBtn;
+}
+
 function openAdminModal(opener: HTMLButtonElement) {
 	adminOpener = opener;
 	adminModal.classList.add("open");
@@ -3375,9 +3384,9 @@ function openAdminModal(opener: HTMLButtonElement) {
 function closeAdminModal() {
 	adminModal.classList.remove("open");
 	adminModal.setAttribute("aria-hidden", "true");
-	// Fall back to the desktop button if the opener is missing — same
-	// rationale as closeTemplatesModal / closeInvitesModal.
-	(adminOpener ?? adminBtn).focus();
+	// Fall back to the viewport-rendered button if the opener is
+	// missing — same rationale as closeTemplatesModal.
+	(adminOpener ?? resolveAdminOpener()).focus();
 	adminOpener = null;
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1943,7 +1943,7 @@ newSessionForm.addEventListener("submit", async (e) => {
 			// `ORDER BY updated_at DESC`). `openTemplatesModal` already
 			// kicks off `refreshTemplatesList` so no separate fetch
 			// is needed here.
-			openTemplatesModal(sidebarTemplatesBtn);
+			openTemplatesModal(resolveTemplatesOpener());
 		} catch (err) {
 			showToast((err as Error).message, true);
 			newSessionSubmitBtn.disabled = false;
@@ -2117,6 +2117,24 @@ const templatesEmptyHint = document.getElementById("templates-empty-hint") as HT
 
 let templatesOpener: HTMLElement | null = null;
 
+/**
+ * Pick the Templates button that's actually rendered for the current
+ * viewport — `templatesBtn` on desktop, `sidebarTemplatesBtn` on mobile.
+ * `offsetParent === null` is the standard "is this element rendered"
+ * test (returns null for `display:none` ancestors), and the header /
+ * sidebar split is exactly the case it was designed for.
+ *
+ * Used by callers that open the templates modal from a third place
+ * (e.g. the save-template flow re-opening templates after a save) —
+ * those callers don't know which button the user clicked first, so
+ * they must resolve the contextually-correct opener themselves.
+ * Without this, focus restoration on close would land on a hidden
+ * element and silently drop to `document.body`. See PR #257 review.
+ */
+function resolveTemplatesOpener(): HTMLButtonElement {
+	return templatesBtn.offsetParent !== null ? templatesBtn : sidebarTemplatesBtn;
+}
+
 function openTemplatesModal(opener: HTMLElement) {
 	templatesOpener = opener;
 	templatesModal.classList.add("open");
@@ -2253,7 +2271,7 @@ async function useTemplate(id: string) {
 	try {
 		const t = await getTemplate(id);
 		closeTemplatesModal();
-		openNewSessionModal(sidebarTemplatesBtn);
+		openNewSessionModal(resolveTemplatesOpener());
 		applyTemplateToForm(t);
 		showToast(`Loaded template "${t.name}". Fill in any required secrets, then Create.`);
 	} catch (err) {
@@ -2277,7 +2295,7 @@ async function editTemplate(id: string) {
 	try {
 		const t = await getTemplate(id);
 		closeTemplatesModal();
-		openNewSessionModal(sidebarTemplatesBtn);
+		openNewSessionModal(resolveTemplatesOpener());
 		applyTemplateToForm(t);
 		setNewSessionModalMode(t);
 	} catch (err) {


### PR DESCRIPTION
## Summary

- The desktop header (`.header-right`) carried only `Invites` + `Logout`. `Templates` (#195) and `Admin` (#241) were added later but landed only inside `#sidebar-footer`, which CSS hides on desktop (`display: none`; the mobile media query flips it to `flex`). Net effect: **on desktop no user could open Templates and no admin could open the Admin dashboard.**
- The sidebar shared-style selector at `main.css:1263` only named `#sidebar-invites-btn` + `#sidebar-logout-btn`. `#sidebar-templates-btn` + `#sidebar-admin-btn` fell through to default `<button>` rendering — the "greyed-out" mismatch users see on mobile.

Mirror the existing Invites split: add `#templates-btn` + `#admin-btn` to `.header-right` (auto-hidden on mobile by the existing `.header-right { display: none }` rule inside `@media (max-width: 768px)`), wire click handlers using the existing `openTemplatesModal` / `openAdminModal` entry points, extend `applyAdminVisibility()` to toggle `.hidden` on the new admin button, and extend both desktop and sidebar CSS selector groups so the two newcomer buttons pick up the same styling.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/ index.html` clean
- [x] `npx vitest run` — 3 files, 61 tests pass
- [ ] Desktop viewport: as admin, see Templates + Invites + Admin in header → click each → modal opens → Escape closes → focus returns to the originating button
- [ ] Desktop viewport: as non-admin, see Templates only in header (no Invites, no Admin)
- [ ] Mobile viewport (<=768px): header-right hides, sidebar-footer shows Templates / Invites / Admin / Logout, all four styled consistently, hover blue on first three / red on Logout
- [ ] Login as non-admin → promote to admin in D1 → hard-reload → see Admin button appear
- [ ] Logout → admin button hides (no flash for the next login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)