### PR TITLE
feat(bootstrap): persist captured output + 'View log' on failed sessions

### DIFF
--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -709,9 +709,7 @@ describe("runAsyncBootstrap", () => {
 	it("persists captured output to bootstrap_log on failure — and BEFORE failSession runs", async () => {
 		// The order matters: a fast subsequent GET /bootstrap-log
 		// against a session that just flipped to `failed` must see
-		// the populated log, not an empty string. We can't directly
-		// assert "before" in the test (both are awaited sequentially);
-		// instead we assert both happened and the log was non-empty.
+		// the populated log, not an empty string.
 		const { sessions, docker, broadcaster, spies } = makeFakes();
 		spies.runPostCreate.mockImplementation(
 			async (_id: string, _cmd: string, onOutput: (s: string) => void) => {
@@ -732,6 +730,17 @@ describe("runAsyncBootstrap", () => {
 		expect(log).toContain("missing .env file");
 		// Failure path also flipped status — both writes are present.
 		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+		// Order is the load-bearing invariant: setBootstrapLog MUST
+		// land before updateStatus(failed) so a GET /bootstrap-log
+		// racing the flip sees populated content. Vitest's
+		// `invocationCallOrder` is monotonically increasing across all
+		// mocks in the test run, so a strict `<` comparison pins the
+		// relative order. A regression that reversed the awaits (or a
+		// future refactor that moved persistLog after failSession)
+		// would flip this comparison and fail the test loudly.
+		const setLogOrder = spies.setBootstrapLog.mock.invocationCallOrder[0]!;
+		const updateStatusOrder = spies.updateStatus.mock.invocationCallOrder[0]!;
+		expect(setLogOrder).toBeLessThan(updateStatusOrder);
 	});
 
 	it("survives a D1 hiccup on setBootstrapLog without crashing the runner (best-effort persistence)", async () => {

--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -663,6 +663,14 @@ describe("runAsyncBootstrap", () => {
 				exitCode: -1,
 			});
 			expect((failMsg as { error: string }).error).toMatch(/bootstrap timeout/);
+			// #274 NIT fix: the timeout message must also land in the
+			// persisted log (was bypassing `onOutput` and only going to
+			// the WS, so a "View log" modal opened after the timeout
+			// would show every other chunk but NOT the most useful
+			// line — the cap that fired).
+			expect(spies.setBootstrapLog).toHaveBeenCalledTimes(1);
+			const [_sid, log] = spies.setBootstrapLog.mock.calls[0]!;
+			expect(log).toMatch(/bootstrap timeout/);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -212,13 +212,17 @@ describe("runAsyncBootstrap", () => {
 			kill: ReturnType<typeof vi.fn>;
 			runPostCreate: ReturnType<typeof vi.fn>;
 			runPostStart: ReturnType<typeof vi.fn>;
+			setBootstrapLog: ReturnType<typeof vi.fn>;
 		};
 	} {
 		const updateStatus = vi.fn(async () => undefined);
 		const kill = vi.fn(async () => undefined);
 		const runPostCreate = vi.fn();
 		const runPostStart = vi.fn(async () => undefined);
-		const sessions = { updateStatus } as unknown as SessionManager;
+		// #274 — spy on bootstrap-log persistence so per-test assertions
+		// can read back what was written.
+		const setBootstrapLog = vi.fn(async () => undefined);
+		const sessions = { updateStatus, setBootstrapLog } as unknown as SessionManager;
 		const docker = { kill, runPostCreate, runPostStart } as unknown as DockerManager;
 		const broadcaster = new BootstrapBroadcaster();
 		const final: BootstrapMessage[] = [];
@@ -230,7 +234,7 @@ describe("runAsyncBootstrap", () => {
 			docker,
 			broadcaster,
 			final,
-			spies: { updateStatus, kill, runPostCreate, runPostStart },
+			spies: { updateStatus, kill, runPostCreate, runPostStart, setBootstrapLog },
 		};
 	}
 
@@ -662,5 +666,129 @@ describe("runAsyncBootstrap", () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	// ── #274 — bootstrap-log persistence ──────────────────────────────────
+
+	it("persists captured output to bootstrap_log on success", async () => {
+		const { sessions, docker, broadcaster, spies } = makeFakes();
+		spies.runPostCreate.mockImplementation(
+			async (_id: string, _cmd: string, onOutput: (s: string) => void) => {
+				onOutput("npm install\n");
+				onOutput("added 142 packages in 3s\n");
+				return { exitCode: 0 };
+			},
+		);
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 1, duration: 0, last_row_id: 0 },
+		});
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "npm install" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.setBootstrapLog).toHaveBeenCalledTimes(1);
+		const [_sid, log] = spies.setBootstrapLog.mock.calls[0]!;
+		expect(log).toContain("npm install");
+		expect(log).toContain("added 142 packages");
+	});
+
+	it("persists captured output to bootstrap_log on failure — and BEFORE failSession runs", async () => {
+		// The order matters: a fast subsequent GET /bootstrap-log
+		// against a session that just flipped to `failed` must see
+		// the populated log, not an empty string. We can't directly
+		// assert "before" in the test (both are awaited sequentially);
+		// instead we assert both happened and the log was non-empty.
+		const { sessions, docker, broadcaster, spies } = makeFakes();
+		spies.runPostCreate.mockImplementation(
+			async (_id: string, _cmd: string, onOutput: (s: string) => void) => {
+				onOutput("error: missing .env file referenced by postCreate\n");
+				return { exitCode: 1 };
+			},
+		);
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "node check-env.js" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		expect(spies.setBootstrapLog).toHaveBeenCalledTimes(1);
+		const [_sid, log] = spies.setBootstrapLog.mock.calls[0]!;
+		expect(log).toContain("missing .env file");
+		// Failure path also flipped status — both writes are present.
+		expect(spies.updateStatus).toHaveBeenCalledWith("sess-1", "failed");
+	});
+
+	it("survives a D1 hiccup on setBootstrapLog without crashing the runner (best-effort persistence)", async () => {
+		// Bootstrap output persistence is debug-only — if D1 fails to
+		// write the column we must NOT block the terminal broadcast.
+		// Without this guard a transient D1 error would leave the
+		// modal hung waiting for done/fail forever.
+		const { sessions, docker, broadcaster, final, spies } = makeFakes();
+		spies.setBootstrapLog.mockRejectedValue(new Error("D1 down"));
+		spies.runPostCreate.mockImplementation(
+			async (_id: string, _cmd: string, onOutput: (s: string) => void) => {
+				onOutput("ok\n");
+				return { exitCode: 0 };
+			},
+		);
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [],
+			success: true,
+			meta: { changes: 1, duration: 0, last_row_id: 0 },
+		});
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "echo ok" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		// Critical: terminal `done` broadcast fired despite the persist
+		// failure. The user's modal closes normally; only the post-
+		// failure debug surface (bootstrap-log endpoint) is degraded.
+		expect(final).toEqual([{ type: "done", success: true }]);
+	});
+
+	it("tail-truncates output past BOOTSTRAP_LOG_MAX_BYTES — keeps the END (failure messages live there)", async () => {
+		const { BOOTSTRAP_LOG_MAX_BYTES } = await import("./bootstrap.js");
+		const { sessions, docker, broadcaster, spies } = makeFakes();
+		// Emit one chunk of "noise" (early progress lines we expect
+		// to drop) then a chunk with the failure marker at the tail.
+		const noise = "x".repeat(BOOTSTRAP_LOG_MAX_BYTES);
+		const tail = "FATAL: this is the line the user actually needs\n";
+		spies.runPostCreate.mockImplementation(
+			async (_id: string, _cmd: string, onOutput: (s: string) => void) => {
+				onOutput(noise);
+				onOutput(tail);
+				return { exitCode: 1 };
+			},
+		);
+
+		await runAsyncBootstrap(
+			"sess-1",
+			{ postCreateCmd: "false" },
+			{ sessions, docker, broadcaster },
+		);
+		await settle();
+
+		const [_sid, log] = spies.setBootstrapLog.mock.calls[0]!;
+		// CRITICAL: the failure tail survived even though the total
+		// bytes emitted exceeded the cap. A head-trim that lost the
+		// tail would defeat the entire purpose of the feature.
+		expect(log).toContain("FATAL");
+		// The cap held — total length is at most cap + length of one
+		// final chunk (the front-trim drops whole chunks, so the
+		// stored size can briefly exceed the cap by up to one chunk's
+		// worth, but never by an order of magnitude).
+		expect((log as string).length).toBeLessThanOrEqual(BOOTSTRAP_LOG_MAX_BYTES + tail.length);
 	});
 });

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -361,7 +361,14 @@ export async function runAsyncBootstrap(
 	const onOutput = (chunk: string) => {
 		broadcaster.broadcast(sessionId, chunk);
 		logChunks.push(chunk);
-		logBytes += chunk.length;
+		// `Buffer.byteLength(chunk, "utf-8")`, NOT `chunk.length`. The
+		// cap constant is named `BOOTSTRAP_LOG_MAX_BYTES` and the
+		// sibling BootstrapBroadcaster.broadcast measures UTF-8 bytes
+		// too — using `.length` (UTF-16 code units) would undercount
+		// CJK / emoji output by up to 4x and silently let the stored
+		// log exceed the cap. Matches the broadcaster's accounting.
+		const chunkBytes = Buffer.byteLength(chunk, "utf-8");
+		logBytes += chunkBytes;
 		// Cheap front-trim — only fires when we're over the cap, so
 		// the typical success path pays zero work. Drop whole chunks
 		// from the head until we're back under the limit; the user
@@ -369,7 +376,7 @@ export async function runAsyncBootstrap(
 		// stage that actually failed.
 		while (logBytes > BOOTSTRAP_LOG_MAX_BYTES && logChunks.length > 1) {
 			const head = logChunks.shift();
-			if (head !== undefined) logBytes -= head.length;
+			if (head !== undefined) logBytes -= Buffer.byteLength(head, "utf-8");
 		}
 	};
 
@@ -454,11 +461,14 @@ export async function runAsyncBootstrap(
 				: e.message;
 			logger.error(`[bootstrap] ${label} threw for session ${sessionId}: ${message}`);
 			// Surface the timeout reason in-stream so the user sees
-			// the cap, not just a generic fail. Goes through the
-			// broadcaster as a regular `output` chunk first; the
-			// terminal `fail` message has the exit code.
+			// the cap, not just a generic fail. Routed through
+			// `onOutput` (not `broadcaster.broadcast` directly) so the
+			// line lands in `logChunks` and survives in the persisted
+			// log — the timeout reason is the single most useful line
+			// for debugging a timed-out bootstrap, and a "View log"
+			// modal that's missing it defeats the feature's purpose.
 			if (isTimeout) {
-				broadcaster.broadcast(sessionId, `\n${message}\n`);
+				onOutput(`\n${message}\n`);
 			}
 			await finishWithFail({
 				type: "fail",

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -45,6 +45,17 @@ import type { SessionManager } from "./sessionManager.js";
 const BOOTSTRAP_WALL_CLOCK_CAP_MS = 10 * 60 * 1000;
 
 /**
+ * Maximum bytes of captured bootstrap output to persist on the row
+ * (#274). A chatty postCreate (`npm install` produces ~30 KB of
+ * progress lines) shouldn't bloat the sessions table; we keep the
+ * LAST N bytes so the tail — where the failure message lives — is
+ * always present, and head-trim drops earlier noise once we go over.
+ * 64 KiB matches the typical 80×24×80 terminal scrollback the user
+ * sees in the live modal.
+ */
+export const BOOTSTRAP_LOG_MAX_BYTES = 64 * 1024;
+
+/**
  * Atomically mark `session_configs.bootstrapped_at` as set, but only
  * if it was still NULL. Returns true iff THIS caller won the race.
  *
@@ -338,7 +349,44 @@ export async function runAsyncBootstrap(
 	},
 ): Promise<void> {
 	const { sessions, docker, broadcaster } = deps;
-	const onOutput = (chunk: string) => broadcaster.broadcast(sessionId, chunk);
+	// #274 — accumulate every broadcast chunk into a bounded tail
+	// buffer so a failed session's captured output survives after the
+	// WS modal closes. Persisted to `sessions.bootstrap_log` on the
+	// terminal `done`/`fail` branch. `BOOTSTRAP_LOG_MAX_BYTES` is a
+	// soft cap; if the pipeline emits more we keep the LAST N bytes
+	// (postCreate errors are at the tail, which is the part the user
+	// actually needs to debug).
+	const logChunks: string[] = [];
+	let logBytes = 0;
+	const onOutput = (chunk: string) => {
+		broadcaster.broadcast(sessionId, chunk);
+		logChunks.push(chunk);
+		logBytes += chunk.length;
+		// Cheap front-trim — only fires when we're over the cap, so
+		// the typical success path pays zero work. Drop whole chunks
+		// from the head until we're back under the limit; the user
+		// loses some early "Cloning into ..." noise but keeps the
+		// stage that actually failed.
+		while (logBytes > BOOTSTRAP_LOG_MAX_BYTES && logChunks.length > 1) {
+			const head = logChunks.shift();
+			if (head !== undefined) logBytes -= head.length;
+		}
+	};
+
+	// Persist the accumulated log on a terminal event (success or
+	// failure). Best-effort: if D1 hiccups, we log a warning and let
+	// the broadcaster's terminal message go out anyway — the WS modal
+	// shows everything regardless, and a missing log column is the
+	// pre-#274 behaviour.
+	const persistLog = async (): Promise<void> => {
+		try {
+			await sessions.setBootstrapLog(sessionId, logChunks.join(""));
+		} catch (err) {
+			logger.warn(
+				`[bootstrap] failed to persist log for session ${sessionId}: ${(err as Error).message}`,
+			);
+		}
+	};
 
 	// 10-min wall-clock cap (#191 PR 191b). The controller is aborted
 	// either by the timer or by a stage that wants to short-circuit
@@ -353,6 +401,11 @@ export async function runAsyncBootstrap(
 
 	const finishWithFail = async (msg: BootstrapMessage): Promise<void> => {
 		clearTimeout(timer);
+		// Persist BEFORE flipping status so a fast subsequent GET
+		// /sessions/:id/bootstrap-log races against a populated log,
+		// not an empty one. failSession itself does updateStatus +
+		// kill; the log column is unrelated to that flip.
+		await persistLog();
 		await failSession(sessionId, sessions, docker);
 		broadcaster.finish(sessionId, msg);
 	};
@@ -539,6 +592,12 @@ export async function runAsyncBootstrap(
 			);
 		}
 	}
+	// Persist the captured log on success too — a user who configured
+	// a postCreate and wants to see what `npm install` printed can
+	// inspect after the modal closes. Same best-effort shape as the
+	// failure branch (warn on D1 hiccup, don't gate the terminal
+	// broadcast on it).
+	await persistLog();
 	broadcaster.finish(sessionId, { type: "done", success: true });
 }
 

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -152,6 +152,7 @@ export async function migrateDb(): Promise<void> {
                         env_vars        TEXT NOT NULL DEFAULT '{}',
                         created_at      TEXT NOT NULL DEFAULT (datetime('now')),
                         last_connected_at TEXT,
+                        bootstrap_log   TEXT,
                         FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
                 )`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_user
@@ -460,6 +461,20 @@ export async function migrateDb(): Promise<void> {
 	// to the post-migration "off" state.
 	try {
 		await d1Query("ALTER TABLE session_configs ADD COLUMN allow_privileged_ports INTEGER");
+	} catch (err) {
+		if (!/duplicate column name|already exists/i.test((err as Error).message)) {
+			throw err;
+		}
+	}
+	// #274: `bootstrap_log` column on `sessions` — captures the last
+	// bootstrap pipeline output (success or failure) so the user can
+	// inspect what went wrong on a failed session after the WS modal
+	// closes. Truncated to a tail of `BOOTSTRAP_LOG_MAX_BYTES` so a
+	// chatty hook can't bloat the row. Lives on `sessions` (not
+	// `session_configs`) because bare-create sessions with no config
+	// row still benefit from capturing postCreate output.
+	try {
+		await d1Query("ALTER TABLE sessions ADD COLUMN bootstrap_log TEXT");
 	} catch (err) {
 		if (!/duplicate column name|already exists/i.test((err as Error).message)) {
 			throw err;

--- a/backend/src/routes.bootstrapLog.test.ts
+++ b/backend/src/routes.bootstrapLog.test.ts
@@ -70,7 +70,7 @@ vi.mock("./db.js", () => dbStubs);
 import type { BootstrapBroadcaster } from "./bootstrap.js";
 import type { DockerManager } from "./dockerManager.js";
 import { buildRouter } from "./routes.js";
-import { NotFoundError, type SessionManager } from "./sessionManager.js";
+import { ForbiddenError, NotFoundError, type SessionManager } from "./sessionManager.js";
 
 let server: http.Server | null = null;
 let baseUrl = "";
@@ -85,11 +85,11 @@ afterEach(async () => {
 });
 
 async function spinUp(
-	assertOwnership: ReturnType<typeof vi.fn>,
+	assertOwnedBy: ReturnType<typeof vi.fn>,
 	getBootstrapLog: ReturnType<typeof vi.fn>,
 ) {
 	const sessions = {
-		assertOwnership,
+		assertOwnedBy,
 		getBootstrapLog,
 	} as unknown as SessionManager;
 	const docker = {
@@ -130,27 +130,27 @@ describe("GET /sessions/:id/bootstrap-log (#274)", () => {
 	});
 
 	it("returns 200 with { log: string } when a log was captured", async () => {
-		const assertOwnership = vi.fn(async () => ({}) as unknown);
+		const assertOwnedBy = vi.fn(async () => undefined);
 		const getBootstrapLog = vi.fn(async () => "Cloning into target...\nFATAL: clone failed\n");
-		await spinUp(assertOwnership, getBootstrapLog);
+		await spinUp(assertOwnedBy, getBootstrapLog);
 
 		const res = await fetch(`${baseUrl}/api/sessions/s1/bootstrap-log`);
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as { log: string | null };
 		expect(body.log).toContain("FATAL");
-		// Owner-gated path: assertOwnership ran with the authed user
-		// id from the requireAuth stub. A regression that skipped this
+		// Owner-gated path: assertOwnedBy ran with the authed user id
+		// from the requireAuth stub. A regression that skipped this
 		// would be a cross-user data leak.
-		expect(assertOwnership).toHaveBeenCalledWith("s1", "u1");
+		expect(assertOwnedBy).toHaveBeenCalledWith("s1", "u1");
 	});
 
 	it("returns 200 with { log: null } when no bootstrap output is recorded", async () => {
 		// Pre-#274 sessions (column NULL) and bare-create sessions with
 		// no hooks both surface as null. Frontend renders a "no captured
 		// output" placeholder.
-		const assertOwnership = vi.fn(async () => ({}) as unknown);
+		const assertOwnedBy = vi.fn(async () => undefined);
 		const getBootstrapLog = vi.fn(async () => null);
-		await spinUp(assertOwnership, getBootstrapLog);
+		await spinUp(assertOwnedBy, getBootstrapLog);
 
 		const res = await fetch(`${baseUrl}/api/sessions/s1/bootstrap-log`);
 		expect(res.status).toBe(200);
@@ -158,22 +158,38 @@ describe("GET /sessions/:id/bootstrap-log (#274)", () => {
 		expect(body.log).toBeNull();
 	});
 
-	it("returns 404 when assertOwnership throws NotFoundError (foreign or missing session)", async () => {
-		// `assertOwnership` collapses missing + foreign-owned into 404
-		// (probe-attacker enumeration via status-code timing — same
-		// shape as templates / observeLog / the rest of the per-session
-		// reads). The bootstrap-log endpoint MUST inherit that gate.
-		const assertOwnership = vi.fn(async () => {
+	it("returns 404 when assertOwnedBy throws NotFoundError (missing session)", async () => {
+		// SessionManager distinguishes missing (NotFoundError → 404) from
+		// foreign-owned (ForbiddenError → 403); covered separately below.
+		const assertOwnedBy = vi.fn(async () => {
 			throw new NotFoundError("Session not found");
 		});
 		const getBootstrapLog = vi.fn(async () => null);
-		await spinUp(assertOwnership, getBootstrapLog);
+		await spinUp(assertOwnedBy, getBootstrapLog);
 
 		const res = await fetch(`${baseUrl}/api/sessions/missing/bootstrap-log`);
 		expect(res.status).toBe(404);
-		// CRITICAL: getBootstrapLog must NOT fire for a non-owned
-		// session id. A regression that reached the column read would
+		// CRITICAL: getBootstrapLog must NOT fire when the auth gate
+		// rejects. A regression that reached the column read would
 		// leak the foreign owner's log content via the response body.
+		expect(getBootstrapLog).not.toHaveBeenCalled();
+	});
+
+	it("returns 403 when assertOwnedBy throws ForbiddenError (foreign-owned session)", async () => {
+		// Foreign-owned (a session that exists but belongs to another
+		// user) gets 403, NOT 404 — sessions don't collapse the two the
+		// way templates does. The behaviour we MUST pin: getBootstrapLog
+		// never fires, so the foreign owner's log bytes never reach the
+		// response body regardless of how `handleSessionError` maps the
+		// error class.
+		const assertOwnedBy = vi.fn(async () => {
+			throw new ForbiddenError("Forbidden");
+		});
+		const getBootstrapLog = vi.fn(async () => null);
+		await spinUp(assertOwnedBy, getBootstrapLog);
+
+		const res = await fetch(`${baseUrl}/api/sessions/foreign/bootstrap-log`);
+		expect(res.status).toBe(403);
 		expect(getBootstrapLog).not.toHaveBeenCalled();
 	});
 });

--- a/backend/src/routes.bootstrapLog.test.ts
+++ b/backend/src/routes.bootstrapLog.test.ts
@@ -1,0 +1,179 @@
+/**
+ * routes.bootstrapLog.test.ts — REST integration for #274's
+ * `GET /api/sessions/:id/bootstrap-log` endpoint.
+ *
+ * Pins owner-gating (assertOwnership), the wire shape (`{ log }` with
+ * null vs. string), and 404 on a missing session. The persistence
+ * side (the runner writing to the column) is covered in
+ * `bootstrap.test.ts`; this file covers the route layer.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authStubs = vi.hoisted(() => ({
+	requireAuth: (req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	},
+	requireAdmin: vi.fn((req: { userId?: string }, _res: unknown, next: () => void) => {
+		req.userId = "u1";
+		next();
+	}),
+	AUTH_COOKIE_NAME: "st_token",
+	setAuthCookie: vi.fn(),
+	clearAuthCookie: vi.fn(),
+	extractTokenFromCookieHeader: vi.fn(() => null),
+	verifyJwt: vi.fn(() => null),
+	hasAnyUsers: vi.fn(async () => true),
+	registerUser: vi.fn(),
+	loginUser: vi.fn(),
+	listInvites: vi.fn(async () => [] as unknown[]),
+	createInvite: vi.fn(),
+	revokeInvite: vi.fn(),
+	InvalidCredentialsError: class extends Error {
+		constructor() {
+			super("invalid");
+		}
+	},
+	UsernameTakenError: class extends Error {
+		constructor() {
+			super("taken");
+		}
+	},
+	InviteRequiredError: class extends Error {
+		constructor() {
+			super("invite required");
+		}
+	},
+	InviteQuotaExceededError: class extends Error {
+		constructor() {
+			super("invite quota");
+		}
+	},
+}));
+vi.mock("./auth.js", () => authStubs);
+
+const dbStubs = vi.hoisted(() => ({
+	d1Query: vi.fn(async () => ({
+		results: [] as unknown[],
+		success: true as const,
+		meta: { changes: 0, duration: 0, last_row_id: 0 },
+	})),
+	getD1CallsSinceBoot: vi.fn(() => 0),
+	__resetD1CallsForTests: vi.fn(),
+}));
+vi.mock("./db.js", () => dbStubs);
+
+import type { BootstrapBroadcaster } from "./bootstrap.js";
+import type { DockerManager } from "./dockerManager.js";
+import { buildRouter } from "./routes.js";
+import { NotFoundError, type SessionManager } from "./sessionManager.js";
+
+let server: http.Server | null = null;
+let baseUrl = "";
+
+afterEach(async () => {
+	if (server) {
+		await new Promise<void>((resolve, reject) => {
+			server?.close((e) => (e ? reject(e) : resolve()));
+		});
+		server = null;
+	}
+});
+
+async function spinUp(
+	assertOwnership: ReturnType<typeof vi.fn>,
+	getBootstrapLog: ReturnType<typeof vi.fn>,
+) {
+	const sessions = {
+		assertOwnership,
+		getBootstrapLog,
+	} as unknown as SessionManager;
+	const docker = {
+		getUploadTmpDir: () => "/tmp/shared-terminal-test-uploads",
+		getReconcileStats: () => ({
+			lastRunAt: null,
+			sessionsCheckedSinceBoot: 0,
+			errorsSinceBoot: 0,
+		}),
+		gatherStats: vi.fn(async () => new Map()),
+	} as unknown as DockerManager;
+	const broadcaster = {} as BootstrapBroadcaster;
+	const router = buildRouter(sessions, docker, broadcaster, {
+		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+		register: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+		logout: { ipMax: 1000, ipWindowMs: 60_000 },
+		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+		adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
+	});
+	const app = express();
+	app.use(express.json());
+	app.use("/api", router);
+	const s = http.createServer(app);
+	server = s;
+	await new Promise<void>((resolve) => s.listen(0, "127.0.0.1", resolve));
+	const { port } = s.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+}
+
+describe("GET /sessions/:id/bootstrap-log (#274)", () => {
+	beforeEach(() => {
+		dbStubs.d1Query.mockReset();
+	});
+
+	it("returns 200 with { log: string } when a log was captured", async () => {
+		const assertOwnership = vi.fn(async () => ({}) as unknown);
+		const getBootstrapLog = vi.fn(async () => "Cloning into target...\nFATAL: clone failed\n");
+		await spinUp(assertOwnership, getBootstrapLog);
+
+		const res = await fetch(`${baseUrl}/api/sessions/s1/bootstrap-log`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { log: string | null };
+		expect(body.log).toContain("FATAL");
+		// Owner-gated path: assertOwnership ran with the authed user
+		// id from the requireAuth stub. A regression that skipped this
+		// would be a cross-user data leak.
+		expect(assertOwnership).toHaveBeenCalledWith("s1", "u1");
+	});
+
+	it("returns 200 with { log: null } when no bootstrap output is recorded", async () => {
+		// Pre-#274 sessions (column NULL) and bare-create sessions with
+		// no hooks both surface as null. Frontend renders a "no captured
+		// output" placeholder.
+		const assertOwnership = vi.fn(async () => ({}) as unknown);
+		const getBootstrapLog = vi.fn(async () => null);
+		await spinUp(assertOwnership, getBootstrapLog);
+
+		const res = await fetch(`${baseUrl}/api/sessions/s1/bootstrap-log`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { log: string | null };
+		expect(body.log).toBeNull();
+	});
+
+	it("returns 404 when assertOwnership throws NotFoundError (foreign or missing session)", async () => {
+		// `assertOwnership` collapses missing + foreign-owned into 404
+		// (probe-attacker enumeration via status-code timing — same
+		// shape as templates / observeLog / the rest of the per-session
+		// reads). The bootstrap-log endpoint MUST inherit that gate.
+		const assertOwnership = vi.fn(async () => {
+			throw new NotFoundError("Session not found");
+		});
+		const getBootstrapLog = vi.fn(async () => null);
+		await spinUp(assertOwnership, getBootstrapLog);
+
+		const res = await fetch(`${baseUrl}/api/sessions/missing/bootstrap-log`);
+		expect(res.status).toBe(404);
+		// CRITICAL: getBootstrapLog must NOT fire for a non-owned
+		// session id. A regression that reached the column read would
+		// leak the foreign owner's log content via the response body.
+		expect(getBootstrapLog).not.toHaveBeenCalled();
+	});
+});

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -1463,6 +1463,23 @@ export function buildRouter(
 		}
 	});
 
+	// #274 — Bootstrap log read. Returns the captured output from the
+	// last bootstrap run (success or failure). Owner-gated via
+	// `assertOwnership`, same shape as the rest of /sessions/:id/*.
+	// Returns 200 with `{ log: string | null }`; null means no
+	// bootstrap ever ran for this session (bare-create with no hooks),
+	// or the row pre-dates the #274 migration and the column is NULL.
+	router.get("/sessions/:id/bootstrap-log", async (req: Request, res: Response) => {
+		const { userId } = req as AuthedRequest;
+		try {
+			await sessions.assertOwnership(req.params.id, userId);
+			const log = await sessions.getBootstrapLog(req.params.id);
+			res.json({ log });
+		} catch (err) {
+			handleSessionError(err, res);
+		}
+	});
+
 	// Per-session observe-log read (#201d). Returns the audit history
 	// for a single session — who watched, when, and whether they're
 	// still watching (`endedAt: null`). Gated by `assertCanObserve`:

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -1472,7 +1472,12 @@ export function buildRouter(
 	router.get("/sessions/:id/bootstrap-log", async (req: Request, res: Response) => {
 		const { userId } = req as AuthedRequest;
 		try {
-			await sessions.assertOwnership(req.params.id, userId);
+			// `assertOwnedBy`, NOT `assertOwnership` — we don't use the
+			// returned meta and assertOwnership pays an unconditional
+			// D1 read on the positive path. Matches the convention the
+			// other read-only routes that discard meta use (stop / start
+			// / restore / observe-log read).
+			await sessions.assertOwnedBy(req.params.id, userId);
 			const log = await sessions.getBootstrapLog(req.params.id);
 			res.json({ log });
 		} catch (err) {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -1477,6 +1477,18 @@ export function buildRouter(
 			// D1 read on the positive path. Matches the convention the
 			// other read-only routes that discard meta use (stop / start
 			// / restore / observe-log read).
+			//
+			// Hard-delete race: if the row is deleted between
+			// `assertOwnedBy` (which can short-circuit via the
+			// ownership cache) and `getBootstrapLog`, the second call
+			// returns null and the route responds 200 { log: null } —
+			// indistinguishable from the legitimate "no bootstrap ever
+			// ran" state. This is intentional. The auth gate already
+			// passed and there is no log content to leak; collapsing
+			// the race into the no-op response is simpler than wiring
+			// `getBootstrapLog` to distinguish missing-row from
+			// present-but-null-column purely for this route's 404
+			// shape.
 			await sessions.assertOwnedBy(req.params.id, userId);
 			const log = await sessions.getBootstrapLog(req.params.id);
 			res.json({ log });

--- a/backend/src/sessionManager.ts
+++ b/backend/src/sessionManager.ts
@@ -533,6 +533,30 @@ export class SessionManager {
 		]);
 	}
 
+	/**
+	 * Persist the captured bootstrap output (success or failure) to D1
+	 * so a failed session's modal contents survive after the WS closes.
+	 * Surfaced via `GET /sessions/:id/bootstrap-log` (#274).
+	 *
+	 * Caller is responsible for tail-truncation — `BOOTSTRAP_LOG_MAX_BYTES`
+	 * inside `bootstrap.ts` keeps the row size bounded.
+	 */
+	async setBootstrapLog(sessionId: string, log: string): Promise<void> {
+		await d1Query("UPDATE sessions SET bootstrap_log = ? WHERE session_id = ?", [log, sessionId]);
+	}
+
+	/** Read just the bootstrap_log column. Returns null when the column
+	 *  is null (no bootstrap ever ran, or a session created before #274
+	 *  migrated). Separate from `get()` so a sidebar refresh doesn't
+	 *  pull a potentially-large 64 KiB blob on every poll. */
+	async getBootstrapLog(sessionId: string): Promise<string | null> {
+		const result = await d1Query<{ bootstrap_log: string | null }>(
+			"SELECT bootstrap_log FROM sessions WHERE session_id = ?",
+			[sessionId],
+		);
+		return result.results[0]?.bootstrap_log ?? null;
+	}
+
 	async terminate(sessionId: string): Promise<void> {
 		await this.updateStatus(sessionId, "terminated");
 	}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -590,6 +590,20 @@ export async function getSession(id: string): Promise<SessionInfo> {
 	return res.json();
 }
 
+/** #274 — Read the captured bootstrap output (success or failure) for
+ *  a session. `log` is `null` when no bootstrap ever ran (bare-create
+ *  with no hooks). Used by the failed-row "View log" action so a user
+ *  can debug a postCreate/clone failure after the live modal closes. */
+export async function fetchBootstrapLog(id: string): Promise<string | null> {
+	const res = await apiFetch(`/sessions/${id}/bootstrap-log`);
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? "Failed to load bootstrap log");
+	}
+	const data = (await res.json()) as { log: string | null };
+	return data.log;
+}
+
 /** Soft delete stops the container and keeps the workspace; `hard` also wipes files + row. */
 export async function deleteSession(id: string, hard = false): Promise<void> {
 	const qs = hard ? "?hard=true" : "";

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1375,6 +1375,18 @@ main:not([data-sidebar-ready]) #sidebar {
   word-break: break-word;
   margin: 0;
 }
+/* #274 — Standalone bootstrap-log viewer (failed-row click → modal).
+   Wider than the default modal so a 64 KiB log doesn't word-wrap into
+   an unreadable column, and a taller scroll region than the inline
+   `.bootstrap-error-output` cap of 200px since the user came here
+   specifically to read it. */
+.bootstrap-log-card {
+  max-width: 900px;
+  width: 90vw;
+}
+.bootstrap-log-card .bootstrap-error-output {
+  max-height: 60vh;
+}
 #session-list {
   flex: 1;
   overflow-y: auto;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -36,6 +36,7 @@ import {
 	fetchAdminObserveLog,
 	fetchAdminSessions,
 	fetchAdminStats,
+	fetchBootstrapLog,
 	fetchMyGroups,
 	fetchMyObservableSessions,
 	fetchSessionObserveLog,
@@ -662,10 +663,11 @@ function renderSessionList() {
 				showToast("Start the session first", true);
 			} else if (s.status === "failed") {
 				// Failed sessions are unrecoverable via /start (the server
-				// 409s); clicking them used to silently no-op which left
-				// the user wondering if the click registered. Toast points
-				// them at the recovery path: recreate to retry.
-				showToast("Session failed during postCreate — recreate to retry", true);
+				// 409s). #274 lets the user inspect the captured bootstrap
+				// output (clone / postCreate stderr) so they can fix the
+				// config before recreating — pre-#274 the toast told them
+				// to recreate but offered no way to see WHY it failed.
+				void openBootstrapLogModal(s);
 			}
 		});
 
@@ -1408,6 +1410,99 @@ function teardownBootstrapTail() {
 
 function clearBootstrapError() {
 	document.getElementById("bootstrap-error-panel")?.remove();
+}
+
+/**
+ * #274 — Open a modal showing the persisted bootstrap output for a
+ * failed (or successful) session. Built programmatically rather than
+ * declared in index.html because it's a leaf utility used only when
+ * the user clicks a failed row; pulling the markup into HTML would
+ * add weight everyone else pays for. Reuses the global `.modal` /
+ * `.modal-backdrop` / `.modal-card` styles so the visual matches
+ * other modals.
+ */
+async function openBootstrapLogModal(session: SessionInfo): Promise<void> {
+	// Remove a stale viewer first so a rapid second click doesn't
+	// stack modals on top of each other.
+	document.getElementById("bootstrap-log-modal")?.remove();
+
+	const modal = document.createElement("div");
+	modal.id = "bootstrap-log-modal";
+	modal.className = "modal open";
+	modal.setAttribute("aria-hidden", "false");
+
+	const backdrop = document.createElement("div");
+	backdrop.className = "modal-backdrop";
+	backdrop.setAttribute("data-close-modal", "");
+	modal.appendChild(backdrop);
+
+	const card = document.createElement("div");
+	card.className = "modal-card bootstrap-log-card";
+	card.setAttribute("role", "dialog");
+	card.setAttribute("aria-modal", "true");
+
+	const header = document.createElement("div");
+	header.className = "modal-header";
+	const h2 = document.createElement("h2");
+	h2.textContent = `Bootstrap log — ${session.name}`;
+	header.appendChild(h2);
+	const closeBtn = document.createElement("button");
+	closeBtn.className = "modal-close";
+	closeBtn.type = "button";
+	closeBtn.setAttribute("aria-label", "Close");
+	closeBtn.setAttribute("data-close-modal", "");
+	closeBtn.textContent = "×";
+	header.appendChild(closeBtn);
+	card.appendChild(header);
+
+	const hint = document.createElement("p");
+	hint.className = "modal-hint";
+	hint.textContent =
+		session.status === "failed"
+			? "Captured output from the failed bootstrap (clone / dotfiles / agentSeed / postCreate). Fix the cause and create a new session."
+			: "Captured output from the last bootstrap run.";
+	card.appendChild(hint);
+
+	const pre = document.createElement("pre");
+	pre.className = "bootstrap-error-output";
+	pre.textContent = "Loading…";
+	card.appendChild(pre);
+
+	modal.appendChild(card);
+	document.body.appendChild(modal);
+
+	const close = () => {
+		modal.remove();
+	};
+	// Close on backdrop / × / Esc — same affordances as the rest of
+	// the app's modals. The shared admin-modal click handler doesn't
+	// reach us (different element); wire ours explicitly.
+	modal.addEventListener("click", (e) => {
+		if ((e.target as HTMLElement).hasAttribute("data-close-modal")) close();
+	});
+	const escHandler = (e: KeyboardEvent) => {
+		if (e.key === "Escape") {
+			close();
+			document.removeEventListener("keydown", escHandler);
+		}
+	};
+	document.addEventListener("keydown", escHandler);
+
+	try {
+		const log = await fetchBootstrapLog(session.sessionId);
+		if (log === null || log === "") {
+			pre.textContent =
+				"(no captured output — session may pre-date the bootstrap-log feature, or no bootstrap ever ran)";
+		} else {
+			pre.textContent = log;
+			// Auto-scroll to the bottom so the user sees the tail —
+			// failure messages are at the END of the log, not the
+			// start.
+			pre.scrollTop = pre.scrollHeight;
+		}
+	} catch (err) {
+		pre.textContent = `Failed to load log: ${(err as Error).message}`;
+	}
 }
 
 function closeNewSessionModal() {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1471,8 +1471,17 @@ async function openBootstrapLogModal(session: SessionInfo): Promise<void> {
 	modal.appendChild(card);
 	document.body.appendChild(modal);
 
+	// `escHandler` declared first so `close()` can unregister it on
+	// every close path (backdrop / × / Esc). Without this, the
+	// non-Esc close paths leak a listener on `document` each time
+	// the modal opens — they self-heal on the next Esc press but
+	// accumulate in between.
+	const escHandler = (e: KeyboardEvent) => {
+		if (e.key === "Escape") close();
+	};
 	const close = () => {
 		modal.remove();
+		document.removeEventListener("keydown", escHandler);
 	};
 	// Close on backdrop / × / Esc — same affordances as the rest of
 	// the app's modals. The shared admin-modal click handler doesn't
@@ -1480,12 +1489,6 @@ async function openBootstrapLogModal(session: SessionInfo): Promise<void> {
 	modal.addEventListener("click", (e) => {
 		if ((e.target as HTMLElement).hasAttribute("data-close-modal")) close();
 	});
-	const escHandler = (e: KeyboardEvent) => {
-		if (e.key === "Escape") {
-			close();
-			document.removeEventListener("keydown", escHandler);
-		}
-	};
 	document.addEventListener("keydown", escHandler);
 
 	try {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1421,9 +1421,22 @@ function clearBootstrapError() {
  * `.modal-backdrop` / `.modal-card` styles so the visual matches
  * other modals.
  */
+// #274 — single-modal invariant. A rapid double-click on a failed
+// row would otherwise register two `escHandler` closures on document
+// (the second open removes the stale DOM element but the prior
+// listener is still attached). Calling the prior `close()` first
+// unregisters its handler cleanly. Module-level so an in-flight
+// log fetch from the first open can still resolve into the closed
+// modal harmlessly — `pre.textContent =` on an orphaned node is a
+// no-op.
+let activeBootstrapLogClose: (() => void) | null = null;
+
 async function openBootstrapLogModal(session: SessionInfo): Promise<void> {
-	// Remove a stale viewer first so a rapid second click doesn't
-	// stack modals on top of each other.
+	// Close any previous viewer cleanly (removes its escHandler) before
+	// stacking a new one. Falls through to a defensive DOM-remove for
+	// the case where activeBootstrapLogClose is null but a stale
+	// element somehow survived (shouldn't happen post-fix, but cheap).
+	activeBootstrapLogClose?.();
 	document.getElementById("bootstrap-log-modal")?.remove();
 
 	const modal = document.createElement("div");
@@ -1482,7 +1495,13 @@ async function openBootstrapLogModal(session: SessionInfo): Promise<void> {
 	const close = () => {
 		modal.remove();
 		document.removeEventListener("keydown", escHandler);
+		// Clear the module-level reference only if it still points at
+		// our close — a second-open before our close ran would have
+		// already swapped it. Avoids the second modal's `close` being
+		// silently nulled out by the first's tear-down.
+		if (activeBootstrapLogClose === close) activeBootstrapLogClose = null;
 	};
+	activeBootstrapLogClose = close;
 	// Close on backdrop / × / Esc — same affordances as the rest of
 	// the app's modals. The shared admin-modal click handler doesn't
 	// reach us (different element); wire ours explicitly.


### PR DESCRIPTION
## Why this exists

User reported a session that failed at the postCreate stage while trying to clone a private repo with a PAT and set up env vars. The bootstrap modal showed live output during the run, but the moment they dismissed it the output was gone — and a `failed` session is unrecoverable via /start, so the user had **no way** to know whether the failure was in the clone, the postCreate, or the env-var path. Their workaround was to recreate from scratch, watch the modal closely, and hope nothing scrolled past.

This PR fixes the underlying debuggability gap: the captured pipeline output is now persisted on the row and surfaced via a "View log" modal when the user clicks a failed (orange) sidebar entry.

## Backend

- **Schema**: new \`sessions.bootstrap_log\` TEXT column. Migration uses the existing ADD COLUMN-with-duplicate-swallow idiom; CREATE TABLE declares it for fresh deploys.
- **Capture**: \`runAsyncBootstrap\` accumulates every broadcast chunk into a bounded tail buffer (\`BOOTSTRAP_LOG_MAX_BYTES = 64 KiB\`). Over-cap noise is **head-trimmed**, not tail-trimmed — failures live at the end of the log, so the tail is the part that actually needs to survive.
- **Persist on both branches**: \`done\` and \`fail\` both write the column. Failure-path persist runs **before** \`failSession\` so a race-y subsequent GET sees populated data, not an empty string. Best-effort D1 — a write error logs and lets the terminal broadcast fire anyway (debug surface degrades; the user's modal still resolves correctly).
- **Endpoint**: \`GET /api/sessions/:id/bootstrap-log\` returns \`{ log: string | null }\`, gated by the existing \`assertOwnership\` choke point. \`null\` covers both pre-#274 rows and sessions that never bootstrapped.

## Frontend

- New \`fetchBootstrapLog(id)\` in api.ts.
- Failed sidebar rows: click now opens a programmatic modal (no permanent HTML) showing the captured output in a monospace, scrollable region. Auto-scrolls to the tail. Closes on backdrop click / × / Escape.
- Previous "recreate to retry" toast was actionable-free; replaced.

## Tests

Backend: 845 pass.
- \`bootstrap.test.ts\`: persist on success, persist on failure, tail-truncation preserves the END, D1-hiccup-on-persist must not block the terminal broadcast.
- \`routes.bootstrapLog.test.ts\` (new): 200/log, 200/null, **404 with no column-read** when \`assertOwnership\` throws (pins the foreign-session leak guard).

Frontend: 66 pass; tsc + Biome + vite build clean.

## Test plan

- [ ] \`cd backend && npm run lint && npm test && npm run build\`
- [ ] \`cd frontend && npm run lint && npm test && npm run build\`
- [ ] Manual repro:
  - [ ] Create a session with an intentionally-broken postCreate (e.g. \`exit 1\`). Confirm the orange row.
  - [ ] Click the failed row. Modal opens with the \`exit 1\` chunk visible.
  - [ ] Reload the page; click the same row. Log persists (came from D1, not the WS).
  - [ ] Create a session with a working clone + simple postCreate. Confirm log is captured on success too (clickable on a stopped row).

## Why this should unblock the original bug

Once merged, the user can recreate their failing session and click "View log" on the failed row to see the exact stderr from the clone or postCreate step. We can then fix the specific issue (PAT format, env var availability, .env file write permissions, etc.) once we know what actually broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)