### PR TITLE
feat(groups): schema + groups.ts + admin CRUD routes (#201, PR 201a of 5)

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -272,6 +272,52 @@ export async function migrateDb(): Promise<void> {
                 )`,
 		`CREATE INDEX IF NOT EXISTS idx_templates_owner
                         ON templates(owner_user_id)`,
+		// User groups for the tech-lead role (#201). A group is an admin-
+		// created collection of users with one designated "lead" who can
+		// observe (read-only) the sessions of every member. The lead is
+		// implicitly inserted into `user_group_members` on group create
+		// so "sessions visible to user X" reduces to "X's own ∪ sessions
+		// of any group where X is the lead" with a single JOIN.
+		//
+		// `lead_user_id` carries `ON DELETE RESTRICT` rather than
+		// CASCADE: deleting a user who's still leading a group should
+		// fail loudly at the DB layer so an admin has to reassign the
+		// lead before the user can be removed — silent CASCADE would
+		// leave the group leaderless (lead_user_id NULL would require
+		// a nullable column we don't want) or orphaned. v1 has no
+		// user-deletion API, so this is forward-looking defense.
+		//
+		// `user_group_members` rows CASCADE on either side: deleting a
+		// group nukes its membership rows; deleting a user removes them
+		// from every group they were in. Composite primary key catches
+		// duplicate (group, user) at the DB layer (defence-in-depth
+		// against a future racy add-member path).
+		//
+		// idx_group_members_user covers the lead-of-which-groups lookup
+		// — `WHERE user_id = ?` in `assertCanObserve` (#201b). Without
+		// it that becomes a table scan per auth check on the observe
+		// path; same shape as the other per-user indexes in this file.
+		`CREATE TABLE IF NOT EXISTS user_groups (
+                        id              TEXT PRIMARY KEY,
+                        name            TEXT NOT NULL,
+                        description     TEXT,
+                        lead_user_id    TEXT NOT NULL,
+                        created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                        updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                        FOREIGN KEY (lead_user_id) REFERENCES users(id) ON DELETE RESTRICT
+                )`,
+		`CREATE INDEX IF NOT EXISTS idx_user_groups_lead
+                        ON user_groups(lead_user_id)`,
+		`CREATE TABLE IF NOT EXISTS user_group_members (
+                        group_id        TEXT NOT NULL,
+                        user_id         TEXT NOT NULL,
+                        added_at        TEXT NOT NULL DEFAULT (datetime('now')),
+                        PRIMARY KEY (group_id, user_id),
+                        FOREIGN KEY (group_id) REFERENCES user_groups(id) ON DELETE CASCADE,
+                        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                )`,
+		`CREATE INDEX IF NOT EXISTS idx_group_members_user
+                        ON user_group_members(user_id)`,
 		`CREATE TABLE IF NOT EXISTS session_configs (
                         session_id              TEXT PRIMARY KEY,
                         workspace_strategy      TEXT,

--- a/backend/src/groups.test.ts
+++ b/backend/src/groups.test.ts
@@ -247,6 +247,22 @@ describe("groups.update", () => {
 		const g = await groups.update("g-1", { name: "X", leadUserId: "u-new-lead" });
 		expect(g.leadUserId).toBe("u-new-lead");
 	});
+
+	it("skips the lead-as-member INSERT when the lead is unchanged (rename-only PUT)", async () => {
+		// Pins #262 round-3 NIT: a rename-only PUT (same lead) should
+		// NOT re-INSERT the lead-as-member. Pre-fix this issued a
+		// 5th D1 call that always hit a swallowed UNIQUE error.
+		mockNextRows([groupRow({ leadUserId: "u-lead" })]); // getById
+		mockNextRows([{ id: "u-lead" }]); // user-exists (same lead)
+		mockNextRows([], 1); // UPDATE
+		mockNextRows([groupRow({ leadUserId: "u-lead", name: "Renamed" })]); // re-read
+		const g = await groups.update("g-1", { name: "Renamed", leadUserId: "u-lead" });
+		expect(g.name).toBe("Renamed");
+		expect(g.leadUserId).toBe("u-lead");
+		// Exactly 4 D1 calls — getById, user-exists, UPDATE, re-read.
+		// No member INSERT.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(4);
+	});
 });
 
 // ── deleteGroup ─────────────────────────────────────────────────────────────

--- a/backend/src/groups.test.ts
+++ b/backend/src/groups.test.ts
@@ -1,0 +1,359 @@
+/**
+ * groups.test.ts — unit tests for the user-groups module (#201a).
+ *
+ * Stubs d1Query so each case can drive the call sequence the module
+ * issues. Mirrors templates.test.ts and routes.admin.test.ts setup.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import * as groups from "./groups.js";
+import { NotFoundError } from "./sessionManager.js";
+
+beforeEach(() => {
+	dbStubs.d1Query.mockReset();
+	dbStubs.d1Query.mockImplementation(async () => ({
+		results: [],
+		success: true,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	}));
+});
+
+function groupRow(opts: {
+	id?: string;
+	name?: string;
+	description?: string | null;
+	leadUserId?: string;
+	createdAt?: string;
+	updatedAt?: string;
+}) {
+	return {
+		id: opts.id ?? "g-1",
+		name: opts.name ?? "Frontend",
+		description: opts.description ?? null,
+		lead_user_id: opts.leadUserId ?? "u-lead",
+		created_at: opts.createdAt ?? "2026-05-11 12:00:00",
+		updated_at: opts.updatedAt ?? "2026-05-11 12:00:00",
+	};
+}
+
+function mockNextRows(rows: unknown[], changes = 0) {
+	dbStubs.d1Query.mockImplementationOnce(async () => ({
+		results: rows,
+		success: true,
+		meta: { changes, duration: 0, last_row_id: 0 },
+	}));
+}
+
+// ── create ──────────────────────────────────────────────────────────────────
+
+describe("groups.create", () => {
+	it("inserts a group, inserts the lead as a member, and returns the row", async () => {
+		// Calls in order:
+		//   1. SELECT COUNT(*) FROM user_groups        → 5
+		//   2. SELECT id FROM users WHERE id = ?        → [{id:'u-lead'}]
+		//   3. INSERT INTO user_groups
+		//   4. INSERT INTO user_group_members (lead)
+		//   5. SELECT * FROM user_groups WHERE id = ?
+		mockNextRows([{ n: 5 }]); // count
+		mockNextRows([{ id: "u-lead" }]); // user-exists
+		mockNextRows([], 1); // INSERT group
+		mockNextRows([], 1); // INSERT member
+		mockNextRows([groupRow({ name: "Frontend", leadUserId: "u-lead" })]);
+
+		const group = await groups.create({
+			name: "Frontend",
+			description: null,
+			leadUserId: "u-lead",
+		});
+		expect(group.name).toBe("Frontend");
+		expect(group.leadUserId).toBe("u-lead");
+		// Member-insert call shape: pinned so a future SQL refactor doesn't
+		// drop the implicit-lead-membership invariant silently.
+		const memberInsertCall = dbStubs.d1Query.mock.calls[3]!;
+		expect(memberInsertCall[0]).toMatch(/INSERT INTO user_group_members/);
+		expect(memberInsertCall[1]).toContain("u-lead");
+	});
+
+	it("throws GroupQuotaExceededError when at the deployment cap", async () => {
+		mockNextRows([{ n: groups.MAX_GROUPS_TOTAL }]);
+		await expect(groups.create({ name: "X", leadUserId: "u-lead" })).rejects.toBeInstanceOf(
+			groups.GroupQuotaExceededError,
+		);
+		// Only the COUNT query should have fired.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws GroupUserNotFoundError when the lead user doesn't exist", async () => {
+		mockNextRows([{ n: 0 }]);
+		mockNextRows([]); // user-exists check empty
+		await expect(groups.create({ name: "X", leadUserId: "u-missing" })).rejects.toBeInstanceOf(
+			groups.GroupUserNotFoundError,
+		);
+		// Should NOT have reached the INSERT.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(2);
+	});
+
+	it("swallows a UNIQUE-constraint error on the implicit lead-member insert", async () => {
+		// Race: a concurrent addMember(groupId, leadId) lands first. The
+		// implicit-lead INSERT then hits a UNIQUE constraint, which we
+		// deliberately swallow — the invariant is "lead is a member",
+		// not "the lead-member row was inserted by THIS code path."
+		mockNextRows([{ n: 0 }]); // count
+		mockNextRows([{ id: "u-lead" }]); // user-exists
+		mockNextRows([], 1); // INSERT group
+		dbStubs.d1Query.mockImplementationOnce(async () => {
+			throw new Error("UNIQUE constraint failed: user_group_members.group_id, user_id");
+		});
+		mockNextRows([groupRow({})]); // re-read
+		const group = await groups.create({ name: "X", leadUserId: "u-lead" });
+		expect(group.id).toBe("g-1");
+	});
+});
+
+// ── listAll ─────────────────────────────────────────────────────────────────
+
+describe("groups.listAll", () => {
+	it("returns the typed shape with leadUsername + memberCount from the JOIN", async () => {
+		mockNextRows([
+			{
+				id: "g-1",
+				name: "Frontend",
+				description: "FE team",
+				lead_user_id: "u-lead",
+				created_at: "2026-05-11 12:00:00",
+				updated_at: "2026-05-11 12:00:00",
+				lead_username: "alice",
+				member_count: 8,
+			},
+		]);
+		const list = await groups.listAll();
+		expect(list).toHaveLength(1);
+		expect(list[0]?.leadUsername).toBe("alice");
+		expect(list[0]?.memberCount).toBe(8);
+		expect(list[0]?.name).toBe("Frontend");
+	});
+
+	it("returns an empty array when no groups exist", async () => {
+		mockNextRows([]);
+		expect(await groups.listAll()).toEqual([]);
+	});
+});
+
+// ── getById ─────────────────────────────────────────────────────────────────
+
+describe("groups.getById", () => {
+	it("returns the typed row", async () => {
+		mockNextRows([groupRow({ name: "Mobile" })]);
+		const g = await groups.getById("g-1");
+		expect(g.name).toBe("Mobile");
+	});
+
+	it("throws NotFoundError for an unknown id", async () => {
+		mockNextRows([]);
+		await expect(groups.getById("g-nope")).rejects.toBeInstanceOf(NotFoundError);
+	});
+});
+
+// ── listMembers ─────────────────────────────────────────────────────────────
+
+describe("groups.listMembers", () => {
+	it("returns members joined with usernames in added_at ASC order", async () => {
+		mockNextRows([groupRow({})]); // getById guard
+		mockNextRows([
+			{ user_id: "u-1", username: "alice", added_at: "2026-05-11 12:00:00" },
+			{ user_id: "u-2", username: "bob", added_at: "2026-05-11 12:00:01" },
+		]);
+		const members = await groups.listMembers("g-1");
+		expect(members).toHaveLength(2);
+		expect(members[0]?.username).toBe("alice");
+		expect(members[1]?.username).toBe("bob");
+	});
+
+	it("throws NotFoundError when the group doesn't exist", async () => {
+		mockNextRows([]); // getById empty
+		await expect(groups.listMembers("g-nope")).rejects.toBeInstanceOf(NotFoundError);
+	});
+});
+
+// ── groupsLedBy ─────────────────────────────────────────────────────────────
+
+describe("groups.groupsLedBy", () => {
+	it("returns the ids of every group the user leads", async () => {
+		mockNextRows([{ id: "g-1" }, { id: "g-2" }]);
+		expect(await groups.groupsLedBy("u-lead")).toEqual(["g-1", "g-2"]);
+	});
+
+	it("returns an empty array when the user leads no groups", async () => {
+		mockNextRows([]);
+		expect(await groups.groupsLedBy("u-other")).toEqual([]);
+	});
+});
+
+// ── update ──────────────────────────────────────────────────────────────────
+
+describe("groups.update", () => {
+	it("updates the row, inserts the new lead as a member, and re-reads", async () => {
+		mockNextRows([groupRow({ id: "g-1", leadUserId: "u-old-lead" })]); // getById guard
+		mockNextRows([{ id: "u-new-lead" }]); // user-exists
+		mockNextRows([], 1); // UPDATE
+		mockNextRows([], 1); // INSERT new-lead-as-member
+		mockNextRows([groupRow({ id: "g-1", leadUserId: "u-new-lead", name: "Renamed" })]);
+		const g = await groups.update("g-1", {
+			name: "Renamed",
+			description: null,
+			leadUserId: "u-new-lead",
+		});
+		expect(g.name).toBe("Renamed");
+		expect(g.leadUserId).toBe("u-new-lead");
+		// The UPDATE call must scope by id.
+		const updateCall = dbStubs.d1Query.mock.calls[2]!;
+		expect(updateCall[0]).toMatch(/^UPDATE user_groups/);
+		expect(updateCall[1]).toContain("g-1");
+	});
+
+	it("throws NotFoundError if the group doesn't exist", async () => {
+		mockNextRows([]); // getById empty
+		await expect(groups.update("g-nope", { name: "X", leadUserId: "u" })).rejects.toBeInstanceOf(
+			NotFoundError,
+		);
+	});
+
+	it("throws GroupUserNotFoundError if the new lead doesn't exist", async () => {
+		mockNextRows([groupRow({})]); // getById guard
+		mockNextRows([]); // user-exists empty
+		await expect(
+			groups.update("g-1", { name: "X", leadUserId: "u-missing" }),
+		).rejects.toBeInstanceOf(groups.GroupUserNotFoundError);
+	});
+
+	it("swallows a UNIQUE error when re-inserting the new lead who is already a member", async () => {
+		mockNextRows([groupRow({})]); // getById
+		mockNextRows([{ id: "u-new-lead" }]); // user-exists
+		mockNextRows([], 1); // UPDATE
+		dbStubs.d1Query.mockImplementationOnce(async () => {
+			throw new Error("UNIQUE constraint failed");
+		});
+		mockNextRows([groupRow({ leadUserId: "u-new-lead" })]);
+		const g = await groups.update("g-1", { name: "X", leadUserId: "u-new-lead" });
+		expect(g.leadUserId).toBe("u-new-lead");
+	});
+});
+
+// ── deleteGroup ─────────────────────────────────────────────────────────────
+
+describe("groups.deleteGroup", () => {
+	it("deletes the row after the existence guard", async () => {
+		mockNextRows([groupRow({})]); // getById
+		mockNextRows([], 1); // DELETE
+		await groups.deleteGroup("g-1");
+		const deleteCall = dbStubs.d1Query.mock.calls[1]!;
+		expect(deleteCall[0]).toMatch(/^DELETE FROM user_groups/);
+		expect(deleteCall[1]).toContain("g-1");
+	});
+
+	it("throws NotFoundError if the group is already gone", async () => {
+		mockNextRows([]); // getById empty
+		await expect(groups.deleteGroup("g-nope")).rejects.toBeInstanceOf(NotFoundError);
+	});
+});
+
+// ── addMember ───────────────────────────────────────────────────────────────
+
+describe("groups.addMember", () => {
+	function mockHappyPrechecks(opts: { memberCount?: number } = {}) {
+		mockNextRows([groupRow({})]); // getById guard
+		mockNextRows([{ id: "u-new" }]); // user-exists
+		mockNextRows([{ n: opts.memberCount ?? 0 }]); // members count
+		mockNextRows([{ n: 0 }]); // duplicate-check
+	}
+
+	it("inserts the member when all guards pass", async () => {
+		mockHappyPrechecks();
+		mockNextRows([], 1); // INSERT
+		await groups.addMember("g-1", "u-new");
+		const insertCall = dbStubs.d1Query.mock.calls[4]!;
+		expect(insertCall[0]).toMatch(/^INSERT INTO user_group_members/);
+		expect(insertCall[1]).toEqual(["g-1", "u-new"]);
+	});
+
+	it("throws NotFoundError when the group is missing", async () => {
+		mockNextRows([]); // getById empty
+		await expect(groups.addMember("g-nope", "u-1")).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it("throws GroupUserNotFoundError when the user is missing", async () => {
+		mockNextRows([groupRow({})]); // getById
+		mockNextRows([]); // user-exists empty
+		await expect(groups.addMember("g-1", "u-missing")).rejects.toBeInstanceOf(
+			groups.GroupUserNotFoundError,
+		);
+	});
+
+	it("throws GroupMembersCapExceededError when the group is at the per-group cap", async () => {
+		mockNextRows([groupRow({})]); // getById
+		mockNextRows([{ id: "u-new" }]); // user-exists
+		mockNextRows([{ n: groups.MAX_MEMBERS_PER_GROUP }]); // at cap
+		await expect(groups.addMember("g-1", "u-new")).rejects.toBeInstanceOf(
+			groups.GroupMembersCapExceededError,
+		);
+	});
+
+	it("throws GroupMemberAlreadyExistsError when the duplicate pre-check fires", async () => {
+		mockNextRows([groupRow({})]); // getById
+		mockNextRows([{ id: "u-dup" }]); // user-exists
+		mockNextRows([{ n: 5 }]); // members count
+		mockNextRows([{ n: 1 }]); // duplicate-check
+		await expect(groups.addMember("g-1", "u-dup")).rejects.toBeInstanceOf(
+			groups.GroupMemberAlreadyExistsError,
+		);
+	});
+
+	it("translates a UNIQUE-constraint race into GroupMemberAlreadyExistsError", async () => {
+		mockHappyPrechecks();
+		dbStubs.d1Query.mockImplementationOnce(async () => {
+			throw new Error("UNIQUE constraint failed: user_group_members.group_id, user_id");
+		});
+		await expect(groups.addMember("g-1", "u-dup")).rejects.toBeInstanceOf(
+			groups.GroupMemberAlreadyExistsError,
+		);
+	});
+});
+
+// ── removeMember ────────────────────────────────────────────────────────────
+
+describe("groups.removeMember", () => {
+	it("deletes the member row when not the lead", async () => {
+		mockNextRows([groupRow({ leadUserId: "u-lead" })]); // getById
+		mockNextRows([], 1); // DELETE
+		await groups.removeMember("g-1", "u-member");
+		const del = dbStubs.d1Query.mock.calls[1]!;
+		expect(del[0]).toMatch(/^DELETE FROM user_group_members/);
+		expect(del[1]).toEqual(["g-1", "u-member"]);
+	});
+
+	it("refuses to remove the lead", async () => {
+		mockNextRows([groupRow({ leadUserId: "u-lead" })]);
+		await expect(groups.removeMember("g-1", "u-lead")).rejects.toBeInstanceOf(
+			groups.GroupCannotRemoveLeadError,
+		);
+		// Should not have fired a DELETE.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("is silent when the user wasn't a member (DELETE matches 0 rows)", async () => {
+		mockNextRows([groupRow({ leadUserId: "u-lead" })]);
+		mockNextRows([], 0); // DELETE no-op
+		await groups.removeMember("g-1", "u-never-was");
+		// No throw — convention is post-condition over precondition.
+	});
+});

--- a/backend/src/groups.ts
+++ b/backend/src/groups.ts
@@ -321,29 +321,37 @@ export async function create(input: GroupInput): Promise<Group> {
  * see what they're doing.
  */
 export async function update(groupId: string, input: GroupUpdateInput): Promise<Group> {
-	// Read first so a missing group returns 404 rather than a
-	// silent "0 rows updated" that the route would otherwise have
-	// to translate manually. Cheap — one D1 round-trip we'd need
-	// anyway to return the fresh row.
-	await getById(groupId);
+	// Read first so a missing group returns 404 rather than a silent
+	// "0 rows updated" that the route would otherwise have to translate
+	// manually. The current row is also used to skip the member-INSERT
+	// below when the lead is unchanged (avoiding a wasted D1 call +
+	// swallowed UNIQUE error on every rename-only PUT).
+	const current = await getById(groupId);
 	await assertUserExists(input.leadUserId);
 	await d1Query(
 		"UPDATE user_groups SET name = ?, description = ?, lead_user_id = ?, " +
 			"updated_at = datetime('now') WHERE id = ?",
 		[input.name, input.description ?? null, input.leadUserId, groupId],
 	);
-	// Mirror create's behaviour: the new lead becomes an implicit
-	// member if not already one. Duplicate-INSERT is the expected
-	// path when the lead is already a member; swallow the unique
-	// constraint error.
-	try {
-		await d1Query("INSERT INTO user_group_members (group_id, user_id) VALUES (?, ?)", [
-			groupId,
-			input.leadUserId,
-		]);
-	} catch (err) {
-		if (!/UNIQUE constraint failed|already exists/i.test((err as Error).message)) {
-			throw err;
+	// Only re-insert the lead-as-member when the lead actually changed.
+	// On a rename-only PUT (lead unchanged), the lead is already in the
+	// member table from `create` (or a previous lead-reassignment), so
+	// running the INSERT just to swallow a UNIQUE error is one wasted
+	// D1 call per call. See #262 round 3 NIT.
+	if (input.leadUserId !== current.leadUserId) {
+		try {
+			await d1Query("INSERT INTO user_group_members (group_id, user_id) VALUES (?, ?)", [
+				groupId,
+				input.leadUserId,
+			]);
+		} catch (err) {
+			// The new lead might already be a regular member from a
+			// prior `addMember` — that's the legitimate path the
+			// unique-constraint catch handles. Anything else
+			// propagates.
+			if (!/UNIQUE constraint failed|already exists/i.test((err as Error).message)) {
+				throw err;
+			}
 		}
 	}
 	const row = await fetchRow(groupId);

--- a/backend/src/groups.ts
+++ b/backend/src/groups.ts
@@ -1,0 +1,451 @@
+/**
+ * groups.ts — admin-managed groups for the tech-lead role (#201).
+ *
+ * A group is a named collection of users with one designated "lead"
+ * who can observe (read-only) the sessions of every member. Schema
+ * lives in `db.ts` (user_groups + user_group_members). All CRUD here
+ * is admin-only at the route layer — this module has no per-user
+ * ownership concept of its own (analogous to `invites` rather than
+ * `templates`).
+ *
+ * Forward-looking 201b/c hooks:
+ *   - `groupsLedBy(userId)` powers the `assertCanObserve` extension.
+ *   - `sessionsObservableBy(userId)` is the cross-user session list
+ *     surface for the tech lead's "My group" view.
+ *
+ * The lead is implicitly inserted into `user_group_members` on
+ * create / re-assigned-via-update, so "sessions visible to user X"
+ * reduces to a single JOIN against `user_group_members` (no special-
+ * case for the lead's own membership).
+ */
+
+import { randomUUID } from "node:crypto";
+import { parseD1Utc } from "./d1Time.js";
+import { d1Query } from "./db.js";
+import { ForbiddenError, NotFoundError } from "./sessionManager.js";
+
+// ── Limits ──────────────────────────────────────────────────────────────────
+
+/**
+ * Deployment-wide cap on total groups. Groups are admin-created, not
+ * user-created, so there's no per-user quota equivalent — but an
+ * unbounded admin-mistake (a script that creates groups in a loop)
+ * could still bloat D1. 1000 is generous for a v1 self-hosted
+ * deployment without being a free-for-all. Adjust upward if a real
+ * deployment hits the cap; the route maps the error to 429 so the
+ * operator sees the ceiling clearly.
+ */
+export const MAX_GROUPS_TOTAL = 1000;
+
+/**
+ * Per-group member cap. Same shape rationale as `MAX_GROUPS_TOTAL`
+ * — defence against a runaway `addMember` loop or a misconfigured
+ * import. A real org with more than 500 users in one tech-lead's
+ * scope should split the group, not stretch this cap.
+ */
+export const MAX_MEMBERS_PER_GROUP = 500;
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface GroupRow {
+	id: string;
+	name: string;
+	description: string | null;
+	lead_user_id: string;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Domain shape returned by single-row reads / writes. */
+export interface Group {
+	id: string;
+	name: string;
+	description: string | null;
+	leadUserId: string;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+/** List shape — extends `Group` with the lead's username (admin UI
+ *  doesn't have to do a second lookup per row) and the member count
+ *  (so the dashboard can show "Frontend — 8 members" without a
+ *  second JOIN per group). */
+export interface GroupSummary extends Group {
+	leadUsername: string;
+	memberCount: number;
+}
+
+/** Single member row as returned by `listMembers`. Joins
+ *  `users.username` so the route can serialise without a second
+ *  D1 round-trip per member. */
+export interface GroupMember {
+	userId: string;
+	username: string;
+	addedAt: Date;
+}
+
+export interface GroupInput {
+	name: string;
+	description?: string | null;
+	leadUserId: string;
+}
+
+export interface GroupUpdateInput {
+	name: string;
+	description?: string | null;
+	leadUserId: string;
+}
+
+const GROUP_NOT_FOUND = "Group not found";
+
+// ── Custom errors ───────────────────────────────────────────────────────────
+
+/** Raised by `create` when the deployment-wide group count is at the
+ *  cap. The route maps this to 429. */
+export class GroupQuotaExceededError extends Error {
+	constructor() {
+		super(`Group count exceeds deployment cap of ${MAX_GROUPS_TOTAL}`);
+		this.name = "GroupQuotaExceededError";
+	}
+}
+
+/** Raised by `addMember` when the group is already at its per-group
+ *  member cap. The route maps this to 429. */
+export class GroupMembersCapExceededError extends Error {
+	constructor() {
+		super(`Group already at member cap of ${MAX_MEMBERS_PER_GROUP}`);
+		this.name = "GroupMembersCapExceededError";
+	}
+}
+
+/** Raised when a referenced user (lead or member candidate) doesn't
+ *  exist in `users`. Route maps to 404. */
+export class GroupUserNotFoundError extends Error {
+	constructor(userId: string) {
+		super(`User ${userId} not found`);
+		this.name = "GroupUserNotFoundError";
+	}
+}
+
+/** Raised when the caller tries to add a user who's already a member.
+ *  The route maps this to 409 (the duplicate is observable, unlike
+ *  most NotFoundError shapes in this codebase, because the caller
+ *  asked for an action that's a no-op on an existing row). */
+export class GroupMemberAlreadyExistsError extends Error {
+	constructor(userId: string) {
+		super(`User ${userId} is already a member of this group`);
+		this.name = "GroupMemberAlreadyExistsError";
+	}
+}
+
+/** Raised when the caller tries to remove the lead from member rows.
+ *  The lead is implicitly a member by invariant — the only way to
+ *  remove them is to reassign the lead first (via `update`). The
+ *  route maps this to 409. */
+export class GroupCannotRemoveLeadError extends Error {
+	constructor() {
+		super("Cannot remove the lead from group members; reassign the lead first");
+		this.name = "GroupCannotRemoveLeadError";
+	}
+}
+
+// ── Row → domain mapping ────────────────────────────────────────────────────
+
+function rowToGroup(row: GroupRow): Group {
+	return {
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		leadUserId: row.lead_user_id,
+		createdAt: parseD1Utc(row.created_at, "groups"),
+		updatedAt: parseD1Utc(row.updated_at, "groups"),
+	};
+}
+
+// ── Reads ───────────────────────────────────────────────────────────────────
+
+/**
+ * List every group on the deployment, newest-first. Each row carries
+ * the lead's username and the member count for the admin UI's row
+ * chrome — saves N+1 round-trips on the dashboard render.
+ *
+ * Admin-gated at the route layer; do NOT call from non-admin paths
+ * (it bypasses any scoping).
+ */
+export async function listAll(): Promise<GroupSummary[]> {
+	// Single JOIN: groups ⋈ users (lead) + correlated subquery for
+	// member count. Member-count subquery is small (typically 0–500
+	// rows per group, hard-capped at `MAX_MEMBERS_PER_GROUP`) so the
+	// optimiser can resolve it inline rather than spinning up an
+	// extra grouped scan. Same shape as `sessionManager.listAll`
+	// using ownerUsername.
+	const result = await d1Query<{
+		id: string;
+		name: string;
+		description: string | null;
+		lead_user_id: string;
+		created_at: string;
+		updated_at: string;
+		lead_username: string;
+		member_count: number;
+	}>(
+		"SELECT g.id, g.name, g.description, g.lead_user_id, g.created_at, g.updated_at, " +
+			"u.username AS lead_username, " +
+			"(SELECT COUNT(*) FROM user_group_members m WHERE m.group_id = g.id) AS member_count " +
+			"FROM user_groups g " +
+			"JOIN users u ON u.id = g.lead_user_id " +
+			"ORDER BY g.created_at DESC",
+	);
+	return result.results.map((row) => ({
+		...rowToGroup(row),
+		leadUsername: row.lead_username,
+		memberCount: row.member_count,
+	}));
+}
+
+/** Read one group by id. Throws `NotFoundError` if no row exists.
+ *  Admin-gated at the route layer. */
+export async function getById(groupId: string): Promise<Group> {
+	const row = await fetchRow(groupId);
+	if (!row) throw new NotFoundError(GROUP_NOT_FOUND);
+	return rowToGroup(row);
+}
+
+/**
+ * List the members of a group. Inner-joins `users` so the route can
+ * emit `username` alongside `userId` without a second round-trip per
+ * row. Ordered by `added_at` ascending so the UI can render in
+ * stable insertion order across refreshes.
+ */
+export async function listMembers(groupId: string): Promise<GroupMember[]> {
+	// Validate the group exists first — without this, a typo'd groupId
+	// returns an empty array which a client could mistake for an
+	// existing-but-empty group.
+	await getById(groupId);
+	const result = await d1Query<{ user_id: string; username: string; added_at: string }>(
+		"SELECT m.user_id, u.username, m.added_at " +
+			"FROM user_group_members m JOIN users u ON u.id = m.user_id " +
+			"WHERE m.group_id = ? ORDER BY m.added_at ASC",
+		[groupId],
+	);
+	return result.results.map((row) => ({
+		userId: row.user_id,
+		username: row.username,
+		addedAt: parseD1Utc(row.added_at, "groups"),
+	}));
+}
+
+/**
+ * Forward-looking helper for 201b/c. Returns the ids of every group
+ * the caller leads — the gate `assertCanObserve` uses to test
+ * "can user X observe session S?" via `lead-of-any-group-containing
+ * -ownerOfS`.
+ *
+ * Kept here (not in 201b) because the SQL belongs alongside the
+ * other group reads. 201b wires the auth check that consumes it.
+ */
+export async function groupsLedBy(userId: string): Promise<string[]> {
+	const result = await d1Query<{ id: string }>(
+		"SELECT id FROM user_groups WHERE lead_user_id = ?",
+		[userId],
+	);
+	return result.results.map((row) => row.id);
+}
+
+// ── Writes ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a group with the given lead. The lead is implicitly added
+ * to `user_group_members` so the group's own member list never has
+ * to special-case "the lead's not in members yet."
+ *
+ * Race window: the count check and the INSERT aren't atomic on
+ * D1's HTTP API (no multi-statement transaction). Two concurrent
+ * `create` calls at cap-1 could both land at cap+1 — acceptable
+ * because admin-only mutations are low-frequency and the cap is
+ * deployment-wide (not per-user, so the worst case is one extra
+ * group, not a quota-bypass). Mirrors the templates-quota
+ * tradeoff.
+ *
+ * Throws:
+ *   - `GroupUserNotFoundError` if `leadUserId` doesn't exist.
+ *   - `GroupQuotaExceededError` if at the deployment cap.
+ *   - The FK violation on `lead_user_id` is already caught above
+ *     by the explicit pre-check, but D1 enforces the FK too if a
+ *     concurrent user-delete races the INSERT.
+ */
+export async function create(input: GroupInput): Promise<Group> {
+	const countResult = await d1Query<{ n: number }>("SELECT COUNT(*) AS n FROM user_groups");
+	const existing = countResult.results[0]?.n ?? 0;
+	if (existing >= MAX_GROUPS_TOTAL) throw new GroupQuotaExceededError();
+	// Pre-validate the lead exists. The FK `ON DELETE RESTRICT` blocks
+	// deletion of a referenced user, but an INSERT against a NEVER-
+	// existed user would land as a FK violation with an opaque
+	// "FOREIGN KEY constraint failed" error. Pre-checking lets the
+	// route layer return a clean 404 with a clear message instead.
+	await assertUserExists(input.leadUserId);
+	const id = randomUUID();
+	await d1Query(
+		"INSERT INTO user_groups (id, name, description, lead_user_id) VALUES (?, ?, ?, ?)",
+		[id, input.name, input.description ?? null, input.leadUserId],
+	);
+	// Insert the lead as the first member. Race window: an admin who
+	// concurrently runs `addMember(groupId, leadUserId)` could see a
+	// "duplicate" — but the composite PK on `(group_id, user_id)`
+	// makes the second INSERT a no-op error that we deliberately
+	// swallow here (the invariant is "lead is a member", not "lead
+	// is exactly one row, inserted via this code path").
+	try {
+		await d1Query("INSERT INTO user_group_members (group_id, user_id) VALUES (?, ?)", [
+			id,
+			input.leadUserId,
+		]);
+	} catch (err) {
+		if (!/UNIQUE constraint failed|already exists/i.test((err as Error).message)) {
+			throw err;
+		}
+	}
+	const row = await fetchRow(id);
+	if (!row) throw new Error("groups.create: row vanished after insert");
+	return rowToGroup(row);
+}
+
+/**
+ * Update name / description / leadUserId. Reassigning the lead
+ * auto-inserts the new lead into `user_group_members` if not
+ * already there (preserves the "lead is implicitly a member"
+ * invariant). The OLD lead stays as a regular member — admin can
+ * remove explicitly via `removeMember` if desired. We don't
+ * silently drop the old lead because demoting and remove are
+ * separate operations with different semantics; the admin should
+ * see what they're doing.
+ */
+export async function update(groupId: string, input: GroupUpdateInput): Promise<Group> {
+	// Read first so a missing group returns 404 rather than a
+	// silent "0 rows updated" that the route would otherwise have
+	// to translate manually. Cheap — one D1 round-trip we'd need
+	// anyway to return the fresh row.
+	await getById(groupId);
+	await assertUserExists(input.leadUserId);
+	await d1Query(
+		"UPDATE user_groups SET name = ?, description = ?, lead_user_id = ?, " +
+			"updated_at = datetime('now') WHERE id = ?",
+		[input.name, input.description ?? null, input.leadUserId, groupId],
+	);
+	// Mirror create's behaviour: the new lead becomes an implicit
+	// member if not already one. Duplicate-INSERT is the expected
+	// path when the lead is already a member; swallow the unique
+	// constraint error.
+	try {
+		await d1Query("INSERT INTO user_group_members (group_id, user_id) VALUES (?, ?)", [
+			groupId,
+			input.leadUserId,
+		]);
+	} catch (err) {
+		if (!/UNIQUE constraint failed|already exists/i.test((err as Error).message)) {
+			throw err;
+		}
+	}
+	const row = await fetchRow(groupId);
+	if (!row) throw new NotFoundError(GROUP_NOT_FOUND);
+	return rowToGroup(row);
+}
+
+/**
+ * Delete the group. CASCADE on `user_group_members.group_id` cleans
+ * up membership rows; no manual sweep needed. A second call on an
+ * already-deleted id throws `NotFoundError` (route 404). Sessions
+ * of former members are untouched — they simply become invisible
+ * to the (now-gone) lead.
+ */
+export async function deleteGroup(groupId: string): Promise<void> {
+	await getById(groupId);
+	await d1Query("DELETE FROM user_groups WHERE id = ?", [groupId]);
+}
+
+/**
+ * Add a user to the group's members. Throws:
+ *   - `NotFoundError` if the group doesn't exist.
+ *   - `GroupUserNotFoundError` if the user doesn't exist.
+ *   - `GroupMemberAlreadyExistsError` if the user is already a member.
+ *   - `GroupMembersCapExceededError` if the group is at its per-group cap.
+ */
+export async function addMember(groupId: string, userId: string): Promise<void> {
+	await getById(groupId);
+	await assertUserExists(userId);
+	const countResult = await d1Query<{ n: number }>(
+		"SELECT COUNT(*) AS n FROM user_group_members WHERE group_id = ?",
+		[groupId],
+	);
+	const existing = countResult.results[0]?.n ?? 0;
+	if (existing >= MAX_MEMBERS_PER_GROUP) throw new GroupMembersCapExceededError();
+	// Pre-check duplicate so the error path is a clean 409 not a
+	// raw FK/UNIQUE error message. Race-safe: a concurrent add
+	// landing between this SELECT and the INSERT below would still
+	// hit the UNIQUE constraint at the DB layer and bubble up.
+	const exists = await d1Query<{ n: number }>(
+		"SELECT COUNT(*) AS n FROM user_group_members WHERE group_id = ? AND user_id = ?",
+		[groupId, userId],
+	);
+	if ((exists.results[0]?.n ?? 0) > 0) {
+		throw new GroupMemberAlreadyExistsError(userId);
+	}
+	try {
+		await d1Query("INSERT INTO user_group_members (group_id, user_id) VALUES (?, ?)", [
+			groupId,
+			userId,
+		]);
+	} catch (err) {
+		// Surface a concurrent-add race as 409 too, not 500. The
+		// pre-check above narrows the window but doesn't close it
+		// (D1's HTTP API has no transaction primitive).
+		if (/UNIQUE constraint failed|already exists/i.test((err as Error).message)) {
+			throw new GroupMemberAlreadyExistsError(userId);
+		}
+		throw err;
+	}
+}
+
+/**
+ * Remove a member. Refuses to remove the lead — the invariant is
+ * that the lead is always a member. Admin must reassign the lead
+ * via `update` first if they want the current lead out of the
+ * member list.
+ *
+ * Idempotent at the user-not-in-group level: removing a user who
+ * isn't a member returns silently (matches the DELETE-method
+ * convention elsewhere — the post-condition is the same either
+ * way). The lead-protection check fires BEFORE the not-a-member
+ * check so calling this with the lead's id gives a clear 409
+ * instead of a silent no-op.
+ */
+export async function removeMember(groupId: string, userId: string): Promise<void> {
+	const group = await getById(groupId);
+	if (group.leadUserId === userId) {
+		throw new GroupCannotRemoveLeadError();
+	}
+	await d1Query("DELETE FROM user_group_members WHERE group_id = ? AND user_id = ?", [
+		groupId,
+		userId,
+	]);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+async function fetchRow(groupId: string): Promise<GroupRow | null> {
+	const result = await d1Query<GroupRow>("SELECT * FROM user_groups WHERE id = ?", [groupId]);
+	return result.results[0] ?? null;
+}
+
+async function assertUserExists(userId: string): Promise<void> {
+	const result = await d1Query<{ id: string }>("SELECT id FROM users WHERE id = ? LIMIT 1", [
+		userId,
+	]);
+	if (result.results.length === 0) {
+		throw new GroupUserNotFoundError(userId);
+	}
+}
+
+// Re-export the standard auth errors so the route layer can import a
+// stable set from this module without reaching into sessionManager.
+export { ForbiddenError, NotFoundError };

--- a/backend/src/routes.admin.groups.test.ts
+++ b/backend/src/routes.admin.groups.test.ts
@@ -301,6 +301,38 @@ describe("POST /api/admin/groups", () => {
 		expect(res.status).toBe(400);
 	});
 
+	it("rejects a whitespace-only leadUserId with 400 (not a confusing 404)", async () => {
+		// Pins #262 round-5 SHOULD-FIX: a whitespace-only leadUserId
+		// pre-fix passed the length-zero gate (length 3), got trimmed
+		// to "", then assertUserExists("") returned a misleading
+		// `404 User  not found` (double-space message). The trim-first
+		// shape catches this at the boundary as a 400.
+		await spinUp();
+		const res = await post({ name: "X", leadUserId: "   " });
+		expect(res.status).toBe(400);
+		expect(groupsStubs.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects a whitespace-only name with 400", async () => {
+		await spinUp();
+		const res = await post({ name: "   ", leadUserId: "u-lead" });
+		expect(res.status).toBe(400);
+		expect(groupsStubs.create).not.toHaveBeenCalled();
+	});
+
+	it("accepts a name padded with whitespace and stores it trimmed", async () => {
+		// Pre-trim length caps would have rejected "a" + " ".repeat(100)
+		// as too long (101 chars) even though only 1 char persists.
+		// Trim-first cap matches the template route convention.
+		await spinUp();
+		const padded = `${"x".repeat(50)}${" ".repeat(50)}`; // 100 raw, 50 trimmed
+		const res = await post({ name: padded, leadUserId: "u-lead" });
+		expect(res.status).toBe(201);
+		expect(groupsStubs.create).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "x".repeat(50) }),
+		);
+	});
+
 	it("creates and returns 201 with the serialised group", async () => {
 		await spinUp();
 		const res = await post({ name: "Frontend", leadUserId: "u-lead" });

--- a/backend/src/routes.admin.groups.test.ts
+++ b/backend/src/routes.admin.groups.test.ts
@@ -1,0 +1,527 @@
+/**
+ * routes.admin.groups.test.ts — REST integration for /api/admin/groups (#201a).
+ *
+ * Pins the wire shape for each endpoint and the admin gate. Uses the
+ * same stub style as routes.admin.test.ts — auth middleware mocked,
+ * the underlying `groups.ts` mocked at the module boundary so we
+ * exercise the route's validation + error mapping logic without
+ * driving D1 call sequences.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authStubs = vi.hoisted(() => ({
+	requireAuth: (req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	},
+	// Flipped per-test to drive the 403 path. Default passthrough.
+	requireAdmin: vi.fn((req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	}),
+	AUTH_COOKIE_NAME: "st_token",
+	setAuthCookie: vi.fn(),
+	clearAuthCookie: vi.fn(),
+	extractTokenFromCookieHeader: vi.fn(() => null),
+	verifyJwt: vi.fn(() => null),
+	hasAnyUsers: vi.fn(async () => true),
+	registerUser: vi.fn(),
+	loginUser: vi.fn(),
+	listInvites: vi.fn(async () => [] as unknown[]),
+	createInvite: vi.fn(),
+	revokeInvite: vi.fn(),
+	InvalidCredentialsError: class extends Error {
+		constructor() {
+			super("invalid");
+		}
+	},
+	UsernameTakenError: class extends Error {
+		constructor() {
+			super("taken");
+		}
+	},
+	InviteRequiredError: class extends Error {
+		constructor() {
+			super("invite required");
+		}
+	},
+	InviteQuotaExceededError: class extends Error {
+		constructor() {
+			super("invite quota");
+		}
+	},
+}));
+vi.mock("./auth.js", () => authStubs);
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+	getD1CallsSinceBoot: vi.fn(() => 0),
+	__resetD1CallsForTests: vi.fn(),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+// Mock the groups module wholesale so route tests don't drive the
+// underlying D1 call sequences (those live in groups.test.ts).
+const groupsStubs = vi.hoisted(() => {
+	class GroupQuotaExceededError extends Error {
+		constructor() {
+			super("Group count exceeds deployment cap of 1000");
+			this.name = "GroupQuotaExceededError";
+		}
+	}
+	class GroupMembersCapExceededError extends Error {
+		constructor() {
+			super("Group already at member cap of 500");
+			this.name = "GroupMembersCapExceededError";
+		}
+	}
+	class GroupUserNotFoundError extends Error {
+		constructor(userId: string) {
+			super(`User ${userId} not found`);
+			this.name = "GroupUserNotFoundError";
+		}
+	}
+	class GroupMemberAlreadyExistsError extends Error {
+		constructor(userId: string) {
+			super(`User ${userId} is already a member of this group`);
+			this.name = "GroupMemberAlreadyExistsError";
+		}
+	}
+	class GroupCannotRemoveLeadError extends Error {
+		constructor() {
+			super("Cannot remove the lead from group members; reassign the lead first");
+			this.name = "GroupCannotRemoveLeadError";
+		}
+	}
+	return {
+		listAll: vi.fn(async () => [] as unknown[]),
+		getById: vi.fn(async () => ({
+			id: "g-1",
+			name: "Frontend",
+			description: null,
+			leadUserId: "u-lead",
+			createdAt: new Date("2026-05-11T12:00:00Z"),
+			updatedAt: new Date("2026-05-11T12:00:00Z"),
+		})),
+		listMembers: vi.fn(async () => [] as unknown[]),
+		create: vi.fn(async () => ({
+			id: "g-new",
+			name: "Frontend",
+			description: null,
+			leadUserId: "u-lead",
+			createdAt: new Date("2026-05-11T12:00:00Z"),
+			updatedAt: new Date("2026-05-11T12:00:00Z"),
+		})),
+		update: vi.fn(async () => ({
+			id: "g-1",
+			name: "Renamed",
+			description: null,
+			leadUserId: "u-lead",
+			createdAt: new Date("2026-05-11T12:00:00Z"),
+			updatedAt: new Date("2026-05-11T13:00:00Z"),
+		})),
+		deleteGroup: vi.fn(async () => undefined),
+		addMember: vi.fn(async () => undefined),
+		removeMember: vi.fn(async () => undefined),
+		groupsLedBy: vi.fn(async () => [] as string[]),
+		GroupQuotaExceededError,
+		GroupMembersCapExceededError,
+		GroupUserNotFoundError,
+		GroupMemberAlreadyExistsError,
+		GroupCannotRemoveLeadError,
+		MAX_GROUPS_TOTAL: 1000,
+		MAX_MEMBERS_PER_GROUP: 500,
+	};
+});
+vi.mock("./groups.js", () => groupsStubs);
+
+import type { BootstrapBroadcaster } from "./bootstrap.js";
+import type { DockerManager } from "./dockerManager.js";
+import { __resetDispatcherStatsForTests } from "./portDispatcher.js";
+import { buildRouter } from "./routes.js";
+import type { SessionManager } from "./sessionManager.js";
+// The route's `handleGroupError` checks `err instanceof NotFoundError`
+// against the class imported from `sessionManager.js`. Use the real
+// one in throws below so the instanceof gate matches — a parallel
+// mocked class would be a different identity and fall through to 500.
+import { NotFoundError as SessionNotFoundError } from "./sessionManager.js";
+
+let server: http.Server | null = null;
+let baseUrl = "";
+
+afterEach(async () => {
+	if (server) {
+		await new Promise<void>((resolve, reject) => {
+			server?.close((e) => (e ? reject(e) : resolve()));
+		});
+		server = null;
+	}
+	authStubs.requireAdmin.mockReset();
+	authStubs.requireAdmin.mockImplementation((req, _res, next) => {
+		(req as { userId?: string }).userId = "u1";
+		next();
+	});
+});
+
+async function spinUp(): Promise<void> {
+	const sessions = {
+		// `countByStatus` is wired for the /admin/stats handler even
+		// though we don't exercise it here — the router wiring calls
+		// `getStats?.()` on it during construction. Returning a frozen
+		// shape avoids any incidental D1 fanout.
+		countByStatus: vi.fn(async () => ({ running: 0, stopped: 0, terminated: 0, failed: 0 })),
+		// Defensive: a hit on any other SessionManager method surfaces
+		// as a 500 with a clear "is not a function" message — better
+		// than a silent test pass.
+	} as unknown as SessionManager;
+	const docker = {
+		getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
+		getReconcileStats: () => ({
+			lastRunAt: null,
+			sessionsCheckedSinceBoot: 0,
+			errorsSinceBoot: 0,
+		}),
+	} as unknown as DockerManager;
+	const broadcaster = {} as BootstrapBroadcaster;
+	const router = buildRouter(sessions, docker, broadcaster, {
+		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+		register: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+		logout: { ipMax: 1000, ipWindowMs: 60_000 },
+		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
+	});
+	const app = express();
+	app.use(express.json());
+	app.use("/api", router);
+	const s = http.createServer(app);
+	server = s;
+	await new Promise<void>((resolve) => s.listen(0, "127.0.0.1", resolve));
+	const { port } = s.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+}
+
+describe("GET /api/admin/groups", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.listAll.mockReset();
+	});
+
+	it("returns the serialised summary list", async () => {
+		groupsStubs.listAll.mockImplementationOnce(async () => [
+			{
+				id: "g-1",
+				name: "Frontend",
+				description: "FE team",
+				leadUserId: "u-lead",
+				createdAt: new Date("2026-05-11T12:00:00Z"),
+				updatedAt: new Date("2026-05-11T12:00:00Z"),
+				leadUsername: "alice",
+				memberCount: 8,
+			},
+		]);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{
+			id: string;
+			leadUsername: string;
+			memberCount: number;
+			createdAt: string;
+		}>;
+		expect(body).toHaveLength(1);
+		expect(body[0]?.leadUsername).toBe("alice");
+		expect(body[0]?.memberCount).toBe(8);
+		// Dates round-trip as ISO strings.
+		expect(body[0]?.createdAt).toBe("2026-05-11T12:00:00.000Z");
+	});
+
+	it("returns 403 when requireAdmin denies the caller", async () => {
+		authStubs.requireAdmin.mockImplementationOnce(
+			(_req: unknown, res: { status: (code: number) => { json: (b: unknown) => void } }) => {
+				res.status(403).json({ error: "Admin privileges required" });
+			},
+		);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups`);
+		expect(res.status).toBe(403);
+	});
+});
+
+describe("POST /api/admin/groups", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.create.mockReset();
+		groupsStubs.create.mockImplementation(async () => ({
+			id: "g-new",
+			name: "Frontend",
+			description: null,
+			leadUserId: "u-lead",
+			createdAt: new Date("2026-05-11T12:00:00Z"),
+			updatedAt: new Date("2026-05-11T12:00:00Z"),
+		}));
+	});
+
+	async function post(body: unknown): Promise<Response> {
+		return fetch(`${baseUrl}/api/admin/groups`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	}
+
+	it("rejects a missing body.name with 400", async () => {
+		await spinUp();
+		const res = await post({ leadUserId: "u-lead" });
+		expect(res.status).toBe(400);
+		expect(groupsStubs.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects a missing body.leadUserId with 400", async () => {
+		await spinUp();
+		const res = await post({ name: "X" });
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects a too-long name with 400", async () => {
+		await spinUp();
+		const res = await post({ name: "x".repeat(101), leadUserId: "u-lead" });
+		expect(res.status).toBe(400);
+	});
+
+	it("creates and returns 201 with the serialised group", async () => {
+		await spinUp();
+		const res = await post({ name: "Frontend", leadUserId: "u-lead" });
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { id: string; leadUserId: string };
+		expect(body.id).toBe("g-new");
+		expect(body.leadUserId).toBe("u-lead");
+	});
+
+	it("maps GroupUserNotFoundError to 404", async () => {
+		groupsStubs.create.mockImplementationOnce(async () => {
+			throw new groupsStubs.GroupUserNotFoundError("u-missing");
+		});
+		await spinUp();
+		const res = await post({ name: "X", leadUserId: "u-missing" });
+		expect(res.status).toBe(404);
+	});
+
+	it("maps GroupQuotaExceededError to 429", async () => {
+		groupsStubs.create.mockImplementationOnce(async () => {
+			throw new groupsStubs.GroupQuotaExceededError();
+		});
+		await spinUp();
+		const res = await post({ name: "X", leadUserId: "u-lead" });
+		expect(res.status).toBe(429);
+	});
+});
+
+describe("GET /api/admin/groups/:id", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.getById.mockReset();
+		groupsStubs.listMembers.mockReset();
+	});
+
+	it("returns the group + members joined with usernames", async () => {
+		groupsStubs.getById.mockImplementationOnce(async () => ({
+			id: "g-1",
+			name: "Frontend",
+			description: null,
+			leadUserId: "u-lead",
+			createdAt: new Date("2026-05-11T12:00:00Z"),
+			updatedAt: new Date("2026-05-11T12:00:00Z"),
+		}));
+		groupsStubs.listMembers.mockImplementationOnce(async () => [
+			{ userId: "u-lead", username: "alice", addedAt: new Date("2026-05-11T12:00:00Z") },
+			{ userId: "u-2", username: "bob", addedAt: new Date("2026-05-11T12:00:01Z") },
+		]);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups/g-1`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			id: string;
+			members: Array<{ userId: string; username: string }>;
+		};
+		expect(body.id).toBe("g-1");
+		expect(body.members).toHaveLength(2);
+		expect(body.members[0]?.username).toBe("alice");
+	});
+
+	it("maps NotFoundError to 404", async () => {
+		groupsStubs.getById.mockImplementationOnce(async () => {
+			throw new SessionNotFoundError("Group not found");
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups/g-nope`);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe("PUT /api/admin/groups/:id", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.update.mockReset();
+		groupsStubs.update.mockImplementation(async () => ({
+			id: "g-1",
+			name: "Renamed",
+			description: null,
+			leadUserId: "u-lead",
+			createdAt: new Date("2026-05-11T12:00:00Z"),
+			updatedAt: new Date("2026-05-11T13:00:00Z"),
+		}));
+	});
+
+	async function put(id: string, body: unknown): Promise<Response> {
+		return fetch(`${baseUrl}/api/admin/groups/${id}`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	}
+
+	it("returns the renamed group on success", async () => {
+		await spinUp();
+		const res = await put("g-1", { name: "Renamed", leadUserId: "u-lead" });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { name: string };
+		expect(body.name).toBe("Renamed");
+	});
+
+	it("maps NotFoundError to 404", async () => {
+		groupsStubs.update.mockImplementationOnce(async () => {
+			throw new SessionNotFoundError("Group not found");
+		});
+		await spinUp();
+		const res = await put("g-nope", { name: "X", leadUserId: "u-lead" });
+		expect(res.status).toBe(404);
+	});
+});
+
+describe("DELETE /api/admin/groups/:id", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.deleteGroup.mockReset();
+	});
+
+	it("returns 204 on success", async () => {
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups/g-1`, { method: "DELETE" });
+		expect(res.status).toBe(204);
+		expect(groupsStubs.deleteGroup).toHaveBeenCalledWith("g-1");
+	});
+
+	it("maps NotFoundError to 404", async () => {
+		groupsStubs.deleteGroup.mockImplementationOnce(async () => {
+			throw new SessionNotFoundError("Group not found");
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups/g-nope`, { method: "DELETE" });
+		expect(res.status).toBe(404);
+	});
+});
+
+describe("POST /api/admin/groups/:id/members", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.addMember.mockReset();
+	});
+
+	async function post(id: string, body: unknown): Promise<Response> {
+		return fetch(`${baseUrl}/api/admin/groups/${id}/members`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	}
+
+	it("returns 204 on success", async () => {
+		await spinUp();
+		const res = await post("g-1", { userId: "u-new" });
+		expect(res.status).toBe(204);
+		expect(groupsStubs.addMember).toHaveBeenCalledWith("g-1", "u-new");
+	});
+
+	it("rejects a missing body.userId with 400", async () => {
+		await spinUp();
+		const res = await post("g-1", {});
+		expect(res.status).toBe(400);
+		expect(groupsStubs.addMember).not.toHaveBeenCalled();
+	});
+
+	it("maps GroupMemberAlreadyExistsError to 409", async () => {
+		groupsStubs.addMember.mockImplementationOnce(async () => {
+			throw new groupsStubs.GroupMemberAlreadyExistsError("u-dup");
+		});
+		await spinUp();
+		const res = await post("g-1", { userId: "u-dup" });
+		expect(res.status).toBe(409);
+	});
+
+	it("maps GroupMembersCapExceededError to 429", async () => {
+		groupsStubs.addMember.mockImplementationOnce(async () => {
+			throw new groupsStubs.GroupMembersCapExceededError();
+		});
+		await spinUp();
+		const res = await post("g-1", { userId: "u-new" });
+		expect(res.status).toBe(429);
+	});
+
+	it("maps GroupUserNotFoundError to 404", async () => {
+		groupsStubs.addMember.mockImplementationOnce(async () => {
+			throw new groupsStubs.GroupUserNotFoundError("u-missing");
+		});
+		await spinUp();
+		const res = await post("g-1", { userId: "u-missing" });
+		expect(res.status).toBe(404);
+	});
+});
+
+describe("DELETE /api/admin/groups/:id/members/:userId", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.removeMember.mockReset();
+	});
+
+	it("returns 204 on success", async () => {
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups/g-1/members/u-2`, { method: "DELETE" });
+		expect(res.status).toBe(204);
+		expect(groupsStubs.removeMember).toHaveBeenCalledWith("g-1", "u-2");
+	});
+
+	it("maps GroupCannotRemoveLeadError to 409", async () => {
+		groupsStubs.removeMember.mockImplementationOnce(async () => {
+			throw new groupsStubs.GroupCannotRemoveLeadError();
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups/g-1/members/u-lead`, {
+			method: "DELETE",
+		});
+		expect(res.status).toBe(409);
+	});
+
+	it("maps NotFoundError to 404", async () => {
+		groupsStubs.removeMember.mockImplementationOnce(async () => {
+			throw new SessionNotFoundError("Group not found");
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/groups/g-nope/members/u-2`, {
+			method: "DELETE",
+		});
+		expect(res.status).toBe(404);
+	});
+});

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -670,9 +670,15 @@ export function buildRouter(
 			res.status(400).json({ error: "body.leadUserId is required (non-empty string)" });
 			return null;
 		}
+		// Trim + collapse-empty mirrors the template description handling.
+		// A `"   "` value passed verbatim would render visually blank in
+		// the admin UI while the column reports non-null, which is
+		// indistinguishable from an intentionally-set description on the
+		// wire. See #262 round 1 NIT.
 		return {
 			name: body.name.trim(),
-			description: typeof body.description === "string" ? body.description : null,
+			description:
+				typeof body.description === "string" ? body.description.trim() || null : null,
 			leadUserId: body.leadUserId,
 		};
 	};
@@ -708,8 +714,17 @@ export function buildRouter(
 		requireAdmin,
 		async (req: Request, res: Response) => {
 			try {
-				const group = await groups.getById(req.params.id);
-				const members = await groups.listMembers(req.params.id);
+				// Parallelise the two reads — `listMembers` does its own
+				// existence guard via `getById`, so the serial shape
+				// `await getById; await listMembers` stalled on the
+				// network for a check `listMembers` will redo anyway.
+				// `Promise.all` rejects on the first error, so a
+				// missing-group still 404s cleanly via the
+				// `handleGroupError` catch below. See #262 round 1 NIT.
+				const [group, members] = await Promise.all([
+					groups.getById(req.params.id),
+					groups.listMembers(req.params.id),
+				]);
 				res.json({
 					...serializeGroup(group),
 					members: members.map((m) => ({

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -608,6 +608,15 @@ export function buildRouter(
 			res.status(404).json({ error: err.message });
 			return;
 		}
+		// Pre-wired for 201b — `assertCanObserve` will throw
+		// ForbiddenError when a non-lead tries to read a group's
+		// member sessions. Adding the arm now means 201b doesn't
+		// have to remember to extend this handler. See #262 round
+		// 6 NIT.
+		if (err instanceof ForbiddenError) {
+			res.status(403).json({ error: err.message });
+			return;
+		}
 		if (err instanceof groups.GroupUserNotFoundError) {
 			res.status(404).json({ error: err.message });
 			return;
@@ -693,6 +702,20 @@ export function buildRouter(
 		const leadUserId = body.leadUserId.trim();
 		if (leadUserId.length === 0) {
 			res.status(400).json({ error: "body.leadUserId is required (non-empty string)" });
+			return null;
+		}
+		// Cap at 128 — UUIDs are 36 chars, this allows headroom for any
+		// future ID format. Mirrors the boundary-validation convention
+		// for every other user-controlled string in this codebase
+		// (name=100, description=500, …). Without this cap, only the
+		// 100 KB `express.json` body limit bounds the value; in
+		// practice `assertUserExists` 404s immediately on a multi-KB
+		// string, but the cap is cheap defence-in-depth. See #262
+		// round 6 NIT.
+		if (leadUserId.length > USER_ID_MAX_LEN) {
+			res
+				.status(400)
+				.json({ error: `body.leadUserId must be at most ${USER_ID_MAX_LEN} characters` });
 			return null;
 		}
 		return { name, description, leadUserId };
@@ -818,6 +841,15 @@ export function buildRouter(
 			// string match against `users.id`, so the padded value 404s
 			// even when the user genuinely exists. See #262 round 2 NIT.
 			const userId = body.userId.trim();
+			// Mirror the boundary cap from `validateGroupBody`'s leadUserId
+			// — same #262 round 6 NIT rationale. The two caps must stay
+			// in lockstep; `USER_ID_MAX_LEN` is the single knob.
+			if (userId.length > USER_ID_MAX_LEN) {
+				res
+					.status(400)
+					.json({ error: `body.userId must be at most ${USER_ID_MAX_LEN} characters` });
+				return;
+			}
 			try {
 				await groups.addMember(req.params.id, userId);
 				res.status(204).send();
@@ -1839,6 +1871,13 @@ function handleTemplateError(err: unknown, res: Response): void {
 // (most clients stay under 500×200) and well below sizes that would
 // upset xterm/tmux. See #149.
 const SESSION_NAME_MAX_LEN = 64;
+// Upper bound for any `user_id` we accept at the request boundary
+// (group lead / group member). UUIDs are 36 chars; the 128 cap is
+// headroom for any future ID format while keeping the value bounded
+// well below `assertUserExists`'s D1 round-trip cost on malformed
+// input. Used by the admin-group routes; see the trim-first
+// validators there. #262 round 6 NIT.
+const USER_ID_MAX_LEN = 128;
 // Exported so wsHandler can apply the same upper bound when validating
 // cols/rows from the WS upgrade URL — keep both guards moving together.
 export const TERMINAL_DIM_MAX = 1024;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -720,13 +720,21 @@ export function buildRouter(
 		requireAdmin,
 		async (req: Request, res: Response) => {
 			try {
-				// Parallelise the two reads — `listMembers` does its own
-				// existence guard via `getById`, so the serial shape
-				// `await getById; await listMembers` stalled on the
-				// network for a check `listMembers` will redo anyway.
-				// `Promise.all` rejects on the first error, so a
+				// Parallelise the two reads so the outer `getById` fires
+				// concurrently with `listMembers` (which issues its own
+				// internal `getById` for the existence guard + the
+				// member query). D1 call count is the same — three —
+				// but the wallclock drops from three serial hops to two
+				// (the outer getById and listMembers' inner getById
+				// finish together, then the member query runs alone).
+				// `Promise.all` rejects on the first error so a
 				// missing-group still 404s cleanly via the
-				// `handleGroupError` catch below. See #262 round 1 NIT.
+				// `handleGroupError` catch below. Eliminating the
+				// duplicate guard entirely would mean dropping the
+				// existence check inside `listMembers`, which the v1
+				// API contract relies on (it 404s an unknown groupId
+				// instead of silently returning []). See #262 rounds
+				// 1 + 4 NITs.
 				const [group, members] = await Promise.all([
 					groups.getById(req.params.id),
 					groups.listMembers(req.params.id),

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -677,8 +677,7 @@ export function buildRouter(
 		// wire. See #262 round 1 NIT.
 		return {
 			name: body.name.trim(),
-			description:
-				typeof body.description === "string" ? body.description.trim() || null : null,
+			description: typeof body.description === "string" ? body.description.trim() || null : null,
 			leadUserId: body.leadUserId,
 		};
 	};

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -32,6 +32,7 @@ import { d1Query, getD1CallsSinceBoot } from "./db.js";
 import type { DockerManager } from "./dockerManager.js";
 import { UploadQuotaExceededError } from "./dockerManager.js";
 import { EnvVarValidationError, validateEnvVars } from "./envVarValidation.js";
+import * as groups from "./groups.js";
 import type { IdleSweeperStats } from "./idleSweeper.js";
 import { logger } from "./logger.js";
 import { getDispatcherStats } from "./portDispatcher.js";
@@ -585,6 +586,214 @@ export function buildRouter(
 			} catch (err) {
 				logger.error(`[admin] force-delete failed: ${(err as Error).message}`);
 				res.status(500).json({ error: "Internal server error" });
+			}
+		},
+	);
+
+	// ── Admin group-management routes (#201a) ─────────────────────────────────
+	// Six routes mounted under /admin/groups for managing user-groups + the
+	// tech-lead designation. Routes are gated by `requireAdmin` (via the
+	// `/admin` prefix's `requireAuth` + the explicit `requireAdmin` middleware
+	// chained on each one). Reads use the shared `adminStatsIp` limiter (high
+	// cap, same bucket dashboards poll); writes use `adminActionIp` (lower
+	// cap, destructive). Per the lock-in on issue #201 — group authoring is
+	// admin-only; the lead's view of their group lives on `/api/groups/mine`
+	// in 201c, which is NOT admin-gated.
+	//
+	// `handleGroupError` collapses every typed error this module raises into
+	// the right HTTP status + body shape. Anything else surfaces as 500 with
+	// a logged message, matching the rest of the admin-routes pattern.
+	const handleGroupError = (err: unknown, res: Response, context: string): void => {
+		if (err instanceof NotFoundError) {
+			res.status(404).json({ error: err.message });
+			return;
+		}
+		if (err instanceof groups.GroupUserNotFoundError) {
+			res.status(404).json({ error: err.message });
+			return;
+		}
+		if (err instanceof groups.GroupQuotaExceededError) {
+			res.status(429).json({ error: err.message });
+			return;
+		}
+		if (err instanceof groups.GroupMembersCapExceededError) {
+			res.status(429).json({ error: err.message });
+			return;
+		}
+		if (err instanceof groups.GroupMemberAlreadyExistsError) {
+			res.status(409).json({ error: err.message });
+			return;
+		}
+		if (err instanceof groups.GroupCannotRemoveLeadError) {
+			res.status(409).json({ error: err.message });
+			return;
+		}
+		logger.error(`[admin] ${context} failed: ${(err as Error).message}`);
+		res.status(500).json({ error: "Internal server error" });
+	};
+
+	// Shared body validator. Used by POST + PUT. Returns the parsed
+	// shape or null + writes a 400 response — caller `return`s when
+	// null.
+	const validateGroupBody = (
+		req: Request,
+		res: Response,
+	): { name: string; description: string | null; leadUserId: string } | null => {
+		const body = req.body as {
+			name?: unknown;
+			description?: unknown;
+			leadUserId?: unknown;
+		};
+		if (typeof body.name !== "string" || body.name.trim().length === 0) {
+			res.status(400).json({ error: "body.name is required (non-empty string)" });
+			return null;
+		}
+		// Cap consistent with other user-controlled strings — same shape
+		// as session-name / template-name caps elsewhere in the codebase.
+		if (body.name.length > 100) {
+			res.status(400).json({ error: "body.name must be at most 100 characters" });
+			return null;
+		}
+		if (
+			body.description !== undefined &&
+			body.description !== null &&
+			typeof body.description !== "string"
+		) {
+			res.status(400).json({ error: "body.description must be a string, null, or omitted" });
+			return null;
+		}
+		if (typeof body.description === "string" && body.description.length > 500) {
+			res.status(400).json({ error: "body.description must be at most 500 characters" });
+			return null;
+		}
+		if (typeof body.leadUserId !== "string" || body.leadUserId.length === 0) {
+			res.status(400).json({ error: "body.leadUserId is required (non-empty string)" });
+			return null;
+		}
+		return {
+			name: body.name.trim(),
+			description: typeof body.description === "string" ? body.description : null,
+			leadUserId: body.leadUserId,
+		};
+	};
+
+	// Single serializer keeps the wire shape consistent across list / get /
+	// create / update. Dates are emitted as ISO strings via toJSON.
+	const serializeGroup = (g: groups.Group) => ({
+		id: g.id,
+		name: g.name,
+		description: g.description,
+		leadUserId: g.leadUserId,
+		createdAt: g.createdAt.toISOString(),
+		updatedAt: g.updatedAt.toISOString(),
+	});
+	const serializeGroupSummary = (g: groups.GroupSummary) => ({
+		...serializeGroup(g),
+		leadUsername: g.leadUsername,
+		memberCount: g.memberCount,
+	});
+
+	router.get("/admin/groups", adminStatsIp, requireAdmin, async (_req: Request, res: Response) => {
+		try {
+			const list = await groups.listAll();
+			res.json(list.map(serializeGroupSummary));
+		} catch (err) {
+			handleGroupError(err, res, "groups list");
+		}
+	});
+
+	router.get(
+		"/admin/groups/:id",
+		adminStatsIp,
+		requireAdmin,
+		async (req: Request, res: Response) => {
+			try {
+				const group = await groups.getById(req.params.id);
+				const members = await groups.listMembers(req.params.id);
+				res.json({
+					...serializeGroup(group),
+					members: members.map((m) => ({
+						userId: m.userId,
+						username: m.username,
+						addedAt: m.addedAt.toISOString(),
+					})),
+				});
+			} catch (err) {
+				handleGroupError(err, res, "groups get");
+			}
+		},
+	);
+
+	router.post("/admin/groups", adminActionIp, requireAdmin, async (req: Request, res: Response) => {
+		const input = validateGroupBody(req, res);
+		if (!input) return;
+		try {
+			const group = await groups.create(input);
+			res.status(201).json(serializeGroup(group));
+		} catch (err) {
+			handleGroupError(err, res, "groups create");
+		}
+	});
+
+	router.put(
+		"/admin/groups/:id",
+		adminActionIp,
+		requireAdmin,
+		async (req: Request, res: Response) => {
+			const input = validateGroupBody(req, res);
+			if (!input) return;
+			try {
+				const group = await groups.update(req.params.id, input);
+				res.json(serializeGroup(group));
+			} catch (err) {
+				handleGroupError(err, res, "groups update");
+			}
+		},
+	);
+
+	router.delete(
+		"/admin/groups/:id",
+		adminActionIp,
+		requireAdmin,
+		async (req: Request, res: Response) => {
+			try {
+				await groups.deleteGroup(req.params.id);
+				res.status(204).send();
+			} catch (err) {
+				handleGroupError(err, res, "groups delete");
+			}
+		},
+	);
+
+	router.post(
+		"/admin/groups/:id/members",
+		adminActionIp,
+		requireAdmin,
+		async (req: Request, res: Response) => {
+			const body = req.body as { userId?: unknown };
+			if (typeof body.userId !== "string" || body.userId.length === 0) {
+				res.status(400).json({ error: "body.userId is required (non-empty string)" });
+				return;
+			}
+			try {
+				await groups.addMember(req.params.id, body.userId);
+				res.status(204).send();
+			} catch (err) {
+				handleGroupError(err, res, "groups addMember");
+			}
+		},
+	);
+
+	router.delete(
+		"/admin/groups/:id/members/:userId",
+		adminActionIp,
+		requireAdmin,
+		async (req: Request, res: Response) => {
+			try {
+				await groups.removeMember(req.params.id, req.params.userId);
+				res.status(204).send();
+			} catch (err) {
+				handleGroupError(err, res, "groups removeMember");
 			}
 		},
 	);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -675,10 +675,17 @@ export function buildRouter(
 		// the admin UI while the column reports non-null, which is
 		// indistinguishable from an intentionally-set description on the
 		// wire. See #262 round 1 NIT.
+		//
+		// Trim `leadUserId` too — a whitespace-padded value slips past
+		// the `length === 0` check, then `assertUserExists` runs an
+		// exact-string `SELECT id FROM users WHERE id = ?` against
+		// the padded string and returns 404 even when the user exists.
+		// Same shape as the `body.userId` trim in the addMember route
+		// below. See #262 round 2 NIT.
 		return {
 			name: body.name.trim(),
 			description: typeof body.description === "string" ? body.description.trim() || null : null,
-			leadUserId: body.leadUserId,
+			leadUserId: body.leadUserId.trim(),
 		};
 	};
 
@@ -785,12 +792,17 @@ export function buildRouter(
 		requireAdmin,
 		async (req: Request, res: Response) => {
 			const body = req.body as { userId?: unknown };
-			if (typeof body.userId !== "string" || body.userId.length === 0) {
+			if (typeof body.userId !== "string" || body.userId.trim().length === 0) {
 				res.status(400).json({ error: "body.userId is required (non-empty string)" });
 				return;
 			}
+			// Trim before persistence — a whitespace-padded id slips past
+			// the length check above but `assertUserExists` does an exact-
+			// string match against `users.id`, so the padded value 404s
+			// even when the user genuinely exists. See #262 round 2 NIT.
+			const userId = body.userId.trim();
 			try {
-				await groups.addMember(req.params.id, body.userId);
+				await groups.addMember(req.params.id, userId);
 				res.status(204).send();
 			} catch (err) {
 				handleGroupError(err, res, "groups addMember");

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -644,49 +644,58 @@ export function buildRouter(
 			description?: unknown;
 			leadUserId?: unknown;
 		};
-		if (typeof body.name !== "string" || body.name.trim().length === 0) {
+		// Trim-first, then check empty + cap. Mirrors the template route
+		// convention (`routes.ts` template handler) and closes two foot-
+		// guns the earlier pre-trim shape had:
+		//   1. `leadUserId: "   "` slipped past `length === 0`, got
+		//      trimmed to "", and `assertUserExists("")` returned a
+		//      confusing `404 User  not found` (double-space message).
+		//      See #262 round 5 SHOULD-FIX.
+		//   2. Length caps fired against the pre-trim string, so
+		//      `"a"+" ".repeat(100)` got rejected at 100 chars even
+		//      though only 1 char would actually persist — inconsistent
+		//      with how the template route handles the same shape.
+		if (typeof body.name !== "string") {
+			res.status(400).json({ error: "body.name is required (non-empty string)" });
+			return null;
+		}
+		const name = body.name.trim();
+		if (name.length === 0) {
 			res.status(400).json({ error: "body.name is required (non-empty string)" });
 			return null;
 		}
 		// Cap consistent with other user-controlled strings — same shape
 		// as session-name / template-name caps elsewhere in the codebase.
-		if (body.name.length > 100) {
+		if (name.length > 100) {
 			res.status(400).json({ error: "body.name must be at most 100 characters" });
 			return null;
 		}
-		if (
-			body.description !== undefined &&
-			body.description !== null &&
-			typeof body.description !== "string"
-		) {
-			res.status(400).json({ error: "body.description must be a string, null, or omitted" });
-			return null;
+		let description: string | null = null;
+		if (body.description !== undefined && body.description !== null) {
+			if (typeof body.description !== "string") {
+				res.status(400).json({ error: "body.description must be a string, null, or omitted" });
+				return null;
+			}
+			const trimmed = body.description.trim();
+			if (trimmed.length > 500) {
+				res.status(400).json({ error: "body.description must be at most 500 characters" });
+				return null;
+			}
+			// Collapse whitespace-only to null so a `"   "` payload
+			// doesn't render visually blank while the column reports
+			// non-null. Same shape as the template description handling.
+			description = trimmed || null;
 		}
-		if (typeof body.description === "string" && body.description.length > 500) {
-			res.status(400).json({ error: "body.description must be at most 500 characters" });
-			return null;
-		}
-		if (typeof body.leadUserId !== "string" || body.leadUserId.length === 0) {
+		if (typeof body.leadUserId !== "string") {
 			res.status(400).json({ error: "body.leadUserId is required (non-empty string)" });
 			return null;
 		}
-		// Trim + collapse-empty mirrors the template description handling.
-		// A `"   "` value passed verbatim would render visually blank in
-		// the admin UI while the column reports non-null, which is
-		// indistinguishable from an intentionally-set description on the
-		// wire. See #262 round 1 NIT.
-		//
-		// Trim `leadUserId` too — a whitespace-padded value slips past
-		// the `length === 0` check, then `assertUserExists` runs an
-		// exact-string `SELECT id FROM users WHERE id = ?` against
-		// the padded string and returns 404 even when the user exists.
-		// Same shape as the `body.userId` trim in the addMember route
-		// below. See #262 round 2 NIT.
-		return {
-			name: body.name.trim(),
-			description: typeof body.description === "string" ? body.description.trim() || null : null,
-			leadUserId: body.leadUserId.trim(),
-		};
+		const leadUserId = body.leadUserId.trim();
+		if (leadUserId.length === 0) {
+			res.status(400).json({ error: "body.leadUserId is required (non-empty string)" });
+			return null;
+		}
+		return { name, description, leadUserId };
 	};
 
 	// Single serializer keeps the wire shape consistent across list / get /


### PR DESCRIPTION
## Summary

First slice of the tech-lead role from issue #201. Adds the **data model** plus the **admin authoring surface** for user groups. Tech-lead consumers (\`assertCanObserve\` auth primitive, \`/api/groups/mine\` view, observe-mode WS attach, frontend UI) ship in 201b–201e.

### Schema (\`db.ts\`)

- **\`user_groups\`** — \`id\`, \`name\`, \`description\`, \`lead_user_id\` (FK \`users\` \`ON DELETE RESTRICT\` — admin must reassign before a leading user can be deleted), \`created_at\`, \`updated_at\`.
- **\`user_group_members\`** — composite PK \`(group_id, user_id)\`, CASCADE on both FKs. \`idx_group_members_user\` covers the lead-of-which-groups lookup \`assertCanObserve\` issues in 201b.

### \`backend/src/groups.ts\`

- \`Group\`, \`GroupSummary\` (with \`leadUsername\` + \`memberCount\` from the listAll JOIN), \`GroupMember\` types + \`rowToGroup\` mapper.
- \`create\` pre-counts against \`MAX_GROUPS_TOTAL=1000\`, validates the lead exists, inserts the group, then implicitly inserts the lead as the first member (preserves the "lead is always a member" invariant). Swallows the lead-already-member race.
- \`update\` re-inserts the new lead as a member on reassignment. Old lead stays as a regular member; admin removes explicitly via \`removeMember\` if desired.
- \`addMember\` pre-checks against \`MAX_MEMBERS_PER_GROUP=500\` + user-exists + duplicate; translates a UNIQUE-constraint race into the same \`GroupMemberAlreadyExistsError\`.
- \`removeMember\` refuses to remove the lead (\`GroupCannotRemoveLeadError\`); idempotent for non-members.
- \`deleteGroup\` — CASCADE on the FK cleans up membership rows.
- \`groupsLedBy(userId)\` forward-looking helper consumed by 201b.

### Routes (admin-only, \`/api/admin/groups\`)

| Method | Path | Limiter | Description |
|---|---|---|---|
| GET | /admin/groups | adminStatsIp | List (summary shape with leadUsername + memberCount) |
| GET | /admin/groups/:id | adminStatsIp | Group + members |
| POST | /admin/groups | adminActionIp | Create |
| PUT | /admin/groups/:id | adminActionIp | Rename / reassign lead |
| DELETE | /admin/groups/:id | adminActionIp | Delete (CASCADE drops members) |
| POST | /admin/groups/:id/members | adminActionIp | Add user |
| DELETE | /admin/groups/:id/members/:userId | adminActionIp | Remove user |

\`handleGroupError\` centralises the typed-error → HTTP-status mapping (404 / 409 / 429 / 500) so each handler is just the happy path.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check src/\` clean
- [x] \`npx vitest run\` — 29 files, 713 tests pass (was 664; +49 new: 27 in \`groups.test.ts\` + 22 in \`routes.admin.groups.test.ts\`)
- [ ] Apply migration to a real D1 → POST /api/admin/groups → GET /admin/groups returns the row with leadUsername + memberCount=1 (the lead is implicitly a member)
- [ ] Add a member → list shows memberCount=2 → try to remove the lead → 409 \`Cannot remove the lead from group members\`
- [ ] Try to PUT a non-existent lead user → 404 \`User <id> not found\`
- [ ] DELETE the group → user_group_members rows cascade out

## What's not in this PR

- No \`assertCanObserve\` / \`assertCanModify\` split — that's 201b.
- No tech-lead view (\`/api/groups/mine\` etc.) — that's 201c.
- No WS observe attach — that's 201d.
- No frontend — that's 201e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)