### PR TITLE
feat(terminal): brief copy-success toast on auto-copy (#158)

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1894,6 +1894,14 @@ main:not([data-sidebar-ready]) #sidebar {
   border-color: #f85149;
   color: #f85149;
 }
+/* Success variant — used for the copy-on-select confirmation. Held to a
+ * shorter timeout in showCopySuccessToast() because the auto-copy path
+ * fires on every selection-finalise; a 4s lingering toast would be
+ * spammy. Green chip matches GitHub's success accent. */
+#toast.success {
+  border-color: #3fb950;
+  color: #3fb950;
+}
 
 /* ── Mobile ─────────────────────────────────────────────────── */
 /* Breakpoint mirrored in main.ts as MOBILE_BREAKPOINT_PX — keep in sync. */

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -986,9 +986,6 @@ function openTab(tabId: string) {
 					showToast(`${msg} Reload the tab to retry GPU rendering.`);
 				},
 				onCopy: (ok: boolean) => {
-					// Failure-only toast policy: silent on success matches
-					// the native Cmd-C feel and avoids flooding the user
-					// with chips on every selection-finalize (#158).
 					// Identity guards mirror onStatus / onError above:
 					// session match prevents stale toasts from a
 					// torn-down tab in a different session, and active-tab
@@ -997,7 +994,25 @@ function openTab(tabId: string) {
 					// currently looking at.
 					if (activeSessionId !== ownSessionId) return;
 					if (tabId !== currentActiveTabId) return;
-					if (!ok) showToast("Copy failed — clipboard permission denied?", true);
+					if (ok) {
+						// Success chip is intentionally brief (1.2s vs the
+						// 4s error toast) — auto-copy fires on every
+						// selection-finalise, and originally the design
+						// rationale for failure-only was "matches native
+						// Cmd-C feel". Field reports showed users with no
+						// signal that the copy happened didn't trust the
+						// mechanism — the short chip is the smallest
+						// addition that confirms without spamming. The
+						// chip is unconditional rather than first-time-
+						// only because the auto-copy path is genuinely
+						// invisible (no Cmd-C kinaesthetic feedback,
+						// selection stays highlighted as terminals do)
+						// and a one-time confirmation would leave power
+						// users wondering "did that one copy too?".
+						showCopySuccessToast();
+					} else {
+						showToast("Copy failed — clipboard permission denied?", true);
+					}
 				},
 				isActive: () => activeSessionId === ownSessionId && tabId === currentActiveTabId,
 			});
@@ -2905,6 +2920,26 @@ function showToast(message: string, isError = false) {
 		// a one-time secret like a freshly-minted invite code (#49).
 		toast.textContent = "";
 	}, 4000);
+}
+
+// Brief success indicator for the copy-on-select path. Kept short
+// (1.2s) and on its own helper rather than a `success` flag on
+// `showToast` because the auto-copy path fires on every selection-
+// finalise — a 4s toast that lingers across multiple selections
+// would feel intrusive, and reusing the failure toast's duration
+// would let a recent copy-success chip occlude a real error toast
+// that follows it. Reuses the same #toast element + textContent
+// clear-out for the same DOM-queryable-leftover reason as
+// `showToast`.
+const COPY_TOAST_DURATION_MS = 1200;
+function showCopySuccessToast() {
+	toast.textContent = "✓ Copied";
+	toast.className = "visible success";
+	if (toastTimer) clearTimeout(toastTimer);
+	toastTimer = setTimeout(() => {
+		toast.className = "";
+		toast.textContent = "";
+	}, COPY_TOAST_DURATION_MS);
 }
 
 // ── First-session selection hint ────────────────────────────────────────────


### PR DESCRIPTION
Closes the loop on #158's desktop side. After #283 (auto-copy reliability) and #284 (Mac selection + Shift/Option hint), copy actually works — but the failure-only \`onCopy\` policy means **users get no signal that a successful copy happened**. The auto-copy path doesn't have a Cmd-C keystroke kinaesthetic, the selection stays highlighted (standard terminal behaviour, intentional), and the clipboard write is silent. Field report confirms users don't trust the mechanism without confirmation.

## Summary

- **\`showCopySuccessToast()\`** — short 1.2 s "✓ Copied" chip, separate helper from \`showToast\` because the auto-copy path fires on every selection-finalise and the 4 s error-toast duration would feel intrusive at that frequency; also keeps a recent success chip from occluding a follow-up real error.
- **\`#toast.success\`** CSS mirroring the existing \`.error\` variant — GitHub success accent (#3fb950) on the same chip shape.
- **\`onCopy\` wired to call success unconditionally on \`ok=true\`**, failure path unchanged. Unconditional rather than first-time-only because the original "matches native Cmd-C feel" rationale doesn't apply to a path that has no keystroke feel — without per-event confirmation users always wonder "did that one copy too?".

## Render

\`\`\`
                    ┌────────────┐
                    │ ✓ Copied   │ ← 1.2s, bottom-right (existing toast slot)
                    └────────────┘
\`\`\`

Error path keeps its 4s + red styling unchanged.

## Out of scope

- Mobile copy entry — still tracked on #158.
- One-time vs every-time toast — picked every-time after the field report; can re-evaluate if "spammy" feedback comes in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)