### PR TITLE
chore: leftover NIT sweep — redactStoredEntries copy + depth step

### DIFF
--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -1038,7 +1038,18 @@ export function redactStoredAuth(stored: AuthStored | undefined): AuthPublic | u
  */
 export function redactStoredEntries(entries: EnvVarEntryStored[]): EnvVarEntryPublic[] {
 	return entries.map((entry) => {
-		if (entry.type === "plain") return entry;
+		// Copy plain entries rather than returning the stored object by
+		// reference. The two variant shapes are structurally identical,
+		// so TS accepts the by-reference return silently — but a future
+		// GET-endpoint caller that mutates an element of the public
+		// array (a reasonable thing to do before serialization) would
+		// also mutate the corresponding stored entry it came from. The
+		// secret branch already constructs a fresh object; mirror that
+		// shape here so both variants are defensive. See #210 round 1
+		// NIT.
+		if (entry.type === "plain") {
+			return { name: entry.name, type: "plain", value: entry.value };
+		}
 		return { name: entry.name, type: "secret", isSet: true };
 	});
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -325,6 +325,7 @@
                   placeholder="(empty = full)"
                   min="1"
                   max="10000"
+                  step="1"
                 />
               </label>
             </div>


### PR DESCRIPTION
## Summary

Two unaddressed NITs from the epic #184 series.

1. **backend/src/sessionConfig.ts** — \`redactStoredEntries\` returned stored plain entries by reference rather than as a copy. The declared return type is \`EnvVarEntryPublic[]\`, but plain elements shared object identity with the input \`EnvVarEntryStored[]\` because the two plain shapes are structurally identical and TS accepted the by-reference path silently. A future GET-endpoint caller that mutates an element before serialization would also mutate the corresponding stored entry. The secret branch already constructs a fresh object — mirror that on the plain branch so both variants are defensive. From #210 round 1 NIT.

2. **frontend/index.html** — \`#repo-depth\` \`<input type="number">\` had \`min="1" max="10000"\` but no \`step="1"\`. \`collectRepoForSubmit()\` calls \`Number.parseInt(depthRaw, 10)\` which silently truncates fractional values, so the user types one value and submits another with no feedback. From #216 round 1 NIT.

## Test plan

- [x] Backend: tsc + biome + sessionConfig vitest (116 tests) clean
- [x] Frontend: tsc + biome clean
- [ ] Try entering \`1.5\` in the depth field → step="1" makes the browser round to the nearest integer instead of letting fractional through

🤖 Generated with [Claude Code](https://claude.com/claude-code)