### PR TITLE
feat(terminal): mobile copy path (#286)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1239,7 +1239,7 @@
         </button>
         <button class="actions-menu-item" id="actions-select-btn" type="button" role="menuitem">
           <span class="actions-menu-item-title">Select &amp; copy</span>
-          <span class="actions-menu-item-hint">Drag a finger across the terminal to select text — it copies automatically</span>
+          <span class="actions-menu-item-hint">Copy the current selection; on touch, drag to select — it copies automatically</span>
         </button>
       </div>
     </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1237,6 +1237,10 @@
           <span class="actions-menu-item-title">Attach file</span>
           <span class="actions-menu-item-hint">Upload an image, PDF, or any file Claude CLI can read</span>
         </button>
+        <button class="actions-menu-item" id="actions-select-btn" type="button" role="menuitem">
+          <span class="actions-menu-item-title">Select &amp; copy</span>
+          <span class="actions-menu-item-hint">Drag a finger across the terminal to select text — it copies automatically</span>
+        </button>
       </div>
     </div>
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -187,6 +187,7 @@ const actionsBtn = document.getElementById("actions-btn") as HTMLButtonElement;
 const actionsMenu = document.getElementById("actions-menu")!;
 const actionsPasteBtn = document.getElementById("actions-paste-btn") as HTMLButtonElement;
 const actionsAttachBtn = document.getElementById("actions-attach-btn") as HTMLButtonElement;
+const actionsSelectBtn = document.getElementById("actions-select-btn") as HTMLButtonElement;
 const fileInput = document.getElementById("file-input") as HTMLInputElement;
 const pasteModal = document.getElementById("paste-modal")!;
 const pasteTextarea = document.getElementById("paste-textarea") as HTMLTextAreaElement;
@@ -3746,6 +3747,27 @@ actionsAttachBtn.addEventListener("click", () => {
 	// fires `change` (browsers no-op when value is unchanged).
 	fileInput.value = "";
 	fileInput.click();
+});
+
+// "Select & copy" (#286). On touch there's no Cmd-C and tmux `mouse on`
+// forwards finger drags as scroll, so the user has no way to make — let
+// alone copy — a selection. This entry copies an existing selection if
+// one's present, then arms select-mode so the *next* finger drag builds a
+// fresh selection that auto-copies on release (the auto-copy + toast path
+// from #158 fires it; select-mode self-clears after one selection). On
+// desktop `enterSelectMode` is a harmless no-op — only the copy runs.
+actionsSelectBtn.addEventListener("click", () => {
+	closeActionsMenu();
+	const term = getActiveTerminal();
+	if (!term) {
+		showToast("No active session", true);
+		return;
+	}
+	// copySelection toasts via the onCopy callback when it copies, so only
+	// surface the drag hint when there was nothing to copy yet.
+	const copied = term.copySelection();
+	term.enterSelectMode();
+	if (!copied) showToast("Drag across the terminal to select — it copies automatically");
 });
 
 // ── File attachment flow ────────────────────────────────────────────────────

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3763,11 +3763,16 @@ actionsSelectBtn.addEventListener("click", () => {
 		showToast("No active session", true);
 		return;
 	}
-	// copySelection toasts via the onCopy callback when it copies, so only
-	// surface the drag hint when there was nothing to copy yet.
+	// When a selection already exists the user's intent is "copy this" —
+	// copySelection handles it (and toasts via onCopy). Only when there's
+	// nothing to copy do we arm select-mode for a fresh drag; arming it
+	// after a successful copy would make the user's next scroll gesture
+	// silently intercept as a selection attempt.
 	const copied = term.copySelection();
-	term.enterSelectMode();
-	if (!copied) showToast("Drag across the terminal to select — it copies automatically");
+	if (!copied) {
+		term.enterSelectMode();
+		showToast("Drag across the terminal to select — it copies automatically");
+	}
 });
 
 // ── File attachment flow ────────────────────────────────────────────────────

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -982,6 +982,9 @@ export function openTerminalSession(opts: {
 		// path readable as one rule and avoids poisoning the dedup state for
 		// a future off-active caller. Return true: a selection was present,
 		// the caller's question is answered; we just declined to write.
+		// No onCopy here — onCopy?.(false) would fire the "permission denied"
+		// error toast, which is wrong (this is a background-tab suppression,
+		// not a write failure); an off-active caller gets silence by design.
 		if (isActive && !isActive()) return true;
 		if (sel === lastCopiedSelection) {
 			// Already on the clipboard from the auto-copy/mouseup path.
@@ -998,6 +1001,11 @@ export function openTerminalSession(opts: {
 	}
 
 	function enterSelectMode() {
+		// Observe-mode never registers the touch handlers (see the `!observe`
+		// gate on the listeners), so all three selectMode clear sites are
+		// absent there — arming it would strand the flag true. Bail so the
+		// public method can't leave a read-only pane in a stuck state.
+		if (observe) return;
 		selectMode = true;
 	}
 

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -13,6 +13,19 @@ export interface TerminalSession {
 	dispose(): void;
 	setFontSize(px: number): void;
 	paste(text: string): void;
+	/** Copy the current xterm selection to the clipboard if non-empty.
+	 *  Returns true iff a selection was present (copy attempted), false
+	 *  if nothing was selected. Routes through the same internal
+	 *  clipboard helper + `lastCopiedSelection` dedup the auto-copy path
+	 *  uses, so an explicit menu copy of an already-auto-copied selection
+	 *  re-toasts without issuing a redundant write (#286). */
+	copySelection(): boolean;
+	/** Arm touch select-mode: the next single-finger drag produces a real
+	 *  xterm text selection instead of being translated to scroll, and
+	 *  auto-copies when the selection settles. Mode clears itself after
+	 *  one finalised selection. No-op on desktop, where a mouse drag with
+	 *  the platform modifier already selects (#286). */
+	enterSelectMode(): void;
 }
 
 export type StatusCallback = (status: SessionStatus) => void;
@@ -427,6 +440,18 @@ export function openTerminalSession(opts: {
 				lastCopiedSelection = "";
 				return;
 			}
+			// A finalised non-empty selection ends touch select-mode: the
+			// gesture armed from the actions menu is complete, so the next
+			// finger drag should scroll again. Cleared HERE — inside the
+			// debounced finalise, not the raw onSelectionChange — because
+			// the raw event fires continuously *during* the drag; exiting
+			// mid-drag would flip onTouchMove back to scroll synthesis and
+			// abort the in-progress selection. Placed before the dedup
+			// early-return below so select-mode still clears when the
+			// mouseup-immediate path (compat mouseup on touch) already
+			// copied this selection. Harmless no-op on desktop, where
+			// selectMode is never armed.
+			selectMode = false;
 			if (sel === lastCopiedSelection) return;
 			// Don't clobber the clipboard for a background tab — user
 			// might have switched to another tab during the 100 ms
@@ -632,6 +657,12 @@ export function openTerminalSession(opts: {
 	// which is the wheel-down direction.
 	let lastTouchY: number | null = null;
 	let touchIsScroll = false; // true once the gesture has moved ≥1 cell
+	// Touch select-mode (#286). When true, onTouchMove yields the gesture
+	// to xterm so a finger drag makes a text selection instead of scroll.
+	// Armed by enterSelectMode() (the actions-menu "Select & copy" entry);
+	// cleared by the onSelectionChange finalise path once a non-empty
+	// selection settles, so it lasts exactly one selection.
+	let selectMode = false;
 	const getCellHeight = () => (term.rows > 0 ? container.clientHeight / term.rows : 20);
 
 	const onTouchStart = (ev: TouchEvent) => {
@@ -644,6 +675,17 @@ export function openTerminalSession(opts: {
 		touchIsScroll = false;
 	};
 	const onTouchMove = (ev: TouchEvent) => {
+		// Select-mode: let xterm own the gesture so a finger drag builds a
+		// text selection instead of being synthesised into scroll input.
+		// We deliberately do NOT preventDefault here — the browser's
+		// compatibility mouse events (mousedown/mousemove/mouseup, emitted
+		// for the touch because `touch-action: none` suppresses native
+		// panning) are exactly what xterm's SelectionService listens on to
+		// extend the selection. Calling preventDefault would cancel them
+		// and the selection would never grow. The onSelectionChange
+		// finalise path clears selectMode once the selection settles, so
+		// the *next* drag resumes scrolling.
+		if (selectMode) return;
 		if (lastTouchY === null || ev.touches.length !== 1) {
 			// Defence-in-depth: clear lastTouchY whenever we see a non-
 			// single-touch frame. onTouchStart already clears it when a
@@ -703,7 +745,11 @@ export function openTerminalSession(opts: {
 		// Guard on lastTouchY !== null: a multi-touch start (pinch) clears
 		// lastTouchY and resets touchIsScroll, so when one finger lifts we
 		// must not treat it as a tap and pop the keyboard.
-		if (!touchIsScroll && lastTouchY !== null) term.focus();
+		// Guard on !selectMode: a select-mode drag never sets touchIsScroll
+		// (onTouchMove returns early), so without this it would read as a
+		// tap and pop the soft keyboard right over the text the user is
+		// trying to select-and-copy (#286).
+		if (!selectMode && !touchIsScroll && lastTouchY !== null) term.focus();
 		lastTouchY = null;
 		touchIsScroll = false;
 	};
@@ -915,6 +961,32 @@ export function openTerminalSession(opts: {
 		term.paste(text);
 	}
 
+	// Explicit copy of the current selection (actions-menu "Select & copy"
+	// on touch, where there's no Cmd-C). Shares `lastCopiedSelection` with
+	// the auto-copy / mouseup paths so a desktop user who triggers both the
+	// menu entry and the drag-release auto-copy of the SAME selection
+	// doesn't get a double write (#286 acceptance: "no double-copy").
+	function copySelection(): boolean {
+		const sel = term.getSelection();
+		if (!sel) return false;
+		if (sel === lastCopiedSelection) {
+			// Already on the clipboard from the auto-copy/mouseup path.
+			// Re-confirm to the user (their explicit tap deserves feedback)
+			// but skip the redundant clipboard write.
+			onCopy?.(true);
+			return true;
+		}
+		lastCopiedSelection = sel;
+		copyToClipboard(sel).then((ok) => {
+			if (!ok && lastCopiedSelection === sel) lastCopiedSelection = "";
+		});
+		return true;
+	}
+
+	function enterSelectMode() {
+		selectMode = true;
+	}
+
 	// ── Dispose ─────────────────────────────────────────────────────────────
 	function dispose() {
 		disposed = true;
@@ -954,7 +1026,7 @@ export function openTerminalSession(opts: {
 		term.dispose();
 	}
 
-	return { dispose, setFontSize, paste };
+	return { dispose, setFontSize, paste, copySelection, enterSelectMode };
 }
 
 // ── Multiline URL link provider ─────────────────────────────────────────────

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -973,6 +973,16 @@ export function openTerminalSession(opts: {
 	function copySelection(): boolean {
 		const sel = term.getSelection();
 		if (!sel) return false;
+		// Same active-tab gate the mouseup + debounced auto-copy paths apply
+		// (see the rationale at the onSelectionChange write): never clobber
+		// the foreground clipboard with a background tab's selection. Today's
+		// sole caller is the actions-menu handler over getActiveTerminal(),
+		// so this can't trip — but it's a public method now, and placing the
+		// guard HERE (before touching lastCopiedSelection) keeps every copy
+		// path readable as one rule and avoids poisoning the dedup state for
+		// a future off-active caller. Return true: a selection was present,
+		// the caller's question is answered; we just declined to write.
+		if (isActive && !isActive()) return true;
 		if (sel === lastCopiedSelection) {
 			// Already on the clipboard from the auto-copy/mouseup path.
 			// Re-confirm to the user (their explicit tap deserves feedback)

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -657,6 +657,11 @@ export function openTerminalSession(opts: {
 		if (ev.touches.length !== 1) {
 			lastTouchY = null;
 			touchIsScroll = false;
+			// Disarm select-mode on a multi-touch start too, keeping the
+			// three reset sites symmetric (here, onTouchEnd, onTouchCancel).
+			// A pinch isn't a selection gesture; clearing here means it
+			// can't carry an armed flag into its move phase.
+			selectMode = false;
 			return;
 		}
 		lastTouchY = ev.touches[0]!.clientY;

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -440,18 +440,6 @@ export function openTerminalSession(opts: {
 				lastCopiedSelection = "";
 				return;
 			}
-			// A finalised non-empty selection ends touch select-mode: the
-			// gesture armed from the actions menu is complete, so the next
-			// finger drag should scroll again. Cleared HERE — inside the
-			// debounced finalise, not the raw onSelectionChange — because
-			// the raw event fires continuously *during* the drag; exiting
-			// mid-drag would flip onTouchMove back to scroll synthesis and
-			// abort the in-progress selection. Placed before the dedup
-			// early-return below so select-mode still clears when the
-			// mouseup-immediate path (compat mouseup on touch) already
-			// copied this selection. Harmless no-op on desktop, where
-			// selectMode is never armed.
-			selectMode = false;
 			if (sel === lastCopiedSelection) return;
 			// Don't clobber the clipboard for a background tab — user
 			// might have switched to another tab during the 100 ms
@@ -660,8 +648,8 @@ export function openTerminalSession(opts: {
 	// Touch select-mode (#286). When true, onTouchMove yields the gesture
 	// to xterm so a finger drag makes a text selection instead of scroll.
 	// Armed by enterSelectMode() (the actions-menu "Select & copy" entry);
-	// cleared by the onSelectionChange finalise path once a non-empty
-	// selection settles, so it lasts exactly one selection.
+	// disarmed on the next touchend/touchcancel, so it scopes to exactly
+	// one gesture whether or not that gesture produced a selection.
 	let selectMode = false;
 	const getCellHeight = () => (term.rows > 0 ? container.clientHeight / term.rows : 20);
 
@@ -682,9 +670,8 @@ export function openTerminalSession(opts: {
 		// for the touch because `touch-action: none` suppresses native
 		// panning) are exactly what xterm's SelectionService listens on to
 		// extend the selection. Calling preventDefault would cancel them
-		// and the selection would never grow. The onSelectionChange
-		// finalise path clears selectMode once the selection settles, so
-		// the *next* drag resumes scrolling.
+		// and the selection would never grow. onTouchEnd disarms selectMode
+		// when this gesture finishes, so the *next* drag resumes scrolling.
 		if (selectMode) return;
 		if (lastTouchY === null || ev.touches.length !== 1) {
 			// Defence-in-depth: clear lastTouchY whenever we see a non-
@@ -752,10 +739,22 @@ export function openTerminalSession(opts: {
 		if (!selectMode && !touchIsScroll && lastTouchY !== null) term.focus();
 		lastTouchY = null;
 		touchIsScroll = false;
+		// Disarm select-mode at the END of the gesture, not at
+		// selection-finalise. selectMode only needs to be true while
+		// onTouchMove fires (to suppress scroll synthesis); the xterm
+		// selection itself is built from compat mouse events independent
+		// of the touch flag, so clearing here can't truncate it. Clearing
+		// per-gesture (rather than only when a non-empty selection
+		// settles) is what prevents a drag that selects NOTHING — blank
+		// area, or a browser that doesn't stream compat mousemove — from
+		// leaving select-mode stuck on and silently killing touch-scroll
+		// until the next successful selection (#286).
+		selectMode = false;
 	};
 	const onTouchCancel = () => {
 		lastTouchY = null;
 		touchIsScroll = false;
+		selectMode = false;
 	};
 
 	// Skip touch-scroll-as-input wiring entirely in observe-mode (#201e):

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -994,6 +994,9 @@ export function openTerminalSession(opts: {
 			return true;
 		}
 		lastCopiedSelection = sel;
+		// copyToClipboard fires onCopy(true/false) itself — no explicit
+		// onCopy here, unlike the dedup-hit branch above which has no write
+		// to hang the callback off of.
 		copyToClipboard(sel).then((ok) => {
 			if (!ok && lastCopiedSelection === sel) lastCopiedSelection = "";
 		});


### PR DESCRIPTION
Closes #286. Carries forward the third, deferred layer of the #158 copy work: a working copy path on touch devices, where tmux `mouse on` forwards finger drags as scroll and there is no Cmd-C, so users previously had no way to make — let alone copy — an xterm selection.

## What changed

- **Actions-menu entry "Select & copy"** (`index.html`, `main.ts`). On tap it copies any existing selection immediately, then arms touch select-mode for a fresh drag. Routes through the same `copyToClipboard` + `lastCopiedSelection` dedup #158 hardened, so an explicit menu copy of an already-auto-copied selection re-toasts without a redundant write (no double-copy).
- **`selectMode` flag** read at the top of `onTouchMove` (`terminal.ts`). While armed, the touch handler yields the gesture to xterm instead of synthesising scroll — the browser's compatibility mouse events build the selection — and `onTouchEnd` pops no keyboard.
- **Auto-copy + auto-exit.** A finalised selection rides the existing #158 auto-copy-on-finalise path (copy + brief ✓ toast). Select-mode disarms on the next `touchend`/`touchcancel`, scoping it to exactly one gesture.

## Two API additions on `TerminalSession`

`copySelection(): boolean` and `enterSelectMode(): void` — both no-op-safe on desktop (`enterSelectMode` is inert without touch events; `copySelection` just copies the current selection).

## Review notes

A self-review surfaced and fixed one trap: clearing select-mode only on selection-*finalise* left it stuck armed when a drag selected nothing, silently killing touch-scroll. Fixed by disarming per-gesture on `touchend`/`touchcancel` (2nd commit).

## ⚠️ Needs device verification

The selection relies on the browser streaming compatibility `mousemove` during a finger drag (`touch-action: none`). **Android Chrome does this; iOS Safari is known not to** — it fires mouse events only after `touchend` with no mid-drag `mousemove`, so xterm may see a click rather than a drag-select. **This needs testing on a real iOS device.** If it fails there, the robust follow-up is to drive the selection manually from touch coordinates via `term.select(col, row, length)` rather than relying on synthesized mouse events — deliberately not built blind.

## Out of scope (per #286)

Long-press-to-enter-select-mode; iOS share-sheet integration.

## Verification done

`npm run lint` + `npm run build` + `npm test` (66 passing) green in `frontend/`. Behavioural verification on a touch device still pending (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)