### PR TITLE
docs(env): note compose-only forwarding + tsx-no-dotenv at top of .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,15 @@
 # ── Shared Terminal — Environment Variables ──────────────────────────────────
+#
+# This file is read by Docker Compose (it auto-loads `.env` from the compose
+# project root), NOT by the Node backend directly — `tsx watch src/index.ts`
+# has no dotenv loader, so in bare-dev workflows you need to export the vars
+# yourself (or use direnv / a process manager).
+#
+# Compose then forwards values to the backend container ONLY for keys
+# explicitly listed under `services.app.environment` in `docker-compose.yml`.
+# Adding a new tunable here without also wiring it through the compose
+# environment list means the backend silently runs without it. Both spots
+# must be touched together.
 
 # Server port
 PORT=3001


### PR DESCRIPTION
## Summary

- Adds an 11-line note at the top of \`.env.example\` calling out two non-obvious facts so the next person adding a tunable doesn't get bitten the same way \`PORT_PROXY_BASE_DOMAIN\` / \`COOKIE_DOMAIN\` were in #276:
  1. \`tsx watch\` (the bare-dev path) has no dotenv loader, so \`.env\` is only auto-loaded by Docker Compose — bare-dev workflows need to export the vars themselves.
  2. Compose forwards values only for keys explicitly listed under \`services.app.environment\` in \`docker-compose.yml\`. Adding a var here without wiring the compose entry too means the backend silently runs without it.

Both points are derivable from the codebase but easy to miss until they silently fail in production.

## Test plan

- [ ] CI green (Biome / tsc / vitest — comment-only change in a non-source file, no functional impact expected)
- [ ] Render: top-of-file comment is the first thing a reader sees on \`cp .env.example .env\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)