### PR TITLE
fix(sessions): sidebar crash on session create / post-create

### DIFF
--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -293,6 +293,44 @@ describe("POST /sessions — async bootstrap dispatch (PR 185b2b)", () => {
 		expect(bootstrapStubs.runAsyncBootstrap).not.toHaveBeenCalled();
 	});
 
+	// #273 regression — the POST /sessions 201 body MUST include the
+	// `cpuLimit/memLimit/usage` fields the frontend's `SessionInfo`
+	// shape now requires (added in #271 to the list response). Without
+	// them, `sessions.unshift(session)` after create lands an object
+	// with `usage: undefined`, and `renderSessionList`'s `s.usage !==
+	// null` guard passes through to `.cpuPercent` access — crashes the
+	// sidebar. All three fields are `null` on a brand-new create (no
+	// usage sample taken, caps not re-read here); the next sidebar
+	// auto-poll fills them in from the list endpoint.
+	it.each([
+		["bare", {}],
+		["postStart-only", { config: { postStartCmd: "code tunnel" } }],
+		["postCreate (bootstrapping)", { config: { postCreateCmd: "npm install" } }],
+	])("201 response includes cpuLimit/memLimit/usage (=null) — %s create path", async (_label, extra) => {
+		const { sessions, docker } = makeFakes();
+		await spinUp(sessions, docker);
+
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "test", ...extra }),
+		});
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as {
+			sessionId: string;
+			cpuLimit: number | null;
+			memLimit: number | null;
+			usage: unknown;
+		};
+		// `null`, NOT `undefined`. The whole point of the regression is
+		// that the frontend's truthy-vs-strict-equal guard breaks when
+		// the field is absent; pin the present-but-null shape so a
+		// future refactor that drops the field surfaces here.
+		expect(body).toHaveProperty("cpuLimit", null);
+		expect(body).toHaveProperty("memLimit", null);
+		expect(body).toHaveProperty("usage", null);
+	});
+
 	// Unchanged from PR 185b2a round 6: sessions.create itself failing
 	// must NOT crash the rollback even though `meta` is still null.
 	it("does not crash the rollback when sessions.create itself throws (meta is null)", async () => {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -2242,7 +2242,21 @@ function isValidTerminalDim(value: unknown): value is number {
 	);
 }
 
-function serializeMeta(m: SessionMeta) {
+function serializeMeta(m: SessionMeta): {
+	sessionId: string;
+	name: string;
+	status: SessionMeta["status"];
+	containerId: string | null;
+	containerName: string;
+	createdAt: string;
+	lastConnectedAt: string | null;
+	cols: number;
+	rows: number;
+	envVars: Record<string, string>;
+	cpuLimit: number | null;
+	memLimit: number | null;
+	usage: ReturnType<typeof serializeUsage>;
+} {
 	return {
 		sessionId: m.sessionId,
 		name: m.name,
@@ -2254,6 +2268,19 @@ function serializeMeta(m: SessionMeta) {
 		cols: m.cols,
 		rows: m.rows,
 		envVars: m.envVars,
+		// #270 / #271 added these to the /sessions list response. Every
+		// other single-session endpoint (POST /sessions, GET /:id,
+		// POST /:id/start, POST /:id/stop) returns serializeMeta
+		// directly — without these defaults the frontend's `SessionInfo`
+		// shape has `cpuLimit/memLimit/usage` missing, and
+		// `renderSessionList`'s `s.usage !== null` guard reads `undefined`
+		// (truthy on `!== null`), then `.cpuPercent` access throws on
+		// the newly-created session. Default to null here so every
+		// response is shape-consistent; the list route's `...spread`
+		// overrides with real values when it has them.
+		cpuLimit: null,
+		memLimit: null,
+		usage: null,
 	};
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -541,7 +541,13 @@ function renderSessionList() {
 		// sessions whose stats fetch succeeded — stopped/terminated/
 		// failed rows have no live data and a "—" placeholder would be
 		// noise on what's usually most of an inactive list.
-		if (s.status === "running" && s.usage !== null) {
+		// Truthy check (not `!== null`) so a SessionInfo with `usage`
+		// undefined — e.g. a POST /sessions response immediately after
+		// create, before the next auto-poll has refilled the list —
+		// doesn't slip past the guard. Pre-fix this crashed with
+		// "Cannot read properties of undefined (reading 'cpuPercent')"
+		// on the line below.
+		if (s.status === "running" && s.usage) {
 			const cpuCores = s.usage.cpuPercent / 100;
 			const cpuLine = document.createElement("span");
 			cpuLine.className = "session-usage";
@@ -3958,7 +3964,11 @@ function formatRowResources(s: AdminSession): string {
 	if (s.status !== "running") {
 		return `cap: ${cpuLabel} · ${memLabel}`;
 	}
-	if (s.usage === null) {
+	// Truthy check covers both null (intentional "no stats") and
+	// undefined (a SessionInfo that came back from a non-list endpoint
+	// before #271's serializeMeta defaults landed); without this the
+	// `.cpuPercent` access on the next line throws on undefined.
+	if (!s.usage) {
 		return `cap: ${cpuLabel} · ${memLabel} · usage: —`;
 	}
 	const cpuUsedCores = s.usage.cpuPercent / 100;


### PR DESCRIPTION
## Symptom

After creating a session, the sidebar throws \`Cannot read properties of undefined (reading 'cpuPercent')\` and the new row never renders. Reported by the user as "got an error creating a new session" and "post create error as well".

## Cause

PR #271 added \`cpuLimit/memLimit/usage\` to the \`GET /api/sessions\` list response — but every OTHER single-session endpoint (POST /sessions, GET /:id, POST /:id/start, POST /:id/stop) kept returning the narrower \`serializeMeta\` shape without the new fields.

The frontend flow after create:

\`\`\`ts
const session = await createSession(...);     // response has no cpuLimit/memLimit/usage
sessions.unshift(session);                    // pushed into the list anyway
renderSessionList();                          // tries to render the new row
\`\`\`

Inside \`renderSessionList\`:

\`\`\`ts
if (s.status === "running" && s.usage !== null) {   // undefined !== null → TRUE
    const cpuCores = s.usage.cpuPercent / 100;      // 💥
\`\`\`

\`s.usage\` is \`undefined\` (field absent in the response), the strict-equal guard lets it through, then the property access throws and the whole \`renderSessionList\` loop aborts mid-iteration.

## Fix

Both sides, defence in depth:

**Backend** — \`serializeMeta\` now emits \`cpuLimit: null, memLimit: null, usage: null\` defaults. Every endpoint that returns it (create, single-session read, start, stop, restore) ships a shape-consistent \`SessionInfo\`. The list route's spread continues to override with real values when it has them, so no behavior change for the list.

**Frontend** — Defensive truthy check: \`s.usage\` instead of \`s.usage !== null\`. Catches both \`null\` (intentional "no stats yet") and any future code path that hands us \`undefined\`. Applied at both call sites (\`renderSessionList\` and admin \`formatRowResources\`).

## Tests

- Three new parametrised regression tests in \`routes.create.test.ts\` pin the 201 body shape (\`cpuLimit/memLimit/usage\` are \`null\`-not-absent) across the bare-create, postStart-only, and postCreate (bootstrapping) paths.
- Backend: 838/838 vitest pass; lint + tsc clean.
- Frontend: 66/66 pass; lint + tsc + vite build clean.

## Test plan

- [ ] \`cd backend && npm test && npm run lint && npm run build\`
- [ ] \`cd frontend && npm test && npm run lint && npm run build\`
- [ ] Manual:
  - [ ] Create a bare session — sidebar renders the new row, no console error.
  - [ ] Create a session with a postCreateCmd — bootstrap modal opens, sidebar row appears.
  - [ ] Wait ~5 s — auto-poll populates the CPU/Mem subtitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)