### PR TITLE
docs: add MIT license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,4 +115,4 @@ refactor: extract auth middleware
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the same license as the project.
+By contributing, you agree that your contributions will be licensed under the project's [MIT License](./LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Diego Ferreyra
+Copyright (c) 2024 - 2026 Diego Ferreyra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Diego Ferreyra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ A self-hosted web-based terminal that runs on an always-on Linux server at home.
 | Containers | Docker (dockerode), tmux                           |
 | Tunnel     | Cloudflare Tunnel                                  |
 | Hosting    | Cloudflare Pages (frontend), self-hosted (backend) |
+
+## License
+
+Released under the [MIT License](./LICENSE).

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,6 +2,7 @@
   "name": "shared-terminal-backend",
   "version": "2.0.0",
   "description": "Shared terminal service — Docker-based sessions with persistent storage",
+  "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "shared-terminal-frontend",
   "version": "1.0.0",
   "description": "Shared terminal service frontend",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Adds an open-source license to this public repo, which previously had none.

- **`LICENSE`** — MIT License, copyright 2026 Diego Ferreyra. GitHub will auto-detect and surface the MIT badge on the repo page.
- **`backend/package.json`** + **`frontend/package.json`** — declare `"license": "MIT"` so package metadata matches the LICENSE file.
- **`README.md`** — new License section linking to the file.
- **`CONTRIBUTING.md`** — license clause now names MIT explicitly and links the file, instead of the generic "same license as the project".

## Notes

MIT was chosen as the permissive default. Copyright holder is taken from the git config (`Diego Ferreyra`) — swap to a handle/org if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)