### PR TITLE
feat(groups): admin Groups CRUD + observe-log views (#201, PR 201e-2 of 6 — closes #201)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -153,6 +153,21 @@
             >
               Aa
             </button>
+            <!-- #201e-2: surfaces the per-session observe history.
+                 Owner / admin / lead-of-group-containing-owner can
+                 read; the backend `/api/sessions/:id/observe-log`
+                 enforces via assertCanObserve. The button is shown
+                 for every authenticated user on every session — the
+                 modal itself surfaces a 403 toast if the caller
+                 isn't authorised. -->
+            <button
+              id="observers-btn"
+              type="button"
+              title="Who has watched this session"
+              aria-label="Show observe log"
+            >
+              Observers
+            </button>
           </div>
           <div id="terminal-tabs"></div>
           <div id="terminal-container"></div>
@@ -823,6 +838,27 @@
               <p class="modal-hint">Loading sessions…</p>
             </div>
           </section>
+          <!-- #201e-2: admin Groups CRUD section. List + create + edit
+               + delete + add/remove member. Backend routes are gated
+               by `requireAdmin`; this section is hidden by being
+               inside the admin-only modal. -->
+          <section class="admin-sessions">
+            <div class="admin-section-header">
+              <h3 class="admin-section-title">Groups</h3>
+              <button id="admin-group-create-btn" type="button">+ New group</button>
+            </div>
+            <div id="admin-groups-list">
+              <p class="modal-hint">Loading groups…</p>
+            </div>
+          </section>
+          <!-- #201e-2: cross-user observe-log. Shows who watched whose
+               session, when. Read-only — actions live elsewhere. -->
+          <section class="admin-sessions">
+            <h3 class="admin-section-title">Observe log (all users)</h3>
+            <div id="admin-observe-log">
+              <p class="modal-hint">Loading observe log…</p>
+            </div>
+          </section>
         </div>
       </div>
     </div>
@@ -899,6 +935,158 @@
           logged.
         </p>
         <div id="observe-terminal-host"></div>
+      </div>
+    </div>
+
+    <!-- #201e-2: per-session observe-log dialog. Opened from the
+         Observers button on the terminal toolbar. Lists who watched
+         the session (and whether they're still watching, via
+         endedAt: null). Auth-gated server-side by assertCanObserve;
+         a non-authorised viewer sees a toast on open. -->
+    <div id="observers-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="observers-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="observers-modal-title">Observers</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint" id="observers-modal-hint">
+          Read-only attaches to this session. Each row is one open →
+          close cycle; an unset end time means the observer is still
+          watching.
+        </p>
+        <div id="observers-modal-list">
+          <p class="modal-hint">Loading…</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- #201e-2: admin Group create/edit dialog. Surfaces from the
+         admin dashboard's Groups section (+ New group / Edit per
+         row). Opens on top of the admin modal; same nested-dialog
+         pattern as save-template-modal. Submitting POSTs (create) /
+         PUTs (edit) and refreshes the admin Groups list. -->
+    <div id="admin-group-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="admin-group-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="admin-group-modal-title">New group</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint">
+          The lead is implicitly added as a member. Members can be
+          added via the row actions on the Groups list after the
+          group is created.
+        </p>
+        <form id="admin-group-form" novalidate>
+          <label class="modal-field">
+            <span>Name</span>
+            <input
+              id="admin-group-name"
+              type="text"
+              maxlength="100"
+              autocomplete="off"
+              required
+            />
+          </label>
+          <label class="modal-field">
+            <span>Description (optional)</span>
+            <input
+              id="admin-group-description"
+              type="text"
+              maxlength="500"
+              autocomplete="off"
+            />
+          </label>
+          <label class="modal-field">
+            <span>Lead user id</span>
+            <input
+              id="admin-group-lead-user-id"
+              type="text"
+              maxlength="128"
+              autocomplete="off"
+              placeholder="UUID of the lead user"
+              required
+            />
+          </label>
+          <div class="modal-actions">
+            <button type="button" data-close-modal>Cancel</button>
+            <button type="submit" id="admin-group-submit-btn">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- #201e-2: admin Group members management dialog. Surfaces
+         from the admin Groups list (Members per row). Lists current
+         members + lets the admin add (by user id) or remove. The
+         lead is shown but cannot be removed (backend returns 409). -->
+    <div id="admin-group-members-modal" class="modal" aria-hidden="true">
+      <div class="modal-backdrop" data-close-modal></div>
+      <div
+        class="modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="admin-group-members-modal-title"
+      >
+        <div class="modal-header">
+          <h2 id="admin-group-members-modal-title">Members</h2>
+          <button
+            class="modal-close"
+            type="button"
+            aria-label="Close"
+            data-close-modal
+          >
+            ×
+          </button>
+        </div>
+        <p class="modal-hint" id="admin-group-members-modal-hint">
+          The lead is shown with a badge and cannot be removed —
+          reassign the lead via Edit first.
+        </p>
+        <form id="admin-group-add-member-form" novalidate>
+          <label class="modal-field">
+            <span>Add member by user id</span>
+            <input
+              id="admin-group-add-member-input"
+              type="text"
+              maxlength="128"
+              autocomplete="off"
+              placeholder="UUID of the user to add"
+              required
+            />
+          </label>
+          <div class="modal-actions">
+            <button type="submit">Add</button>
+          </div>
+        </form>
+        <div id="admin-group-members-list">
+          <p class="modal-hint">Loading members…</p>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -748,6 +748,162 @@ export async function adminForceDelete(sessionId: string, hard: boolean): Promis
 	}
 }
 
+// ── Admin groups CRUD (#201e-2) ─────────────────────────────────────────────
+//
+// Wire-shape mirrors of the backend `Group` / `GroupSummary` /
+// `GroupMember` types from `backend/src/groups.ts`. All endpoints
+// here are admin-gated server-side; calling them as a non-admin
+// returns 403.
+
+export interface AdminGroupSummary {
+	id: string;
+	name: string;
+	description: string | null;
+	leadUserId: string;
+	leadUsername: string;
+	memberCount: number;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface AdminGroupMember {
+	userId: string;
+	username: string;
+	addedAt: string;
+}
+
+export interface AdminGroupDetail {
+	id: string;
+	name: string;
+	description: string | null;
+	leadUserId: string;
+	createdAt: string;
+	updatedAt: string;
+	members: AdminGroupMember[];
+}
+
+export interface AdminGroupInput {
+	name: string;
+	description?: string | null;
+	leadUserId: string;
+}
+
+export async function fetchAdminGroups(): Promise<AdminGroupSummary[]> {
+	const res = await apiFetch("/admin/groups");
+	if (!res.ok) throw new Error(`Failed to load groups (${res.status})`);
+	return res.json();
+}
+
+export async function fetchAdminGroup(id: string): Promise<AdminGroupDetail> {
+	const res = await apiFetch(`/admin/groups/${encodeURIComponent(id)}`);
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to load group (${res.status})`);
+	}
+	return res.json();
+}
+
+export async function createAdminGroup(input: AdminGroupInput): Promise<AdminGroupSummary> {
+	const res = await apiFetch("/admin/groups", {
+		method: "POST",
+		body: JSON.stringify(input),
+	});
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to create group (${res.status})`);
+	}
+	return res.json();
+}
+
+export async function updateAdminGroup(
+	id: string,
+	input: AdminGroupInput,
+): Promise<AdminGroupSummary> {
+	const res = await apiFetch(`/admin/groups/${encodeURIComponent(id)}`, {
+		method: "PUT",
+		body: JSON.stringify(input),
+	});
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to update group (${res.status})`);
+	}
+	return res.json();
+}
+
+export async function deleteAdminGroup(id: string): Promise<void> {
+	const res = await apiFetch(`/admin/groups/${encodeURIComponent(id)}`, { method: "DELETE" });
+	if (res.status === 404) return; // race: deleted between list + action
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to delete group (${res.status})`);
+	}
+}
+
+export async function addAdminGroupMember(groupId: string, userId: string): Promise<void> {
+	const res = await apiFetch(`/admin/groups/${encodeURIComponent(groupId)}/members`, {
+		method: "POST",
+		body: JSON.stringify({ userId }),
+	});
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to add member (${res.status})`);
+	}
+}
+
+export async function removeAdminGroupMember(groupId: string, userId: string): Promise<void> {
+	const res = await apiFetch(
+		`/admin/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(userId)}`,
+		{ method: "DELETE" },
+	);
+	if (res.status === 404) return; // race: removed between list + action
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to remove member (${res.status})`);
+	}
+}
+
+// ── Observe-log (#201e-2) ──────────────────────────────────────────────────
+//
+// Owner / lead / admin can read a session's observe history;
+// admin only can read the cross-user log. Wire-shape mirrors of
+// the backend `ObserveLogEntry` / `AdminObserveLogEntry` types
+// from `backend/src/observeLog.ts`.
+
+export interface ObserveLogEntry {
+	id: string;
+	observerUserId: string;
+	observerUsername: string;
+	sessionId: string;
+	ownerUserId: string;
+	startedAt: string;
+	endedAt: string | null;
+}
+
+export interface AdminObserveLogEntry extends ObserveLogEntry {
+	ownerUsername: string;
+}
+
+/** Per-session observe history. Gated by `assertCanObserve`
+ *  server-side — owner / admin / lead-of-group-containing-owner
+ *  can read; everyone else gets 403. */
+export async function fetchSessionObserveLog(sessionId: string): Promise<ObserveLogEntry[]> {
+	const res = await apiFetch(`/sessions/${encodeURIComponent(sessionId)}/observe-log`);
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Failed to load observe log (${res.status})`);
+	}
+	return res.json();
+}
+
+/** Cross-user observe log for the admin dashboard. Hard-capped at
+ *  500 entries newest-first server-side; older entries are silently
+ *  dropped if the deployment ever hits the cap. */
+export async function fetchAdminObserveLog(): Promise<AdminObserveLogEntry[]> {
+	const res = await apiFetch("/admin/observe-log");
+	if (!res.ok) throw new Error(`Failed to load admin observe log (${res.status})`);
+	return res.json();
+}
+
 // ── Groups (#201e — lead-side reads) ────────────────────────────────────────
 //
 // Wire-shape mirrors of the backend `LeadGroup` and `ObservableSessionMeta`

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1080,6 +1080,31 @@ main:not([data-sidebar-ready]) #sidebar {
   color: #e6edf3;
   margin-bottom: 0.5rem;
 }
+/* #201e-2: section header that hosts an inline action button (e.g.
+   "Groups" + "+ New group"). The h3 keeps its bottom margin removed
+   so the row aligns; the button sits flush to the right. */
+.admin-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+}
+.admin-section-header .admin-section-title {
+  margin-bottom: 0;
+}
+.admin-section-header button {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0.3rem 0.65rem;
+  color: #e6edf3;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.admin-section-header button:hover {
+  background: #30363d;
+}
 .admin-session-row {
   display: flex;
   align-items: center;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3969,6 +3969,15 @@ adminGroupAddMemberForm.addEventListener("submit", async (e) => {
 	}
 	if (membersGroupId === null) return;
 	const groupId = membersGroupId;
+	// Disable the submit button across the in-flight window so a
+	// double-click or fast second Enter doesn't fire a duplicate
+	// POST. The backend's composite PK on (group_id, user_id) would
+	// 409 the second call (caught + toasted), but keeping the noise
+	// out is cheaper than handling it. Same shape as
+	// `adminGroupSubmitBtn.disabled` on the create/edit handler.
+	const submitBtn =
+		adminGroupAddMemberForm.querySelector<HTMLButtonElement>("button[type='submit']");
+	if (submitBtn) submitBtn.disabled = true;
 	try {
 		await addAdminGroupMember(groupId, userId);
 		showToast("Member added");
@@ -3984,6 +3993,8 @@ adminGroupAddMemberForm.addEventListener("submit", async (e) => {
 		await refreshAdmin();
 	} catch (err) {
 		showToast((err as Error).message, true);
+	} finally {
+		if (submitBtn) submitBtn.disabled = false;
 	}
 });
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,23 +11,33 @@
 import "./main.css";
 
 import {
+	type AdminGroupDetail,
+	type AdminGroupSummary,
+	type AdminObserveLogEntry,
 	type AdminSession,
 	type AdminStats,
+	addAdminGroupMember,
 	adminForceDelete,
 	adminForceStop,
 	checkAuthStatus,
+	createAdminGroup,
 	createInvite,
 	createSession,
 	createTab,
 	createTemplate,
+	deleteAdminGroup,
 	deleteSession,
 	deleteTab,
 	deleteTemplate,
 	type EnvVarEntryInput,
+	fetchAdminGroup,
+	fetchAdminGroups,
+	fetchAdminObserveLog,
 	fetchAdminSessions,
 	fetchAdminStats,
 	fetchMyGroups,
 	fetchMyObservableSessions,
+	fetchSessionObserveLog,
 	getTemplate,
 	type Invite,
 	InviteRequiredError,
@@ -44,8 +54,10 @@ import {
 	logout,
 	memBytesToFormUnit,
 	type ObservableSession,
+	type ObserveLogEntry,
 	openBootstrapWs,
 	register,
+	removeAdminGroupMember,
 	revokeInvite,
 	SESSION_EXPIRED_EVENT,
 	type SessionConfigPayload,
@@ -57,6 +69,7 @@ import {
 	TabNotFoundError,
 	type Template,
 	type TemplateSummary,
+	updateAdminGroup,
 	updateTemplate,
 	uploadSessionFiles,
 } from "./api.js";
@@ -110,6 +123,39 @@ const adminStatsEl = document.getElementById("admin-stats")!;
 const adminSessionsListEl = document.getElementById("admin-sessions-list")!;
 const adminRefreshBtn = document.getElementById("admin-refresh-btn") as HTMLButtonElement;
 const adminUptimeEl = document.getElementById("admin-uptime")!;
+// #201e-2 — admin Groups CRUD (in admin dashboard) + admin observe-log
+// + per-session Observers button. Visibility for the Groups + observe-log
+// sections is the parent admin modal (admin-only). Observers button is
+// shown for everyone; the backend returns 403 if the caller can't
+// observe the session.
+const adminGroupsListEl = document.getElementById("admin-groups-list")!;
+const adminGroupCreateBtn = document.getElementById("admin-group-create-btn") as HTMLButtonElement;
+const adminObserveLogEl = document.getElementById("admin-observe-log")!;
+const adminGroupModal = document.getElementById("admin-group-modal")!;
+const adminGroupModalTitle = document.getElementById("admin-group-modal-title")!;
+const adminGroupForm = document.getElementById("admin-group-form") as HTMLFormElement;
+const adminGroupNameInput = document.getElementById("admin-group-name") as HTMLInputElement;
+const adminGroupDescriptionInput = document.getElementById(
+	"admin-group-description",
+) as HTMLInputElement;
+const adminGroupLeadUserIdInput = document.getElementById(
+	"admin-group-lead-user-id",
+) as HTMLInputElement;
+const adminGroupSubmitBtn = document.getElementById("admin-group-submit-btn") as HTMLButtonElement;
+const adminGroupMembersModal = document.getElementById("admin-group-members-modal")!;
+const adminGroupMembersModalTitle = document.getElementById("admin-group-members-modal-title")!;
+const adminGroupMembersModalHint = document.getElementById("admin-group-members-modal-hint")!;
+const adminGroupAddMemberForm = document.getElementById(
+	"admin-group-add-member-form",
+) as HTMLFormElement;
+const adminGroupAddMemberInput = document.getElementById(
+	"admin-group-add-member-input",
+) as HTMLInputElement;
+const adminGroupMembersListEl = document.getElementById("admin-group-members-list")!;
+const observersBtn = document.getElementById("observers-btn") as HTMLButtonElement;
+const observersModal = document.getElementById("observers-modal")!;
+const observersModalListEl = document.getElementById("observers-modal-list")!;
+
 // #201e — lead-side "My groups" surface. Visibility flips on isLead()
 // from the api-layer mirror. Sidebar + header buttons are gated together
 // (same shape as the Admin pair above).
@@ -2724,7 +2770,12 @@ document.addEventListener("keydown", (e) => {
 		// would close the sidebar drawer instead of dismissing
 		// the dialog.
 		myGroupsModal.classList.contains("open") ||
-		observeModal.classList.contains("open")
+		observeModal.classList.contains("open") ||
+		// #201e-2 — admin Group dialogs + per-session Observers
+		// modal need the same guard.
+		adminGroupModal.classList.contains("open") ||
+		adminGroupMembersModal.classList.contains("open") ||
+		observersModal.classList.contains("open")
 	)
 		return;
 	if (!mainEl.classList.contains("sidebar-open")) return;
@@ -3065,6 +3116,19 @@ document.addEventListener("keydown", (e) => {
 		closeObserveModal();
 	} else if (myGroupsModal.classList.contains("open")) {
 		closeMyGroupsModal();
+	} else if (adminGroupMembersModal.classList.contains("open")) {
+		// #201e-2 — admin Groups dialogs open ON TOP of the parent
+		// admin dashboard. Same topmost-first ordering as
+		// observeModal above: members management nested-dialog →
+		// create/edit nested-dialog → admin parent → other modals.
+		closeAdminGroupMembersModal();
+	} else if (adminGroupModal.classList.contains("open")) {
+		closeAdminGroupModal();
+	} else if (observersModal.classList.contains("open")) {
+		// #201e-2 — Observers modal is opened from the per-session
+		// toolbar, not from inside another dialog, so it slots
+		// alongside the other top-level modals (admin/invites/etc).
+		closeObserversModal();
 	} else if (newSessionModal.classList.contains("open")) {
 		closeNewSessionModal();
 	} else if (templatesModal.classList.contains("open")) {
@@ -3452,19 +3516,28 @@ adminRefreshBtn.addEventListener("click", () => {
 });
 
 async function refreshAdmin(): Promise<void> {
-	// Fetch both endpoints in parallel — they're independent reads
-	// gated by the same admin token, and a sequential await would
-	// double the dashboard latency without any safety upside.
+	// Fetch all four endpoints in parallel — independent reads gated
+	// by the same admin token. Sequential awaits would multiply the
+	// dashboard latency without any safety upside. `Promise.allSettled`
+	// rather than `all` so a transient on one endpoint doesn't wipe
+	// the other three panels — each section renders or shows its own
+	// per-section error.
 	adminRefreshBtn.disabled = true;
 	try {
-		const [stats, sessions] = await Promise.all([fetchAdminStats(), fetchAdminSessions()]);
-		renderAdminStats(stats);
-		renderAdminSessions(sessions);
-	} catch (err) {
-		// Per-endpoint failure surfaces via the toast; the panels keep
-		// their previous state rather than wiping to a half-rendered
-		// shell.
-		showToast((err as Error).message, true);
+		const [statsR, sessionsR, groupsR, observeLogR] = await Promise.allSettled([
+			fetchAdminStats(),
+			fetchAdminSessions(),
+			fetchAdminGroups(),
+			fetchAdminObserveLog(),
+		]);
+		if (statsR.status === "fulfilled") renderAdminStats(statsR.value);
+		else showToast(`Stats: ${statsR.reason.message}`, true);
+		if (sessionsR.status === "fulfilled") renderAdminSessions(sessionsR.value);
+		else showToast(`Sessions: ${sessionsR.reason.message}`, true);
+		if (groupsR.status === "fulfilled") renderAdminGroups(groupsR.value);
+		else showToast(`Groups: ${groupsR.reason.message}`, true);
+		if (observeLogR.status === "fulfilled") renderAdminObserveLog(observeLogR.value);
+		else showToast(`Observe log: ${observeLogR.reason.message}`, true);
 	} finally {
 		adminRefreshBtn.disabled = false;
 	}
@@ -3652,6 +3725,367 @@ async function confirmAndAct(
 		btn.disabled = false;
 	}
 }
+
+// ── Admin Groups CRUD (#201e-2) ────────────────────────────────────────────
+//
+// New section in the admin dashboard. List + create + edit + delete
+// + add/remove members. Backend routes are gated by `requireAdmin`;
+// these handlers run only inside the admin modal which is itself
+// admin-gated. The create/edit dialog (`adminGroupModal`) and the
+// members-management dialog (`adminGroupMembersModal`) open ON TOP
+// of the admin dashboard — same nested-dialog pattern the
+// save-template dialog uses on top of the new-session modal.
+
+let editingGroupId: string | null = null;
+let membersGroupId: string | null = null;
+
+function renderAdminGroups(groups: AdminGroupSummary[]): void {
+	adminGroupsListEl.textContent = "";
+	if (groups.length === 0) {
+		const empty = document.createElement("p");
+		empty.className = "modal-hint";
+		empty.textContent = "No groups yet — create one with + New group.";
+		adminGroupsListEl.appendChild(empty);
+		return;
+	}
+	for (const g of groups) {
+		const row = document.createElement("div");
+		row.className = "admin-session-row";
+
+		const meta = document.createElement("div");
+		meta.className = "admin-session-meta";
+		const name = document.createElement("strong");
+		name.textContent = g.description ? `${g.name} — ${g.description}` : g.name;
+		const sub = document.createElement("span");
+		sub.className = "admin-session-sub";
+		sub.textContent = `lead: ${g.leadUsername} · ${g.memberCount} member${g.memberCount === 1 ? "" : "s"}`;
+		meta.appendChild(name);
+		meta.appendChild(sub);
+
+		const actions = document.createElement("div");
+		actions.className = "admin-session-actions";
+
+		const editBtn = document.createElement("button");
+		editBtn.type = "button";
+		editBtn.textContent = "Edit";
+		editBtn.addEventListener("click", () => {
+			void openAdminGroupModalForEdit(g);
+		});
+
+		const membersBtn = document.createElement("button");
+		membersBtn.type = "button";
+		membersBtn.textContent = "Members";
+		membersBtn.addEventListener("click", () => {
+			void openAdminGroupMembersModal(g);
+		});
+
+		const deleteBtn = document.createElement("button");
+		deleteBtn.type = "button";
+		deleteBtn.textContent = "Delete";
+		deleteBtn.className = "admin-session-delete";
+		deleteBtn.addEventListener("click", () =>
+			confirmAndAct(
+				`Delete group "${g.name}"?\n\nMembership rows cascade automatically. The lead user is NOT deleted.`,
+				deleteBtn,
+				async () => {
+					await deleteAdminGroup(g.id);
+					showToast(`Deleted ${g.name}`);
+				},
+			),
+		);
+
+		actions.appendChild(editBtn);
+		actions.appendChild(membersBtn);
+		actions.appendChild(deleteBtn);
+		row.appendChild(meta);
+		row.appendChild(actions);
+		adminGroupsListEl.appendChild(row);
+	}
+}
+
+function openAdminGroupModalForCreate(): void {
+	editingGroupId = null;
+	adminGroupModalTitle.textContent = "New group";
+	adminGroupNameInput.value = "";
+	adminGroupDescriptionInput.value = "";
+	adminGroupLeadUserIdInput.value = "";
+	adminGroupSubmitBtn.textContent = "Create";
+	adminGroupModal.classList.add("open");
+	adminGroupModal.setAttribute("aria-hidden", "false");
+	adminGroupNameInput.focus();
+}
+
+function openAdminGroupModalForEdit(g: AdminGroupSummary): void {
+	editingGroupId = g.id;
+	adminGroupModalTitle.textContent = `Edit group "${g.name}"`;
+	adminGroupNameInput.value = g.name;
+	adminGroupDescriptionInput.value = g.description ?? "";
+	adminGroupLeadUserIdInput.value = g.leadUserId;
+	adminGroupSubmitBtn.textContent = "Save";
+	adminGroupModal.classList.add("open");
+	adminGroupModal.setAttribute("aria-hidden", "false");
+	adminGroupNameInput.focus();
+}
+
+function closeAdminGroupModal(): void {
+	adminGroupModal.classList.remove("open");
+	adminGroupModal.setAttribute("aria-hidden", "true");
+	editingGroupId = null;
+}
+
+adminGroupModal.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeAdminGroupModal();
+});
+
+adminGroupCreateBtn.addEventListener("click", () => openAdminGroupModalForCreate());
+
+adminGroupForm.addEventListener("submit", async (e) => {
+	e.preventDefault();
+	const name = adminGroupNameInput.value.trim();
+	const description = adminGroupDescriptionInput.value.trim() || null;
+	const leadUserId = adminGroupLeadUserIdInput.value.trim();
+	if (!name) {
+		showToast("Name is required", true);
+		return;
+	}
+	if (!leadUserId) {
+		showToast("Lead user id is required", true);
+		return;
+	}
+	adminGroupSubmitBtn.disabled = true;
+	try {
+		if (editingGroupId === null) {
+			await createAdminGroup({ name, description, leadUserId });
+			showToast(`Created group "${name}"`);
+		} else {
+			await updateAdminGroup(editingGroupId, { name, description, leadUserId });
+			showToast(`Saved group "${name}"`);
+		}
+		closeAdminGroupModal();
+		await refreshAdmin();
+	} catch (err) {
+		showToast((err as Error).message, true);
+	} finally {
+		adminGroupSubmitBtn.disabled = false;
+	}
+});
+
+async function openAdminGroupMembersModal(g: AdminGroupSummary): Promise<void> {
+	membersGroupId = g.id;
+	adminGroupMembersModalTitle.textContent = `Members of "${g.name}"`;
+	adminGroupMembersModalHint.textContent = `Lead is "${g.leadUsername}" — cannot be removed (reassign via Edit first).`;
+	adminGroupAddMemberInput.value = "";
+	adminGroupMembersListEl.textContent = "";
+	const loading = document.createElement("p");
+	loading.className = "modal-hint";
+	loading.textContent = "Loading members…";
+	adminGroupMembersListEl.appendChild(loading);
+	adminGroupMembersModal.classList.add("open");
+	adminGroupMembersModal.setAttribute("aria-hidden", "false");
+	adminGroupAddMemberInput.focus();
+	await refreshAdminGroupMembers(g.id, g.leadUserId);
+}
+
+function closeAdminGroupMembersModal(): void {
+	adminGroupMembersModal.classList.remove("open");
+	adminGroupMembersModal.setAttribute("aria-hidden", "true");
+	membersGroupId = null;
+}
+
+adminGroupMembersModal.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeAdminGroupMembersModal();
+});
+
+async function refreshAdminGroupMembers(groupId: string, leadUserId: string): Promise<void> {
+	let detail: AdminGroupDetail;
+	try {
+		detail = await fetchAdminGroup(groupId);
+	} catch (err) {
+		showToast((err as Error).message, true);
+		return;
+	}
+	adminGroupMembersListEl.textContent = "";
+	if (detail.members.length === 0) {
+		const empty = document.createElement("p");
+		empty.className = "modal-hint";
+		empty.textContent = "No members.";
+		adminGroupMembersListEl.appendChild(empty);
+		return;
+	}
+	for (const m of detail.members) {
+		const row = document.createElement("div");
+		row.className = "admin-session-row";
+		const meta = document.createElement("div");
+		meta.className = "admin-session-meta";
+		const name = document.createElement("strong");
+		name.textContent = m.username;
+		meta.appendChild(name);
+		const sub = document.createElement("span");
+		sub.className = "admin-session-sub";
+		sub.textContent =
+			m.userId === leadUserId
+				? `lead · added ${new Date(m.addedAt).toLocaleString()}`
+				: `added ${new Date(m.addedAt).toLocaleString()}`;
+		meta.appendChild(sub);
+		row.appendChild(meta);
+
+		const actions = document.createElement("div");
+		actions.className = "admin-session-actions";
+		const removeBtn = document.createElement("button");
+		removeBtn.type = "button";
+		removeBtn.textContent = "Remove";
+		removeBtn.className = "admin-session-delete";
+		// Lead can't be removed without reassignment — disable the
+		// button rather than letting the click 409 from the backend.
+		// Same shape as `Stop` being disabled on a non-running session.
+		removeBtn.disabled = m.userId === leadUserId;
+		removeBtn.addEventListener("click", async () => {
+			if (!confirm(`Remove ${m.username} from this group?`)) return;
+			removeBtn.disabled = true;
+			try {
+				await removeAdminGroupMember(groupId, m.userId);
+				showToast(`Removed ${m.username}`);
+				await refreshAdminGroupMembers(groupId, leadUserId);
+				await refreshAdmin();
+			} catch (err) {
+				showToast((err as Error).message, true);
+				removeBtn.disabled = false;
+			}
+		});
+		actions.appendChild(removeBtn);
+		row.appendChild(actions);
+		adminGroupMembersListEl.appendChild(row);
+	}
+}
+
+adminGroupAddMemberForm.addEventListener("submit", async (e) => {
+	e.preventDefault();
+	const userId = adminGroupAddMemberInput.value.trim();
+	if (!userId) {
+		showToast("User id is required", true);
+		return;
+	}
+	if (membersGroupId === null) return;
+	const groupId = membersGroupId;
+	try {
+		await addAdminGroupMember(groupId, userId);
+		showToast("Member added");
+		adminGroupAddMemberInput.value = "";
+		// Refresh the members list — re-fetch the current group's
+		// detail to render the new row, and refresh the parent admin
+		// dashboard so the member-count chip on the row updates.
+		// `editingGroupId` is for the create/edit modal; this path
+		// keeps `membersGroupId` intact so subsequent operations on
+		// the same dialog still target the right group.
+		const meta = await fetchAdminGroup(groupId);
+		await refreshAdminGroupMembers(groupId, meta.leadUserId);
+		await refreshAdmin();
+	} catch (err) {
+		showToast((err as Error).message, true);
+	}
+});
+
+// ── Admin observe-log (#201e-2) ────────────────────────────────────────────
+
+function renderAdminObserveLog(entries: AdminObserveLogEntry[]): void {
+	adminObserveLogEl.textContent = "";
+	if (entries.length === 0) {
+		const empty = document.createElement("p");
+		empty.className = "modal-hint";
+		empty.textContent = "No observe events yet.";
+		adminObserveLogEl.appendChild(empty);
+		return;
+	}
+	for (const e of entries) {
+		const row = document.createElement("div");
+		row.className = "admin-session-row";
+		const meta = document.createElement("div");
+		meta.className = "admin-session-meta";
+		const name = document.createElement("strong");
+		name.textContent = `${e.observerUsername} → ${e.ownerUsername}`;
+		const sub = document.createElement("span");
+		sub.className = "admin-session-sub";
+		const started = new Date(e.startedAt).toLocaleString();
+		const ended = e.endedAt ? new Date(e.endedAt).toLocaleString() : "still watching";
+		sub.textContent = `session ${e.sessionId.slice(0, 8)}… · ${started} → ${ended}`;
+		meta.appendChild(name);
+		meta.appendChild(sub);
+		row.appendChild(meta);
+		adminObserveLogEl.appendChild(row);
+	}
+}
+
+// ── Per-session Observers button (#201e-2) ─────────────────────────────────
+// Surfaces the per-session observe history. Owner / admin / lead-of-
+// group-containing-owner can read; the backend `assertCanObserve`
+// gate handles auth and surfaces the right 403/404 to the toast on
+// fail. The button is shown for every authenticated user — gating it
+// on isLead/isAdmin would hide it from owners, who are the primary
+// audience ("who has been watching me?"). A non-authorised viewer
+// just sees a toast.
+
+function openObserversModal(): void {
+	if (!activeSessionId) return;
+	const sessionId = activeSessionId;
+	observersModalListEl.textContent = "";
+	const loading = document.createElement("p");
+	loading.className = "modal-hint";
+	loading.textContent = "Loading…";
+	observersModalListEl.appendChild(loading);
+	observersModal.classList.add("open");
+	observersModal.setAttribute("aria-hidden", "false");
+	void refreshObserversModal(sessionId);
+}
+
+function closeObserversModal(): void {
+	observersModal.classList.remove("open");
+	observersModal.setAttribute("aria-hidden", "true");
+}
+
+async function refreshObserversModal(sessionId: string): Promise<void> {
+	let entries: ObserveLogEntry[];
+	try {
+		entries = await fetchSessionObserveLog(sessionId);
+	} catch (err) {
+		showToast((err as Error).message, true);
+		closeObserversModal();
+		return;
+	}
+	observersModalListEl.textContent = "";
+	if (entries.length === 0) {
+		const empty = document.createElement("p");
+		empty.className = "modal-hint";
+		empty.textContent = "No observers yet.";
+		observersModalListEl.appendChild(empty);
+		return;
+	}
+	for (const e of entries) {
+		const row = document.createElement("div");
+		row.className = "admin-session-row";
+		const meta = document.createElement("div");
+		meta.className = "admin-session-meta";
+		const name = document.createElement("strong");
+		name.textContent = e.observerUsername;
+		const sub = document.createElement("span");
+		sub.className = "admin-session-sub";
+		const started = new Date(e.startedAt).toLocaleString();
+		const ended = e.endedAt ? new Date(e.endedAt).toLocaleString() : "still watching";
+		sub.textContent = `${started} → ${ended}`;
+		meta.appendChild(name);
+		meta.appendChild(sub);
+		row.appendChild(meta);
+		observersModalListEl.appendChild(row);
+	}
+}
+
+observersModal.addEventListener("click", (e) => {
+	const target = e.target as HTMLElement;
+	if (target.hasAttribute("data-close-modal")) closeObserversModal();
+});
+
+observersBtn.addEventListener("click", () => openObserversModal());
 
 // ── My groups (#201e — lead-side observe surface) ──────────────────────────
 //


### PR DESCRIPTION
## Summary

Final slice of the tech-lead role from #201. Wires three operator-facing surfaces against existing backend routes — **no backend changes in this PR.**

### Admin Groups CRUD

New section in the admin dashboard (admin-modal). Lists every group with lead username + member count. Per-row actions:

- **Edit** — opens `admin-group-modal` with name / description / leadUserId pre-filled, submits PUT `/api/admin/groups/:id`.
- **Members** — opens `admin-group-members-modal` with the current member list. Per-row Remove (disabled for the lead) + add-by-user-id form. Refreshes both the modal and the parent Groups list on success so the member count chip stays current.
- **Delete** — `confirmAndAct` cascade-aware delete.

The `+ New group` header button opens the same `admin-group-modal` in create mode (POST `/api/admin/groups`). The modal is nested ON TOP of the admin dashboard — same shape as save-template's nesting on top of the new-session modal.

Both group dialogs participate in the Escape cascade (topmost first: members → edit → admin parent) and the mobile-drawer guard.

### Admin observe-log

Read-only cross-user view of the audit trail from #201d. New section in the admin dashboard. Each row: observer username → owner username, session id (truncated to 8 chars), started timestamp → ended timestamp (or "still watching" for in-progress observers). Hard-capped at 500 server-side; older entries silently dropped if the deployment ever hits that.

### Per-session Observers

Owner / admin / lead can read a session's observe history. New "Observers" button in the terminal toolbar — shown for everyone (owners are the primary audience: "who's watched my session?"). Backend returns 403 on unauthorised callers; frontend surfaces a toast and dismisses the modal cleanly. Same row shape as the admin log minus the owner-side column (per-session view = single owner).

### `refreshAdmin` parallelism

Switched the dashboard refresh from `Promise.all` to `Promise.allSettled` so a transient on one endpoint doesn't blank the other three sections — each renders or shows its own per-section toast. Sessions, Stats, Groups, and Observe log all fire in parallel for the same wall-clock latency the original two-endpoint shape had.

### `api.ts` additions

Wrappers around the existing 201a/201d backend routes: `fetchAdminGroups`, `fetchAdminGroup`, `createAdminGroup`, `updateAdminGroup`, `deleteAdminGroup`, `addAdminGroupMember`, `removeAdminGroupMember`, `fetchSessionObserveLog`, `fetchAdminObserveLog`. Types mirror the backend serializer shapes; date columns stay as ISO strings (parsed only when a Date is needed at render time).

## Test plan

- [x] backend: tsc + biome + vitest 780/780 (no backend changes; re-ran to confirm)
- [x] frontend: tsc + biome + vitest 61/61 (no new tests; the CRUD + log views are DOM-imperative consumers of routes already covered by backend tests, same coverage shape as the admin Sessions panel from 201d)
- [ ] **UI smoke not possible from this environment.** Recommend manual browser pass before merge:
    - As admin: open Admin → Groups, create / rename / reassign-lead / delete a group; open Members, add/remove a non-lead user; verify Remove is disabled on the lead; verify the Observe log section populates after a lead opens an observe attach.
    - As any user: click Observers on the toolbar. As owner / lead / admin → see entries. As an unrelated user → see toast + dismiss.

## What this closes

This is the last slice of the 6-PR plan for #201 (the original 5-PR plan was extended to 6 when 201e was split into lead UX [#267 — 201e-1] and admin/observe-log UI [this PR — 201e-2]). All locked-in design decisions from the issue have shipped:

- groups schema + admin CRUD (201a, #262)
- `assertCanObserve` auth helpers (201b, #263)
- lead-side reads (201c, #265)
- WS observe-mode + audit log (201d, #266)
- frontend lead UX (201e-1, #267)
- admin Groups CRUD + observe-log views (this PR — 201e-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)