### PR TITLE
feat(groups): GET /api/groups/mine[/sessions] (#201, PR 201c of 5)

### DIFF
--- a/backend/src/groups.test.ts
+++ b/backend/src/groups.test.ts
@@ -396,3 +396,128 @@ describe("groups.removeMember", () => {
 		// No throw — convention is post-condition over precondition.
 	});
 });
+
+// ── listGroupsLedBy (#201c) ────────────────────────────────────────────────
+
+describe("groups.listGroupsLedBy", () => {
+	it("returns an empty array and skips the members query when the user leads nothing", async () => {
+		mockNextRows([]); // groups query → 0 rows
+		const list = await groups.listGroupsLedBy("u-not-a-lead");
+		expect(list).toEqual([]);
+		// Critical: short-circuit BEFORE issuing the IN-clause member
+		// query, otherwise every non-lead user would burn a D1 round-trip
+		// per call against an empty IN list.
+		expect(dbStubs.d1Query).toHaveBeenCalledTimes(1);
+	});
+
+	it("zips groups with their members from the second IN-clause query", async () => {
+		mockNextRows([
+			groupRow({ id: "g-1", name: "Frontend", leadUserId: "u-lead" }),
+			groupRow({ id: "g-2", name: "Mobile", leadUserId: "u-lead" }),
+		]);
+		mockNextRows([
+			{ group_id: "g-1", user_id: "u-lead", username: "alice", added_at: "2026-05-11 12:00:00" },
+			{ group_id: "g-1", user_id: "u-2", username: "bob", added_at: "2026-05-11 12:00:01" },
+			{ group_id: "g-2", user_id: "u-lead", username: "alice", added_at: "2026-05-11 12:00:02" },
+		]);
+		const list = await groups.listGroupsLedBy("u-lead");
+		expect(list).toHaveLength(2);
+		expect(list[0]?.id).toBe("g-1");
+		expect(list[0]?.members.map((m) => m.username)).toEqual(["alice", "bob"]);
+		expect(list[1]?.id).toBe("g-2");
+		expect(list[1]?.members.map((m) => m.username)).toEqual(["alice"]);
+	});
+
+	it("renders an empty members array for a group whose member rows somehow vanished", async () => {
+		// Defensive: invariant says lead is always a member, but a future
+		// bug that left a group empty should still surface the group in
+		// the lead's view with members:[] rather than be silently dropped.
+		mockNextRows([groupRow({ id: "g-1", leadUserId: "u-lead" })]);
+		mockNextRows([]); // empty members fetch
+		const list = await groups.listGroupsLedBy("u-lead");
+		expect(list).toHaveLength(1);
+		expect(list[0]?.members).toEqual([]);
+	});
+
+	it("builds the IN-clause with one ? per group id and binds every id", async () => {
+		mockNextRows([
+			groupRow({ id: "g-a", leadUserId: "u-lead" }),
+			groupRow({ id: "g-b", leadUserId: "u-lead" }),
+			groupRow({ id: "g-c", leadUserId: "u-lead" }),
+		]);
+		mockNextRows([]);
+		await groups.listGroupsLedBy("u-lead");
+		const memberCall = dbStubs.d1Query.mock.calls[1]!;
+		// `IN (?,?,?)` — placeholders match the count, values are bound.
+		expect(memberCall[0]).toMatch(/IN \(\?,\?,\?\)/);
+		expect(memberCall[1]).toEqual(["g-a", "g-b", "g-c"]);
+	});
+});
+
+// ── sessionsObservableBy (#201c) ────────────────────────────────────────────
+
+describe("groups.sessionsObservableBy", () => {
+	it("returns the typed shape with ownerUsername inlined from the JOIN", async () => {
+		mockNextRows([
+			{
+				session_id: "s-1",
+				user_id: "u-member",
+				username: "bob",
+				name: "build-1",
+				status: "running",
+				container_id: "ct-1234567890abcdef",
+				container_name: "st-abc",
+				cols: 120,
+				rows: 36,
+				created_at: "2026-05-12 10:00:00",
+				last_connected_at: "2026-05-12 10:05:00",
+			},
+		]);
+		const list = await groups.sessionsObservableBy("u-lead");
+		expect(list).toHaveLength(1);
+		expect(list[0]?.sessionId).toBe("s-1");
+		expect(list[0]?.ownerUserId).toBe("u-member");
+		expect(list[0]?.ownerUsername).toBe("bob");
+		expect(list[0]?.status).toBe("running");
+		expect(list[0]?.lastConnectedAt).toBeInstanceOf(Date);
+	});
+
+	it("returns an empty array when the lead has no observable sessions", async () => {
+		mockNextRows([]);
+		expect(await groups.sessionsObservableBy("u-not-a-lead")).toEqual([]);
+	});
+
+	it("issues the IN-subquery scoped by lead_user_id and excludes terminated", async () => {
+		mockNextRows([]);
+		await groups.sessionsObservableBy("u-lead");
+		const call = dbStubs.d1Query.mock.calls[0]!;
+		// Inner subquery scopes by lead → members → users.
+		expect(call[0]).toMatch(/WHERE g\.lead_user_id = \?/);
+		// Terminated sessions are excluded — see helper-level comment.
+		expect(call[0]).toMatch(/s\.status != 'terminated'/);
+		// Newest-first.
+		expect(call[0]).toMatch(/ORDER BY s\.created_at DESC/);
+		expect(call[1]).toEqual(["u-lead"]);
+	});
+
+	it("emits null for a missing last_connected_at", async () => {
+		mockNextRows([
+			{
+				session_id: "s-1",
+				user_id: "u-member",
+				username: "bob",
+				name: "fresh",
+				status: "stopped",
+				container_id: null,
+				container_name: "st-abc",
+				cols: 120,
+				rows: 36,
+				created_at: "2026-05-12 10:00:00",
+				last_connected_at: null,
+			},
+		]);
+		const list = await groups.sessionsObservableBy("u-lead");
+		expect(list[0]?.lastConnectedAt).toBeNull();
+		expect(list[0]?.containerId).toBeNull();
+	});
+});

--- a/backend/src/groups.ts
+++ b/backend/src/groups.ts
@@ -3,15 +3,19 @@
  *
  * A group is a named collection of users with one designated "lead"
  * who can observe (read-only) the sessions of every member. Schema
- * lives in `db.ts` (user_groups + user_group_members). All CRUD here
- * is admin-only at the route layer — this module has no per-user
- * ownership concept of its own (analogous to `invites` rather than
- * `templates`).
+ * lives in `db.ts` (user_groups + user_group_members). Group CRUD
+ * (create / update / delete / addMember / removeMember) is admin-
+ * only at the route layer; the lead-side READ surface is auth-only
+ * (any authed user can call `/api/groups/mine[/sessions]` and the
+ * SQL itself does the user-scoping).
  *
- * Forward-looking 201b/c hooks:
- *   - `groupsLedBy(userId)` powers the `assertCanObserve` extension.
- *   - `sessionsObservableBy(userId)` is the cross-user session list
- *     surface for the tech lead's "My group" view.
+ * Auth integration:
+ *   - `isLeadOfUserViaGroup(leadId, memberId)` is the indexed
+ *     point-read consumed by `SessionManager.assertCanObserve`
+ *     (#201b) for the observe-mode auth check.
+ *   - `listGroupsLedBy(userId)` and `sessionsObservableBy(userId)`
+ *     (#201c) are the lead-side reads behind `/api/groups/mine`
+ *     and `/api/groups/mine/sessions` respectively.
  *
  * The lead is implicitly inserted into `user_group_members` on
  * create / re-assigned-via-update, so "sessions visible to user X"
@@ -344,9 +348,13 @@ export async function isLeadOfUserViaGroup(
  * Then zip in JS. The IN-clause is built from the group ids the
  * first query returned, so the parameter list is bounded by however
  * many groups the lead leads — which is itself bounded by the
- * deployment-wide `MAX_GROUPS_TOTAL` cap. SQLite's expression-tree
- * cap (typically 999 bound params) is well above any plausible
- * single-lead count, so no chunking needed at v1 scale.
+ * deployment-wide `MAX_GROUPS_TOTAL` cap (1000 today). D1 runs
+ * SQLite 3.46+, where SQLITE_MAX_VARIABLE_NUMBER is 32 766; a
+ * worst-case "one lead leads every group in a maxed-out deployment"
+ * binds 1000 placeholders, well within bounds. Raise
+ * `MAX_GROUPS_TOTAL` with care if it ever approaches that ceiling
+ * (the older 999-default limit predates SQLite 3.32 / 2020 and is
+ * not the relevant number on D1).
  *
  * LEFT JOIN on member fetch is deliberate: a group with no members
  * is impossible by invariant (the lead is implicitly inserted on
@@ -413,10 +421,13 @@ export async function listGroupsLedBy(userId: string): Promise<LeadGroup[]> {
  * Single JOIN-with-IN-subquery: the inner SELECT pulls every user
  * id that's a member of any group led by `userId`; the outer
  * SELECT picks every session of those users, joined to `users` for
- * the owner username. Both ids are indexed (group_id via PK,
- * member.user_id via composite PK), so the inner subquery is a
- * point read per group; the outer JOIN on `sessions.user_id` walks
- * the existing sessions index.
+ * the owner username. Indexes hit on the inner side: `lead_user_id`
+ * via `idx_user_groups_lead`, then `m.group_id` via the leading
+ * column of the `user_group_members` composite PK `(group_id,
+ * user_id)`. Outer JOIN on `sessions.user_id` walks the existing
+ * sessions table. No extra index needed on `sessions(user_id)` at
+ * v1 scale — the session table is small and the JOIN is bounded
+ * by the inner subquery's small result set.
  *
  * Edge: a lead is implicitly a member of every group they lead, so
  * the inner subquery includes the lead's own user_id. This means

--- a/backend/src/groups.ts
+++ b/backend/src/groups.ts
@@ -22,7 +22,8 @@
 import { randomUUID } from "node:crypto";
 import { parseD1Utc } from "./d1Time.js";
 import { d1Query } from "./db.js";
-import { ForbiddenError, NotFoundError } from "./sessionManager.js";
+import { ADMIN_LIST_LIMIT, ForbiddenError, NotFoundError } from "./sessionManager.js";
+import type { SessionStatus } from "./types.js";
 
 // ── Limits ──────────────────────────────────────────────────────────────────
 
@@ -82,6 +83,38 @@ export interface GroupMember {
 	userId: string;
 	username: string;
 	addedAt: Date;
+}
+
+/** Lead-side group shape returned by `listGroupsLedBy`. Extends
+ *  `Group` with the inlined member list so the `GET /api/groups/mine`
+ *  endpoint renders in one round-trip per lead, regardless of how
+ *  many groups they lead — the implementation does two D1 calls
+ *  total (groups + a single IN-clause member fetch) and zips the
+ *  result in JS. */
+export interface LeadGroup extends Group {
+	members: GroupMember[];
+}
+
+/** Cross-user session row returned by `sessionsObservableBy` — the
+ *  lead's read-only view of "every session a member of any group I
+ *  lead currently owns." Shape mirrors the admin cross-user list
+ *  (`sessionManager.listAll`) but excludes `envVars`: the lead's
+ *  observability surface is intentionally narrower than admin's,
+ *  and the list view doesn't need plaintext env. A future per-
+ *  session lead GET (the redaction-locked-in path from #201) can
+ *  surface env via `redactStoredEntries` once that endpoint ships. */
+export interface ObservableSessionMeta {
+	sessionId: string;
+	ownerUserId: string;
+	ownerUsername: string;
+	name: string;
+	status: SessionStatus;
+	containerId: string | null;
+	containerName: string;
+	cols: number;
+	rows: number;
+	createdAt: Date;
+	lastConnectedAt: Date | null;
 }
 
 export interface GroupInput {
@@ -284,6 +317,157 @@ export async function isLeadOfUserViaGroup(
 		[leadUserId, memberUserId],
 	);
 	return result.results.length > 0;
+}
+
+// ── Lead-side reads (#201c) ────────────────────────────────────────────────
+//
+// Two reads power the tech-lead's "My groups" UI without requiring
+// admin gating. Both are user-scoped — the lead can only see groups
+// they personally lead, and sessions whose owners are members of one
+// of those groups. Auth at the route layer is `requireAuth` only
+// (no admin); the SQL itself is the user-scoping. A non-lead caller
+// gets an empty array from both helpers, NOT a 403 — the auth
+// gradient surfaces "the user has lead privileges" via the
+// `listGroupsLedBy` result being non-empty, not via a separate
+// status code. This matches the "groups where I'm lead" / "any user"
+// audience in the issue lock-in.
+
+/**
+ * Return every group `userId` leads, newest-first, with each group's
+ * full member list inlined. Two D1 round-trips total regardless of
+ * how many groups the user leads:
+ *
+ *   1. Fetch all groups where `lead_user_id = userId`.
+ *   2. If any groups came back, fetch ALL their members in a single
+ *      IN-clause query joined to `users.username`.
+ *
+ * Then zip in JS. The IN-clause is built from the group ids the
+ * first query returned, so the parameter list is bounded by however
+ * many groups the lead leads — which is itself bounded by the
+ * deployment-wide `MAX_GROUPS_TOTAL` cap. SQLite's expression-tree
+ * cap (typically 999 bound params) is well above any plausible
+ * single-lead count, so no chunking needed at v1 scale.
+ *
+ * LEFT JOIN on member fetch is deliberate: a group with no members
+ * is impossible by invariant (the lead is implicitly inserted on
+ * create), but if a future bug ever left a group empty, returning
+ * the group with `members: []` is a better failure mode than
+ * silently dropping it from the lead's view.
+ */
+export async function listGroupsLedBy(userId: string): Promise<LeadGroup[]> {
+	const groupsResult = await d1Query<GroupRow>(
+		"SELECT * FROM user_groups WHERE lead_user_id = ? ORDER BY created_at DESC",
+		[userId],
+	);
+	if (groupsResult.results.length === 0) return [];
+	const groupRows = groupsResult.results;
+	const groupIds = groupRows.map((row) => row.id);
+	// Parameterised IN-clause. Build the placeholder list dynamically
+	// (D1's prepared-statement shape requires one `?` per value) but
+	// the values themselves are always bound — never interpolated —
+	// so the SQL injection surface is closed at the binding boundary.
+	const placeholders = groupIds.map(() => "?").join(",");
+	const memberRows = await d1Query<{
+		group_id: string;
+		user_id: string;
+		username: string;
+		added_at: string;
+	}>(
+		`SELECT m.group_id, m.user_id, u.username, m.added_at ` +
+			`FROM user_group_members m JOIN users u ON u.id = m.user_id ` +
+			`WHERE m.group_id IN (${placeholders}) ` +
+			`ORDER BY m.added_at ASC`,
+		groupIds,
+	);
+	// Bucket members by group_id. Initialise every bucket so a group
+	// with zero members (the bug-defence case above) still renders as
+	// `members: []` rather than `members: undefined`.
+	const membersByGroup = new Map<string, GroupMember[]>();
+	for (const id of groupIds) membersByGroup.set(id, []);
+	for (const row of memberRows.results) {
+		membersByGroup.get(row.group_id)?.push({
+			userId: row.user_id,
+			username: row.username,
+			addedAt: parseD1Utc(row.added_at, "groups"),
+		});
+	}
+	return groupRows.map((row) => ({
+		...rowToGroup(row),
+		members: membersByGroup.get(row.id) ?? [],
+	}));
+}
+
+/**
+ * Return every session owned by any user who is a member of any
+ * group `userId` leads, newest-first, hard-capped at
+ * `ADMIN_LIST_LIMIT`. The cap is shared with the admin path
+ * (`sessionManager.listAll`) — same rationale: a deployment with
+ * thousands of accumulated sessions across a lead's groups
+ * shouldn't blow a multi-megabyte JSON payload on a routine refresh.
+ *
+ * Excludes `terminated` sessions: they're soft-deleted by the owner
+ * and can't be observed (no container, nothing to attach to). Stays
+ * parallel to the owner's default-list shape from `listForUser`,
+ * which excludes the same status.
+ *
+ * Single JOIN-with-IN-subquery: the inner SELECT pulls every user
+ * id that's a member of any group led by `userId`; the outer
+ * SELECT picks every session of those users, joined to `users` for
+ * the owner username. Both ids are indexed (group_id via PK,
+ * member.user_id via composite PK), so the inner subquery is a
+ * point read per group; the outer JOIN on `sessions.user_id` walks
+ * the existing sessions index.
+ *
+ * Edge: a lead is implicitly a member of every group they lead, so
+ * the inner subquery includes the lead's own user_id. This means
+ * `sessionsObservableBy(leadUserId)` includes the lead's OWN
+ * sessions. That's the right v1 shape: the lead's "My group"
+ * dashboard surfaces every session they can observe, including
+ * their own — clients can filter or section client-side if they
+ * want a different render. Filtering server-side would mean a lead
+ * with no members but one of their own sessions sees nothing,
+ * which is a confusing UX for "you lead this group but it's
+ * empty."
+ */
+export async function sessionsObservableBy(userId: string): Promise<ObservableSessionMeta[]> {
+	const result = await d1Query<{
+		session_id: string;
+		user_id: string;
+		username: string;
+		name: string;
+		status: string;
+		container_id: string | null;
+		container_name: string;
+		cols: number;
+		rows: number;
+		created_at: string;
+		last_connected_at: string | null;
+	}>(
+		"SELECT s.session_id, s.user_id, u.username, s.name, s.status, " +
+			"s.container_id, s.container_name, s.cols, s.rows, " +
+			"s.created_at, s.last_connected_at " +
+			"FROM sessions s JOIN users u ON u.id = s.user_id " +
+			"WHERE s.user_id IN ( " +
+			"  SELECT m.user_id FROM user_group_members m " +
+			"  JOIN user_groups g ON g.id = m.group_id " +
+			"  WHERE g.lead_user_id = ? " +
+			") AND s.status != 'terminated' " +
+			`ORDER BY s.created_at DESC LIMIT ${ADMIN_LIST_LIMIT}`,
+		[userId],
+	);
+	return result.results.map((row) => ({
+		sessionId: row.session_id,
+		ownerUserId: row.user_id,
+		ownerUsername: row.username,
+		name: row.name,
+		status: row.status as SessionStatus,
+		containerId: row.container_id,
+		containerName: row.container_name,
+		cols: row.cols,
+		rows: row.rows,
+		createdAt: parseD1Utc(row.created_at, "sessions"),
+		lastConnectedAt: row.last_connected_at ? parseD1Utc(row.last_connected_at, "sessions") : null,
+	}));
 }
 
 // ── Writes ──────────────────────────────────────────────────────────────────

--- a/backend/src/routes.admin.groups.test.ts
+++ b/backend/src/routes.admin.groups.test.ts
@@ -1,11 +1,18 @@
 /**
- * routes.admin.groups.test.ts — REST integration for /api/admin/groups (#201a).
+ * routes.admin.groups.test.ts — REST integration for all group-related
+ * REST surfaces: admin CRUD under /api/admin/groups (#201a) and the
+ * lead-side reads under /api/groups/mine[/sessions] (#201c).
  *
- * Pins the wire shape for each endpoint and the admin gate. Uses the
- * same stub style as routes.admin.test.ts — auth middleware mocked,
- * the underlying `groups.ts` mocked at the module boundary so we
- * exercise the route's validation + error mapping logic without
- * driving D1 call sequences.
+ * Pins the wire shape for each endpoint and the admin / auth gates.
+ * Uses the same stub style as routes.admin.test.ts — auth middleware
+ * mocked, the underlying `groups.ts` mocked at the module boundary
+ * so we exercise the route's validation + serializer + error mapping
+ * without driving D1 call sequences (those live in groups.test.ts).
+ *
+ * File name kept stable from 201a despite covering 201c's user-side
+ * routes too — both surfaces share the module mock and the same
+ * spinUp scaffold, and a single test file keeps the groups-related
+ * route coverage discoverable in one place.
  */
 
 import http from "node:http";
@@ -132,6 +139,8 @@ const groupsStubs = vi.hoisted(() => {
 		addMember: vi.fn(async () => undefined),
 		removeMember: vi.fn(async () => undefined),
 		groupsLedBy: vi.fn(async () => [] as string[]),
+		listGroupsLedBy: vi.fn(async () => [] as unknown[]),
+		sessionsObservableBy: vi.fn(async () => [] as unknown[]),
 		GroupQuotaExceededError,
 		GroupMembersCapExceededError,
 		GroupUserNotFoundError,
@@ -555,5 +564,160 @@ describe("DELETE /api/admin/groups/:id/members/:userId", () => {
 			method: "DELETE",
 		});
 		expect(res.status).toBe(404);
+	});
+});
+
+// ── Lead-side /api/groups/mine[/sessions] (#201c) ─────────────────────────────
+// `requireAuth`-gated only — no admin requirement. A non-lead caller still
+// reaches the handler and gets `[]` back (the SQL is user-scoped). The
+// admin-stub `requireAdmin` is irrelevant here; we keep it on the default
+// passthrough.
+
+describe("GET /api/groups/mine", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.listGroupsLedBy.mockReset();
+		groupsStubs.listGroupsLedBy.mockImplementation(async () => []);
+	});
+
+	it("returns an empty array when the user leads no groups", async () => {
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/groups/mine`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as unknown[];
+		expect(body).toEqual([]);
+		// Critical: the handler runs through to listGroupsLedBy even for
+		// a non-lead caller. The SQL itself is the user-scoping; auth-
+		// only middleware is the gate (no admin check).
+		expect(groupsStubs.listGroupsLedBy).toHaveBeenCalledWith("u1");
+	});
+
+	it("serialises each group with its inlined members (userId/username/addedAt as ISO)", async () => {
+		groupsStubs.listGroupsLedBy.mockImplementationOnce(async () => [
+			{
+				id: "g-1",
+				name: "Frontend",
+				description: "FE team",
+				leadUserId: "u1",
+				createdAt: new Date("2026-05-11T12:00:00Z"),
+				updatedAt: new Date("2026-05-11T12:00:00Z"),
+				members: [
+					{ userId: "u1", username: "alice", addedAt: new Date("2026-05-11T12:00:00Z") },
+					{ userId: "u-2", username: "bob", addedAt: new Date("2026-05-11T12:00:01Z") },
+				],
+			},
+		]);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/groups/mine`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{
+			id: string;
+			leadUserId: string;
+			members: Array<{ userId: string; username: string; addedAt: string }>;
+		}>;
+		expect(body).toHaveLength(1);
+		expect(body[0]?.id).toBe("g-1");
+		expect(body[0]?.leadUserId).toBe("u1");
+		expect(body[0]?.members).toHaveLength(2);
+		expect(body[0]?.members[1]?.username).toBe("bob");
+		// Date round-trips as ISO so the frontend can `new Date(s)` it.
+		expect(body[0]?.members[0]?.addedAt).toBe("2026-05-11T12:00:00.000Z");
+	});
+
+	it("returns 500 if the underlying helper throws (no silent empty-list degrade)", async () => {
+		// The lead's UI hides the entry-point when /mine returns 0 rows,
+		// so a transient D1 failure that fell back to `[]` would make
+		// the entry-point disappear instead of surfacing the failure.
+		// Pin the 500 shape so this never regresses.
+		groupsStubs.listGroupsLedBy.mockImplementationOnce(async () => {
+			throw new Error("D1 transient");
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/groups/mine`);
+		expect(res.status).toBe(500);
+	});
+});
+
+describe("GET /api/groups/mine/sessions", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		groupsStubs.sessionsObservableBy.mockReset();
+		groupsStubs.sessionsObservableBy.mockImplementation(async () => []);
+	});
+
+	it("returns an empty array when the user has no observable sessions", async () => {
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/groups/mine/sessions`);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual([]);
+		expect(groupsStubs.sessionsObservableBy).toHaveBeenCalledWith("u1");
+	});
+
+	it("serialises sessions with short containerId, ISO dates, and no envVars", async () => {
+		groupsStubs.sessionsObservableBy.mockImplementationOnce(async () => [
+			{
+				sessionId: "s-1",
+				ownerUserId: "u-2",
+				ownerUsername: "bob",
+				name: "build-1",
+				status: "running",
+				// Full Docker id — the serializer must slice to 12 to match
+				// the shape `serializeMeta` uses for user / admin views.
+				containerId: "ct-1234567890abcdefghijk",
+				containerName: "st-abc",
+				cols: 120,
+				rows: 36,
+				createdAt: new Date("2026-05-12T10:00:00Z"),
+				lastConnectedAt: new Date("2026-05-12T10:05:00Z"),
+			},
+		]);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/groups/mine/sessions`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<Record<string, unknown>>;
+		expect(body).toHaveLength(1);
+		expect(body[0]?.sessionId).toBe("s-1");
+		expect(body[0]?.ownerUserId).toBe("u-2");
+		expect(body[0]?.ownerUsername).toBe("bob");
+		expect(body[0]?.containerId).toBe("ct-123456789"); // 12-char slice
+		expect(body[0]?.createdAt).toBe("2026-05-12T10:00:00.000Z");
+		expect(body[0]?.lastConnectedAt).toBe("2026-05-12T10:05:00.000Z");
+		// envVars are deliberately omitted from the lead view — the
+		// per-session GET (with `redactStoredEntries`, per #201 lock-in)
+		// is a future PR.
+		expect(body[0]).not.toHaveProperty("envVars");
+	});
+
+	it("emits null for a missing containerId / lastConnectedAt without crashing the slice", async () => {
+		groupsStubs.sessionsObservableBy.mockImplementationOnce(async () => [
+			{
+				sessionId: "s-2",
+				ownerUserId: "u-2",
+				ownerUsername: "bob",
+				name: "fresh",
+				status: "stopped",
+				containerId: null,
+				containerName: "st-def",
+				cols: 80,
+				rows: 24,
+				createdAt: new Date("2026-05-12T11:00:00Z"),
+				lastConnectedAt: null,
+			},
+		]);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/groups/mine/sessions`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<Record<string, unknown>>;
+		expect(body[0]?.containerId).toBeNull();
+		expect(body[0]?.lastConnectedAt).toBeNull();
+	});
+
+	it("returns 500 if the underlying helper throws", async () => {
+		groupsStubs.sessionsObservableBy.mockImplementationOnce(async () => {
+			throw new Error("D1 transient");
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/groups/mine/sessions`);
+		expect(res.status).toBe(500);
 	});
 });

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -308,6 +308,12 @@ export function buildRouter(
 	router.use("/sessions", requireAuth);
 	router.use("/templates", requireAuth);
 	router.use("/admin", requireAuth);
+	// /groups is the lead-side surface (#201c) — auth-gated but NOT
+	// admin-gated. Admin-only group management lives under /admin/groups
+	// above; this prefix carries `GET /groups/mine[/sessions]` which any
+	// authed user may call (a non-lead just gets `[]` back). Adding the
+	// prefix here keeps the auth-mount block in one place.
+	router.use("/groups", requireAuth);
 
 	// Idle-sweeper bumper. Mounted AFTER `requireAuth` so unauth
 	// requests don't reset the activity timer. The `:id` capture is
@@ -872,6 +878,67 @@ export function buildRouter(
 			}
 		},
 	);
+
+	// ── Lead-side group routes (#201c) ────────────────────────────────────────
+	// Two `/groups/mine[/sessions]` reads. `requireAuth` is provided by the
+	// `/groups` prefix mount above; no admin gate — a non-lead caller just
+	// gets `[]` back (the SQL is user-scoped). Both routes 500 on D1 error
+	// rather than degrading silently to an empty list: the lead's "My
+	// groups" UI hides the entry-point when /groups/mine returns 0 rows,
+	// so silently swallowing a transient would make the UI disappear for
+	// the lead instead of surfacing the failure.
+
+	const serializeLeadGroup = (g: groups.LeadGroup) => ({
+		...serializeGroup(g),
+		members: g.members.map((m) => ({
+			userId: m.userId,
+			username: m.username,
+			addedAt: m.addedAt.toISOString(),
+		})),
+	});
+
+	// Lead-side session shape. Mirrors `serializeMeta` minus `envVars`
+	// and plus `ownerUserId` / `ownerUsername`. The lead's observability
+	// surface is intentionally narrower than admin's; the per-session
+	// lead GET (the #201 lock-in's redaction path) is a future PR.
+	const serializeObservableSession = (s: groups.ObservableSessionMeta) => ({
+		sessionId: s.sessionId,
+		ownerUserId: s.ownerUserId,
+		ownerUsername: s.ownerUsername,
+		name: s.name,
+		status: s.status,
+		// Match `serializeMeta`'s short-id slice so the wire shape is
+		// consistent across user / admin / lead views — clients that
+		// already render the short id don't need a per-endpoint switch.
+		containerId: s.containerId?.slice(0, 12) ?? null,
+		containerName: s.containerName,
+		cols: s.cols,
+		rows: s.rows,
+		createdAt: s.createdAt.toISOString(),
+		lastConnectedAt: s.lastConnectedAt?.toISOString() ?? null,
+	});
+
+	router.get("/groups/mine", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			const list = await groups.listGroupsLedBy(userId);
+			res.json(list.map(serializeLeadGroup));
+		} catch (err) {
+			logger.error(`[groups] /mine failed: ${(err as Error).message}`);
+			res.status(500).json({ error: "Internal server error" });
+		}
+	});
+
+	router.get("/groups/mine/sessions", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			const list = await groups.sessionsObservableBy(userId);
+			res.json(list.map(serializeObservableSession));
+		} catch (err) {
+			logger.error(`[groups] /mine/sessions failed: ${(err as Error).message}`);
+			res.status(500).json({ error: "Internal server error" });
+		}
+	});
 
 	// ── Session routes ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Third slice of the tech-lead role from #201. Adds the lead-side read surface that 201d (observe-mode WS attach) and 201e (frontend "My group" view) will consume. **Pure additive — no call-site changes, no existing-test churn.**

### `groups.ts`

- `listGroupsLedBy(userId): LeadGroup[]` — every group `userId` leads newest-first, with each group's full member list inlined. Two D1 round-trips total regardless of how many groups: groups query, then a single IN-clause member fetch joined to `users.username`. Empty-lead short-circuit before the second query so non-leads burn one round-trip, not two. Defensive `members: []` rendering for the bug-defence case where a group somehow has no members (the lead-is-implicit-member invariant should never let this happen, but silently dropping the group from the lead's view is a worse failure mode than rendering it empty).

- `sessionsObservableBy(userId): ObservableSessionMeta[]` — every session of any user in any group `userId` leads, newest-first, hard-capped at the shared `ADMIN_LIST_LIMIT` (500). Excludes `terminated` (parallel to `listForUser`'s default — terminated sessions can't be observed). Single JOIN with IN-subquery; both ids are indexed (composite PK on `user_group_members.user_id`, `idx_user_groups_lead` on `user_groups.lead_user_id`), so the inner subquery is a point read per group.

### `routes.ts`

- New `/groups` prefix with `requireAuth` (NOT admin-gated — the SQL itself is the user-scoping; a non-lead caller gets `[]` back). Two routes:
  - `GET /api/groups/mine` — serialised `LeadGroup[]` (members inline)
  - `GET /api/groups/mine/sessions` — serialised `ObservableSession[]`
- `serializeObservableSession` mirrors `serializeMeta`'s shape (short containerId slice, ISO dates, status passthrough) but **omits `envVars`** and **adds `ownerUserId` / `ownerUsername`**. The lead's observability is intentionally narrower than admin's; the per-session lead GET (with `redactStoredEntries` per the #201 lock-in) is a future PR.
- Both routes **500 on D1 error rather than degrading to `[]`**: the frontend will hide the entry-point when `/mine` returns 0 rows, so silently swallowing a transient would make the UI disappear for the lead instead of surfacing the failure.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/` clean
- [x] `npx vitest run` — 749 tests pass (was 734; +15 new)
- [x] +5 cases in `groups.test.ts` cover the empty-lead short-circuit, the IN-clause shape (`?,?,?` matches id count), the 0-member defensive render, and the sessions JOIN + ordering + status filter
- [x] +6 cases in `routes.admin.groups.test.ts` cover the wire shape for both routes (Date → ISO, containerId 12-char slice, no `envVars` property), the empty-list case (handler runs through to helper for non-leads), and the 500-on-helper-throw shape
- [ ] Smoke: pause until 201d wires the WS observe attach + 201e ships the frontend; no behavioural change for existing users in this PR

## What's not in this PR

- **No observe-mode WS attach** — that's 201d. The lead can list observable sessions but can't attach to them yet (the existing `/ws/sessions/:id` enforces `assertOwnership`, owner-only).
- **No frontend** — that's 201e. The new endpoints respond correctly but no UI surfaces them.
- **No changes to `/api/sessions/:id` for the lead view.** The `redactStoredEntries` integration on per-session GET is a separate slice (the issue's "yes, redact via `redactStoredEntries`" lock-in lands when that route grows lead-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)