### PR TITLE
feat(sidebar): auto-poll live usage; stacked CPU + mem lines

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2809,10 +2809,12 @@ async function autoPollTick(): Promise<void> {
 	if (!isLoggedIn()) return;
 	autoPollInFlight = true;
 	try {
+		// `refreshSessions` owns its own error path (catch → toast),
+		// so we don't need a catch here today. The try/finally exists
+		// solely to reset the in-flight latch; a future refactor that
+		// makes refreshSessions re-throw would surface as an
+		// unhandledRejection rather than being silently swallowed.
 		await refreshSessions();
-	} catch {
-		// refreshSessions() already toasts on failure; swallow here so
-		// a transient error doesn't crash the timer.
 	} finally {
 		autoPollInFlight = false;
 	}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2801,6 +2801,12 @@ let autoPollInFlight = false;
 async function autoPollTick(): Promise<void> {
 	if (autoPollInFlight) return;
 	if (document.visibilityState !== "visible") return;
+	// Guard on auth — without this the poll keeps firing on the login
+	// screen and after logout/session-expiry, each tick toasting a red
+	// "Failed to list sessions" error (apiFetch returns 401, listSessions
+	// throws, refreshSessions toasts). Matches the pre-existing 15 s
+	// timer's gate that this poller replaces.
+	if (!isLoggedIn()) return;
 	autoPollInFlight = true;
 	try {
 		await refreshSessions();
@@ -2818,7 +2824,8 @@ setInterval(() => {
 // doesn't have to wait up to 5 s for the first refresh after
 // switching back. Use `visibilitychange` rather than `focus`
 // because `focus` doesn't fire on programmatic tab switches in
-// some browsers.
+// some browsers. `autoPollTick` itself re-checks the auth + in-
+// flight guards.
 document.addEventListener("visibilitychange", () => {
 	if (document.visibilityState === "visible") void autoPollTick();
 });
@@ -4695,11 +4702,8 @@ observeModal.addEventListener("click", (e) => {
 	if (target.hasAttribute("data-close-modal")) closeObserveModal();
 });
 
-// ── Auto-refresh ────────────────────────────────────────────────────────────
-
-setInterval(() => {
-	if (isLoggedIn()) refreshSessions();
-}, 15_000);
+// (Auto-refresh moved to `autoPollTick` higher in this file — the 5 s
+//  cadence subsumes the older 15 s timer that used to live here.)
 
 // ── Init ────────────────────────────────────────────────────────────────────
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -536,18 +536,22 @@ function renderSessionList() {
 		name.textContent = s.name;
 		nameCol.appendChild(name);
 
-		// Live usage line. Render only for running sessions whose stats
-		// fetch succeeded — stopped/terminated/failed rows have no live
-		// data and "—" placeholder would be noise on what's usually
-		// most of an inactive list.
+		// Live usage lines (#272: stacked CPU + mem on separate rows so
+		// each metric is its own visual line). Render only for running
+		// sessions whose stats fetch succeeded — stopped/terminated/
+		// failed rows have no live data and a "—" placeholder would be
+		// noise on what's usually most of an inactive list.
 		if (s.status === "running" && s.usage !== null) {
-			const usageEl = document.createElement("span");
-			usageEl.className = "session-usage";
 			const cpuCores = s.usage.cpuPercent / 100;
-			usageEl.textContent =
-				`${formatCpuCores(cpuCores)} cores (${formatCpuPercent(s.usage.cpuPercent)})` +
-				` · ${formatBytes(s.usage.memBytes)} (${s.usage.memPercent.toFixed(0)}%)`;
-			nameCol.appendChild(usageEl);
+			const cpuLine = document.createElement("span");
+			cpuLine.className = "session-usage";
+			cpuLine.textContent = `CPU ${formatCpuCores(cpuCores)} cores (${formatCpuPercent(s.usage.cpuPercent)})`;
+			nameCol.appendChild(cpuLine);
+
+			const memLine = document.createElement("span");
+			memLine.className = "session-usage";
+			memLine.textContent = `Mem ${formatBytes(s.usage.memBytes)} (${s.usage.memPercent.toFixed(0)}%)`;
+			nameCol.appendChild(memLine);
 		}
 
 		item.appendChild(nameCol);
@@ -2769,9 +2773,9 @@ showTerminatedToggle.addEventListener("change", () => {
 	refreshSessions();
 });
 
-// #271 — Manual sidebar refresh. We deliberately do NOT poll the
-// session list; refresh is user-driven so usage numbers don't burn
-// Docker-stats round-trips while a tab is idle in the background.
+// #271 — Manual sidebar refresh. Also wired up to the auto-poll
+// below; both paths funnel through `refreshSessions()` so the live-
+// usage subtitle updates whether the user clicked or the timer fired.
 sidebarRefreshBtn.addEventListener("click", async () => {
 	sidebarRefreshBtn.disabled = true;
 	try {
@@ -2779,6 +2783,44 @@ sidebarRefreshBtn.addEventListener("click", async () => {
 	} finally {
 		sidebarRefreshBtn.disabled = false;
 	}
+});
+
+// #272 — Auto-poll for live usage. 5 s cadence matches the admin
+// dashboard's manual-refresh feel without becoming a battery drain.
+// We use Page Visibility API to pause the poll when the tab is
+// hidden — a background tab shouldn't fan out Docker stats calls
+// per-session every 5 s. The poll also skips while an in-flight
+// refresh is still pending so a slow Docker daemon doesn't pile up
+// overlapping requests; this also serves as a back-pressure signal
+// (if the previous refresh hasn't returned in 5 s, the next tick
+// no-ops rather than doubling the daemon load). The 2 s TTL cache
+// in containerStats.ts softens the case where the user clicks the
+// manual button right after a tick fired.
+const AUTO_POLL_INTERVAL_MS = 5_000;
+let autoPollInFlight = false;
+async function autoPollTick(): Promise<void> {
+	if (autoPollInFlight) return;
+	if (document.visibilityState !== "visible") return;
+	autoPollInFlight = true;
+	try {
+		await refreshSessions();
+	} catch {
+		// refreshSessions() already toasts on failure; swallow here so
+		// a transient error doesn't crash the timer.
+	} finally {
+		autoPollInFlight = false;
+	}
+}
+setInterval(() => {
+	void autoPollTick();
+}, AUTO_POLL_INTERVAL_MS);
+// Re-fire immediately when the tab regains focus so the user
+// doesn't have to wait up to 5 s for the first refresh after
+// switching back. Use `visibilitychange` rather than `focus`
+// because `focus` doesn't fire on programmatic tab switches in
+// some browsers.
+document.addEventListener("visibilitychange", () => {
+	if (document.visibilityState === "visible") void autoPollTick();
 });
 
 // ── Sidebar toggle ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two follow-ups on PR #271 the user asked for:

1. **Real-time usage in the sidebar.** Auto-poll every 5 s while the tab is visible — usage numbers tick on their own without a click. Pauses on hidden tabs via Page Visibility API.
2. **Stacked layout.** CPU and memory now render on two separate lines per row (CPU on top, Mem underneath) instead of one combined string.

## Implementation

- `setInterval(5_000)` fires `autoPollTick()` which calls `refreshSessions()`. Gated on `document.visibilityState === "visible"` and an in-flight latch so a slow Docker daemon can't pile up overlapping requests (also acts as natural back-pressure — if a tick takes >5 s the next no-ops).
- `visibilitychange → visible` re-fires immediately so a returning user doesn't wait up to 5 s for the first refresh.
- Manual ↻ button retained; both paths funnel through the same `refreshSessions()`.
- Render: replaced the dot-separated single span with two `.session-usage` children inside `.session-name-col` — existing CSS picks them up as stacked rows since the column already has `display: flex; flex-direction: column`.

## Cost

5 s × per-running-session Docker stats call. The 2 s TTL cache in `containerStats.ts` softens the case where manual + auto land in the same window; an idle tab (hidden or no running sessions) costs nothing.

## Test plan

- [ ] `cd frontend && npm run lint && npm test && npm run build`
- [ ] Manual:
  - [ ] Open the app, spawn a session, run `yes >/dev/null &` inside; confirm the CPU number ticks every ~5 s.
  - [ ] Hide the tab (switch tabs / minimise) for ≥10 s; confirm via browser devtools network panel that `GET /api/sessions` does NOT fire.
  - [ ] Bring the tab back; confirm the request fires immediately (no 5 s wait).
  - [ ] Confirm CPU and memory render on separate lines under the session name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)