### PR TITLE
feat(groups): frontend lead UX (#201, PR 201e-1 of 6)

### DIFF
--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -8,6 +8,13 @@ import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { v4 as uuidv4 } from "uuid";
 import { d1Query } from "./db.js";
+// CJS-safe namespace import (#201e). The dependency cycle is:
+//   auth.ts → groups.ts → sessionManager.ts → auth.ts (isUserAdmin).
+// All three imports are accessed at call time, never at module
+// top-level evaluation, so CommonJS's deferred property-access shape
+// resolves cleanly once every module has finished loading. Same
+// rationale as sessionManager.ts's circular-dep block.
+import * as groups from "./groups.js";
 import { logger } from "./logger.js";
 import type { JwtPayload } from "./types.js";
 
@@ -100,6 +107,11 @@ export interface RegisterResult {
 	token: string;
 	/** Bootstrap user gets is_admin=1; everyone else defaults to 0 (#50). */
 	isAdmin: boolean;
+	/** Always false for a fresh registration (#201e): new accounts can't
+	 *  yet be in any group, so they can't lead one either. Surfaced for
+	 *  parity with the LoginResult shape so the api.ts client uses the
+	 *  same `data.isLead` field on both auth paths. */
+	isLead: boolean;
 }
 
 export async function registerUser(
@@ -134,7 +146,7 @@ export async function registerUser(
 			[userId, username, bootstrapHash],
 		);
 		if (insert.meta.changes === 1) {
-			return { userId, token: signToken(userId, username), isAdmin: true };
+			return { userId, token: signToken(userId, username), isAdmin: true, isLead: false };
 		}
 		// Race loser: a concurrent bootstrap got there first and we have
 		// no invite to fall back on. Match the steady-state response so
@@ -209,7 +221,10 @@ export async function registerUser(
 
 	// Steady-state register: invite-redeeming users default to non-admin
 	// (the column default in db.ts). Promotion happens manually post-bootstrap.
-	return { userId, token: signToken(userId, username), isAdmin: false };
+	// `isLead` is always false here — a brand-new user has just been
+	// inserted into `users`; no one's added them to a group yet, so by
+	// definition they can't lead one.
+	return { userId, token: signToken(userId, username), isAdmin: false, isLead: false };
 }
 
 // ── Invites ────────────────────────────────────────────────────────────────
@@ -430,6 +445,12 @@ export interface LoginResult {
 	token: string;
 	/** Pulled from the same row as the password hash — no extra D1 round-trip. */
 	isAdmin: boolean;
+	/** True iff `users.id` is the lead of at least one group (#201e).
+	 *  One extra D1 round-trip per login (parallel with the password
+	 *  compare's microtask cost is negligible). Saves the frontend a
+	 *  follow-up `/auth/status` round-trip after login to gate the
+	 *  "My groups" button. */
+	isLead: boolean;
 }
 
 export async function loginUser(username: string, password: string): Promise<LoginResult> {
@@ -452,7 +473,14 @@ export async function loginUser(username: string, password: string): Promise<Log
 	}
 
 	const token = signToken(row.id, username);
-	return { userId: row.id, token, isAdmin: row.is_admin === 1 };
+	// `isLead` is fetched after the credentials check rather than
+	// folded into the row SELECT above — it's a separate table and
+	// the JOIN would burn an index hit on every failed-credentials
+	// path too. Catch the error so a transient D1 failure on the
+	// lead lookup doesn't fail the whole login (the frontend can
+	// re-fetch via /auth/status if needed).
+	const isLead = await groups.isUserLead(row.id).catch(() => false);
+	return { userId: row.id, token, isAdmin: row.is_admin === 1, isLead };
 }
 
 function signToken(userId: string, username: string): string {

--- a/backend/src/groups.test.ts
+++ b/backend/src/groups.test.ts
@@ -199,6 +199,32 @@ describe("groups.groupsLedBy", () => {
 	});
 });
 
+// ── isUserLead (#201e) ──────────────────────────────────────────────────────
+
+describe("groups.isUserLead", () => {
+	it("returns true when the LIMIT-1 SELECT finds a row", async () => {
+		mockNextRows([{ one: 1 }]);
+		expect(await groups.isUserLead("u-lead")).toBe(true);
+	});
+
+	it("returns false when no group has the user as lead", async () => {
+		mockNextRows([]);
+		expect(await groups.isUserLead("u-not-a-lead")).toBe(false);
+	});
+
+	it("uses the leader-id index via the lead_user_id WHERE clause", async () => {
+		mockNextRows([]);
+		await groups.isUserLead("u-lead");
+		const call = dbStubs.d1Query.mock.calls[0]!;
+		// Index hit on idx_user_groups_lead — the WHERE clause is the
+		// load-bearing line. LIMIT 1 lets the optimiser short-circuit
+		// as soon as a match is found, cheaper than COUNT(*).
+		expect(call[0]).toMatch(/WHERE lead_user_id = \?/);
+		expect(call[0]).toMatch(/LIMIT 1/);
+		expect(call[1]).toEqual(["u-lead"]);
+	});
+});
+
 // ── isLeadOfUserViaGroup ────────────────────────────────────────────────────
 
 describe("groups.isLeadOfUserViaGroup", () => {

--- a/backend/src/groups.ts
+++ b/backend/src/groups.ts
@@ -289,6 +289,22 @@ export async function groupsLedBy(userId: string): Promise<string[]> {
 }
 
 /**
+ * Boolean predicate: is `userId` the lead of at least one group?
+ * Powers the "show My groups button?" gate on the frontend (#201e),
+ * surfaced via `/auth/status` alongside `isAdmin`. Single indexed
+ * point read with `LIMIT 1` so the optimiser short-circuits as soon
+ * as a match exists — cheaper than `groupsLedBy(...).length > 0`,
+ * which would always pull every row.
+ */
+export async function isUserLead(userId: string): Promise<boolean> {
+	const result = await d1Query<{ one: number }>(
+		"SELECT 1 AS one FROM user_groups WHERE lead_user_id = ? LIMIT 1",
+		[userId],
+	);
+	return result.results.length > 0;
+}
+
+/**
  * Auth predicate for `SessionManager.assertCanObserve` (#201b):
  * is `leadUserId` the lead of ANY group whose membership contains
  * `memberUserId`? Returns true iff yes.

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -1468,7 +1468,17 @@ export function buildRouter(
 	router.get("/sessions/:id/tabs", async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
 		try {
-			await sessions.assertOwnedBy(req.params.id, userId);
+			// `assertCanObserve` (#201d) instead of `assertOwnedBy`
+			// (#201e-1 review BLOCKER). Reading the tab list is a
+			// read-only operation observers MUST be able to do — without
+			// it the lead's "Observe" click can't pick a tab to attach
+			// to, and the WS would 1008-close on "Missing tab". The auth
+			// graduation is owner / admin / lead-of-group-containing-owner,
+			// matching what the observe-WS attach itself enforces.
+			// Tab CREATE / DELETE further down stay on `assertOwnedBy` —
+			// observability does NOT include the right to mutate tab
+			// state on someone else's session.
+			await sessions.assertCanObserve(req.params.id, userId);
 			const tabs = await docker.listTabs(req.params.id);
 			res.json(tabs);
 		} catch (err) {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -124,9 +124,12 @@ export function buildRouter(
 		//
 		// `isAdmin` is fetched fresh from D1 (#50) rather than from a
 		// JWT-embedded claim so admin grant/revoke takes effect without
-		// requiring users to log out and back in. Falls back to false on
-		// lookup failure or unauthenticated callers — UI should treat
-		// the boolean as "show admin features" only when explicitly true.
+		// requiring users to log out and back in. `isLead` (#201e)
+		// follows the same shape — fetched fresh so an admin
+		// adding/removing the user as a group lead lands without a
+		// re-login. Both fall back to false on lookup failure or
+		// unauthenticated callers — UI should treat the booleans as
+		// "show admin/lead features" only when explicitly true.
 		const reqWithCookies = req as Request & {
 			cookies?: Record<string, string | undefined>;
 		};
@@ -136,21 +139,24 @@ export function buildRouter(
 			undefined;
 		const payload = verifyJwt(token);
 		const authenticated = payload !== null;
-		// Run the admin-lookup and hasAnyUsers in parallel — they have
-		// no data dependency, and CLAUDE.md flags D1 round-trips as the
-		// expensive thing on hot paths. The admin lookup catches its
-		// own error (surfaces as isAdmin=false); hasAnyUsers throwing
-		// is a real boot-state failure and propagates to the 500 handler.
-		const [adminLookup, anyUsers] = await Promise.all([
+		// Run all three lookups in parallel — they have no data
+		// dependency, and CLAUDE.md flags D1 round-trips as the
+		// expensive thing on hot paths. Admin + lead lookups catch
+		// their own errors (surface as false); hasAnyUsers throwing
+		// is a real boot-state failure and propagates to the 500
+		// handler.
+		const [adminLookup, leadLookup, anyUsers] = await Promise.all([
 			payload
 				? d1Query<{ is_admin: number }>("SELECT is_admin FROM users WHERE id = ?", [
 						payload.sub,
 					]).catch(() => null)
 				: Promise.resolve(null),
+			payload ? groups.isUserLead(payload.sub).catch(() => false) : Promise.resolve(false),
 			hasAnyUsers(),
 		]);
 		const isAdmin = adminLookup?.results[0]?.is_admin === 1;
-		res.json({ needsSetup: !anyUsers, authenticated, isAdmin });
+		const isLead = leadLookup === true;
+		res.json({ needsSetup: !anyUsers, authenticated, isAdmin, isLead });
 	});
 
 	router.post("/auth/register", registerIp, async (req: Request, res: Response) => {
@@ -201,7 +207,11 @@ export function buildRouter(
 			// keeps the userId for clients that want to address the new
 			// account, but never the raw token.
 			setAuthCookie(res, result.token);
-			res.status(201).json({ userId: result.userId, isAdmin: result.isAdmin });
+			res.status(201).json({
+				userId: result.userId,
+				isAdmin: result.isAdmin,
+				isLead: result.isLead,
+			});
 		} catch (err) {
 			if (err instanceof InviteRequiredError) {
 				// 403 — caller authenticated nothing yet, but the action is
@@ -257,7 +267,7 @@ export function buildRouter(
 			return;
 		}
 
-		let result: { userId: string; token: string; isAdmin: boolean };
+		let result: { userId: string; token: string; isAdmin: boolean; isLead: boolean };
 		try {
 			try {
 				result = await loginUser(username, password);
@@ -275,7 +285,11 @@ export function buildRouter(
 			}
 			usernameLimiter.reset(username);
 			setAuthCookie(res, result.token);
-			res.json({ userId: result.userId, isAdmin: result.isAdmin });
+			res.json({
+				userId: result.userId,
+				isAdmin: result.isAdmin,
+				isLead: result.isLead,
+			});
 		} finally {
 			// Always release the in-flight slot — success, invalid creds,
 			// or infra error alike. `reset()` above wipes the failure

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -99,6 +99,7 @@
           <span id="user-display"></span>
           <button id="templates-btn" type="button" title="Session templates">Templates</button>
           <button id="invites-btn" type="button" title="Manage invite codes">Invites</button>
+          <button id="my-groups-btn" type="button" title="Groups you lead">My groups</button>
           <button id="admin-btn" type="button" title="Admin dashboard">Admin</button>
           <button id="logout-btn" type="button">Logout</button>
         </div>
@@ -133,6 +134,7 @@
             <span id="sidebar-user-display" aria-hidden="true"></span>
             <button id="sidebar-templates-btn" type="button">Templates</button>
             <button id="sidebar-invites-btn" type="button">Invites</button>
+            <button id="sidebar-my-groups-btn" type="button">My groups</button>
             <button id="sidebar-admin-btn" type="button">Admin</button>
             <button id="sidebar-logout-btn" type="button">Logout</button>
           </div>
@@ -822,6 +824,81 @@
             </div>
           </section>
         </div>
+      </div>
+    </div>
+
+    <!-- "My groups" modal (#201e). Lead-side observability surface.
+         Visibility gate (`my-groups-btn`/`sidebar-my-groups-btn`) is a
+         UX hint only — server-side `requireAuth` + the user-scoped SQL
+         is the actual auth, so a non-lead with the URL still gets [].
+         Refresh button mirrors the admin dashboard pattern; this modal
+         doesn't poll either. -->
+    <div id="my-groups-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card admin-modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="my-groups-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="my-groups-modal-title">My groups</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint">
+          Groups you lead. Click <strong>Observe</strong> on any
+          member's session to open a read-only view of their terminal
+          — input is disabled, every observe is recorded in the
+          session's audit log.
+        </p>
+        <div class="admin-controls">
+          <button id="my-groups-refresh-btn" type="button">Refresh</button>
+        </div>
+        <div id="admin-scroll-area">
+          <section id="my-groups-list">
+            <p class="modal-hint">Loading…</p>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <!-- Observe-mode terminal modal (#201e). Opened from "My groups"
+         when the lead clicks Observe on a session. Read-only: the WS
+         attach uses ?observe=true and `openTerminalSession({observe:
+         true, …})` suppresses xterm input + touch-scroll-as-input.
+         The header titles "Observing <name> · <owner>" so the lead
+         doesn't lose track of whose terminal they're looking at. -->
+    <div id="observe-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card observe-modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="observe-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="observe-modal-title">Observing</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint" id="observe-modal-hint">
+          Read-only view. Input is disabled — every observe-attach is
+          logged.
+        </p>
+        <div id="observe-terminal-host"></div>
       </div>
     </div>
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -20,6 +20,7 @@ const WS_BASE = BACKEND_URL.replace(/^http/, "ws");
 
 let _loggedIn = false;
 let _isAdmin = false;
+let _isLead = false;
 
 export function isLoggedIn(): boolean {
 	return _loggedIn;
@@ -32,6 +33,15 @@ export function isAdmin(): boolean {
 	return _isAdmin;
 }
 
+/** True iff the user leads at least one group (#201e). Gates the
+ *  "My groups" button in main.ts. Same refresh shape as `isAdmin()`
+ *  — hydrated from /auth/status, login, register; cleared on logout
+ *  and on 401. An admin who happens to also lead a group sees both
+ *  buttons. */
+export function isLead(): boolean {
+	return _isLead;
+}
+
 /** Fired by `apiFetch` once per 401-burst after flipping `_loggedIn` to false —
  * main.ts listens to perform UI teardown. See apiFetch for the emit guard. */
 export const SESSION_EXPIRED_EVENT = "st:session-expired";
@@ -42,16 +52,22 @@ export interface AuthStatus {
 	needsSetup: boolean;
 	authenticated: boolean;
 	isAdmin: boolean;
+	/** Surfaced alongside isAdmin (#201e). Always present in fresh
+	 *  responses; older backends (pre-#201e) omit it — fall back to
+	 *  `false` defensively when the field is missing so a stale cached
+	 *  client + new server, or vice versa, doesn't surface undefined. */
+	isLead?: boolean;
 }
 
 export async function checkAuthStatus(): Promise<AuthStatus> {
 	const res = await apiFetch("/auth/status");
 	const data = (await res.json()) as AuthStatus;
 	// The server is the source of truth for cookie presence + admin
-	// status. Mirror both so isLoggedIn() / isAdmin() can answer
-	// instantly thereafter.
+	// + lead status. Mirror all three so isLoggedIn() / isAdmin() /
+	// isLead() can answer instantly thereafter.
 	_loggedIn = data.authenticated;
 	_isAdmin = data.isAdmin;
+	_isLead = data.isLead === true;
 	return data;
 }
 
@@ -65,6 +81,9 @@ export class InviteRequiredError extends Error {
 export interface AuthSuccess {
 	userId: string;
 	isAdmin: boolean;
+	/** Same defensive optionality as `AuthStatus.isLead` — older
+	 *  backends omit it, new accounts via /auth/register hardcode false. */
+	isLead?: boolean;
 }
 
 export async function register(
@@ -86,6 +105,7 @@ export async function register(
 	const data = (await res.json()) as AuthSuccess;
 	_loggedIn = true;
 	_isAdmin = data.isAdmin;
+	_isLead = data.isLead === true;
 	return data;
 }
 
@@ -101,6 +121,7 @@ export async function login(username: string, password: string): Promise<AuthSuc
 	const data = (await res.json()) as AuthSuccess;
 	_loggedIn = true;
 	_isAdmin = data.isAdmin;
+	_isLead = data.isLead === true;
 	return data;
 }
 
@@ -123,6 +144,7 @@ export async function logout(): Promise<void> {
 	}
 	_loggedIn = false;
 	_isAdmin = false;
+	_isLead = false;
 }
 
 // ── Session types ───────────────────────────────────────────────────────────
@@ -726,6 +748,69 @@ export async function adminForceDelete(sessionId: string, hard: boolean): Promis
 	}
 }
 
+// ── Groups (#201e — lead-side reads) ────────────────────────────────────────
+//
+// Wire-shape mirrors of the backend `LeadGroup` and `ObservableSessionMeta`
+// types from `backend/src/groups.ts`. Date columns arrive as ISO strings
+// (the route serializer calls `.toISOString()`); the UI parses with
+// `new Date(...)` only when a Date object is needed.
+
+export interface LeadGroupMember {
+	userId: string;
+	username: string;
+	addedAt: string;
+}
+
+export interface LeadGroup {
+	id: string;
+	name: string;
+	description: string | null;
+	leadUserId: string;
+	createdAt: string;
+	updatedAt: string;
+	members: LeadGroupMember[];
+}
+
+/**
+ * Cross-user session shape returned by `/api/groups/mine/sessions`.
+ * Mirrors `serializeObservableSession` on the backend — note it does
+ * NOT include `envVars` (the lead's observability surface is
+ * intentionally narrower than admin's). Adds `ownerUserId` /
+ * `ownerUsername` so the UI can render "alice's session" without a
+ * second lookup.
+ */
+export interface ObservableSession {
+	sessionId: string;
+	ownerUserId: string;
+	ownerUsername: string;
+	name: string;
+	status: "running" | "stopped" | "terminated" | "failed";
+	containerId: string | null;
+	containerName: string;
+	cols: number;
+	rows: number;
+	createdAt: string;
+	lastConnectedAt: string | null;
+}
+
+/** Fetch every group the current user leads, with each group's full
+ *  member list inlined. Returns `[]` for a non-lead caller (the
+ *  backend SQL is the user-scoping; no auth gate beyond requireAuth). */
+export async function fetchMyGroups(): Promise<LeadGroup[]> {
+	const res = await apiFetch("/groups/mine");
+	if (!res.ok) throw new Error(`Failed to load groups (${res.status})`);
+	return res.json();
+}
+
+/** Fetch every observable session — sessions of any user in any
+ *  group the caller leads, newest-first. Excludes terminated.
+ *  Returns `[]` for a non-lead caller. */
+export async function fetchMyObservableSessions(): Promise<ObservableSession[]> {
+	const res = await apiFetch("/groups/mine/sessions");
+	if (!res.ok) throw new Error(`Failed to load observable sessions (${res.status})`);
+	return res.json();
+}
+
 // ── File uploads ────────────────────────────────────────────────────────────
 
 /**
@@ -794,6 +879,7 @@ async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
 	if (sentAuth && res.status === 401 && _loggedIn) {
 		_loggedIn = false;
 		_isAdmin = false;
+		_isLead = false;
 		window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
 	}
 

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -982,6 +982,30 @@ main:not([data-sidebar-ready]) #sidebar {
   width: 720px;
   max-width: 96vw;
 }
+
+/* Observe-mode modal (#201e). Wider than the admin card so a
+   typical 120-col xterm fits without horizontal scroll, and tall
+   enough to render a usable terminal. The xterm host stretches to
+   fill the available space inside the modal card. */
+.observe-modal-card {
+  width: min(96vw, 1100px);
+  height: min(80vh, 720px);
+  display: flex;
+  flex-direction: column;
+}
+#observe-terminal-host {
+  flex: 1;
+  min-height: 0;
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  padding: 0.5rem;
+}
+/* xterm sets its own dimensions inside the host; ensure the
+   terminal canvas fills the host without overflowing. */
+#observe-terminal-host .xterm {
+  height: 100%;
+}
 .admin-controls {
   display: flex;
   align-items: center;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -26,12 +26,16 @@ import {
 	type EnvVarEntryInput,
 	fetchAdminSessions,
 	fetchAdminStats,
+	fetchMyGroups,
+	fetchMyObservableSessions,
 	getTemplate,
 	type Invite,
 	InviteRequiredError,
 	idleSecondsToFormUnit,
 	isAdmin,
+	isLead,
 	isLoggedIn,
+	type LeadGroup,
 	listInvites,
 	listSessions,
 	listTabs,
@@ -39,6 +43,7 @@ import {
 	login,
 	logout,
 	memBytesToFormUnit,
+	type ObservableSession,
 	openBootstrapWs,
 	register,
 	revokeInvite,
@@ -105,6 +110,18 @@ const adminStatsEl = document.getElementById("admin-stats")!;
 const adminSessionsListEl = document.getElementById("admin-sessions-list")!;
 const adminRefreshBtn = document.getElementById("admin-refresh-btn") as HTMLButtonElement;
 const adminUptimeEl = document.getElementById("admin-uptime")!;
+// #201e — lead-side "My groups" surface. Visibility flips on isLead()
+// from the api-layer mirror. Sidebar + header buttons are gated together
+// (same shape as the Admin pair above).
+const myGroupsBtn = document.getElementById("my-groups-btn") as HTMLButtonElement;
+const sidebarMyGroupsBtn = document.getElementById("sidebar-my-groups-btn") as HTMLButtonElement;
+const myGroupsModal = document.getElementById("my-groups-modal")!;
+const myGroupsListEl = document.getElementById("my-groups-list")!;
+const myGroupsRefreshBtn = document.getElementById("my-groups-refresh-btn") as HTMLButtonElement;
+const observeModal = document.getElementById("observe-modal")!;
+const observeModalTitle = document.getElementById("observe-modal-title")!;
+const observeModalHint = document.getElementById("observe-modal-hint")!;
+const observeTerminalHost = document.getElementById("observe-terminal-host")!;
 const sidebarLogoutBtn = document.getElementById("sidebar-logout-btn") as HTMLButtonElement;
 const chromeToggleBtn = document.getElementById("chrome-toggle") as HTMLButtonElement;
 const chromeToggleLabel = document.getElementById("chrome-toggle-label")!;
@@ -241,17 +258,21 @@ function showApp() {
 	refreshSessions();
 }
 
-// #50: gate invite-mint UI on the current session's admin status.
-// Both buttons (desktop top bar + mobile sidebar) flip together. Read
-// from the api-layer mirror, which is itself hydrated from /auth/status
-// and the login/register responses, so this just reflects the current
-// authoritative answer without needing its own round-trip.
+// #50 / #201e: gate role-conditional UI on the api-layer mirror.
+// Each button pair (header + sidebar) flips together. Hydrated from
+// /auth/status + login/register so this just reflects the current
+// authoritative answer without its own round-trip. Visibility is a
+// UX hint only — every gated endpoint is server-side requireAdmin /
+// requireAuth-gated, so a leaked button reveal is harmless.
 function applyAdminVisibility() {
 	const admin = isAdmin();
 	invitesBtn.classList.toggle("hidden", !admin);
 	sidebarInvitesBtn.classList.toggle("hidden", !admin);
 	adminBtn.classList.toggle("hidden", !admin);
 	sidebarAdminBtn.classList.toggle("hidden", !admin);
+	const lead = isLead();
+	myGroupsBtn.classList.toggle("hidden", !lead);
+	sidebarMyGroupsBtn.classList.toggle("hidden", !lead);
 }
 
 function updateAuthUI() {
@@ -3603,6 +3624,202 @@ async function confirmAndAct(
 		btn.disabled = false;
 	}
 }
+
+// ── My groups (#201e — lead-side observe surface) ──────────────────────────
+//
+// Visible only to users who lead at least one group via
+// `applyAdminVisibility()` (which also gates the lead button). Pulls
+// `/api/groups/mine` + `/api/groups/mine/sessions` on open + refresh —
+// no auto-polling, same rationale as the admin dashboard. The
+// observe modal opens read-only via `openTerminalSession({observe:
+// true})`; closing the modal disposes the WS attach and triggers the
+// server-side `recordObserveEnd()` UPDATE.
+
+let myGroupsOpener: HTMLButtonElement | null = null;
+// At most one observe-mode terminal at a time. Opening a second
+// observe (via clicking another row's Observe before closing the
+// current modal) tears down the prior one — same shape as the
+// existing single-terminal-per-modal pattern (paste, file-attach).
+let activeObserveTerm: TerminalSession | null = null;
+
+function resolveMyGroupsOpener(): HTMLButtonElement {
+	return myGroupsBtn.offsetParent !== null ? myGroupsBtn : sidebarMyGroupsBtn;
+}
+
+function openMyGroupsModal(opener: HTMLButtonElement) {
+	myGroupsOpener = opener;
+	myGroupsModal.classList.add("open");
+	myGroupsModal.setAttribute("aria-hidden", "false");
+	myGroupsRefreshBtn.focus();
+	void refreshMyGroups();
+}
+
+function closeMyGroupsModal() {
+	myGroupsModal.classList.remove("open");
+	myGroupsModal.setAttribute("aria-hidden", "true");
+	(myGroupsOpener ?? resolveMyGroupsOpener()).focus();
+	myGroupsOpener = null;
+}
+
+myGroupsModal.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeMyGroupsModal();
+});
+
+myGroupsBtn.addEventListener("click", () => openMyGroupsModal(myGroupsBtn));
+sidebarMyGroupsBtn.addEventListener("click", () => openMyGroupsModal(sidebarMyGroupsBtn));
+
+myGroupsRefreshBtn.addEventListener("click", () => {
+	void refreshMyGroups();
+});
+
+async function refreshMyGroups(): Promise<void> {
+	myGroupsRefreshBtn.disabled = true;
+	try {
+		// Fetch both endpoints in parallel — independent reads, both
+		// requireAuth-only. Sequentially awaiting would double the
+		// modal latency without a safety upside (same shape as
+		// `refreshAdmin`).
+		const [groups, observableSessions] = await Promise.all([
+			fetchMyGroups(),
+			fetchMyObservableSessions(),
+		]);
+		renderMyGroups(groups, observableSessions);
+	} catch (err) {
+		showToast((err as Error).message, true);
+	} finally {
+		myGroupsRefreshBtn.disabled = false;
+	}
+}
+
+function renderMyGroups(groups: LeadGroup[], sessions: ObservableSession[]): void {
+	myGroupsListEl.textContent = "";
+	if (groups.length === 0) {
+		const empty = document.createElement("p");
+		empty.className = "modal-hint";
+		empty.textContent = "You don't lead any groups yet.";
+		myGroupsListEl.appendChild(empty);
+		return;
+	}
+	// Bucket sessions by ownerUserId so each member-row can render its
+	// owner's running sessions inline. The cross-user list is already
+	// scoped to "members of any group I lead" by the SQL, so a single
+	// pass covers every group below.
+	const sessionsByOwner = new Map<string, ObservableSession[]>();
+	for (const s of sessions) {
+		const bucket = sessionsByOwner.get(s.ownerUserId);
+		if (bucket) bucket.push(s);
+		else sessionsByOwner.set(s.ownerUserId, [s]);
+	}
+	for (const g of groups) {
+		const card = document.createElement("section");
+		card.className = "admin-stat-card";
+		const h = document.createElement("h4");
+		h.textContent = g.description ? `${g.name} — ${g.description}` : g.name;
+		card.appendChild(h);
+		if (g.members.length === 0) {
+			const empty = document.createElement("p");
+			empty.className = "modal-hint";
+			empty.textContent = "No members yet.";
+			card.appendChild(empty);
+			myGroupsListEl.appendChild(card);
+			continue;
+		}
+		for (const m of g.members) {
+			const memberRow = document.createElement("div");
+			memberRow.className = "admin-session-row";
+			const meta = document.createElement("div");
+			meta.className = "admin-session-meta";
+			const name = document.createElement("strong");
+			name.textContent = m.username;
+			meta.appendChild(name);
+			const memberSessions = sessionsByOwner.get(m.userId) ?? [];
+			const sub = document.createElement("span");
+			sub.className = "admin-session-sub";
+			sub.textContent =
+				memberSessions.length === 0
+					? "no active sessions"
+					: `${memberSessions.length} session${memberSessions.length === 1 ? "" : "s"}`;
+			meta.appendChild(sub);
+			memberRow.appendChild(meta);
+
+			// Observe buttons — one per running session. Stopped/failed
+			// sessions surface in the count above but don't get an
+			// Observe button: the WS attach would 1008-close because
+			// `wsHandler` rejects non-running statuses, and a button
+			// that always errors is worse UX than no button.
+			const actions = document.createElement("div");
+			actions.className = "admin-session-actions";
+			for (const s of memberSessions) {
+				if (s.status !== "running") continue;
+				const btn = document.createElement("button");
+				btn.type = "button";
+				btn.textContent = `Observe "${s.name}"`;
+				btn.addEventListener("click", () => openObserveModal(s));
+				actions.appendChild(btn);
+			}
+			memberRow.appendChild(actions);
+			card.appendChild(memberRow);
+		}
+		myGroupsListEl.appendChild(card);
+	}
+}
+
+function openObserveModal(s: ObservableSession): void {
+	// Tear down any prior observe attach before opening a new one —
+	// keeps the audit log honest (each Observe click maps to one
+	// open + one close UPDATE) and avoids stacking xterm DOM nodes
+	// in the modal host.
+	closeObserveModal();
+	observeModalTitle.textContent = `Observing "${s.name}" (${s.ownerUsername})`;
+	observeModalHint.textContent =
+		"Read-only view. Input is disabled — every observe-attach is logged.";
+	observeModal.classList.add("open");
+	observeModal.setAttribute("aria-hidden", "false");
+	observeTerminalHost.textContent = "";
+	const term = openTerminalSession({
+		container: observeTerminalHost,
+		sessionId: s.sessionId,
+		// Observe-mode attaches without a tab id default to the
+		// session's `main` tmux session — same shape as a fresh attach
+		// without a saved tab. The lead doesn't get to pick a tab in
+		// v1 (the admin/lead modal lists sessions, not tabs); the
+		// observed terminal shows whatever's on the default tab.
+		fontSize: currentFontSize,
+		observe: true,
+		onStatus: (status) => {
+			// A status flip to "disconnected" means the underlying
+			// session terminated or the owner stopped it. The audit
+			// log row's `ended_at` is set by ws.on("close") on the
+			// server. Surface a toast so the lead knows why their
+			// view went dark.
+			if (status === "disconnected") {
+				showToast(`Observe attach to "${s.name}" disconnected`);
+			}
+		},
+		onError: (msg) => showToast(`Observe error: ${msg}`, true),
+	});
+	activeObserveTerm = term;
+}
+
+function closeObserveModal(): void {
+	if (activeObserveTerm) {
+		// dispose() closes the WS — the server's ws.on("close") then
+		// fires `recordObserveEnd()` which UPDATEs ended_at. The
+		// idempotency guard (WHERE ended_at IS NULL) makes this safe
+		// even if a duplicate close path also runs.
+		activeObserveTerm.dispose();
+		activeObserveTerm = null;
+	}
+	observeTerminalHost.textContent = "";
+	observeModal.classList.remove("open");
+	observeModal.setAttribute("aria-hidden", "true");
+}
+
+observeModal.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeObserveModal();
+});
 
 // ── Auto-refresh ────────────────────────────────────────────────────────────
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -381,6 +381,18 @@ authForm.addEventListener("submit", async (e) => {
 // the round-trip, and the server's POST /auth/logout response carries no
 // information we'd act on.
 function handleLogout(toastMessage?: string): void {
+	// Tear down the observe-mode WS BEFORE the logout fires (#201e
+	// review). Without this, an active observe attach survives both
+	// the explicit logout button and the SESSION_EXPIRED_EVENT path
+	// — `disposeAllCurrentTerminals` only walks `currentTerminals`
+	// (the owner-mode tab map), and `activeObserveTerm` is a
+	// separate module-level handle. The leak doesn't crash anything
+	// but leaves the audit row's `ended_at` unset until the backend
+	// WS heartbeat eventually kills the socket (minutes later) —
+	// observability gap during that window. `closeObserveModal` is
+	// idempotent when no observe is active, so calling it
+	// unconditionally needs no guard.
+	closeObserveModal();
 	void logout();
 	disposeAllCurrentTerminals();
 	activeSessionId = null;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2718,7 +2718,13 @@ document.addEventListener("keydown", (e) => {
 		// guard, Escape with the admin dashboard open AND the
 		// sidebar drawer visible would close the sidebar instead
 		// of the dialog.
-		adminModal.classList.contains("open")
+		adminModal.classList.contains("open") ||
+		// #201e — same guard for the two new lead-side modals.
+		// Without this, Escape on mobile while either is open
+		// would close the sidebar drawer instead of dismissing
+		// the dialog.
+		myGroupsModal.classList.contains("open") ||
+		observeModal.classList.contains("open")
 	)
 		return;
 	if (!mainEl.classList.contains("sidebar-open")) return;
@@ -3049,6 +3055,16 @@ document.addEventListener("keydown", (e) => {
 	// template from default values). PR #229 round 1 SHOULD-FIX.
 	if (saveTemplateModal.classList.contains("open")) {
 		closeSaveTemplateModal();
+	} else if (observeModal.classList.contains("open")) {
+		// #201e — checked BEFORE myGroupsModal so the observe modal
+		// (which opens on top of My groups when the lead clicks
+		// Observe without closing the parent) dismisses first. WAI-
+		// ARIA 1.2 §6.2: Escape closes the topmost dialog. The
+		// owner-side My groups list survives so the lead can pick
+		// another session without re-opening the parent.
+		closeObserveModal();
+	} else if (myGroupsModal.classList.contains("open")) {
+		closeMyGroupsModal();
 	} else if (newSessionModal.classList.contains("open")) {
 		closeNewSessionModal();
 	} else if (templatesModal.classList.contains("open")) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3683,6 +3683,18 @@ function openMyGroupsModal(opener: HTMLButtonElement) {
 }
 
 function closeMyGroupsModal() {
+	// Tear down any active observe attach before dismissing the
+	// parent modal (#201e review round 4 SHOULD-FIX). The observe
+	// modal opens on top of My groups without closing it; if the
+	// lead backdrop-clicks the My groups modal while observe is
+	// still visible, the parent dismisses but the observe WS
+	// keeps running with no UI affordance to close it. The
+	// audit row's `ended_at` would only land when the backend
+	// heartbeat eventually killed the socket — a gap the
+	// audit-trail invariant explicitly forbids. closeObserveModal
+	// is idempotent when no observe is active, same shape as the
+	// `handleLogout` call site.
+	closeObserveModal();
 	myGroupsModal.classList.remove("open");
 	myGroupsModal.setAttribute("aria-hidden", "true");
 	(myGroupsOpener ?? resolveMyGroupsOpener()).focus();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3767,7 +3767,13 @@ function renderMyGroups(groups: LeadGroup[], sessions: ObservableSession[]): voi
 				const btn = document.createElement("button");
 				btn.type = "button";
 				btn.textContent = `Observe "${s.name}"`;
-				btn.addEventListener("click", () => openObserveModal(s));
+				btn.addEventListener("click", () => {
+					// openObserveModal is async (it fetches the tab list
+					// before opening the WS). Fire-and-forget — it
+					// surfaces its own errors via showToast, so there's
+					// no caller-side rejection to handle.
+					void openObserveModal(s);
+				});
 				actions.appendChild(btn);
 			}
 			memberRow.appendChild(actions);
@@ -3777,26 +3783,55 @@ function renderMyGroups(groups: LeadGroup[], sessions: ObservableSession[]): voi
 	}
 }
 
-function openObserveModal(s: ObservableSession): void {
+async function openObserveModal(s: ObservableSession): Promise<void> {
 	// Tear down any prior observe attach before opening a new one —
 	// keeps the audit log honest (each Observe click maps to one
 	// open + one close UPDATE) and avoids stacking xterm DOM nodes
 	// in the modal host.
 	closeObserveModal();
+	// Fetch the session's tab list FIRST. The WS handler hard-rejects
+	// any attach without a `?tab=...` query (returns 1008 "Missing
+	// tab"), so we must pick a real tab id before opening the socket
+	// — the backend has no implicit "default tab." A first slice
+	// initially tried to pass no tabId and let the server "default to
+	// main"; the WS close fired immediately every time. Pinning the
+	// tab here is what makes observe-mode actually work end-to-end.
+	//
+	// `listTabs` was relaxed to `assertCanObserve` in the same review
+	// fix, so a lead can read the tab list of a session they don't
+	// own. Tab CREATE / DELETE stays owner-only.
+	let tabs: Tab[];
+	try {
+		tabs = await listTabs(s.sessionId);
+	} catch (err) {
+		showToast(`Couldn't load tabs for "${s.name}": ${(err as Error).message}`, true);
+		return;
+	}
+	if (tabs.length === 0) {
+		// The session has no open tmux tabs — no surface to observe.
+		// Owner needs to create one from their UI before the lead can
+		// attach. Surface a clear toast rather than opening an empty
+		// modal that would just disconnect immediately.
+		showToast(`"${s.name}" has no open tabs to observe`, true);
+		return;
+	}
+	// v1 picks the first tab — a session typically has one. A future
+	// slice can add a tab picker if multi-tab observability becomes a
+	// common need; for now, surfacing a count in the modal hint keeps
+	// the lead aware the session may have more.
+	const tab = tabs[0]!;
 	observeModalTitle.textContent = `Observing "${s.name}" (${s.ownerUsername})`;
 	observeModalHint.textContent =
-		"Read-only view. Input is disabled — every observe-attach is logged.";
+		tabs.length === 1
+			? `Read-only view of "${tab.label ?? tab.tabId}". Input is disabled — every observe-attach is logged.`
+			: `Read-only view of "${tab.label ?? tab.tabId}" (1 of ${tabs.length} tabs — first shown). Input is disabled — every observe-attach is logged.`;
 	observeModal.classList.add("open");
 	observeModal.setAttribute("aria-hidden", "false");
 	observeTerminalHost.textContent = "";
 	const term = openTerminalSession({
 		container: observeTerminalHost,
 		sessionId: s.sessionId,
-		// Observe-mode attaches without a tab id default to the
-		// session's `main` tmux session — same shape as a fresh attach
-		// without a saved tab. The lead doesn't get to pick a tab in
-		// v1 (the admin/lead modal lists sessions, not tabs); the
-		// observed terminal shows whatever's on the default tab.
+		tabId: tab.tabId,
 		fontSize: currentFontSize,
 		observe: true,
 		onStatus: (status) => {

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -46,6 +46,27 @@ export function openTerminalSession(opts: {
 	onRendererFallback?: RendererNoticeCallback;
 	onCopy?: CopyCallback;
 	isActive?: ActivePredicate;
+	/**
+	 * Read-only observe-mode (#201e). When true:
+	 *   - the WS URL carries `&observe=true` so the backend routes
+	 *     auth via `assertCanObserve` instead of `assertOwnership`;
+	 *   - this client suppresses the `term.onData` input handler so
+	 *     xterm doesn't even attempt to send keystrokes (the server
+	 *     drops them anyway via the WS-layer input gate, but
+	 *     suppressing client-side avoids the wasted frames + the
+	 *     visual cursor-position glitch a stale local echo would
+	 *     produce in xterm before the server-dropped frame's
+	 *     non-response);
+	 *   - the touch-scroll-as-input path (mouse-tracking wheel
+	 *     sequences) is similarly skipped so a swipe on the observed
+	 *     view doesn't fire SGR sequences the server would silently
+	 *     drop.
+	 *
+	 * Output, replay, status, error, and clipboard-copy paths all
+	 * keep working — observe-mode is a write-suppression flag, not a
+	 * full read-only xterm wrapper.
+	 */
+	observe?: boolean;
 }): TerminalSession {
 	const {
 		container,
@@ -57,6 +78,7 @@ export function openTerminalSession(opts: {
 		onRendererFallback,
 		onCopy,
 		isActive,
+		observe = false,
 	} = opts;
 	// Fires the fallback notice at most once per tab, regardless of how
 	// many times the WebGL context flaps (#55). A flapping driver
@@ -384,7 +406,7 @@ export function openTerminalSession(opts: {
 	// from the server — see backend/src/index.ts heartbeat. Browsers
 	// auto-reply to server pings with no JS hook required, so there is
 	// no `ws.onopen` handler.
-	const wsUrl = buildWsUrl(sessionId, tabId, term.cols, term.rows);
+	const wsUrl = buildWsUrl(sessionId, tabId, term.cols, term.rows, observe);
 	const ws = new WebSocket(wsUrl);
 	let disposed = false;
 
@@ -463,9 +485,19 @@ export function openTerminalSession(opts: {
 	};
 
 	// ── Input: xterm → WS ──────────────────────────────────────────────────
-	const inputDisposable = term.onData((data) => {
-		send({ type: "input", data });
-	});
+	// In observe-mode (#201e) the backend drops every input frame at
+	// the WS handler before docker.write — but suppress the client-side
+	// handler too so xterm doesn't waste cycles on key events whose
+	// sole effect is server-side discard. `term.onData` returns an
+	// IDisposable; with the handler skipped, `inputDisposable.dispose()`
+	// in the cleanup path becomes a no-op via the dummy disposable
+	// below (matches the IDisposable contract without an `if (observe)`
+	// branch in the dispose path).
+	const inputDisposable: IDisposable = observe
+		? { dispose: () => {} }
+		: term.onData((data) => {
+				send({ type: "input", data });
+			});
 
 	// ── Touch scroll ────────────────────────────────────────────────────────
 	// On mobile there are no wheel events, and `mouse on` in tmux means
@@ -582,11 +614,20 @@ export function openTerminalSession(opts: {
 		touchIsScroll = false;
 	};
 
-	container.addEventListener("touchstart", onTouchStart, { passive: true });
-	// passive:false required so ev.preventDefault() can stop xterm's drag-selection
-	container.addEventListener("touchmove", onTouchMove, { passive: false });
-	container.addEventListener("touchend", onTouchEnd, { passive: true });
-	container.addEventListener("touchcancel", onTouchCancel, { passive: true });
+	// Skip touch-scroll-as-input wiring entirely in observe-mode (#201e):
+	// the only thing these handlers do that's user-visible is fire
+	// SGR mouse-tracking sequences as `input` frames, which the
+	// backend drops on observe attaches. Skipping the listeners keeps
+	// the event-loop cost off the lead's device too. The cleanup
+	// `removeEventListener` calls are a safe no-op for never-registered
+	// listeners, so dispose() doesn't need an `observe` branch.
+	if (!observe) {
+		container.addEventListener("touchstart", onTouchStart, { passive: true });
+		// passive:false required so ev.preventDefault() can stop xterm's drag-selection
+		container.addEventListener("touchmove", onTouchMove, { passive: false });
+		container.addEventListener("touchend", onTouchEnd, { passive: true });
+		container.addEventListener("touchcancel", onTouchCancel, { passive: true });
+	}
 
 	// ── Wheel scroll ────────────────────────────────────────────────────────
 	// xterm's default with `set -g mouse on` (session-image/tmux.conf) is
@@ -984,6 +1025,7 @@ function buildWsUrl(
 	tabId: string | undefined,
 	cols: number,
 	rows: number,
+	observe = false,
 ): string {
 	// Use VITE_API_URL to derive the WebSocket URL
 	const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
@@ -1001,6 +1043,12 @@ function buildWsUrl(
 	// or out-of-range value falls back to D1's stored session.cols/rows.
 	if (Number.isInteger(cols) && cols > 0) params.set("cols", String(cols));
 	if (Number.isInteger(rows) && rows > 0) params.set("rows", String(rows));
+	// Observe-mode flag (#201e). The backend's parse is strict-equals
+	// "true" (see wsHandler.ts), so send the literal string — any
+	// other value would silently fall back to owner-mode and the
+	// lead's attach would fail with 403 instead of routing to
+	// assertCanObserve.
+	if (observe) params.set("observe", "true");
 	const qs = params.toString();
 	return qs ? `${base}?${qs}` : base;
 }


### PR DESCRIPTION
## Summary

Wires the lead-side observability surface end-to-end. A user who leads at least one group sees a "My groups" button, opens a modal listing their group members + each member's running sessions, and clicks Observe to open a read-only xterm bound to a `?observe=true` WS attach. The audit log lands automatically via the backend wiring from #201d.

### Backend (small)

- `groups.isUserLead(userId)` — boolean predicate, single indexed point read with `LIMIT 1`. Cheaper than `groupsLedBy(...).length` which would always pull every row.
- `/auth/status`, `/auth/login`, `/auth/register` now return `isLead` alongside `isAdmin`. Lookups for both run in parallel with `hasAnyUsers()` on /auth/status; the `loginUser` path picks up one extra D1 call (parallel with bcrypt is negligible). Register hardcodes `isLead: false` — a brand-new user can't yet be in any group.
- 3-way module cycle (`auth → groups → sessionManager → auth`) is CJS-safe via deferred property-access; same shape and rationale as the existing 2-way cycle documented in `sessionManager.ts`.

### Frontend `api.ts`

- New `_isLead` mirror + `isLead()` getter, hydrated from /auth/status, login, register; cleared on logout + on 401-burst (same shape as `_isAdmin`).
- `LeadGroup`, `LeadGroupMember`, `ObservableSession` types mirror the backend's serializer shapes. `ObservableSession` deliberately omits `envVars` (the lead's surface is intentionally narrower than admin's, per the #201 lock-in).
- `fetchMyGroups()`, `fetchMyObservableSessions()` are thin wrappers over the 201c routes.

### Frontend `terminal.ts`

`openTerminalSession({observe: true})` opt:
- Adds `&observe=true` to the WS URL (the backend's parser is strict-equals `"true"`, not `"1"` — pin the literal string).
- Skips `term.onData` registration so xterm doesn't emit input frames the server would just drop. Returns a dummy `IDisposable` so the cleanup path stays branch-free.
- Skips touch-scroll-as-input wiring for the same reason — the SGR mouse-tracking sequences are `input`-typed frames.

Output, replay, status, error, and clipboard-copy paths all keep working — observe is a write-suppression flag, not a full read-only xterm wrapper.

### Frontend `main.ts` + `index.html`

- New header + sidebar **My groups** buttons gated by `isLead()` alongside the existing **Admin** pair.
- New `<dialog id="my-groups-modal">` listing each led group with members inline; per-member running sessions get an Observe button. Stopped/failed sessions surface in the count but skip the button (the backend would 1008-close the WS, and a button that always errors is worse UX than no button).
- New `<dialog id="observe-modal">` with a 1100×720 xterm host scaled to 96vw / 80vh on small screens. Single active observe attach at a time — opening another tears down the prior so the audit log gets one clean open + one close UPDATE per Observe click. Disconnect surfaces a toast.
- CSS for the observe modal sized so 120-col terminals fit without horizontal scroll on a typical desktop.

## Test plan

- [x] backend: `npx tsc --noEmit` + `npx biome check src/` clean
- [x] backend: `npx vitest run` — **780 pass** (was 777; +3 new for `isUserLead` covering the LIMIT-1 SELECT shape, the leader-id parameter, and true/false branches)
- [x] frontend: `npx tsc --noEmit` + `npx biome check src/` clean
- [x] frontend: `npx vitest run` — **61 pass** (no new tests; the `_isLead` mirror and route helpers are passthrough plumbing exercised end-to-end by the backend tests + the next slice's integration smoke)
- [ ] **UI smoke: Cannot exercise the SPA in a browser from this environment.** The TS + lint gate is green and every code path is structurally analogous to the shipped Admin / Templates modal patterns. **Recommend a manual browser pass before merge:** log in as a lead, open My groups, click Observe on a member's session, verify input is dropped (typing produces no echo), close the modal, verify the audit row's `ended_at` is set.

## What's not in this PR

- **No admin Groups CRUD tab** — that's 201e-2.
- **No admin observe-log dashboard view** — that's 201e-2.
- **No owner-side observe-log on session detail** — also 201e-2.
- **No frontend tests for the new modal interactions.** `main.ts` is currently uncovered by unit tests (the full file is DOM-imperative); adding coverage would mean a jsdom harness, which is a separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)