### PR TITLE
feat(groups): assertCanObserve + isUserAdmin / isLeadOfUserViaGroup helpers (#201, PR 201b of 5)

### DIFF
--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -17,6 +17,7 @@ import {
 	AUTH_COOKIE_NAME,
 	extractTokenFromCookieHeader,
 	isAllowedWsOrigin,
+	isUserAdmin,
 	originMatches,
 	parseCorsOrigins,
 	requireAdmin,
@@ -701,6 +702,45 @@ describe("requireAdmin", () => {
 		expect(json).toHaveBeenCalledWith({ error: "Internal server error" });
 		expect(next).not.toHaveBeenCalled();
 		errSpy.mockRestore();
+	});
+});
+
+// ── isUserAdmin (#201b) ────────────────────────────────────────────────────
+// The boolean predicate extracted from requireAdmin so non-middleware
+// contexts (SessionManager.assertCanObserve) can ask the same question.
+// Critical contract: throws on D1 failure rather than silently returning
+// false — `assertCanObserve` relies on this to surface a 500 instead of
+// silently denying an admin observer when the lookup blips.
+
+describe("isUserAdmin", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+	});
+
+	it("returns true when the row has is_admin = 1", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({ results: [{ is_admin: 1 }], meta: { changes: 0 } });
+		expect(await isUserAdmin("u-admin")).toBe(true);
+	});
+
+	it("returns false when the row has is_admin = 0", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({ results: [{ is_admin: 0 }], meta: { changes: 0 } });
+		expect(await isUserAdmin("u-regular")).toBe(false);
+	});
+
+	it("returns false when no row exists (user deleted mid-session)", async () => {
+		dbStubs.d1Query.mockResolvedValueOnce({ results: [], meta: { changes: 0 } });
+		expect(await isUserAdmin("u-ghost")).toBe(false);
+	});
+
+	it("propagates D1 failures rather than silently returning false", async () => {
+		// Pinning contract — if a future refactor wraps the lookup in
+		// try/catch and returns false on failure, `assertCanObserve`'s
+		// admin tier would silently regress from "D1 down → 500" to
+		// "D1 down → 403" for admin observers. The middleware-level
+		// test above pins requireAdmin's 500, but only this case pins
+		// the throw at the helper level. See #263 round 2 NIT.
+		dbStubs.d1Query.mockRejectedValueOnce(new Error("D1 down"));
+		await expect(isUserAdmin("u-admin")).rejects.toThrow("D1 down");
 	});
 });
 

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -637,19 +637,6 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
 }
 
 /**
- * Gate a route on the caller having `is_admin = 1` in `users`. MUST chain
- * after `requireAuth` — reads `req.userId` from the AuthedRequest the
- * preceding middleware populated. Does its own D1 lookup rather than
- * trusting a JWT-embedded flag so that admin grant/revoke takes effect
- * without users needing to log out and back in.
- *
- * #50: gates GET, POST, and DELETE on /invites — list, mint, and
- * revoke are a single coherent admin surface. Earlier rounds of #146
- * gated only POST/DELETE and let GET fall through on auth, but that
- * left pre-#50 codes minted by non-admins invisible (and so
- * unrevocable) to the admin tier this PR exists to centralise on.
- */
-/**
  * Boolean predicate: is `userId` an admin? Fresh D1 lookup on every
  * call — same rationale as the inline `SELECT` that used to live in
  * `requireAdmin` (don't trust a JWT-embedded claim so admin grant /
@@ -671,6 +658,19 @@ export async function isUserAdmin(userId: string): Promise<boolean> {
 	return result.results[0]?.is_admin === 1;
 }
 
+/**
+ * Gate a route on the caller having `is_admin = 1` in `users`. MUST chain
+ * after `requireAuth` — reads `req.userId` from the AuthedRequest the
+ * preceding middleware populated. Delegates to `isUserAdmin` so the
+ * D1 lookup + "don't trust JWT-embedded claim" rationale stays in one
+ * place; #201b extracted the helper.
+ *
+ * #50: gates GET, POST, and DELETE on /invites — list, mint, and
+ * revoke are a single coherent admin surface. Earlier rounds of #146
+ * gated only POST/DELETE and let GET fall through on auth, but that
+ * left pre-#50 codes minted by non-admins invisible (and so
+ * unrevocable) to the admin tier this PR exists to centralise on.
+ */
 export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
 	const userId = (req as AuthedRequest).userId;
 	if (!userId) {

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -649,6 +649,28 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
  * left pre-#50 codes minted by non-admins invisible (and so
  * unrevocable) to the admin tier this PR exists to centralise on.
  */
+/**
+ * Boolean predicate: is `userId` an admin? Fresh D1 lookup on every
+ * call — same rationale as the inline `SELECT` that used to live in
+ * `requireAdmin` (don't trust a JWT-embedded claim so admin grant /
+ * revoke takes effect without logout). Throws on D1 failure rather
+ * than silently returning false: an admin-gated path should NOT
+ * fall back to a non-admin view because the lookup transiently
+ * failed; the caller turns the throw into a 500.
+ *
+ * Extracted from `requireAdmin` (#201b) so the same predicate is
+ * reachable from non-middleware contexts — specifically the WS
+ * observe-mode auth path (`SessionManager.assertCanObserve`).
+ * Keep both consumers calling this single function so admin
+ * semantics stay in one place.
+ */
+export async function isUserAdmin(userId: string): Promise<boolean> {
+	const result = await d1Query<{ is_admin: number }>("SELECT is_admin FROM users WHERE id = ?", [
+		userId,
+	]);
+	return result.results[0]?.is_admin === 1;
+}
+
 export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
 	const userId = (req as AuthedRequest).userId;
 	if (!userId) {
@@ -658,11 +680,7 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
 		return;
 	}
 	try {
-		const result = await d1Query<{ is_admin: number }>("SELECT is_admin FROM users WHERE id = ?", [
-			userId,
-		]);
-		const row = result.results[0];
-		if (!row || row.is_admin !== 1) {
+		if (!(await isUserAdmin(userId))) {
 			res.status(403).json({ error: "Admin privileges required" });
 			return;
 		}

--- a/backend/src/groups.test.ts
+++ b/backend/src/groups.test.ts
@@ -199,6 +199,29 @@ describe("groups.groupsLedBy", () => {
 	});
 });
 
+// ── isLeadOfUserViaGroup ────────────────────────────────────────────────────
+
+describe("groups.isLeadOfUserViaGroup", () => {
+	it("returns true when the LIMIT-1 JOIN finds a matching row", async () => {
+		mockNextRows([{ one: 1 }]);
+		expect(await groups.isLeadOfUserViaGroup("u-lead", "u-member")).toBe(true);
+	});
+
+	it("returns false when no row matches", async () => {
+		mockNextRows([]);
+		expect(await groups.isLeadOfUserViaGroup("u-not-lead", "u-some-user")).toBe(false);
+	});
+
+	it("uses both ids as parameters in the JOIN query", async () => {
+		mockNextRows([{ one: 1 }]);
+		await groups.isLeadOfUserViaGroup("u-lead", "u-member");
+		const call = dbStubs.d1Query.mock.calls[0]!;
+		expect(call[0]).toMatch(/JOIN user_group_members/);
+		expect(call[0]).toMatch(/LIMIT 1/);
+		expect(call[1]).toEqual(["u-lead", "u-member"]);
+	});
+});
+
 // ── update ──────────────────────────────────────────────────────────────────
 
 describe("groups.update", () => {

--- a/backend/src/groups.ts
+++ b/backend/src/groups.ts
@@ -236,13 +236,12 @@ export async function listMembers(groupId: string): Promise<GroupMember[]> {
 }
 
 /**
- * Forward-looking helper for 201b/c. Returns the ids of every group
- * the caller leads — the gate `assertCanObserve` uses to test
- * "can user X observe session S?" via `lead-of-any-group-containing
- * -ownerOfS`.
- *
- * Kept here (not in 201b) because the SQL belongs alongside the
- * other group reads. 201b wires the auth check that consumes it.
+ * Returns the ids of every group `userId` leads. Surfaced to the
+ * tech-lead "My groups" view in 201c. The SessionManager's
+ * `assertCanObserve` uses the narrower `isLeadOfUserViaGroup`
+ * predicate below instead — it answers the auth question with one
+ * indexed point read rather than fetching every group the lead
+ * owns and filtering client-side.
  */
 export async function groupsLedBy(userId: string): Promise<string[]> {
 	const result = await d1Query<{ id: string }>(
@@ -250,6 +249,41 @@ export async function groupsLedBy(userId: string): Promise<string[]> {
 		[userId],
 	);
 	return result.results.map((row) => row.id);
+}
+
+/**
+ * Auth predicate for `SessionManager.assertCanObserve` (#201b):
+ * is `leadUserId` the lead of ANY group whose membership contains
+ * `memberUserId`? Returns true iff yes.
+ *
+ * Single JOIN with `LIMIT 1` so the optimiser short-circuits as
+ * soon as a match is found. Both ids are indexed (`lead_user_id`
+ * via idx_user_groups_lead, `member.user_id` via the composite
+ * PK on user_group_members), so the query is a point read on
+ * normal volumes. No caching — the observe path is rare relative
+ * to the owner path that does most of the work.
+ *
+ * Edge: a user who leads a group and is also a member of that
+ * group (always true by invariant, since `create` and `update`
+ * insert the lead as a member) returns `true` for
+ * `isLeadOfUserViaGroup(leadId, leadId)`. The caller
+ * (`assertCanObserve`) short-circuits the self-case before
+ * reaching here, so the function staying honest doesn't matter
+ * for auth correctness — but it does mean the function is a
+ * pure relational predicate, not "is X the lead of someone
+ * else."
+ */
+export async function isLeadOfUserViaGroup(
+	leadUserId: string,
+	memberUserId: string,
+): Promise<boolean> {
+	const result = await d1Query<{ one: number }>(
+		"SELECT 1 AS one FROM user_groups g " +
+			"JOIN user_group_members m ON m.group_id = g.id " +
+			"WHERE g.lead_user_id = ? AND m.user_id = ? LIMIT 1",
+		[leadUserId, memberUserId],
+	);
+	return result.results.length > 0;
 }
 
 // ── Writes ──────────────────────────────────────────────────────────────────

--- a/backend/src/sessionManager.test.ts
+++ b/backend/src/sessionManager.test.ts
@@ -336,6 +336,32 @@ describe("SessionManager.assertOwnedBy / assertOwnership cache", () => {
 		}
 	});
 
+	it("expired entry on the observer fast path drops the stale cache entry before await", async () => {
+		const mgr = new SessionManager();
+		vi.useFakeTimers();
+		try {
+			dbStubs.d1Query.mockResolvedValueOnce({
+				results: [fakeSessionRow("s-1", "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			});
+			await mgr.assertOwnedBy("s-1", "u-owner");
+			vi.advanceTimersByTime(OWNERSHIP_CACHE_TTL_MS + 1);
+			// After TTL: assertCanObserveBy goes through expired-cleanup,
+			// fetches fresh meta, repopulates cache. Owner positive path.
+			dbStubs.d1Query.mockResolvedValueOnce({
+				results: [fakeSessionRow("s-1", "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			});
+			await mgr.assertCanObserveBy("s-1", "u-owner");
+			// Now the cache is fresh — next call hits cache, no D1.
+			await mgr.assertCanObserveBy("s-1", "u-owner");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("evicts oldest entry when cap is reached so memory is bounded", async () => {
 		// Fill cache to OWNERSHIP_CACHE_MAX, then add one more — first
 		// inserted must be evicted. We test the eviction by seeing the
@@ -367,5 +393,180 @@ describe("SessionManager.assertOwnedBy / assertOwnership cache", () => {
 		const callsBefore = dbStubs.d1Query.mock.calls.length;
 		await mgr.assertOwnedBy("s-first", "u-owner");
 		expect(dbStubs.d1Query.mock.calls.length).toBeGreaterThan(callsBefore);
+	});
+});
+
+// ── assertCanObserve (#201b) ────────────────────────────────────────────────
+
+describe("SessionManager.assertCanObserve", () => {
+	it("returns meta on the owner positive path with one D1 call", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const meta = await mgr.assertCanObserve("s-1", "u-owner");
+		expect(meta.userId).toBe("u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns meta on the admin positive path (owner != observer, observer is_admin=1)", async () => {
+		const mgr = new SessionManager();
+		// Call 1: getOrThrow returns session owned by u-owner.
+		// Call 2: isUserAdmin(u-admin) → is_admin=1.
+		dbStubs.d1Query
+			.mockResolvedValueOnce({
+				results: [fakeSessionRow("s-1", "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			})
+			.mockResolvedValueOnce({
+				results: [{ is_admin: 1 }],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			});
+		const meta = await mgr.assertCanObserve("s-1", "u-admin");
+		expect(meta.userId).toBe("u-owner");
+		// isLeadOfUserViaGroup must NOT be called when admin already
+		// authorized — short-circuit ordering matters for D1 cost.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns meta on the tech-lead positive path (not owner, not admin, leads owner's group)", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query
+			.mockResolvedValueOnce({
+				results: [fakeSessionRow("s-1", "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			})
+			.mockResolvedValueOnce({
+				results: [{ is_admin: 0 }],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			})
+			.mockResolvedValueOnce({
+				results: [{ one: 1 }],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			});
+		const meta = await mgr.assertCanObserve("s-1", "u-lead");
+		expect(meta.userId).toBe("u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(3);
+	});
+
+	it("throws ForbiddenError when observer is none of owner / admin / lead", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query
+			.mockResolvedValueOnce({
+				results: [fakeSessionRow("s-1", "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			})
+			.mockResolvedValueOnce({
+				results: [{ is_admin: 0 }],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			})
+			.mockResolvedValueOnce({
+				results: [],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			});
+		await expect(mgr.assertCanObserve("s-1", "u-stranger")).rejects.toBeInstanceOf(ForbiddenError);
+	});
+
+	it("throws NotFoundError when the session row is missing", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await expect(mgr.assertCanObserve("s-nope", "u-any")).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it("populates the ownership cache as a side effect on the owner path", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		await mgr.assertCanObserve("s-1", "u-owner");
+		// Owner-only assertOwnedBy must now hit cache, no extra D1.
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ── assertCanObserveBy (#201b void variant) ─────────────────────────────────
+
+describe("SessionManager.assertCanObserveBy", () => {
+	it("short-circuits the cached-owner positive path with zero D1 calls", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		// Prime the cache via assertOwnedBy.
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+		// Observe by the cached owner — zero new D1 calls.
+		await mgr.assertCanObserveBy("s-1", "u-owner");
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls through to admin/lead lookups when observer != cached_owner", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [fakeSessionRow("s-1", "u-owner")],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		// Prime cache as owner.
+		await mgr.assertOwnedBy("s-1", "u-owner");
+		// Observer is a different user — cache hit short-circuit doesn't
+		// apply. Fall through: getOrThrow (cached re-fetch happens since
+		// we don't have a meta-cache, just owner-cache) → isUserAdmin → isLead.
+		dbStubs.d1Query
+			.mockResolvedValueOnce({
+				results: [fakeSessionRow("s-1", "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			})
+			.mockResolvedValueOnce({
+				results: [{ is_admin: 1 }],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			});
+		await mgr.assertCanObserveBy("s-1", "u-admin");
+		// 1 (prime) + 2 (getOrThrow + isUserAdmin) = 3. isLead skipped.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(3);
+	});
+
+	it("throws ForbiddenError when no positive arm matches and the observer is uncached", async () => {
+		const mgr = new SessionManager();
+		dbStubs.d1Query
+			.mockResolvedValueOnce({
+				results: [fakeSessionRow("s-1", "u-owner")],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			})
+			.mockResolvedValueOnce({
+				results: [{ is_admin: 0 }],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			})
+			.mockResolvedValueOnce({
+				results: [],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			});
+		await expect(mgr.assertCanObserveBy("s-1", "u-stranger")).rejects.toBeInstanceOf(
+			ForbiddenError,
+		);
 	});
 });

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -8,12 +8,17 @@ import { v4 as uuidv4 } from "uuid";
 import { isUserAdmin } from "./auth.js";
 import { parseD1Utc } from "./d1Time.js";
 import { d1Query } from "./db.js";
-// Static import is safe despite groups.ts → sessionManager.ts importing
-// `ForbiddenError`/`NotFoundError` — ESM live bindings resolve at use
-// time (inside function bodies) rather than module-init time, and
-// neither module references the other at top level. See the
-// `assertCanObserve` block below for why this primitive lives in
-// `groups.ts` rather than being inlined here.
+// CJS-safe circular dep: the project compiles to CommonJS, where
+// TypeScript emits named imports as property accesses on a captured
+// module-exports reference (e.g. `groups_js_1.isLeadOfUserViaGroup`)
+// rather than destructured variables. The reference is captured early
+// when both modules first load, but the actual property access is
+// deferred to call time — by which point both modules have completed
+// their top-level evaluation and every export is present. The
+// reciprocal import in `groups.ts`
+// (`import { ForbiddenError, NotFoundError } from "./sessionManager.js"`)
+// is safe for the same reason. ESM live bindings give the same
+// behaviour but the load-bearing mechanism here is the CJS shape.
 import { isLeadOfUserViaGroup } from "./groups.js";
 import { logger } from "./logger.js";
 import type { CreateSessionOpts, SessionMeta, SessionStatus } from "./types.js";

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -5,8 +5,16 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
+import { isUserAdmin } from "./auth.js";
 import { parseD1Utc } from "./d1Time.js";
 import { d1Query } from "./db.js";
+// Static import is safe despite groups.ts → sessionManager.ts importing
+// `ForbiddenError`/`NotFoundError` — ESM live bindings resolve at use
+// time (inside function bodies) rather than module-init time, and
+// neither module references the other at top level. See the
+// `assertCanObserve` block below for why this primitive lives in
+// `groups.ts` rather than being inlined here.
+import { isLeadOfUserViaGroup } from "./groups.js";
 import { logger } from "./logger.js";
 import type { CreateSessionOpts, SessionMeta, SessionStatus } from "./types.js";
 
@@ -317,6 +325,96 @@ export class SessionManager {
 			ownerUserId,
 			expiresAt: Date.now() + OWNERSHIP_CACHE_TTL_MS,
 		});
+	}
+
+	// ── Observe-access primitive (#201b) ────────────────────────────────────
+	//
+	// `assertCanObserve` is the auth choke point for the new tech-lead read
+	// paths landing in 201c (the lead's "My groups" cross-user session list)
+	// and 201d (observe-mode WS attach). It accepts a graded set of
+	// observers:
+	//
+	//   1. The session owner (cheapest path — covered by the ownership cache
+	//      from #239 so a repeated observe by the owner hits no D1).
+	//   2. Any user with `is_admin=1` (admins already see every session via
+	//      the admin dashboard; the observe path is just another way in).
+	//   3. The lead of ANY group containing the session owner (the actual
+	//      v1 new capability — gated by a single indexed point read via
+	//      `isLeadOfUserViaGroup`).
+	//
+	// All other callers throw `ForbiddenError` (route → 403). A missing
+	// session row throws `NotFoundError` (route → 404) — collapsing
+	// observe-of-missing into a generic 404 matches the existing
+	// `assertOwnership` shape and the dispatcher's no-status-leak posture.
+	//
+	// No write capability is granted by this method — destructive paths
+	// (stop / start / delete / env-update) still go through
+	// `assertOwnership`. The two checks are deliberately separate so a
+	// future feature that broadens observe (e.g. adding "any authed user
+	// in the same org") doesn't accidentally widen the write surface.
+	//
+	// Caching shape: the ownership cache short-circuits the owner-positive
+	// path (cache hit when observer === cached_owner). Admin lookups and
+	// lead-of-user JOIN are NOT cached — the observe path is rare relative
+	// to the owner-only path, and caching tech-lead access would mean
+	// invalidating on every `addMember` / `removeMember` / `update` (lead
+	// reassignment), which is a bigger surface than the saved round-trip
+	// justifies.
+
+	/**
+	 * Read-access check that returns the SessionMeta on success. Use this
+	 * at call sites that need the meta (the route serializer, the WS
+	 * attach handler). Throws `NotFoundError` if no session row exists,
+	 * `ForbiddenError` if the observer is none of: owner / admin / lead-
+	 * of-group-containing-owner.
+	 */
+	async assertCanObserve(sessionId: string, observerUserId: string): Promise<SessionMeta> {
+		// Owner positive path — leverages the ownership cache. Same
+		// `assertOwnership`-shaped flow that fetches fresh meta even on
+		// cache hit (callers may consume mutable fields).
+		const meta = await this.getOrThrow(sessionId);
+		this.cacheOwnership(sessionId, meta.userId);
+		if (meta.userId === observerUserId) return meta;
+		// Admin positive path. `isUserAdmin` throws on D1 failure rather
+		// than silently returning false — propagate so the route maps
+		// the transient error to 500 instead of falsely returning 403.
+		if (await isUserAdmin(observerUserId)) return meta;
+		// Tech-lead positive path: is the observer the lead of any
+		// group containing the owner? Single indexed JOIN with LIMIT 1
+		// inside `isLeadOfUserViaGroup`.
+		if (await isLeadOfUserViaGroup(observerUserId, meta.userId)) return meta;
+		throw new ForbiddenError();
+	}
+
+	/**
+	 * Void-return sibling of `assertCanObserve` for call sites that don't
+	 * need the SessionMeta (e.g. a future helper that just answers
+	 * "should this user see the observe button?"). Mirrors the
+	 * `assertOwnedBy` shape — short-circuits both positive AND negative
+	 * directions from the ownership cache before falling through to
+	 * admin / lead lookups.
+	 */
+	async assertCanObserveBy(sessionId: string, observerUserId: string): Promise<void> {
+		const cached = this.ownershipCache.get(sessionId);
+		const now = Date.now();
+		// Cache hit, observer is the cached owner — bypass D1 entirely.
+		// Negative-cache shape: observer != cached_owner means we still
+		// have to check admin / lead, so we don't short-circuit there
+		// (mirrors how `assertOwnedBy` only short-circuits the positive
+		// hit + immediate-forbid for owner-only checks).
+		if (cached && cached.expiresAt > now && cached.ownerUserId === observerUserId) return;
+		if (cached && cached.expiresAt <= now) {
+			// Mirror the assertOwnedBy cleanup: drop expired entries
+			// before the await so a `getOrThrow` that throws NotFoundError
+			// (session hard-deleted) leaves a clean map.
+			this.ownershipCache.delete(sessionId);
+		}
+		const meta = await this.getOrThrow(sessionId);
+		this.cacheOwnership(sessionId, meta.userId);
+		if (meta.userId === observerUserId) return;
+		if (await isUserAdmin(observerUserId)) return;
+		if (await isLeadOfUserViaGroup(observerUserId, meta.userId)) return;
+		throw new ForbiddenError();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Second slice of the tech-lead role from #201. Adds the new graded auth primitive that 201c (\`/api/groups/mine/sessions\`) and 201d (observe-mode WS attach) will consume. **Pure additive — no call-site changes, no existing-test churn.**

### \`auth.ts\`

- Extract \`isUserAdmin(userId)\` as a callable helper — the same predicate \`requireAdmin\` middleware uses, now reachable from non-middleware contexts. Refactor \`requireAdmin\` to delegate so the admin SQL stays in one place. Throws on D1 failure rather than silently returning false (an admin-gated path must NOT fall back to non-admin view on a transient).

### \`groups.ts\`

- \`isLeadOfUserViaGroup(leadUserId, memberUserId)\` — single JOIN with LIMIT 1 that answers the observe-path auth question with one indexed point read. Both \`lead_user_id\` (\`idx_user_groups_lead\`) and \`member.user_id\` (composite PK) are indexed; no caching needed at v1 scale.

### \`sessionManager.ts\`

- \`assertCanObserve(sessionId, observerUserId)\` — returns SessionMeta when the observer is owner / admin / lead-of-group-containing-owner. Throws ForbiddenError otherwise.
- \`assertCanObserveBy(sessionId, observerUserId)\` — void-return variant; mirrors the \`assertOwnedBy\`/\`assertOwnership\` split. **Short-circuits via the existing ownership cache** (#239) when the cached owner matches the observer — zero D1 calls on the cached-owner positive path.
- Static \`import { isLeadOfUserViaGroup } from "./groups.js"\` is safe despite the bidirectional dependency. The project compiles to CommonJS (per \`backend/tsconfig.json\`), where TypeScript emits named imports as property accesses on a captured \`module.exports\` reference — the reference is established when both modules first load, but the actual property access is deferred to call time, by which point both modules have completed initialization. The reciprocal \`groups.ts\` import of \`ForbiddenError\`/\`NotFoundError\` is safe for the same reason. The import block in \`sessionManager.ts\` carries this rationale inline.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check src/\` clean
- [x] \`npx vitest run\` — 734 tests pass (was 717; +17 new)
- [x] +3 cases in \`groups.test.ts\` pin the JOIN shape and parameter ordering for \`isLeadOfUserViaGroup\`
- [x] +4 cases in \`auth.test.ts\` pin \`isUserAdmin\` — true / false / missing-row / **D1-failure-propagates** (the load-bearing contract \`assertCanObserve\`'s admin tier relies on)
- [x] +6 cases in \`sessionManager.test.ts\` cover the three positive paths (owner / admin / lead), the forbidden / not-found fall-throughs, the cache side-effect on the owner path, and the cached-owner short-circuit on \`assertCanObserveBy\`
- [ ] Smoke: pause until 201c lands consumers; no behavioural change in this PR

## What's not in this PR

- No new endpoints — those land in 201c (\`/api/groups/mine\`, \`/api/groups/mine/sessions\`) and 201d (\`?observe=true\` WS attach).
- No call-site changes to existing routes. Destructive paths still go through \`assertOwnership\` (owner-only); admin still uses \`/admin/sessions/*\`; \`assertCanObserve\` exists for observe-mode-only paths.
- No frontend — that's 201e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)