### PR TITLE
fix(bootstrap-ws): error-frame parity + null exit code on success

### DIFF
--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -386,7 +386,13 @@ async function handleBootstrapWs(
 			ws.close(1008, "Forbidden");
 			return;
 		}
+		// Symmetric with the NotFoundError / ForbiddenError branches above:
+		// send an inspectable `error` frame before the close so the client
+		// surfaces the actual failure shape rather than the generic
+		// "Bootstrap channel closed unexpectedly" string the openBootstrapWs
+		// path synthesises on bare-close. See #208 round 1 NIT.
 		logger.error(`[ws] bootstrap auth failed for ${sessionId}: ${(err as Error).message}`);
+		sendError(ws, "Internal error");
 		ws.close(1011, "Internal error");
 		return;
 	}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -266,7 +266,14 @@ export function openBootstrapWs(
 			handlers.onOutput(msg.data);
 		} else if (msg.type === "done") {
 			terminal = true;
-			handlers.onDone(true, 0);
+			// Server's `done` message has no exitCode field — postCreate
+			// exited zero by definition (otherwise we'd be in `fail`).
+			// Pass null to match the `exitCode: number | null` type's
+			// "not explicitly carried on the wire" semantic, rather than
+			// hardcoding 0 which a future caller reading `exitCode` on
+			// the success path would mistake for an explicit known
+			// value. See #208 round 1 NIT.
+			handlers.onDone(true, null);
 		} else if (msg.type === "fail") {
 			terminal = true;
 			handlers.onDone(false, msg.exitCode, msg.error, msg.stage);


### PR DESCRIPTION
## Summary

Two leftover NITs from PR #208 review.

1. **Backend** — `handleBootstrapWs` catch-all branch closes with 1011 but doesn't send a preceding inspectable error frame, unlike the sibling `NotFoundError` / `ForbiddenError` branches that both call \`sendError\` before close. The client's \`openBootstrapWs\` synthesises a generic "Bootstrap channel closed unexpectedly" string instead of surfacing the actual failure shape. Add \`sendError(ws, "Internal error")\` before the 1011 close to match the sibling branches.

2. **Frontend** — the \`done\` server message has no exitCode field, but the client hardcoded \`handlers.onDone(true, 0)\`. The \`BootstrapHandlers\` type declares \`exitCode: number | null\` specifically to distinguish "exited with code 0" from "no exit code carried on the wire". Pass \`null\` to match the type's intent.

## Test plan

- [x] Backend: tsc + biome + vitest (664 tests) clean
- [x] Frontend: tsc + biome + vitest (61 tests) clean
- [ ] Force a 1011 path (e.g. simulate a D1 outage during ws.assertOwnedBy) → client surfaces "Internal error" instead of the generic close-only string

🤖 Generated with [Claude Code](https://claude.com/claude-code)