### PR TITLE
chore(gitignore): silence local env artifacts (.config/, .npm-global/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,13 @@ REVIEW.md
 
 # Claude Code worktrees / local agent state — never commit
 .claude/
+
+# Local environment artifacts that leak into the workspace when the dev
+# sandbox runs with $HOME or $XDG_CONFIG_HOME resolving here. Neither
+# belongs in source — .config/gh holds the developer's GitHub auth
+# (`hosts.yml`), and .npm-global is a host-side `npm install -g`
+# leak. The workspace-bound .npm-global referenced in
+# session-image/entrypoint.sh is INSIDE a session container's
+# bind-mounted workspace, NOT this source repo.
+.config/
+.npm-global/


### PR DESCRIPTION
## Summary

Two host-side artifacts that leak into the workspace when the dev sandbox resolves \$HOME or \$XDG_CONFIG_HOME here:

- **\`.config/gh/\`** — the developer's \`gh\` CLI auth (\`config.yml\` + \`hosts.yml\`). Closes a low-grade footgun where \`git add .\` could publish a GitHub token.
- **\`.npm-global/\`** — a host-side \`npm install -g claude\` (or similar) leak. The workspace-bound \`.npm-global\` referenced in \`session-image/entrypoint.sh\` is INSIDE a session container's bind-mounted workspace, NOT this source repo, so the same name appearing here is unrelated and unwanted.

No code change.

## Test plan

- [x] \`git status --short\` after the change shows a clean tree on the dev sandbox
- [ ] No existing tracked file matches the new ignore patterns (verified — \`git ls-files | grep -E '\\.config/|\\.npm-global/'\` returns nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)