### PR TITLE
feat(ops): operator-tunable per-session resource caps (#200)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,35 @@ WORKSPACE_ROOT=/var/shared-terminal/workspaces
 # disk slice you're willing to allocate per user.
 # UPLOAD_QUOTA_BYTES=1073741824
 
+# ── Per-session resource caps (#200) ─────────────────────────────────────────
+# Operator-tunable upper bounds on per-session CPU and memory. Defaults
+# are the v1 ceilings (8 cores / 16 GiB). Both env vars can only LOWER
+# the cap — values above the ceiling are clamped (and warned) at boot,
+# so a deployment that needs MORE than the v1 limits requires a code
+# change to raise the ceilings themselves. The per-session floor is
+# 0.25 cores / 256 MiB; setting a cap below the floor falls back to the
+# default with a warn (every session-create would otherwise 400).
+#
+# Units: MAX_SESSION_CPU is in cores (decimal accepted: 4, 4.5, 0.25).
+#        MAX_SESSION_MEM is in MiB (integer: 4096 = 4 GiB).
+#
+# Effect: rejects POST /api/sessions whose body.config.cpuLimit /
+# memLimit exceed the cap with a 400 naming the env var, AND clamps
+# the spawn defaults (2c / 2 GiB) when the operator caps below them
+# so a session created without explicit limits still respects the
+# cap (otherwise the docker run command would silently spawn above
+# the cap).
+#
+# Already-running containers are NOT affected. Docker cgroup limits
+# are written at `docker run` — a lowered cap only gates future
+# create requests, not the containers spawned before the change.
+#
+# Parsed at startup. Malformed / non-positive / non-finite values
+# fall back to the default with a warn so a typo doesn't gate the
+# server on a non-critical config issue.
+# MAX_SESSION_CPU=8
+# MAX_SESSION_MEM=16384
+
 # ── Port exposure dispatcher (#190) ──────────────────────────────────────────
 # Base domain for the per-session-port reverse proxy. Hosts of the form
 # `p<container>-<sessionId>.<PORT_PROXY_BASE_DOMAIN>` are diverted from

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -22,6 +22,8 @@ import {
 } from "./portMappings.js";
 import {
 	decryptStoredEntries,
+	EFFECTIVE_CPU_NANO_MAX,
+	EFFECTIVE_MEM_BYTES_MAX,
 	getSessionConfig,
 	type SessionConfigRecord,
 } from "./sessionConfig.js";
@@ -36,8 +38,16 @@ const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT ?? "/var/shared-terminal/works
 // override per session by writing `cpu_limit` / `mem_limit` on the
 // session_configs row. Hardcoding the floor here so a missing config
 // row doesn't change behaviour from today's deployment.
-const DEFAULT_MEMORY_BYTES = 2 * 1024 * 1024 * 1024;
-const DEFAULT_NANO_CPUS = 2_000_000_000;
+//
+// #200: when the operator lowered the per-session cap below the spawn
+// default (e.g. MAX_SESSION_CPU=1 with a 2-core default), the default
+// would otherwise exceed the cap and silently bypass it on every
+// session created without an explicit cpuLimit / memLimit. Clamp at
+// module load against EFFECTIVE_*_MAX so the default is always
+// per-session-cap-compliant. Math.min — never raise the default
+// against the cap, only lower it.
+const DEFAULT_MEMORY_BYTES = Math.min(2 * 1024 * 1024 * 1024, EFFECTIVE_MEM_BYTES_MAX);
+const DEFAULT_NANO_CPUS = Math.min(2_000_000_000, EFFECTIVE_CPU_NANO_MAX);
 
 // Owner applied to freshly-created workspace directories. Must match the
 // `developer` user inside session-image/Dockerfile (uid/gid 1000 by default).

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -44,6 +44,8 @@ import {
 	UsernameRateLimiter,
 } from "./rateLimit.js";
 import {
+	EFFECTIVE_CPU_NANO_MAX,
+	EFFECTIVE_MEM_BYTES_MAX,
 	encryptAuthCredentials,
 	encryptSecretEntries,
 	isEmptyConfig,
@@ -156,7 +158,20 @@ export function buildRouter(
 		]);
 		const isAdmin = adminLookup?.results[0]?.is_admin === 1;
 		const isLead = leadLookup === true;
-		res.json({ needsSetup: !anyUsers, authenticated, isAdmin, isLead });
+		// #200: surface the effective per-session resource caps so the
+		// frontend's create-session form can advertise the operator-
+		// lowered max instead of the hardcoded v1 ceiling. Without
+		// this, a user on a deployment with MAX_SESSION_CPU=4 still
+		// sees "8 cores" in the hint and an input that accepts 6,
+		// then gets a 400 from the backend with a message that names
+		// an env var they have no power to read. Computed from the
+		// module-load values in sessionConfig.ts so the wire shape
+		// matches the form's units (cores + MiB) one-to-one.
+		const resourceCaps = {
+			cpuMaxCores: EFFECTIVE_CPU_NANO_MAX / 1_000_000_000,
+			memMaxMiB: EFFECTIVE_MEM_BYTES_MAX / (1024 * 1024),
+		};
+		res.json({ needsSetup: !anyUsers, authenticated, isAdmin, isLead, resourceCaps });
 	});
 
 	router.post("/auth/register", registerIp, async (req: Request, res: Response) => {

--- a/backend/src/sessionConfig.resourceCaps.test.ts
+++ b/backend/src/sessionConfig.resourceCaps.test.ts
@@ -1,0 +1,166 @@
+// #200 — operator-tunable resource-cap env vars (MAX_SESSION_CPU /
+// MAX_SESSION_MEM). Covers the parse helpers' defaulting, clamping,
+// floor / ceiling enforcement, and the warn-on-bad-input behavior.
+// The schema-side rejection (Zod max with the env-var-named message)
+// is covered against the live module-load values rather than via
+// resetModules: tests pin the effective max by reading what
+// parseMaxSessionCpu/Mem return for the same env value, so the
+// assertions don't get fragile if the v1 ceiling ever changes.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "./logger.js";
+import { parseMaxSessionCpu, parseMaxSessionMem } from "./sessionConfig.js";
+
+describe("parseMaxSessionCpu (#200)", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+	});
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	it("defaults to 8 cores (v1 ceiling) when unset", () => {
+		expect(parseMaxSessionCpu(undefined)).toBe(8_000_000_000);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("defaults to 8 cores when whitespace-only", () => {
+		expect(parseMaxSessionCpu("   ")).toBe(8_000_000_000);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("accepts an integer-core lower override", () => {
+		expect(parseMaxSessionCpu("4")).toBe(4_000_000_000);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("accepts a fractional-core lower override (form parity)", () => {
+		expect(parseMaxSessionCpu("0.5")).toBe(500_000_000);
+		expect(parseMaxSessionCpu("2.5")).toBe(2_500_000_000);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("clamps to the v1 ceiling and warns when above 8 cores (env can only LOWER)", () => {
+		expect(parseMaxSessionCpu("16")).toBe(8_000_000_000);
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/exceeds the v1 ceiling/);
+	});
+
+	it("falls back to default and warns when below the per-session floor (0.25 cores)", () => {
+		expect(parseMaxSessionCpu("0.1")).toBe(8_000_000_000);
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/below the per-session floor/);
+	});
+
+	it("accepts the floor value exactly", () => {
+		expect(parseMaxSessionCpu("0.25")).toBe(250_000_000);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("falls back to default and warns on non-numeric input", () => {
+		expect(parseMaxSessionCpu("two")).toBe(8_000_000_000);
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/is not a positive number/);
+	});
+
+	it("falls back to default and warns on zero", () => {
+		expect(parseMaxSessionCpu("0")).toBe(8_000_000_000);
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+
+	it("falls back to default and warns on negative input", () => {
+		expect(parseMaxSessionCpu("-2")).toBe(8_000_000_000);
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+});
+
+describe("parseMaxSessionMem (#200)", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+	});
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	it("defaults to 16 GiB (v1 ceiling) when unset", () => {
+		expect(parseMaxSessionMem(undefined)).toBe(16 * 1024 * 1024 * 1024);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("accepts a MiB integer lower override", () => {
+		expect(parseMaxSessionMem("4096")).toBe(4 * 1024 * 1024 * 1024);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("accepts the 256-MiB floor exactly", () => {
+		expect(parseMaxSessionMem("256")).toBe(256 * 1024 * 1024);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("clamps to the v1 ceiling and warns when above 16 GiB", () => {
+		// 32 GiB in MiB
+		expect(parseMaxSessionMem("32768")).toBe(16 * 1024 * 1024 * 1024);
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/exceeds the v1 ceiling/);
+	});
+
+	it("falls back to default and warns when below the 256-MiB floor", () => {
+		expect(parseMaxSessionMem("128")).toBe(16 * 1024 * 1024 * 1024);
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/below the per-session floor/);
+	});
+
+	it("falls back to default and warns on a fractional value (MiB is integer-only)", () => {
+		expect(parseMaxSessionMem("1024.5")).toBe(16 * 1024 * 1024 * 1024);
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/is not a positive integer/);
+	});
+
+	it("falls back to default and warns on non-numeric input", () => {
+		expect(parseMaxSessionMem("lots")).toBe(16 * 1024 * 1024 * 1024);
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+
+	it("falls back to default and warns on zero / negative input", () => {
+		expect(parseMaxSessionMem("0")).toBe(16 * 1024 * 1024 * 1024);
+		expect(parseMaxSessionMem("-1024")).toBe(16 * 1024 * 1024 * 1024);
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ── Schema integration — verifies the Zod cpuLimit / memLimit max ─────────
+// references the live module-load value (not a stale ceiling) and that the
+// custom error message names the env var so an operator who lowered the
+// cap can point users at it.
+
+describe("SessionConfigSchema resource-cap integration (#200)", () => {
+	it("the live module-load CPU cap matches the floor when env is unset", async () => {
+		// Sanity: in the test environment MAX_SESSION_CPU is unset, so
+		// the effective cap is the v1 ceiling.
+		const { SessionConfigSchema } = await import("./sessionConfig.js");
+		const above = SessionConfigSchema.safeParse({ cpuLimit: 8_000_000_001 });
+		expect(above.success).toBe(false);
+		if (!above.success) {
+			const msg = above.error.issues[0]?.message ?? "";
+			expect(msg).toMatch(/cpuLimit exceeds the per-session cap/);
+			expect(msg).toMatch(/MAX_SESSION_CPU/);
+		}
+		const at = SessionConfigSchema.safeParse({ cpuLimit: 8_000_000_000 });
+		expect(at.success).toBe(true);
+	});
+
+	it("the live module-load memory cap rejects above 16 GiB with the env-var-named message", async () => {
+		const { SessionConfigSchema } = await import("./sessionConfig.js");
+		const above = SessionConfigSchema.safeParse({ memLimit: 16 * 1024 * 1024 * 1024 + 1 });
+		expect(above.success).toBe(false);
+		if (!above.success) {
+			const msg = above.error.issues[0]?.message ?? "";
+			expect(msg).toMatch(/memLimit exceeds the per-session cap/);
+			expect(msg).toMatch(/MAX_SESSION_MEM/);
+		}
+	});
+});

--- a/backend/src/sessionConfig.resourceCaps.test.ts
+++ b/backend/src/sessionConfig.resourceCaps.test.ts
@@ -138,9 +138,10 @@ describe("parseMaxSessionMem (#200)", () => {
 // cap can point users at it.
 
 describe("SessionConfigSchema resource-cap integration (#200)", () => {
-	it("the live module-load CPU cap matches the floor when env is unset", async () => {
-		// Sanity: in the test environment MAX_SESSION_CPU is unset, so
-		// the effective cap is the v1 ceiling.
+	it("the live module-load CPU cap matches the v1 ceiling when env is unset", async () => {
+		// In the test environment MAX_SESSION_CPU is unset, so the
+		// effective cap is the v1 ceiling (8 cores). Above rejects,
+		// at-cap accepts.
 		const { SessionConfigSchema } = await import("./sessionConfig.js");
 		const above = SessionConfigSchema.safeParse({ cpuLimit: 8_000_000_001 });
 		expect(above.success).toBe(false);

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -25,6 +25,107 @@ import { checkEnvVarSafety, EnvVarValidationError } from "./envVarValidation.js"
 import { logger } from "./logger.js";
 import { decryptSecret, encryptSecret } from "./secrets.js";
 
+// ── Resource-cap env overrides (#200) ──────────────────────────────────────
+//
+// Operators on small hosts (a developer laptop, a 4-core VM) can shrink the
+// v1 8-core / 16-GiB ceilings via env vars; on a fat host they can't go
+// past the v1 ceilings (env-var-to-raise is out of scope per #200). The
+// constants below are the effective max used by the Zod schema; the
+// _HARD_MAX names below are the absolute v1 ceilings the env can only
+// lower. Floors stay at CPU_NANO_MIN / MEM_BYTES_MIN regardless of the
+// env override — letting the operator set a cap below the floor would
+// make every session-create return 400 with no path to fix.
+//
+// Parsed at module load. Malformed / non-positive / non-finite values
+// fall back to the hard ceiling with a warn, mirroring
+// `MAX_ACTIVE_SESSIONS_PER_USER`'s pattern in sessionManager.ts. A
+// value above the hard ceiling is also clamped (with warn) instead of
+// being honoured — env-vars-can-only-lower is the explicit policy.
+//
+// NOTE: changing these does not affect already-spawned containers.
+// Docker resource limits are written into the cgroup at `docker run`
+// (see HostConfig.NanoCpus / Memory in dockerManager.ts); a lowered
+// cap only rejects future POST /api/sessions whose `config.cpuLimit`
+// / `memLimit` exceed it.
+const CPU_NANO_HARD_MAX = 8_000_000_000; // 8 cores — v1 ceiling
+const MEM_BYTES_HARD_MAX = 16 * 1024 * 1024 * 1024; // 16 GiB — v1 ceiling
+const CPU_NANO_FLOOR = 250_000_000; // 0.25 cores
+const MEM_BYTES_FLOOR = 256 * 1024 * 1024; // 256 MiB
+
+/**
+ * Convert MAX_SESSION_CPU (in cores, decimal allowed) to nano-CPUs,
+ * clamping to the v1 hard ceiling and the per-session floor. Exported
+ * for unit testing — the production call passes
+ * `process.env.MAX_SESSION_CPU`. #200.
+ */
+export function parseMaxSessionCpu(raw: string | undefined): number {
+	if (raw === undefined || raw.trim() === "") return CPU_NANO_HARD_MAX;
+	// Cores accept decimals (0.25, 1.5) to mirror the form's UX, but
+	// the underlying nano-CPU value must end up an integer. `Number`
+	// handles both — we just need to round-trip cleanly.
+	const cores = Number(raw);
+	if (!Number.isFinite(cores) || cores <= 0) {
+		logger.warn(
+			`[sessionConfig] MAX_SESSION_CPU=${JSON.stringify(raw)} is not a positive number; ` +
+				`falling back to ${CPU_NANO_HARD_MAX / 1_000_000_000} cores`,
+		);
+		return CPU_NANO_HARD_MAX;
+	}
+	const nano = Math.round(cores * 1_000_000_000);
+	if (nano < CPU_NANO_FLOOR) {
+		logger.warn(
+			`[sessionConfig] MAX_SESSION_CPU=${cores} cores is below the per-session floor ` +
+				`(${CPU_NANO_FLOOR / 1_000_000_000} cores); falling back to ` +
+				`${CPU_NANO_HARD_MAX / 1_000_000_000} cores`,
+		);
+		return CPU_NANO_HARD_MAX;
+	}
+	if (nano > CPU_NANO_HARD_MAX) {
+		logger.warn(
+			`[sessionConfig] MAX_SESSION_CPU=${cores} cores exceeds the v1 ceiling ` +
+				`(${CPU_NANO_HARD_MAX / 1_000_000_000} cores); clamping. The env var ` +
+				`can only LOWER the cap.`,
+		);
+		return CPU_NANO_HARD_MAX;
+	}
+	return nano;
+}
+
+/** Same shape as parseMaxSessionCpu but for memory (MiB → bytes). */
+export function parseMaxSessionMem(raw: string | undefined): number {
+	if (raw === undefined || raw.trim() === "") return MEM_BYTES_HARD_MAX;
+	// MiB is integer-only (the form's lowest exposed unit is MiB; the
+	// internal floor is 256 MiB exact). Reject non-integers explicitly
+	// rather than silently truncating — `MAX_SESSION_MEM=1024.5` is
+	// almost certainly an operator typo.
+	const mib = Number(raw);
+	if (!Number.isFinite(mib) || !Number.isInteger(mib) || mib <= 0) {
+		logger.warn(
+			`[sessionConfig] MAX_SESSION_MEM=${JSON.stringify(raw)} is not a positive integer (MiB); ` +
+				`falling back to ${MEM_BYTES_HARD_MAX / (1024 * 1024 * 1024)} GiB`,
+		);
+		return MEM_BYTES_HARD_MAX;
+	}
+	const bytes = mib * 1024 * 1024;
+	if (bytes < MEM_BYTES_FLOOR) {
+		logger.warn(
+			`[sessionConfig] MAX_SESSION_MEM=${mib} MiB is below the per-session floor ` +
+				`(${MEM_BYTES_FLOOR / (1024 * 1024)} MiB); falling back to ` +
+				`${MEM_BYTES_HARD_MAX / (1024 * 1024 * 1024)} GiB`,
+		);
+		return MEM_BYTES_HARD_MAX;
+	}
+	if (bytes > MEM_BYTES_HARD_MAX) {
+		logger.warn(
+			`[sessionConfig] MAX_SESSION_MEM=${mib} MiB exceeds the v1 ceiling ` +
+				`(${MEM_BYTES_HARD_MAX / (1024 * 1024)} MiB); clamping. The env var ` +
+				`can only LOWER the cap.`,
+		);
+		return MEM_BYTES_HARD_MAX;
+	}
+	return bytes;
+}
+
 // ── Bounds (shape-level only; children tighten) ─────────────────────────────
 
 // Hook command bodies. Generous enough for a multi-line shell script
@@ -32,10 +133,13 @@ import { decryptSecret, encryptSecret } from "./secrets.js";
 // session_configs row. #191 is free to lower this when the form lands.
 const MAX_HOOK_LEN = 8 * 1024;
 // Per-session resource bounds:
-//   - CPU: 0.25 → 8 cores. Stored as nano-CPUs (Docker's HostConfig
-//     unit) to keep the wire shape integer-only and avoid the
-//     float-precision foot-gun JSON Number has at the high end.
-//   - Memory: 256 MiB → 16 GiB.
+//   - CPU: 0.25 cores (floor) → operator-tunable MAX_SESSION_CPU
+//     (default 8 cores, can only LOWER below the v1 ceiling per
+//     #200). Stored as nano-CPUs (Docker's HostConfig unit) to keep
+//     the wire shape integer-only and avoid the float-precision
+//     foot-gun JSON Number has at the high end.
+//   - Memory: 256 MiB (floor) → operator-tunable MAX_SESSION_MEM
+//     (default 16 GiB, same lower-only policy).
 //   - Idle TTL: 60 s → 24 h. OMIT the field (undefined) to disable
 //     auto-stop; `null` is NOT accepted — the schema is `.optional()`,
 //     not `.nullable()`, so sending `null` returns 400.
@@ -46,12 +150,28 @@ const MAX_HOOK_LEN = 8 * 1024;
 // resource allocation that's still a legal "user-supplied" entry,
 // keeping the schema and the spawn defaults coherent. The defaults
 // are not AT the lower bounds — the 0.25-core / 256-MiB floors are
-// 8× below them — so a future operator-override layer should not
-// anchor its caps to the defaults.
-const CPU_NANO_MIN = 250_000_000; // 0.25 cores
-const CPU_NANO_MAX = 8_000_000_000; // 8 cores
-const MEM_BYTES_MIN = 256 * 1024 * 1024; // 256 MiB
-const MEM_BYTES_MAX = 16 * 1024 * 1024 * 1024; // 16 GiB
+// 8× below them. CAVEAT: an operator setting MAX_SESSION_CPU below
+// 2 cores or MAX_SESSION_MEM below 2 GiB means the spawn defaults
+// will themselves exceed the new cap, so every session creation that
+// omits explicit limits will get DEFAULT_NANO_CPUS / Memory written
+// to its session_configs row by the route and then rejected by the
+// max here. This is the intended behavior — if an operator declares
+// "no session may exceed 1 core", the default 2-core spawn is the
+// thing they meant to cap. The route surfaces a clean 400 naming
+// the env var so the user knows to set an explicit lower limit.
+const CPU_NANO_MIN = CPU_NANO_FLOOR;
+const CPU_NANO_MAX = parseMaxSessionCpu(process.env.MAX_SESSION_CPU);
+const MEM_BYTES_MIN = MEM_BYTES_FLOOR;
+const MEM_BYTES_MAX = parseMaxSessionMem(process.env.MAX_SESSION_MEM);
+// dockerManager.ts imports these to clamp DEFAULT_NANO_CPUS /
+// DEFAULT_MEMORY_BYTES at spawn — a session created without explicit
+// caps (config.cpuLimit / memLimit undefined) must still respect the
+// operator cap. Without this, an operator setting MAX_SESSION_CPU=1
+// would still see 2-core sessions spawn whenever the user omitted
+// the field, defeating the cap. The Zod max enforces it on explicit
+// values; this export carries the same number to the spawn path.
+export const EFFECTIVE_CPU_NANO_MAX = CPU_NANO_MAX;
+export const EFFECTIVE_MEM_BYTES_MAX = MEM_BYTES_MAX;
 const IDLE_TTL_S_MIN = 60; // 1 minute
 const IDLE_TTL_S_MAX = 24 * 60 * 60; // 24 hours
 // Cap repeating sub-records so a single create can't write a multi-MB
@@ -504,9 +624,30 @@ export const SessionConfigSchema = z
 		// for `auth: "none"`. The route encrypts before persistence —
 		// plaintext is in scope only inside the request handler.
 		auth: WireAuthSpec.optional(),
-		// #194 — populated by the resources form
-		cpuLimit: z.number().int().min(CPU_NANO_MIN).max(CPU_NANO_MAX).optional(),
-		memLimit: z.number().int().min(MEM_BYTES_MIN).max(MEM_BYTES_MAX).optional(),
+		// #194 — populated by the resources form. The .max message
+		// names the env var so an operator who lowered the cap can
+		// tell the user (in the 400) where the limit comes from
+		// without having to read the issue tracker. #200.
+		cpuLimit: z
+			.number()
+			.int()
+			.min(CPU_NANO_MIN)
+			.max(CPU_NANO_MAX, {
+				message:
+					`cpuLimit exceeds the per-session cap of ${CPU_NANO_MAX / 1_000_000_000} cores ` +
+					`(operator-tunable via MAX_SESSION_CPU)`,
+			})
+			.optional(),
+		memLimit: z
+			.number()
+			.int()
+			.min(MEM_BYTES_MIN)
+			.max(MEM_BYTES_MAX, {
+				message:
+					`memLimit exceeds the per-session cap of ${MEM_BYTES_MAX / (1024 * 1024)} MiB ` +
+					`(operator-tunable via MAX_SESSION_MEM)`,
+			})
+			.optional(),
 		idleTtlSeconds: z.number().int().min(IDLE_TTL_S_MIN).max(IDLE_TTL_S_MAX).optional(),
 		// #191 — populated by the hooks form. `.min(1)` so a stored
 		// empty string can never be confused with "no hook configured":

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -150,15 +150,19 @@ const MAX_HOOK_LEN = 8 * 1024;
 // resource allocation that's still a legal "user-supplied" entry,
 // keeping the schema and the spawn defaults coherent. The defaults
 // are not AT the lower bounds — the 0.25-core / 256-MiB floors are
-// 8× below them. CAVEAT: an operator setting MAX_SESSION_CPU below
-// 2 cores or MAX_SESSION_MEM below 2 GiB means the spawn defaults
-// will themselves exceed the new cap, so every session creation that
-// omits explicit limits will get DEFAULT_NANO_CPUS / Memory written
-// to its session_configs row by the route and then rejected by the
-// max here. This is the intended behavior — if an operator declares
-// "no session may exceed 1 core", the default 2-core spawn is the
-// thing they meant to cap. The route surfaces a clean 400 naming
-// the env var so the user knows to set an explicit lower limit.
+// 8× below them.
+//
+// TWO-PATH CAP ENFORCEMENT (#200): the Zod .max() below only fires
+// on EXPLICIT cpuLimit / memLimit values — `.optional()` means an
+// omitted field passes validation cleanly, persists as
+// `cpu_limit = NULL` on the session_configs row, and reaches
+// dockerManager with `config?.cpuLimit === undefined`. The omit-
+// path is handled by `Math.min(DEFAULT_NANO_CPUS, EFFECTIVE_*_MAX)`
+// in dockerManager.ts (using the EFFECTIVE_*_MAX exports below) so
+// the spawn default never exceeds the operator cap. Removing that
+// clamping would silently allow 2-core sessions when the operator
+// has capped below 2 cores, because no 400 is returned for an
+// omitted limit. Both paths are required.
 const CPU_NANO_MIN = CPU_NANO_FLOOR;
 const CPU_NANO_MAX = parseMaxSessionCpu(process.env.MAX_SESSION_CPU);
 const MEM_BYTES_MIN = MEM_BYTES_FLOOR;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -634,7 +634,7 @@
 
             <fieldset class="advanced-section">
               <legend>Resources</legend>
-              <p class="modal-hint">
+              <p class="modal-hint" id="resources-bounds-hint">
                 Per-session limits. Empty fields fall back to the
                 deployment defaults (2 cores / 2 GiB / no auto-stop).
                 Bounds: CPU 0.25–8 cores, memory 256 MiB–16 GiB,

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -10,6 +10,7 @@ interface Api {
 	isLoggedIn: typeof import("./api.js").isLoggedIn;
 	isAdmin: typeof import("./api.js").isAdmin;
 	checkAuthStatus: typeof import("./api.js").checkAuthStatus;
+	getResourceCaps: typeof import("./api.js").getResourceCaps;
 	register: typeof import("./api.js").register;
 	login: typeof import("./api.js").login;
 	logout: typeof import("./api.js").logout;
@@ -434,5 +435,66 @@ describe("admin state mirror", () => {
 
 		expect(api.isAdmin()).toBe(false);
 		expect(api.isLoggedIn()).toBe(false);
+	});
+});
+
+// ── Resource caps mirror (#200) ─────────────────────────────────────────────
+
+describe("resource caps mirror", () => {
+	it("getResourceCaps defaults to the v1 ceilings on a fresh load", async () => {
+		const api = await loadApi();
+		expect(api.getResourceCaps()).toEqual({ cpuMaxCores: 8, memMaxMiB: 16384 });
+	});
+
+	it("checkAuthStatus mirrors the server's resourceCaps into module state", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({
+				json: {
+					needsSetup: false,
+					authenticated: true,
+					isAdmin: false,
+					resourceCaps: { cpuMaxCores: 4, memMaxMiB: 8192 },
+				},
+			}),
+		);
+		await api.checkAuthStatus();
+		expect(api.getResourceCaps()).toEqual({ cpuMaxCores: 4, memMaxMiB: 8192 });
+	});
+
+	it("checkAuthStatus falls back to v1 defaults when resourceCaps is omitted (pre-#200 backend)", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({
+				json: { needsSetup: false, authenticated: true, isAdmin: false },
+			}),
+		);
+		await api.checkAuthStatus();
+		// Same shape as a fresh load — the field omission is treated as
+		// "no signal" rather than "no cap".
+		expect(api.getResourceCaps()).toEqual({ cpuMaxCores: 8, memMaxMiB: 16384 });
+	});
+
+	it("getResourceCaps returns a fresh object so callers can't mutate state by reference", async () => {
+		const api = await loadApi();
+		const caps = api.getResourceCaps();
+		caps.cpuMaxCores = 99;
+		expect(api.getResourceCaps().cpuMaxCores).toBe(8);
+	});
+
+	it("ignores non-finite caps from a malformed response (keeps v1 defaults)", async () => {
+		const api = await loadApi();
+		fetchSpy.mockResolvedValueOnce(
+			mockFetchResponse({
+				json: {
+					needsSetup: false,
+					authenticated: true,
+					isAdmin: false,
+					resourceCaps: { cpuMaxCores: Number.NaN, memMaxMiB: 8192 },
+				},
+			}),
+		);
+		await api.checkAuthStatus();
+		expect(api.getResourceCaps()).toEqual({ cpuMaxCores: 8, memMaxMiB: 16384 });
 	});
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -21,6 +21,15 @@ const WS_BASE = BACKEND_URL.replace(/^http/, "ws");
 let _loggedIn = false;
 let _isAdmin = false;
 let _isLead = false;
+// #200 — effective per-session resource caps mirrored from /auth/status
+// so the create-session form's CPU input `max` and the bounds hint can
+// reflect operator-lowered caps. Defaults match the v1 ceilings so a
+// pre-cap-aware backend (or a status fetch that hasn't completed yet)
+// surfaces the same numbers the form would have shown before #200.
+let _resourceCaps: { cpuMaxCores: number; memMaxMiB: number } = {
+	cpuMaxCores: 8,
+	memMaxMiB: 16 * 1024,
+};
 
 export function isLoggedIn(): boolean {
 	return _loggedIn;
@@ -42,6 +51,17 @@ export function isLead(): boolean {
 	return _isLead;
 }
 
+/** Effective per-session caps from the backend (#200). Mirrored on
+ *  every /auth/status call so an operator change picks up on the next
+ *  page reload. The create-session form reads these to set the CPU
+ *  input `max` and the bounds hint text — without this the form
+ *  would advertise the v1 ceiling and the user would hit a 400 with
+ *  an operator-named env var they can't act on. Returns a fresh
+ *  object so callers can't mutate the module state by reference. */
+export function getResourceCaps(): { cpuMaxCores: number; memMaxMiB: number } {
+	return { ..._resourceCaps };
+}
+
 /** Fired by `apiFetch` once per 401-burst after flipping `_loggedIn` to false —
  * main.ts listens to perform UI teardown. See apiFetch for the emit guard. */
 export const SESSION_EXPIRED_EVENT = "st:session-expired";
@@ -57,6 +77,11 @@ export interface AuthStatus {
 	 *  `false` defensively when the field is missing so a stale cached
 	 *  client + new server, or vice versa, doesn't surface undefined. */
 	isLead?: boolean;
+	/** Effective per-session resource caps (#200). Same backwards-
+	 *  compatible shape — pre-#200 backends omit the field and the
+	 *  client falls back to the hardcoded v1 ceilings. Units mirror
+	 *  the form: cores (decimal) and MiB (integer). */
+	resourceCaps?: { cpuMaxCores: number; memMaxMiB: number };
 }
 
 export async function checkAuthStatus(): Promise<AuthStatus> {
@@ -68,6 +93,19 @@ export async function checkAuthStatus(): Promise<AuthStatus> {
 	_loggedIn = data.authenticated;
 	_isAdmin = data.isAdmin;
 	_isLead = data.isLead === true;
+	// #200: mirror caps if present. A pre-#200 backend omits the field
+	// and leaves the v1 defaults in place — same hardcoded ceilings the
+	// form would have used before this PR.
+	if (
+		data.resourceCaps &&
+		Number.isFinite(data.resourceCaps.cpuMaxCores) &&
+		Number.isFinite(data.resourceCaps.memMaxMiB)
+	) {
+		_resourceCaps = {
+			cpuMaxCores: data.resourceCaps.cpuMaxCores,
+			memMaxMiB: data.resourceCaps.memMaxMiB,
+		};
+	}
 	return data;
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -38,6 +38,7 @@ import {
 	fetchMyGroups,
 	fetchMyObservableSessions,
 	fetchSessionObserveLog,
+	getResourceCaps,
 	getTemplate,
 	type Invite,
 	InviteRequiredError,
@@ -270,6 +271,11 @@ async function initAuth() {
 	// for "show app vs. login" and `needsSetup` for "show invite field".
 	try {
 		const { needsSetup, authenticated } = await checkAuthStatus();
+		// #200: caps now mirrored in the api module — apply to the form
+		// once on init so the very first modal open shows operator-
+		// lowered bounds. Re-applied on every modal open below to catch
+		// the rare case where caps change after initial paint.
+		applyResourceCapsToForm();
 		if (authenticated) {
 			showApp();
 			return;
@@ -1261,6 +1267,9 @@ function openNewSessionModal(opener: HTMLElement) {
 	// `resetEnvTab` no longer fires here — `closeNewSessionModal`
 	// already wiped state on the previous close, and the initial
 	// declaration of `envRows = []` covers the very first open.
+	// #200: re-apply caps in case checkAuthStatus refreshed them since
+	// initAuth ran (idempotent — same numbers if nothing changed).
+	applyResourceCapsToForm();
 	newSessionModal.classList.add("open");
 	newSessionModal.setAttribute("aria-hidden", "false");
 	// Defer focus to the next paint so the input is reliably focusable
@@ -1630,6 +1639,37 @@ function validateAgentSeedSettings(): boolean {
 }
 
 agentSeedSettings.addEventListener("blur", validateAgentSeedSettings);
+
+// #200 — DOM mirror of the operator-tunable per-session caps. The
+// HTML ships with the v1 defaults baked in (cpu max="8", hint says
+// "0.25–8 cores, 256 MiB–16 GiB") so that a pre-#200 backend / a
+// pre-checkAuthStatus paint shows the same numbers the form would
+// have shown before this PR. This function rewrites those two
+// surfaces (input `max`, bounds-hint text) once the API client has
+// the effective caps. Called from `initAuth` after checkAuthStatus
+// succeeds and from `openNewSessionModal` so an operator change
+// between auth-check and modal-open still surfaces correctly on the
+// next modal open. The `min` attribute is NOT changed — the floor is
+// fixed at 0.25c / 256 MiB regardless of operator policy.
+const resourcesBoundsHint = document.getElementById(
+	"resources-bounds-hint",
+) as HTMLParagraphElement;
+
+function applyResourceCapsToForm(): void {
+	const caps = getResourceCaps();
+	resourcesCpuCores.max = String(caps.cpuMaxCores);
+	// Memory hint: surface MiB exactly when the cap is below 1 GiB,
+	// otherwise express in GiB for readability. Same dual-unit shape
+	// the form's mem-unit dropdown uses.
+	const memMaxStr =
+		caps.memMaxMiB >= 1024 && caps.memMaxMiB % 1024 === 0
+			? `${caps.memMaxMiB / 1024} GiB`
+			: `${caps.memMaxMiB} MiB`;
+	resourcesBoundsHint.textContent =
+		`Per-session limits. Empty fields fall back to the deployment defaults ` +
+		`(2 cores / 2 GiB / no auto-stop). Bounds: CPU 0.25–${caps.cpuMaxCores} cores, ` +
+		`memory 256 MiB–${memMaxStr}, idle TTL 1 minute–24 hours.`;
+}
 
 /** Wipe Advanced-tab state on modal close. Important for the agent-
  *  seed textareas — leaving 256 KiB of pasted content mounted between


### PR DESCRIPTION
## Summary

- Adds `MAX_SESSION_CPU` (cores, decimal accepted) and `MAX_SESSION_MEM` (MiB, integer) env vars. Defaults are the v1 ceilings (8 cores / 16 GiB).
- Per the issue, env can only LOWER below the v1 ceilings — values above are clamped at boot with a warn so `MAX_SESSION_CPU=32` on a 64-core box doesn't silently raise the cap. Floors (0.25c / 256 MiB) preserved.
- Custom Zod error messages on `cpuLimit` / `memLimit` name the env var so a user hitting the 400 knows where the cap comes from.
- Clamps `DEFAULT_NANO_CPUS` / `DEFAULT_MEMORY_BYTES` in `dockerManager.ts` against the effective cap. Without this, an operator setting `MAX_SESSION_CPU=1` would still see 2-core sessions spawn whenever the user omitted `config.cpuLimit` (the schema-max only fires on explicit values).
- Already-running containers are not affected — cgroup limits are written at `docker run`. A lowered cap only gates future create requests.

## Test plan

- [x] `npm run lint` / `npm run build` / `npm test` clean in `backend/` and `frontend/`.
- [x] 20 new tests in `sessionConfig.resourceCaps.test.ts` cover defaulting, lower override, clamp-on-raise, floor enforcement, malformed input fallback, and the schema-side custom error message naming the env var.
- [ ] Manual: set `MAX_SESSION_CPU=4`, restart; POST `/api/sessions` with `config.cpuLimit: 5_000_000_000` returns 400 with the env-var-named message. POST with `cpuLimit` omitted spawns at 2c (still within cap).
- [ ] Manual: set `MAX_SESSION_CPU=1`, restart; POST with `cpuLimit` omitted spawns at 1c (default clamped against cap).
- [ ] Manual: set `MAX_SESSION_CPU=garbage`, observe warn at startup and 8-core default in effect.

Closes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)