### PR TITLE
feat(groups): WS observe-mode + audit log (#201, PR 201d of 5)

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -318,6 +318,57 @@ export async function migrateDb(): Promise<void> {
                 )`,
 		`CREATE INDEX IF NOT EXISTS idx_group_members_user
                         ON user_group_members(user_id)`,
+		// Observe-mode audit log (#201d). One row per WS observe-attach:
+		// INSERT on attach open, UPDATE ended_at on close. The owner can
+		// see who watched their session, admins / leads can see their
+		// own observation history. Without this trail, the role would be
+		// the kind of design that gets called out a year later when an
+		// incident asks "who else was in this user's session?" Cost is
+		// two D1 calls per observe attach (INSERT open, UPDATE close)
+		// + the index reads behind the two list endpoints.
+		//
+		// `owner_user_id` is DENORMALISED at insert time — not a FK.
+		// Rationale: the owner is recoverable via `session_id → sessions.user_id`
+		// at read time, but storing it here preserves audit fidelity if
+		// the session row is later hard-deleted (CASCADE below) and
+		// preserves it for forensic queries that JOIN on observer + owner
+		// without re-resolving the session.
+		//
+		// `ON DELETE CASCADE` on `session_id` is the locked-in tradeoff
+		// from the issue: hard-deleting a session purges its observe log
+		// too. Favours operational tidiness over retention. If retention
+		// matters for compliance, switch to `ON DELETE SET NULL` and add
+		// a periodic purge; revisit only when a real requirement surfaces.
+		//
+		// `ON DELETE CASCADE` on `observer_user_id` is forward-looking
+		// (v1 has no user-delete API). When that lands, a deleted user's
+		// observation history vanishes with them — same shape as the
+		// session FK above. The owner-side denormalised column is
+		// deliberately unaffected: an observer who watched a session
+		// owned by a since-deleted user still has their own log entry
+		// preserved, with `owner_user_id` as a tombstone reference.
+		//
+		// Two indexes cover both list endpoints:
+		//   - `idx_observe_log_session` powers `GET /api/sessions/:id/observe-log`
+		//   - `idx_observe_log_observer` powers a forward-looking
+		//     "history of sessions I've observed" view per observer.
+		// `listAll` (admin cross-user) walks the table newest-first
+		// without an index hit — fine at v1 scale; revisit if the log
+		// grows past the hard cap.
+		`CREATE TABLE IF NOT EXISTS session_observe_log (
+                        id                TEXT PRIMARY KEY,
+                        observer_user_id  TEXT NOT NULL,
+                        session_id        TEXT NOT NULL,
+                        owner_user_id     TEXT NOT NULL,
+                        started_at        TEXT NOT NULL DEFAULT (datetime('now')),
+                        ended_at          TEXT,
+                        FOREIGN KEY (observer_user_id) REFERENCES users(id) ON DELETE CASCADE,
+                        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+                )`,
+		`CREATE INDEX IF NOT EXISTS idx_observe_log_session
+                        ON session_observe_log(session_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_observe_log_observer
+                        ON session_observe_log(observer_user_id)`,
 		`CREATE TABLE IF NOT EXISTS session_configs (
                         session_id              TEXT PRIMARY KEY,
                         workspace_strategy      TEXT,

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -1237,6 +1237,18 @@ export class DockerManager {
 		rows: number,
 		onOutput: OutputListener,
 		tabId: string,
+		// Observe-mode (#201d): when true the attach is read-only — the
+		// listener is registered for output fanout but the attachId is
+		// NOT added to `s.clientSizes`, so observers' viewport
+		// dimensions don't influence tmux's min-of-all-clients pane
+		// size. An observer with a smaller terminal would otherwise
+		// shrink the owner's view. wsHandler ALSO drops `input` and
+		// `resize` frames at the message layer for observe-mode
+		// attaches — the dual gate is intentional: this flag is the
+		// defence-in-depth at the docker layer for the size-pollution
+		// half, the wsHandler drop is the auth invariant for the
+		// write-into-someone's-shell half.
+		observe = false,
 	): Promise<{ handle: ExecHandle; replay: string | null; flushTail: () => void }> {
 		const key = this.targetKey(sessionId, tabId);
 
@@ -1355,7 +1367,16 @@ export class DockerManager {
 		};
 
 		s.listeners.set(attachId, bufferedListener);
-		s.clientSizes.set(attachId, { cols, rows });
+		// Observe-mode (#201d): skip the clientSizes registration. tmux
+		// applies a min-of-all-attached-clients pane size via
+		// `recomputeSize`; an observer with a smaller terminal would
+		// otherwise shrink the owner's pane. Skipping the registration
+		// keeps the owner's view unaffected by observer geometry, at
+		// the cost of an observer with a smaller window seeing
+		// horizontal-scroll behaviour rather than a re-flowed pane.
+		// `resize()` and `detach()` already no-op on a missing
+		// `clientSizes` entry, so no other call sites change.
+		if (!observe) s.clientSizes.set(attachId, { cols, rows });
 		this.keyOf.set(attachId, key);
 
 		// Once the listener is in `s.listeners`, any throw before we return

--- a/backend/src/observeLog.test.ts
+++ b/backend/src/observeLog.test.ts
@@ -1,0 +1,230 @@
+/**
+ * observeLog.test.ts — unit tests for the observe-mode audit log
+ * module (#201d). Stubs d1Query so each case drives the call sequence
+ * the module issues. Mirrors groups.test.ts / templates.test.ts setup.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import * as observeLog from "./observeLog.js";
+
+beforeEach(() => {
+	dbStubs.d1Query.mockReset();
+	dbStubs.d1Query.mockImplementation(async () => ({
+		results: [],
+		success: true,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	}));
+});
+
+function mockNextRows(rows: unknown[], changes = 0): void {
+	dbStubs.d1Query.mockImplementationOnce(async () => ({
+		results: rows,
+		success: true,
+		meta: { changes, duration: 0, last_row_id: 0 },
+	}));
+}
+
+// ── recordObserveStart ──────────────────────────────────────────────────────
+
+describe("observeLog.recordObserveStart", () => {
+	it("inserts a row with a uuid id and returns it", async () => {
+		mockNextRows([], 1);
+		const id = await observeLog.recordObserveStart("u-lead", "s-1", "u-owner");
+		// Pin the INSERT shape so a future refactor doesn't silently
+		// drop the denormalised owner column (the audit-fidelity hook
+		// for retention after session hard-delete).
+		const call = dbStubs.d1Query.mock.calls[0]!;
+		expect(call[0]).toMatch(/^INSERT INTO session_observe_log/);
+		const params = call[1] as string[];
+		expect(params).toHaveLength(4);
+		expect(params[1]).toBe("u-lead");
+		expect(params[2]).toBe("s-1");
+		expect(params[3]).toBe("u-owner");
+		// id is the first param and matches the returned value.
+		expect(params[0]).toBe(id);
+		// Standard uuid v4 shape.
+		expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+	});
+
+	it("propagates a D1 INSERT failure so wsHandler can abort the attach", async () => {
+		// The audit-trail invariant requires every observe to be logged.
+		// Swallowing INSERT failure here would let observe sessions
+		// proceed unaudited — the failure must bubble.
+		dbStubs.d1Query.mockImplementationOnce(async () => {
+			throw new Error("D1 transient");
+		});
+		await expect(observeLog.recordObserveStart("u-lead", "s-1", "u-owner")).rejects.toThrow(
+			"D1 transient",
+		);
+	});
+});
+
+// ── recordObserveEnd ────────────────────────────────────────────────────────
+
+describe("observeLog.recordObserveEnd", () => {
+	it("UPDATEs ended_at with the WHERE-ended-at-IS-NULL idempotency guard", async () => {
+		mockNextRows([], 1);
+		await observeLog.recordObserveEnd("log-1");
+		const call = dbStubs.d1Query.mock.calls[0]!;
+		// Pin both the SET and the WHERE shapes — the idempotency
+		// contract is "second call on the same id is a no-op", which
+		// the WHERE l.ended_at IS NULL clause enforces. Removing it
+		// would re-stamp ended_at and lose the original close time
+		// if ws.on("close") and ws.on("error") both fire.
+		expect(call[0]).toMatch(/UPDATE session_observe_log SET ended_at = datetime\('now'\)/);
+		expect(call[0]).toMatch(/WHERE id = \? AND ended_at IS NULL/);
+		expect(call[1]).toEqual(["log-1"]);
+	});
+
+	it("returns successfully when the UPDATE matches zero rows (already ended)", async () => {
+		// changes=0 is the legitimate path when the row was already
+		// ended by a prior call — recordObserveEnd's job is "make sure
+		// ended_at is set", not "set it again". Swallowing changes=0
+		// keeps the close-then-error WS teardown shape clean.
+		mockNextRows([], 0);
+		await expect(observeLog.recordObserveEnd("log-1")).resolves.toBeUndefined();
+	});
+});
+
+// ── listForSession ──────────────────────────────────────────────────────────
+
+describe("observeLog.listForSession", () => {
+	it("returns typed entries with observerUsername inlined and dates parsed", async () => {
+		mockNextRows([
+			{
+				id: "log-1",
+				observer_user_id: "u-lead",
+				session_id: "s-1",
+				owner_user_id: "u-owner",
+				started_at: "2026-05-12 10:00:00",
+				ended_at: "2026-05-12 10:05:00",
+				observer_username: "alice",
+			},
+		]);
+		const list = await observeLog.listForSession("s-1");
+		expect(list).toHaveLength(1);
+		expect(list[0]?.observerUsername).toBe("alice");
+		expect(list[0]?.startedAt).toBeInstanceOf(Date);
+		expect(list[0]?.endedAt).toBeInstanceOf(Date);
+		// Bound parameters: session id only.
+		expect(dbStubs.d1Query.mock.calls[0]![1]).toEqual(["s-1"]);
+	});
+
+	it("surfaces in-progress observers via endedAt: null", async () => {
+		// Live "who's watching me right now" view of the owner's UI.
+		// Without this row shape the owner only sees historical
+		// observes, not current ones — the use case the audit trail
+		// was added for in the first place.
+		mockNextRows([
+			{
+				id: "log-1",
+				observer_user_id: "u-lead",
+				session_id: "s-1",
+				owner_user_id: "u-owner",
+				started_at: "2026-05-12 10:00:00",
+				ended_at: null,
+				observer_username: "alice",
+			},
+		]);
+		const list = await observeLog.listForSession("s-1");
+		expect(list[0]?.endedAt).toBeNull();
+	});
+
+	it("issues the ORDER BY started_at DESC + LIMIT clause", async () => {
+		mockNextRows([]);
+		await observeLog.listForSession("s-1");
+		const call = dbStubs.d1Query.mock.calls[0]!;
+		expect(call[0]).toMatch(/ORDER BY l\.started_at DESC LIMIT 500/);
+	});
+
+	it("returns an empty array for a session with no observe history", async () => {
+		mockNextRows([]);
+		expect(await observeLog.listForSession("s-never-watched")).toEqual([]);
+	});
+});
+
+// ── listAll ─────────────────────────────────────────────────────────────────
+
+describe("observeLog.listAll", () => {
+	it("joins users twice (observer + owner) and inlines both usernames", async () => {
+		mockNextRows([
+			{
+				id: "log-1",
+				observer_user_id: "u-lead",
+				session_id: "s-1",
+				owner_user_id: "u-owner",
+				started_at: "2026-05-12 10:00:00",
+				ended_at: null,
+				observer_username: "alice",
+				owner_username: "bob",
+			},
+		]);
+		const list = await observeLog.listAll();
+		expect(list).toHaveLength(1);
+		expect(list[0]?.observerUsername).toBe("alice");
+		expect(list[0]?.ownerUsername).toBe("bob");
+		// Pin the JOIN shape — admin view depends on both joins firing.
+		const sql = dbStubs.d1Query.mock.calls[0]![0]!;
+		expect(sql).toMatch(/LEFT JOIN users obs/);
+		expect(sql).toMatch(/LEFT JOIN users own/);
+		expect(sql).toMatch(/ORDER BY l\.started_at DESC LIMIT 500/);
+	});
+
+	it("renders (deleted user) tombstones for a LEFT JOIN miss on either side", async () => {
+		// CASCADE on `observer_user_id` (or a future owner-side delete
+		// path) can leave the audit row briefly orphaned. INNER JOIN
+		// would silently drop the row from the admin view — worse
+		// outcome than surfacing a tombstone. Pin the tombstone shape
+		// so an inadvertent INNER-JOIN rewrite is caught.
+		mockNextRows([
+			{
+				id: "log-1",
+				observer_user_id: "u-lead-deleted",
+				session_id: "s-1",
+				owner_user_id: "u-owner",
+				started_at: "2026-05-12 10:00:00",
+				ended_at: null,
+				observer_username: null,
+				owner_username: "bob",
+			},
+			{
+				id: "log-2",
+				observer_user_id: "u-lead",
+				session_id: "s-2",
+				owner_user_id: "u-owner-deleted",
+				started_at: "2026-05-12 09:00:00",
+				ended_at: null,
+				observer_username: "alice",
+				owner_username: null,
+			},
+		]);
+		const list = await observeLog.listAll();
+		expect(list[0]?.observerUsername).toBe("(deleted user)");
+		expect(list[0]?.ownerUsername).toBe("bob");
+		expect(list[1]?.observerUsername).toBe("alice");
+		expect(list[1]?.ownerUsername).toBe("(deleted user)");
+	});
+
+	it("returns an empty array when no observe events have happened", async () => {
+		mockNextRows([]);
+		expect(await observeLog.listAll()).toEqual([]);
+	});
+});
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+describe("OBSERVE_LOG_LIMIT", () => {
+	it("is 500 (sized for parity with the admin session-list cap)", () => {
+		expect(observeLog.OBSERVE_LOG_LIMIT).toBe(500);
+	});
+});

--- a/backend/src/observeLog.ts
+++ b/backend/src/observeLog.ts
@@ -1,0 +1,203 @@
+/**
+ * observeLog.ts — append-only audit log for observe-mode WS attaches (#201d).
+ *
+ * One row per `WS /ws/sessions/:id?observe=true` connection: INSERT
+ * on attach success, UPDATE `ended_at` on socket close. The schema
+ * lives in `db.ts` (session_observe_log table + indexes); this module
+ * is the typed surface that wsHandler + the two log-read routes
+ * consume.
+ *
+ * Why not log on every observe-attempt, including denied ones? A
+ * failed attach is recorded by the existing route/WS access logs
+ * (logger.info / logger.warn) and counted by the IP rate limiter.
+ * The audit trail's purpose is "who saw what bytes" — a 403'd
+ * attempt saw nothing. Logging denied attempts would pollute the
+ * "who's been in this session?" view with noise from misconfigured
+ * clients or probe traffic.
+ */
+
+import { randomUUID } from "node:crypto";
+import { parseD1Utc } from "./d1Time.js";
+import { d1Query } from "./db.js";
+
+/**
+ * Hard cap on rows returned by either list endpoint. Sized at 500
+ * for parity with the admin cross-user session list — a deployment
+ * that's accumulated thousands of observe events on a single session
+ * shouldn't return a multi-megabyte JSON blob on a dashboard refresh.
+ * If a deployment grows past this, the page silently misses older
+ * entries — pagination is a follow-up if anyone hits the cap in
+ * practice.
+ */
+export const OBSERVE_LOG_LIMIT = 500;
+
+interface ObserveLogRow {
+	id: string;
+	observer_user_id: string;
+	session_id: string;
+	owner_user_id: string;
+	started_at: string;
+	ended_at: string | null;
+}
+
+/** Per-session log entry — what `/api/sessions/:id/observe-log`
+ *  returns to the owner (or admin / lead via `assertCanObserve`).
+ *  The `observerUsername` is JOIN-ed at read time so the caller
+ *  can render "alice watched at 12:00" without a second lookup. */
+export interface ObserveLogEntry {
+	id: string;
+	observerUserId: string;
+	observerUsername: string;
+	sessionId: string;
+	ownerUserId: string;
+	startedAt: Date;
+	endedAt: Date | null;
+}
+
+/** Cross-user admin log entry — adds `ownerUsername` so the admin
+ *  dashboard can render "alice watched bob's session at 12:00"
+ *  without a second lookup per row. */
+export interface AdminObserveLogEntry extends ObserveLogEntry {
+	ownerUsername: string;
+}
+
+// ── Writes ──────────────────────────────────────────────────────────────────
+
+/**
+ * Record the start of an observe-attach. Returns the log id so the
+ * caller can pair it with `recordObserveEnd(id)` on socket close.
+ *
+ * `ownerUserId` is denormalised into the row at insert time so a
+ * later hard-delete of the session (which CASCADEs the log via the
+ * FK) doesn't strand the observer-side history WITHOUT preserving
+ * the owner side. The denormalised column is a tombstone for the
+ * observer's history view; the session-side history vanishes with
+ * the session row.
+ *
+ * No throw on D1 failure — the caller (wsHandler) catches and
+ * decides whether to abort the attach. INSERT failure means we
+ * couldn't record the audit row; the locked-in invariant is "audit
+ * trail exists for every observe", so the right policy is to abort
+ * the attach. The route layer translates that into a 500-class WS
+ * close.
+ */
+export async function recordObserveStart(
+	observerUserId: string,
+	sessionId: string,
+	ownerUserId: string,
+): Promise<string> {
+	const id = randomUUID();
+	await d1Query(
+		"INSERT INTO session_observe_log (id, observer_user_id, session_id, owner_user_id) " +
+			"VALUES (?, ?, ?, ?)",
+		[id, observerUserId, sessionId, ownerUserId],
+	);
+	return id;
+}
+
+/**
+ * Mark the observe-attach as ended. Idempotent: a second call on the
+ * same id is a no-op because the WHERE clause filters on
+ * `ended_at IS NULL`. This matters because wsHandler registers both
+ * `ws.on("close")` and `ws.on("error")` handlers — depending on the
+ * teardown shape, either or both can fire for the same socket. Both
+ * call this without coordination; the idempotency in SQL is the
+ * coordination point.
+ *
+ * Errors are logged at the caller (D1 transients during close are
+ * common and shouldn't fail the socket teardown). The route layer
+ * does NOT consume the return; the row either reflects close-time
+ * or stays null forever — both are recoverable.
+ */
+export async function recordObserveEnd(id: string): Promise<void> {
+	await d1Query(
+		"UPDATE session_observe_log SET ended_at = datetime('now') " +
+			"WHERE id = ? AND ended_at IS NULL",
+		[id],
+	);
+}
+
+// ── Reads ──────────────────────────────────────────────────────────────────
+
+/**
+ * List the observe-attach history for one session, newest-first,
+ * capped at `OBSERVE_LOG_LIMIT`. Joins `users` to surface the
+ * observer's username — the caller (the per-session log route)
+ * is gated by `assertCanObserve`, so the owner, an admin, or a lead
+ * of any group containing the owner can all read this view.
+ *
+ * The result includes observe events with `ended_at IS NULL` — i.e.
+ * currently-active observers. That's deliberate: a session's owner
+ * looking at "who's watching me right now" sees the live row. The
+ * route serializer surfaces `null` for endedAt; clients render the
+ * absence as "still watching."
+ *
+ * Returns `[]` for a session with no observe history (including a
+ * never-observed session); the caller's auth gate is what decides
+ * whether the empty array is visible at all.
+ */
+export async function listForSession(sessionId: string): Promise<ObserveLogEntry[]> {
+	const result = await d1Query<ObserveLogRow & { observer_username: string }>(
+		"SELECT l.id, l.observer_user_id, l.session_id, l.owner_user_id, " +
+			"l.started_at, l.ended_at, u.username AS observer_username " +
+			"FROM session_observe_log l " +
+			"JOIN users u ON u.id = l.observer_user_id " +
+			"WHERE l.session_id = ? " +
+			`ORDER BY l.started_at DESC LIMIT ${OBSERVE_LOG_LIMIT}`,
+		[sessionId],
+	);
+	return result.results.map(rowToEntry);
+}
+
+/**
+ * Cross-user observe-log for the admin dashboard. Joins `users`
+ * twice — once for the observer username, once for the owner —
+ * via two aliased LEFT JOINs (LEFT, not INNER, so a deleted user
+ * whose CASCADE hasn't yet fired surfaces as a tombstone row
+ * rather than disappearing from the audit trail).
+ *
+ * Newest-first by `started_at`, hard-capped at `OBSERVE_LOG_LIMIT`.
+ * Admin-gated at the route layer; do NOT call from non-admin code
+ * paths — bypasses the per-session ownership scoping that
+ * `listForSession` relies on.
+ */
+export async function listAll(): Promise<AdminObserveLogEntry[]> {
+	const result = await d1Query<
+		ObserveLogRow & { observer_username: string | null; owner_username: string | null }
+	>(
+		"SELECT l.id, l.observer_user_id, l.session_id, l.owner_user_id, " +
+			"l.started_at, l.ended_at, " +
+			"obs.username AS observer_username, " +
+			"own.username AS owner_username " +
+			"FROM session_observe_log l " +
+			"LEFT JOIN users obs ON obs.id = l.observer_user_id " +
+			"LEFT JOIN users own ON own.id = l.owner_user_id " +
+			`ORDER BY l.started_at DESC LIMIT ${OBSERVE_LOG_LIMIT}`,
+	);
+	return result.results.map((row) => ({
+		...rowToEntry({
+			...row,
+			// LEFT JOIN can land null for a deleted observer (CASCADE
+			// race) or a deleted owner. Surface "(deleted user)" so
+			// the dashboard renders a tombstone rather than blowing
+			// up on a missing string. The audit row is still
+			// meaningful — it records that the observation happened.
+			observer_username: row.observer_username ?? "(deleted user)",
+		}),
+		ownerUsername: row.owner_username ?? "(deleted user)",
+	}));
+}
+
+// ── Row → domain mapper ────────────────────────────────────────────────────
+
+function rowToEntry(row: ObserveLogRow & { observer_username: string }): ObserveLogEntry {
+	return {
+		id: row.id,
+		observerUserId: row.observer_user_id,
+		observerUsername: row.observer_username,
+		sessionId: row.session_id,
+		ownerUserId: row.owner_user_id,
+		startedAt: parseD1Utc(row.started_at, "observeLog"),
+		endedAt: row.ended_at ? parseD1Utc(row.ended_at, "observeLog") : null,
+	};
+}

--- a/backend/src/routes.observeLog.test.ts
+++ b/backend/src/routes.observeLog.test.ts
@@ -1,0 +1,305 @@
+/**
+ * routes.observeLog.test.ts — REST integration for the two observe-log
+ * routes (#201d):
+ *   - `GET /api/sessions/:id/observe-log` (auth + `assertCanObserve`)
+ *   - `GET /api/admin/observe-log` (admin-only)
+ *
+ * Pins the wire shape (Date → ISO, includes/excludes ownerUsername),
+ * the auth gates, and the error-mapping. Mocks `observeLog.ts` at
+ * the module boundary so the route's serializer + auth wiring is
+ * exercised without driving D1 (unit-level D1 call shapes live in
+ * `observeLog.test.ts`).
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authStubs = vi.hoisted(() => ({
+	requireAuth: (req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	},
+	requireAdmin: vi.fn((req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	}),
+	AUTH_COOKIE_NAME: "st_token",
+	setAuthCookie: vi.fn(),
+	clearAuthCookie: vi.fn(),
+	extractTokenFromCookieHeader: vi.fn(() => null),
+	verifyJwt: vi.fn(() => null),
+	hasAnyUsers: vi.fn(async () => true),
+	registerUser: vi.fn(),
+	loginUser: vi.fn(),
+	listInvites: vi.fn(async () => [] as unknown[]),
+	createInvite: vi.fn(),
+	revokeInvite: vi.fn(),
+	InvalidCredentialsError: class extends Error {
+		constructor() {
+			super("invalid");
+		}
+	},
+	UsernameTakenError: class extends Error {
+		constructor() {
+			super("taken");
+		}
+	},
+	InviteRequiredError: class extends Error {
+		constructor() {
+			super("invite required");
+		}
+	},
+	InviteQuotaExceededError: class extends Error {
+		constructor() {
+			super("invite quota");
+		}
+	},
+}));
+vi.mock("./auth.js", () => authStubs);
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+	getD1CallsSinceBoot: vi.fn(() => 0),
+	__resetD1CallsForTests: vi.fn(),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+// Mock the observeLog module so we drive route assertions on the
+// serializer + auth-gate logic without going through D1.
+const observeLogStubs = vi.hoisted(() => ({
+	listForSession: vi.fn(async () => [] as unknown[]),
+	listAll: vi.fn(async () => [] as unknown[]),
+	recordObserveStart: vi.fn(async () => "log-uuid"),
+	recordObserveEnd: vi.fn(async () => undefined),
+	OBSERVE_LOG_LIMIT: 500,
+}));
+vi.mock("./observeLog.js", () => observeLogStubs);
+
+import type { BootstrapBroadcaster } from "./bootstrap.js";
+import type { DockerManager } from "./dockerManager.js";
+import { __resetDispatcherStatsForTests } from "./portDispatcher.js";
+import { buildRouter } from "./routes.js";
+import { ForbiddenError, NotFoundError, type SessionManager } from "./sessionManager.js";
+
+let server: http.Server | null = null;
+let baseUrl = "";
+
+const fakeAssertCanObserve = vi.fn();
+
+afterEach(async () => {
+	if (server) {
+		await new Promise<void>((resolve, reject) => {
+			server?.close((e) => (e ? reject(e) : resolve()));
+		});
+		server = null;
+	}
+	authStubs.requireAdmin.mockReset();
+	authStubs.requireAdmin.mockImplementation((req, _res, next) => {
+		(req as { userId?: string }).userId = "u1";
+		next();
+	});
+	fakeAssertCanObserve.mockReset();
+});
+
+async function spinUp(): Promise<void> {
+	const sessions = {
+		assertCanObserve: fakeAssertCanObserve,
+		countByStatus: vi.fn(async () => ({ running: 0, stopped: 0, terminated: 0, failed: 0 })),
+	} as unknown as SessionManager;
+	const docker = {
+		getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
+		getReconcileStats: () => ({
+			lastRunAt: null,
+			sessionsCheckedSinceBoot: 0,
+			errorsSinceBoot: 0,
+		}),
+	} as unknown as DockerManager;
+	const broadcaster = {} as BootstrapBroadcaster;
+	const router = buildRouter(sessions, docker, broadcaster, {
+		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+		register: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+		logout: { ipMax: 1000, ipWindowMs: 60_000 },
+		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
+	});
+	const app = express();
+	app.use(express.json());
+	app.use("/api", router);
+	const s = http.createServer(app);
+	server = s;
+	await new Promise<void>((resolve) => s.listen(0, "127.0.0.1", resolve));
+	const { port } = s.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+}
+
+// ── GET /api/sessions/:id/observe-log ───────────────────────────────────────
+
+describe("GET /api/sessions/:id/observe-log", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		observeLogStubs.listForSession.mockReset();
+		observeLogStubs.listForSession.mockResolvedValue([]);
+	});
+
+	it("returns the serialised log when assertCanObserve passes (owner/admin/lead)", async () => {
+		fakeAssertCanObserve.mockResolvedValueOnce({
+			sessionId: "s-1",
+			userId: "u-owner",
+			status: "running",
+		});
+		observeLogStubs.listForSession.mockResolvedValueOnce([
+			{
+				id: "log-1",
+				observerUserId: "u-lead",
+				observerUsername: "alice",
+				sessionId: "s-1",
+				ownerUserId: "u-owner",
+				startedAt: new Date("2026-05-12T10:00:00Z"),
+				endedAt: new Date("2026-05-12T10:05:00Z"),
+			},
+			{
+				id: "log-2",
+				observerUserId: "u-lead",
+				observerUsername: "alice",
+				sessionId: "s-1",
+				ownerUserId: "u-owner",
+				startedAt: new Date("2026-05-12T09:00:00Z"),
+				endedAt: null,
+			},
+		]);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{
+			id: string;
+			observerUsername: string;
+			startedAt: string;
+			endedAt: string | null;
+		}>;
+		expect(body).toHaveLength(2);
+		expect(body[0]?.id).toBe("log-1");
+		expect(body[0]?.observerUsername).toBe("alice");
+		expect(body[0]?.startedAt).toBe("2026-05-12T10:00:00.000Z");
+		expect(body[0]?.endedAt).toBe("2026-05-12T10:05:00.000Z");
+		// In-progress observers surface endedAt: null so the owner's UI
+		// can render "still watching." This is the live-view contract
+		// the audit trail was added for in the first place.
+		expect(body[1]?.endedAt).toBeNull();
+	});
+
+	it("returns 404 when assertCanObserve throws NotFoundError", async () => {
+		fakeAssertCanObserve.mockRejectedValueOnce(new NotFoundError());
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-missing/observe-log`);
+		expect(res.status).toBe(404);
+		// listForSession should NOT have been called — auth fired first.
+		expect(observeLogStubs.listForSession).not.toHaveBeenCalled();
+	});
+
+	it("returns 403 when assertCanObserve throws ForbiddenError", async () => {
+		// A user who's neither owner, admin, nor lead of any group
+		// containing the owner — auth must reject BEFORE the log is
+		// fetched, otherwise the route would leak existence via
+		// "session exists but you can't observe it" vs "session doesn't
+		// exist." The 403/404 split mirrors `assertCanObserve`'s
+		// existing shape; both are the right answer at the route layer.
+		fakeAssertCanObserve.mockRejectedValueOnce(new ForbiddenError());
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
+		expect(res.status).toBe(403);
+		expect(observeLogStubs.listForSession).not.toHaveBeenCalled();
+	});
+
+	it("returns 500 when the log fetch throws after a successful auth", async () => {
+		fakeAssertCanObserve.mockResolvedValueOnce({
+			sessionId: "s-1",
+			userId: "u-owner",
+			status: "running",
+		});
+		observeLogStubs.listForSession.mockRejectedValueOnce(new Error("D1 transient"));
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
+		expect(res.status).toBe(500);
+	});
+
+	it("returns an empty array for a session that's never been observed", async () => {
+		fakeAssertCanObserve.mockResolvedValueOnce({
+			sessionId: "s-1",
+			userId: "u-owner",
+			status: "running",
+		});
+		// listForSession default mock returns [].
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual([]);
+	});
+});
+
+// ── GET /api/admin/observe-log ──────────────────────────────────────────────
+
+describe("GET /api/admin/observe-log", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+		observeLogStubs.listAll.mockReset();
+		observeLogStubs.listAll.mockResolvedValue([]);
+	});
+
+	it("returns the admin-shape log with ownerUsername + observerUsername inlined", async () => {
+		observeLogStubs.listAll.mockResolvedValueOnce([
+			{
+				id: "log-1",
+				observerUserId: "u-lead",
+				observerUsername: "alice",
+				sessionId: "s-1",
+				ownerUserId: "u-owner",
+				ownerUsername: "bob",
+				startedAt: new Date("2026-05-12T10:00:00Z"),
+				endedAt: null,
+			},
+		]);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/observe-log`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{
+			ownerUsername: string;
+			observerUsername: string;
+			endedAt: string | null;
+		}>;
+		expect(body).toHaveLength(1);
+		expect(body[0]?.observerUsername).toBe("alice");
+		expect(body[0]?.ownerUsername).toBe("bob");
+		expect(body[0]?.endedAt).toBeNull();
+	});
+
+	it("returns 403 when requireAdmin denies the caller", async () => {
+		authStubs.requireAdmin.mockImplementationOnce(
+			(_req: unknown, res: { status: (code: number) => { json: (b: unknown) => void } }) => {
+				res.status(403).json({ error: "Admin privileges required" });
+			},
+		);
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/observe-log`);
+		expect(res.status).toBe(403);
+		// listAll should NOT have been called — admin gate fired first.
+		expect(observeLogStubs.listAll).not.toHaveBeenCalled();
+	});
+
+	it("returns 500 when the underlying helper throws", async () => {
+		observeLogStubs.listAll.mockRejectedValueOnce(new Error("D1 transient"));
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/admin/observe-log`);
+		expect(res.status).toBe(500);
+	});
+});

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -35,6 +35,7 @@ import { EnvVarValidationError, validateEnvVars } from "./envVarValidation.js";
 import * as groups from "./groups.js";
 import type { IdleSweeperStats } from "./idleSweeper.js";
 import { logger } from "./logger.js";
+import * as observeLog from "./observeLog.js";
 import { getDispatcherStats } from "./portDispatcher.js";
 import type { RateLimitConfig } from "./rateLimit.js";
 import {
@@ -591,6 +592,38 @@ export function buildRouter(
 				res.status(204).send();
 			} catch (err) {
 				logger.error(`[admin] force-delete failed: ${(err as Error).message}`);
+				res.status(500).json({ error: "Internal server error" });
+			}
+		},
+	);
+
+	// ── Admin observe-log (#201d) ────────────────────────────────────────────
+	// Cross-user view of "who watched whose session, when." Uses the
+	// `adminStatsIp` limiter — same bucket dashboards poll for sessions
+	// + stats; the budget assumes one operator dashboard polls multiple
+	// admin reads at once.
+
+	const serializeAdminObserveLogEntry = (e: observeLog.AdminObserveLogEntry) => ({
+		id: e.id,
+		observerUserId: e.observerUserId,
+		observerUsername: e.observerUsername,
+		sessionId: e.sessionId,
+		ownerUserId: e.ownerUserId,
+		ownerUsername: e.ownerUsername,
+		startedAt: e.startedAt.toISOString(),
+		endedAt: e.endedAt?.toISOString() ?? null,
+	});
+
+	router.get(
+		"/admin/observe-log",
+		adminStatsIp,
+		requireAdmin,
+		async (_req: Request, res: Response) => {
+			try {
+				const list = await observeLog.listAll();
+				res.json(list.map(serializeAdminObserveLogEntry));
+			} catch (err) {
+				logger.error(`[admin] observe-log list failed: ${(err as Error).message}`);
 				res.status(500).json({ error: "Internal server error" });
 			}
 		},
@@ -1221,6 +1254,41 @@ export function buildRouter(
 		try {
 			const meta = await sessions.assertOwnership(req.params.id, userId);
 			res.json(serializeMeta(meta));
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
+
+	// Per-session observe-log read (#201d). Returns the audit history
+	// for a single session — who watched, when, and whether they're
+	// still watching (`endedAt: null`). Gated by `assertCanObserve`:
+	// the owner, any admin, and any lead of a group containing the
+	// owner can read this view. A non-authorised caller gets 403/404
+	// from the assert (same shape the other session-scoped reads
+	// emit). The route lives next to `GET /sessions/:id` so the
+	// owner-facing audit view is co-located with the session detail.
+
+	const serializeObserveLogEntry = (e: observeLog.ObserveLogEntry) => ({
+		id: e.id,
+		observerUserId: e.observerUserId,
+		observerUsername: e.observerUsername,
+		sessionId: e.sessionId,
+		ownerUserId: e.ownerUserId,
+		startedAt: e.startedAt.toISOString(),
+		endedAt: e.endedAt?.toISOString() ?? null,
+	});
+
+	router.get("/sessions/:id/observe-log", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			// `assertCanObserve` throws NotFoundError for a missing
+			// session and ForbiddenError for an unauthorised caller —
+			// both shapes flow into `handleSessionError`'s standard 404
+			// / 403 emission, so callers get the same status-code
+			// contract the rest of the /sessions/:id reads use.
+			await sessions.assertCanObserve(req.params.id, userId);
+			const list = await observeLog.listForSession(req.params.id);
+			res.json(list.map(serializeObserveLogEntry));
 		} catch (err) {
 			handleSessionError(err, res);
 		}

--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -1,5 +1,15 @@
 import jwt from "jsonwebtoken";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock observeLog at the module boundary so the observe-mode tests
+// below can assert on the audit-log call shape without driving D1.
+// Hoisted so the mock is in place before wsHandler.js loads it.
+const observeLogStubs = vi.hoisted(() => ({
+	recordObserveStart: vi.fn(async () => "log-uuid"),
+	recordObserveEnd: vi.fn(async () => undefined),
+}));
+vi.mock("./observeLog.js", () => observeLogStubs);
+
 import { __resetJwtSecretForTests, validateJwtSecret } from "./auth.js";
 import type { DockerManager } from "./dockerManager.js";
 import type { SessionManager } from "./sessionManager.js";
@@ -193,6 +203,10 @@ describe("handleWsConnection geometry from URL", () => {
 			expect(docker.attach).toHaveBeenCalled();
 		});
 
+		// 7th positional arg `observe` defaults to false for the
+		// owner-only path (#201d). Pin it explicitly so a future
+		// refactor that swaps the parameter order surfaces here
+		// rather than in the WS handler.
 		expect(docker.attach).toHaveBeenCalledWith(
 			"abc",
 			expect.any(String),
@@ -200,6 +214,7 @@ describe("handleWsConnection geometry from URL", () => {
 			60,
 			expect.any(Function),
 			"tab-1",
+			false,
 		);
 	});
 
@@ -223,6 +238,7 @@ describe("handleWsConnection geometry from URL", () => {
 			40,
 			expect.any(Function),
 			"tab-1",
+			false,
 		);
 	});
 
@@ -247,7 +263,214 @@ describe("handleWsConnection geometry from URL", () => {
 			40,
 			expect.any(Function),
 			"tab-1",
+			false,
 		);
+	});
+});
+
+// ── Observe-mode (#201d) ─────────────────────────────────────────────────
+// `?observe=true` opts into a read-only attach gated on `assertCanObserve`.
+// The WS handler must: switch the auth call, pass `observe: true` to
+// docker.attach (size-vote suppression at the docker layer), write an
+// audit row on attach success / UPDATE on close, and DROP input + resize
+// frames at the message layer. The audit log lives in observeLog.ts —
+// mocked at the module boundary above so these tests assert on the call
+// shape without driving D1.
+
+describe("handleWsConnection observe-mode (#201d)", () => {
+	function makeMocks(opts: { ownerId?: string } = {}) {
+		// assertCanObserve returns the SessionMeta-shaped result with
+		// `userId` so the wsHandler can compute `isObserverNotOwner =
+		// observe && session.userId !== userId`. Auth-mode wsHandler
+		// tests above set up assertOwnership; this block sets up
+		// assertCanObserve.
+		const sessions = {
+			assertCanObserve: vi.fn().mockResolvedValue({
+				status: "running",
+				userId: opts.ownerId ?? "owner-1",
+				cols: 80,
+				rows: 24,
+			}),
+			assertOwnership: vi.fn().mockResolvedValue({
+				status: "running",
+				userId: "user-1",
+				cols: 80,
+				rows: 24,
+			}),
+			updateConnected: vi.fn().mockResolvedValue(undefined),
+		} as unknown as SessionManager;
+		const docker = {
+			attach: vi.fn().mockResolvedValue({ replay: null, flushTail: () => {} }),
+			detach: vi.fn(),
+			write: vi.fn(),
+			resize: vi.fn().mockResolvedValue(undefined),
+		} as unknown as DockerManager;
+		return { sessions, docker };
+	}
+
+	beforeEach(() => {
+		observeLogStubs.recordObserveStart.mockReset();
+		observeLogStubs.recordObserveEnd.mockReset();
+		observeLogStubs.recordObserveStart.mockResolvedValue("log-uuid");
+		observeLogStubs.recordObserveEnd.mockResolvedValue(undefined);
+	});
+
+	it("routes auth via assertCanObserve (not assertOwnership) when ?observe=true", async () => {
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks({ ownerId: "owner-bob" });
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1&observe=true", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(docker.attach).toHaveBeenCalled();
+		});
+		expect(sessions.assertCanObserve).toHaveBeenCalledWith("s-1", "user-1");
+		expect(sessions.assertOwnership).not.toHaveBeenCalled();
+	});
+
+	it("passes observe=true to docker.attach when observer differs from owner", async () => {
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks({ ownerId: "owner-bob" });
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1&observe=true", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(docker.attach).toHaveBeenCalled();
+		});
+		// 7th positional arg is the observe flag.
+		const call = (docker.attach as ReturnType<typeof vi.fn>).mock.calls[0]!;
+		expect(call[6]).toBe(true);
+	});
+
+	it("passes observe=false to docker.attach when observer IS the owner (no-audit edge)", async () => {
+		// `?observe=true` from the owner is allowed (assertCanObserve
+		// accepts owner-self), but the audit log + read-only gate are
+		// behaviourally pointless. The wsHandler sets
+		// `isObserverNotOwner = observe && session.userId !== userId`
+		// so the docker layer attaches normally (size-vote contribution
+		// intact) and no audit row is written. Pin this so a future
+		// refactor of the discriminator doesn't accidentally log the
+		// owner as an observer of their own session.
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks({ ownerId: "user-1" });
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1&observe=true", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(docker.attach).toHaveBeenCalled();
+		});
+		const call = (docker.attach as ReturnType<typeof vi.fn>).mock.calls[0]!;
+		expect(call[6]).toBe(false);
+		expect(observeLogStubs.recordObserveStart).not.toHaveBeenCalled();
+	});
+
+	it("INSERTs an audit row after attach success and UPDATEs on close", async () => {
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks({ ownerId: "owner-bob" });
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1&observe=true", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(observeLogStubs.recordObserveStart).toHaveBeenCalled();
+		});
+		expect(observeLogStubs.recordObserveStart).toHaveBeenCalledWith(
+			"user-1", // observer
+			"s-1", // session
+			"owner-bob", // owner (denormalised at insert)
+		);
+		// Simulate WS close — handler is registered via ws.on("close", …).
+		// Find the close handler from the on() mock calls and invoke it.
+		const closeCall = ws.on.mock.calls.find((c) => c[0] === "close");
+		expect(closeCall).toBeDefined();
+		(closeCall![1] as () => void)();
+		// recordObserveEnd is fire-and-forget (the WS-close path doesn't
+		// await it; the SQL idempotency is the safety net). waitFor
+		// polls until the microtask the close handler scheduled lands.
+		await vi.waitFor(() => {
+			expect(observeLogStubs.recordObserveEnd).toHaveBeenCalledWith("log-uuid");
+		});
+	});
+
+	it("aborts the attach + closes the socket when the audit INSERT fails", async () => {
+		// The audit-trail invariant requires every observe to be logged.
+		// An INSERT failure must bubble out so the socket closes with
+		// 1011 — leaving the attach live and unaudited would defeat
+		// the trail's purpose.
+		observeLogStubs.recordObserveStart.mockRejectedValueOnce(new Error("D1 transient"));
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks({ ownerId: "owner-bob" });
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1&observe=true", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(ws.close).toHaveBeenCalled();
+		});
+		// detach() must run to release the listener registered by
+		// docker.attach — otherwise the bufferedListener would pile
+		// live bytes forever after the audit failure tore everything
+		// else down.
+		expect(docker.detach).toHaveBeenCalled();
+		// Close with 1011 (internal error) is the catch-block's
+		// fall-through for non-NotFound/non-Forbidden throws.
+		const closeCodes = ws.close.mock.calls.map((c) => c[0] as number);
+		expect(closeCodes).toContain(1011);
+	});
+
+	it("drops input frames in observe-mode (does not call docker.write)", async () => {
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks({ ownerId: "owner-bob" });
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1&observe=true", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(observeLogStubs.recordObserveStart).toHaveBeenCalled();
+		});
+		// Fish out the message handler and feed it an input frame.
+		const msgCall = ws.on.mock.calls.find((c) => c[0] === "message");
+		expect(msgCall).toBeDefined();
+		const onMessage = msgCall![1] as (raw: unknown) => void;
+		onMessage(JSON.stringify({ type: "input", data: "rm -rf /" }));
+		// The whole point: a write-to-someone's-shell is silently dropped.
+		expect(docker.write).not.toHaveBeenCalled();
+	});
+
+	it("drops resize frames in observe-mode (does not call docker.resize)", async () => {
+		// Defence-in-depth on top of the docker-layer clientSizes
+		// skip: dropping the frame here avoids the wasted D1 round-trip
+		// through `recomputeSize` and matches the input-drop posture.
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks({ ownerId: "owner-bob" });
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1&observe=true", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(observeLogStubs.recordObserveStart).toHaveBeenCalled();
+		});
+		const msgCall = ws.on.mock.calls.find((c) => c[0] === "message");
+		const onMessage = msgCall![1] as (raw: unknown) => void;
+		onMessage(JSON.stringify({ type: "resize", cols: 40, rows: 12 }));
+		expect(docker.resize).not.toHaveBeenCalled();
+	});
+
+	it("non-observe attaches preserve input/resize forwarding (regression guard)", async () => {
+		// Pin that the observe-mode drop is conditional on
+		// `isObserverNotOwner` — without this guard a future refactor
+		// could accidentally hoist the early-return out of the
+		// observe branch and break every owner attach silently.
+		const ws = makeFakeWs();
+		const { sessions, docker } = makeMocks({ ownerId: "user-1" });
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(docker.attach).toHaveBeenCalled();
+		});
+		const msgCall = ws.on.mock.calls.find((c) => c[0] === "message");
+		const onMessage = msgCall![1] as (raw: unknown) => void;
+		onMessage(JSON.stringify({ type: "input", data: "ls\n" }));
+		onMessage(JSON.stringify({ type: "resize", cols: 100, rows: 30 }));
+		expect(docker.write).toHaveBeenCalledWith(expect.any(String), "ls\n");
+		expect(docker.resize).toHaveBeenCalledWith(expect.any(String), 100, 30);
 	});
 });
 

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -10,6 +10,7 @@ import { verifyWsToken } from "./auth.js";
 import type { BootstrapBroadcaster, BootstrapMessage } from "./bootstrap.js";
 import type { DockerManager } from "./dockerManager.js";
 import { logger } from "./logger.js";
+import { recordObserveEnd, recordObserveStart } from "./observeLog.js";
 import { TERMINAL_DIM_MAX } from "./routes.js";
 import { ForbiddenError, NotFoundError, type SessionManager } from "./sessionManager.js";
 import type { WsClientMessage, WsServerMessage } from "./types.js";
@@ -177,10 +178,38 @@ export function handleWsConnection(
 	const urlCols = parseDim(/[?&]cols=(\d{1,4})/);
 	const urlRows = parseDim(/[?&]rows=(\d{1,4})/);
 
+	// Observe-mode (#201d): `?observe=true` opts the client into a
+	// read-only attach gated by `assertCanObserve` instead of
+	// `assertOwnership`. Anything other than the literal string "true"
+	// (including missing) falls back to the standard owner-only path,
+	// so a caller that types `?observe=1` doesn't accidentally land
+	// in observe mode with reduced expectations. The match is
+	// deliberately strict at the parse layer — auth is the safety net,
+	// not the typo-detection layer.
+	const observe = /[?&]observe=true(?:&|$)/.test(url);
+
 	// Async auth + attach flow
 	(async () => {
-		// Authorise
-		const session = await sessions.assertOwnership(sessionId, userId);
+		// Authorise. Observe-mode uses the graded `assertCanObserve`
+		// (owner OR admin OR lead-of-group-containing-owner, #201b);
+		// non-observe stays on the binary owner-only check. Returning
+		// the same `SessionMeta` shape from both paths means the rest
+		// of this function doesn't have to special-case the graded
+		// route — the observer-vs-owner distinction is captured by
+		// `isObserverNotOwner` below.
+		const session = observe
+			? await sessions.assertCanObserve(sessionId, userId)
+			: await sessions.assertOwnership(sessionId, userId);
+		// An owner who happens to call `?observe=true` (e.g. a UI bug
+		// or explicit "preview my own session in read-only mode")
+		// doesn't generate an audit row, can't shrink their own pane
+		// via dropped resize frames, and can't write — but the auth
+		// already passed, so the only behavioural changes are the
+		// no-write / no-size-vote / no-audit bits below. The
+		// `isObserverNotOwner` discriminator gates the audit + drop
+		// logic so we only pay those costs when an observer is genuinely
+		// looking at someone else's session.
+		const isObserverNotOwner = observe && session.userId !== userId;
 
 		if (session.status === "terminated") {
 			sendError(ws, "Session is terminated");
@@ -225,6 +254,11 @@ export function handleWsConnection(
 		// rationale. `sendMsg` is synchronous, so there is no await
 		// between the replay frame and flushTail() — a stream 'data'
 		// event cannot interleave.
+		//
+		// `observe=isObserverNotOwner` (#201d) is the docker-layer half
+		// of the read-only gate: it keeps the observer's viewport out
+		// of tmux's min-of-all-clients pane size. The WS-layer half
+		// (input/resize frame drop, below) is the auth invariant.
 		const { replay, flushTail } = await docker.attach(
 			sessionId,
 			attachId,
@@ -232,7 +266,34 @@ export function handleWsConnection(
 			urlRows ?? session.rows,
 			outputListener,
 			tabId,
+			isObserverNotOwner,
 		);
+
+		// Record the observe-attach in the audit log AFTER attach()
+		// succeeds. Order matters:
+		//   - If we INSERTed before attach() and attach() threw, the
+		//     row would be orphaned with `ended_at NULL` forever
+		//     (no close event to UPDATE it). Doing it after means a
+		//     failed attach has no audit row, which is the correct
+		//     "observation never happened" shape.
+		//   - If the INSERT itself fails, we abort the attach: the
+		//     audit-trail invariant is "every observe is logged",
+		//     and an unaudited observe would defeat the whole point
+		//     of the trail. detach() to release the listener +
+		//     re-throw so the catch block runs ws.close(1011).
+		let observeLogId: string | null = null;
+		if (isObserverNotOwner) {
+			try {
+				observeLogId = await recordObserveStart(userId, sessionId, session.userId);
+			} catch (err) {
+				docker.detach(attachId);
+				throw err;
+			}
+			logger.info(
+				`[ws] observe attach logged: observer=${userId} session=${sessionId} ` +
+					`owner=${session.userId} log=${observeLogId}`,
+			);
+		}
 
 		sendMsg(ws, { type: "status", status: "running" });
 		if (replay) {
@@ -241,7 +302,8 @@ export function handleWsConnection(
 		flushTail();
 
 		logger.info(
-			`[ws] user=${userId} attached to session=${sessionId} tab=${tabId} (exec=${attachId})`,
+			`[ws] user=${userId}${isObserverNotOwner ? " (observe)" : ""} ` +
+				`attached to session=${sessionId} tab=${tabId} (exec=${attachId})`,
 		);
 
 		// Message handler
@@ -256,10 +318,32 @@ export function handleWsConnection(
 
 			switch (msg.type) {
 				case "input":
+					// Observe-mode (#201d): drop input frames at the
+					// WS layer before `docker.write`. The locked-in
+					// invariant is "lead sees the user's terminal but
+					// can't type"; this is the load-bearing line that
+					// enforces it. A misbehaving client that sends an
+					// input frame on an observe attach gets a silent
+					// drop — surfacing an error would tell the client
+					// "you tried to write, you're not allowed", which
+					// it could enumerate, but the auth-layer
+					// `assertCanObserve` already filtered who's allowed
+					// to attach in the first place. Silent drop is
+					// fine; it's the same shape as a closed pty
+					// would have.
+					if (isObserverNotOwner) break;
 					idleSweeper?.bump(sessionId);
 					docker.write(attachId, msg.data);
 					break;
 				case "resize":
+					// Observe-mode (#201d): drop resize frames too.
+					// docker.attach skipped registering this observer
+					// in `s.clientSizes` so a resize would already
+					// no-op at the docker layer, but dropping it at
+					// the WS layer matches the input-drop posture and
+					// avoids the unnecessary D1 round-trip via
+					// `recomputeSize` for a no-op call.
+					if (isObserverNotOwner) break;
 					if (msg.cols > 0 && msg.rows > 0) {
 						idleSweeper?.bump(sessionId);
 						docker.resize(attachId, msg.cols, msg.rows).catch(() => {});
@@ -268,14 +352,33 @@ export function handleWsConnection(
 			}
 		});
 
-		ws.on("close", () => {
-			logger.info(`[ws] user=${userId} detached from session=${sessionId}`);
+		// Close + error both run the same teardown:
+		//   - detach() releases the docker-layer listener.
+		//   - For observe attaches, recordObserveEnd() flips the audit
+		//     row's `ended_at`. The UPDATE is idempotent (WHERE
+		//     ended_at IS NULL), so if both 'close' and 'error' fire
+		//     for the same socket — common during dirty teardowns —
+		//     the second call is a no-op. Errors during the D1 UPDATE
+		//     are logged and swallowed: a transient at close time
+		//     shouldn't crash the teardown or leak via
+		//     uncaughtException.
+		const teardown = (reason: "close" | "error", logCtx: string): void => {
 			docker.detach(attachId);
-		});
+			if (observeLogId !== null) {
+				recordObserveEnd(observeLogId).catch((err) => {
+					logger.warn(
+						`[ws] observe-log end failed on ${reason}: ${(err as Error).message} ` +
+							`(log=${observeLogId} session=${sessionId})`,
+					);
+				});
+			}
+			logger.info(`[ws] user=${userId} detached from session=${sessionId} (${logCtx})`);
+		};
 
+		ws.on("close", () => teardown("close", "close"));
 		ws.on("error", (err) => {
 			logger.error(`[ws] error on session=${sessionId}: ${err.message}`);
-			docker.detach(attachId);
+			teardown("error", `error: ${err.message}`);
 		});
 	})().catch((err) => {
 		if (err instanceof NotFoundError) {


### PR DESCRIPTION
## Summary

Fourth slice of the tech-lead role from #201. Wires the read-only WS attach + the locked-in audit trail end-to-end:

- `WS /ws/sessions/:id?observe=true` is now a valid attach shape.
- Auth routes via `assertCanObserve` (#201b): owner / admin / lead-of-group-containing-owner. Non-authorised callers get the same 403/404 shape as the standard attach path.
- Observers see live output but **cannot type or resize**. Input and resize frames are dropped at the WS message handler before `docker.write` / `docker.resize`. Defence-in-depth at the docker layer: observers are NOT registered in `s.clientSizes`, so their viewport doesn't contribute to tmux's min-of-all-clients pane size (an observer with a smaller terminal can't shrink the owner's view).
- Every observe attach writes a `session_observe_log` row: INSERT on success, idempotent UPDATE `ended_at = datetime('now')` on close (both `ws.on("close")` and `ws.on("error")` call it; the SQL idempotency is the coordination point).
- An owner who calls `?observe=true` against their own session is short-circuited via the `isObserverNotOwner` discriminator: no audit row, no input/resize drop, no clientSizes opt-out. The observe semantics are pointless on self-attach; treating it as a normal attach avoids a foot-gun where a UI bug would spam the audit log with self-rows.

### Schema (`db.ts`)

`session_observe_log` table with:
- `id`, `observer_user_id` (FK → users, CASCADE), `session_id` (FK → sessions, CASCADE), `owner_user_id` (denormalised, no FK), `started_at` (DEFAULT now), `ended_at` (nullable).
- Indexes: `idx_observe_log_session` (covers per-session read), `idx_observe_log_observer` (covers a forward-looking "history of sessions I observed" view per observer).
- `ON DELETE CASCADE` on session_id is the locked-in tradeoff: hard-deleting a session purges its log. Favours operational tidiness over retention. Switch to `SET NULL` + periodic purge if a real retention requirement surfaces.

### Module (`observeLog.ts`)

- `recordObserveStart(observerUserId, sessionId, ownerUserId) → logId` — INSERT, returns uuid. Propagates D1 errors so wsHandler aborts the attach when the audit row can't be written (the audit-trail invariant is "every observe is logged"; an unaudited attach defeats the trail's purpose).
- `recordObserveEnd(logId)` — UPDATE WHERE ended_at IS NULL, idempotent so the close + error teardown paths can both call it.
- `listForSession(sessionId)` — per-session log, JOIN users for observer username, newest started_at DESC, capped at 500.
- `listAll()` — cross-user admin view, LEFT JOIN users twice (observer + owner) so a CASCADE-deleted user surfaces as `(deleted user)` tombstone rather than dropping the row from the audit trail entirely.

### Routes (`routes.ts`)

- `GET /api/sessions/:id/observe-log` (auth + `assertCanObserve`). Same 403/404 shape the rest of the session-scoped reads emit via `handleSessionError`.
- `GET /api/admin/observe-log` (`requireAdmin` + `adminStatsIp`).

### `dockerManager.ts`

`docker.attach` gains an `observe = false` parameter. When true, skips `s.clientSizes.set(attachId, {cols, rows})`. `resize()` and `detach()` already no-op on a missing clientSizes entry, so no other call site changes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/` clean
- [x] `npx vitest run` — **777 tests pass** (was 749 on main; +28 new)
- [x] **+12 cases** in `observeLog.test.ts` cover INSERT/UPDATE shape, idempotency on changes=0, `ORDER BY` + `LIMIT` clause, tombstone rendering on LEFT JOIN miss, and D1 error propagation
- [x] **+8 cases** in `wsHandler.test.ts` cover the `assertCanObserve` routing, the `observe` flag passed to `docker.attach` (true when observer != owner, false when owner self-attach), the `recordObserveStart` → `recordObserveEnd` lifecycle, the abort-on-audit-failure path, the input + resize frame drop in observe mode, and the non-observe regression guard (input/resize still forwarded for owners)
- [x] **+8 cases** in `routes.observeLog.test.ts` cover both routes' wire shapes (Date → ISO), the `assertCanObserve` gate (403 for `ForbiddenError`, 404 for `NotFoundError`), and the admin gate
- [ ] Smoke: pause until 201e ships the frontend; observe-mode endpoints respond correctly but no UI surfaces them yet

## What's not in this PR

- **No frontend** — that's 201e. The lead can't yet open an observe-mode attach from any UI; the WS shape works for clients that know the URL.
- **No `?all=true` pagination on observe-log reads.** Hard-capped at 500 entries newest-first; revisit if a deployment hits the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)