### PR TITLE
feat(terminal): enable selection on Mac + first-session Shift/Option hint (#158)

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1782,6 +1782,61 @@ main:not([data-sidebar-ready]) #sidebar {
 .tab-pane.active {
   display: block;
 }
+/* First-session hint that points users at the Shift+drag selection
+ * gesture. tmux mouse-on (session-image/tmux.conf:54) forwards plain
+ * mouse drags to tmux for pane/copy-mode handling, so without the
+ * Shift modifier xterm never registers a selection and the
+ * copy-on-select path (terminal.ts) has nothing to copy — silent
+ * dead end with no inline signal. One-time, persisted via
+ * localStorage; clicking ✕ on any pane's badge clears the flag and
+ * removes the badge from every currently-open pane (see
+ * `injectSelectionHint` in main.ts). */
+.select-hint {
+  position: absolute;
+  bottom: 8px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 4px 4px 10px;
+  background: rgba(22, 27, 34, 0.88);
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #8b949e;
+  font-size: 12px;
+  font-family: inherit;
+  z-index: 10;
+  /* Don't let the badge body steal selection drags or text-select on
+   * the terminal beneath it — only the close button needs to swallow
+   * clicks. Browsers honour pointer-events:auto on the descendant
+   * even when the parent is pointer-events:none. */
+  pointer-events: none;
+  user-select: none;
+}
+.select-hint kbd {
+  background: #1c2128;
+  border: 1px solid #30363d;
+  border-radius: 3px;
+  padding: 0 5px;
+  font-family: inherit;
+  font-size: 11px;
+  color: #e6edf3;
+}
+.select-hint button {
+  pointer-events: auto;
+  background: transparent;
+  border: 0;
+  color: #8b949e;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+.select-hint button:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #e6edf3;
+}
 #terminal-container .xterm {
   height: 100%;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1003,6 +1003,7 @@ function openTab(tabId: string) {
 			});
 			entry = { pane, term };
 			currentTerminals.set(tabId, entry);
+			maybeInjectSelectionHint(pane);
 		} catch (err) {
 			pane.remove();
 			if (prevActiveTabId) {
@@ -2904,6 +2905,68 @@ function showToast(message: string, isError = false) {
 		// a one-time secret like a freshly-minted invite code (#49).
 		toast.textContent = "";
 	}, 4000);
+}
+
+// ── First-session selection hint ────────────────────────────────────────────
+// tmux mouse-on (session-image/tmux.conf:54) means a plain mouse drag in the
+// terminal is forwarded to tmux as SGR-1006 mouse-tracking, not interpreted
+// by xterm as a selection — so `term.getSelection()` stays empty and the
+// auto-copy / Cmd-C paths in terminal.ts correctly skip, producing the
+// silent dead end users hit ("I selected text but pasting gave nothing").
+//
+// xterm.js's `SelectionService.shouldForceSelection` is the override gate:
+// on Mac it requires Option + drag AND `macOptionClickForcesSelection: true`
+// (which terminal.ts now sets); on every other platform it's Shift + drag
+// unconditionally. The hint label below is platform-detected to match.
+// Dismissal flag is in localStorage; clicking ✕ on any open pane's badge
+// clears the flag and removes the badge from every currently-rendered
+// pane so a power user dismisses once globally and not per-tab.
+const SELECTION_HINT_STORAGE_KEY = "shared-terminal:selectionHintDismissed";
+function maybeInjectSelectionHint(pane: HTMLElement) {
+	try {
+		if (localStorage.getItem(SELECTION_HINT_STORAGE_KEY) === "1") return;
+	} catch {
+		// Private browsing / disabled storage — show nothing rather
+		// than show-and-never-dismiss.
+		return;
+	}
+	const hint = document.createElement("div");
+	hint.className = "select-hint";
+	const label = document.createElement("span");
+	// Platform-aware modifier label. xterm.js's
+	// SelectionService.shouldForceSelection hard-codes the modifier:
+	// Option on Mac (gated by `macOptionClickForcesSelection`, which
+	// we enable in terminal.ts), Shift everywhere else. We mirror
+	// the SAME `navigator.platform` check xterm.js uses internally
+	// (common/Platform.ts in xterm.js 5.5) so the two agree —
+	// otherwise a user-agent string change in some browser version
+	// would have us hinting one modifier while xterm honours the
+	// other. navigator.platform is deprecated but still works in
+	// every shipping browser and is what xterm.js itself reads.
+	const isMac = ["Macintosh", "MacIntel", "MacPPC", "Mac68K"].includes(navigator.platform);
+	// innerHTML is fine here: every string is a literal we control,
+	// no user input flows in. Using innerHTML rather than three
+	// createElements keeps the markup readable.
+	label.innerHTML = isMac
+		? "Hold <kbd>⌥ Option</kbd> + drag to select text"
+		: "Hold <kbd>Shift</kbd> + drag to select text";
+	const close = document.createElement("button");
+	close.type = "button";
+	close.setAttribute("aria-label", "Dismiss selection hint");
+	close.textContent = "×";
+	close.addEventListener("click", () => {
+		try {
+			localStorage.setItem(SELECTION_HINT_STORAGE_KEY, "1");
+		} catch {
+			/* see above — best effort */
+		}
+		// Sweep every visible badge, not just this one. Multiple
+		// panes (multi-tab sessions) each carry their own hint —
+		// the user is telling us "yes I know" once, globally.
+		for (const el of document.querySelectorAll(".select-hint")) el.remove();
+	});
+	hint.append(label, close);
+	pane.appendChild(hint);
 }
 
 // ── Show terminated toggle ──────────────────────────────────────────────────

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -119,6 +119,17 @@ export function openTerminalSession(opts: {
 		// claude, text jumps to the next row and stays one row off". Default
 		// false matches what Ink (and standard TUI conventions) expect.
 		allowProposedApi: true,
+		// On Mac, force selection when the Option key is held — the
+		// standard xterm convention there. Without this flag, xterm.js
+		// hard-codes `event.altKey && macOptionClickForcesSelection`
+		// in SelectionService.shouldForceSelection (xterm.js 5.5),
+		// which evaluates to `false` regardless of modifier on Mac and
+		// leaves Mac users with NO way to make a selection while tmux
+		// `mouse on` (session-image/tmux.conf:54) forwards every drag
+		// to tmux. Non-Mac platforms use Shift+drag unconditionally
+		// and don't need a config flag. See the hint badge in
+		// `main.ts` for the user-facing label that mirrors this.
+		macOptionClickForcesSelection: true,
 		// Apps like Claude Code emit OSC 8 hyperlink escapes. xterm renders
 		// them (underline + pointer cursor) but needs an explicit handler
 		// to actually open them on click.


### PR DESCRIPTION
Companion to merged #283 — and a real bug fix, not just a UX nicety.

## The actual bug

xterm.js's \`SelectionService.shouldForceSelection\` (v5.5):

\`\`\`ts
if (Browser.isMac) {
    return event.altKey && this._optionsService.rawOptions.macOptionClickForcesSelection;
}
return event.shiftKey;
\`\`\`

We never set \`macOptionClickForcesSelection\`, so on Mac that returns \`false\` regardless of modifier — meaning **Mac users have had no way to make a selection in the terminal at all**. tmux's \`mouse on\` (session-image/tmux.conf:54) consumes every drag, and there's no escape hatch. Non-Mac users could always Shift+drag.

Plus, the existence of the modifier is undiscoverable — no inline signal that a plain drag is a UX cliff.

## Changes

1. **\`terminal.ts\`** — set \`macOptionClickForcesSelection: true\`. Mac users can now \`⌥ Option + drag\` to force a selection over mouse-tracking.

2. **\`main.ts\` + \`main.css\`** — inject a one-time dismissible hint badge into every newly opened terminal pane. Platform-detected to match xterm.js's actual modifier:
   - Mac → \`Hold ⌥ Option + drag to select text\`
   - else → \`Hold Shift + drag to select text\`
   - Same \`navigator.platform\` check xterm.js uses in \`common/Platform.ts\`, so the label and the modifier xterm honours are guaranteed to agree.
   - Persisted via \`localStorage["selectionHintDismissed"]\`. Clicking ✕ on any pane's badge clears the flag and sweeps every other \`.select-hint\` element so dismissal is once-globally rather than per-tab.
   - \`pointer-events: none\` on the badge body, \`auto\` on the close button — the badge sits over the bottom-right corner of xterm without stealing drag-selections beneath it.

## Render

\`\`\`
┌───────────────────────────────────────────┐
│  $ ls -la                                 │
│  total 128                                │
│                                           │
│                                           │
│                                           │
│                ┌────────────────────────┐ │
│                │ Hold ⌥ Option + drag   │ │
│                │ to select text       × │ │
│                └────────────────────────┘ │
└───────────────────────────────────────────┘
\`\`\`

## Out of scope

- Mobile copy path (touch handler still consumes drag for scroll). Tracked on #158.
- Disabling tmux mouse-on per-session — bigger UX surface (alt-buffer mouse apps, wheel forwarding, touch scroll). Not the right shape for a regression fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)