### PR TITLE
fix(docker): clamp stored resource caps to operator cap on respawn

### DIFF
--- a/backend/src/dockerManager.spawnConfig.test.ts
+++ b/backend/src/dockerManager.spawnConfig.test.ts
@@ -39,6 +39,7 @@ vi.mock("node:fs", () => ({
 }));
 
 import { buildContainerEnv, DockerManager, mergeEnvForSpawn } from "./dockerManager.js";
+import { EFFECTIVE_CPU_NANO_MAX, EFFECTIVE_MEM_BYTES_MAX } from "./sessionConfig.js";
 import type { SessionManager } from "./sessionManager.js";
 
 // ── Fakes ────────────────────────────────────────────────────────────────
@@ -246,6 +247,40 @@ describe("DockerManager.spawn config-applied", () => {
 		const hc = captured.opts.HostConfig as { Memory: number; NanoCpus: number };
 		expect(hc.Memory).toBe(8 * 1024 * 1024 * 1024);
 		expect(hc.NanoCpus).toBe(4_000_000_000);
+	});
+
+	it("clamps stored caps that exceed the operator cap on respawn (not just at ingest)", async () => {
+		// Regression: config caps were validated against MAX_SESSION_MEM/CPU
+		// at create/PATCH time, but an operator can LOWER those env caps
+		// afterwards. The stored value then exceeds the new cap, and spawn
+		// must re-clamp it — otherwise the over-cap value lands on the cgroup
+		// on every respawn, silently bypassing the operator cap. Simulate the
+		// post-lowering state with stored caps above the effective max.
+		dbStubs.d1Query.mockResolvedValueOnce({
+			results: [
+				{
+					session_id: "sess-1",
+					workspace_strategy: null,
+					cpu_limit: EFFECTIVE_CPU_NANO_MAX + 1_000_000_000,
+					mem_limit: EFFECTIVE_MEM_BYTES_MAX + 1024 * 1024 * 1024,
+					idle_ttl_seconds: null,
+					post_create_cmd: null,
+					post_start_cmd: null,
+					repos_json: null,
+					ports_json: null,
+					allow_privileged_ports: null,
+					env_vars_json: null,
+					bootstrapped_at: null,
+				},
+			],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		});
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as { Memory: number; NanoCpus: number };
+		expect(hc.Memory).toBe(EFFECTIVE_MEM_BYTES_MAX);
+		expect(hc.NanoCpus).toBe(EFFECTIVE_CPU_NANO_MAX);
 	});
 
 	// Backend-injected fixed entries (SESSION_ID, SESSION_NAME, TERM,

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -347,8 +347,18 @@ export class DockerManager {
 				// id" path picks up new caps when the user fully recycles
 				// (DELETE + POST /start). #194 owns operator-tunable bounds
 				// and per-deployment caps; this PR just wires the consumer.
-				Memory: config?.memLimit ?? DEFAULT_MEMORY_BYTES,
-				NanoCpus: config?.cpuLimit ?? DEFAULT_NANO_CPUS,
+				//
+				// Re-clamp the stored config caps to the operator cap HERE,
+				// not just at ingest. `config.mem_limit`/`cpu_limit` were
+				// validated against MAX_SESSION_MEM/CPU at create/PATCH time,
+				// but an operator can LOWER those env caps afterwards (e.g.
+				// right-sizing the host). On the next respawn the stale stored
+				// value would otherwise be written to the cgroup unclamped,
+				// silently bypassing the new operator cap on every start. The
+				// DEFAULT_* constants are already `Math.min`-clamped (see their
+				// definitions); this keeps the config path symmetric.
+				Memory: Math.min(config?.memLimit ?? DEFAULT_MEMORY_BYTES, EFFECTIVE_MEM_BYTES_MAX),
+				NanoCpus: Math.min(config?.cpuLimit ?? DEFAULT_NANO_CPUS, EFFECTIVE_CPU_NANO_MAX),
 				RestartPolicy: { Name: "unless-stopped" },
 				// Defense-in-depth (issue #15): the image already runs as
 				// unprivileged UID 1000 with no sudo, but we still strip

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -42,11 +42,13 @@ import { decryptSecret, encryptSecret } from "./secrets.js";
 // value above the hard ceiling is also clamped (with warn) instead of
 // being honoured — env-vars-can-only-lower is the explicit policy.
 //
-// NOTE: changing these does not affect already-spawned containers.
+// NOTE: changing these does not affect an already-RUNNING container —
 // Docker resource limits are written into the cgroup at `docker run`
-// (see HostConfig.NanoCpus / Memory in dockerManager.ts); a lowered
-// cap only rejects future POST /api/sessions whose `config.cpuLimit`
-// / `memLimit` exceed it.
+// (see HostConfig.NanoCpus / Memory in dockerManager.ts). But a lowered
+// cap clamps the stored value on every respawn (`spawnWithConfig`
+// re-applies `Math.min(config cap, EFFECTIVE_*_MAX)`) AND rejects new
+// POST /api/sessions whose `config.cpuLimit` / `memLimit` exceed it, so a
+// session can't stay over-cap past its next stop→start.
 const CPU_NANO_HARD_MAX = 8_000_000_000; // 8 cores — v1 ceiling
 const MEM_BYTES_HARD_MAX = 16 * 1024 * 1024 * 1024; // 16 GiB — v1 ceiling
 const CPU_NANO_FLOOR = 250_000_000; // 0.25 cores

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -1331,7 +1331,10 @@ function buildWsUrl(
 	const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
 	const url = new URL(apiUrl);
 	const wsProto = url.protocol === "https:" ? "wss:" : "ws:";
-	const base = `${wsProto}//${url.host}/ws/sessions/${sessionId}`;
+	// Encode the path segment for consistency with `api.ts` (sessionId is a
+	// server-issued UUID re-validated server-side, so this is defensive
+	// tidiness rather than a fix for a live injection).
+	const base = `${wsProto}//${url.host}/ws/sessions/${encodeURIComponent(sessionId)}`;
 	const params = new URLSearchParams();
 	// tabId is server-issued and re-validated on the backend before any
 	// `tmux attach -t` — see backend/src/wsHandler.ts (rawTab regex


### PR DESCRIPTION
## Summary

Found during a complete-repo review pass. One **SHOULD-FIX** (verified) plus a folded-in NIT from the same review.

`DockerManager.spawnWithConfig` passed the stored `config.mem_limit` / `cpu_limit` to Docker **verbatim**, while the fallback defaults (`DEFAULT_MEMORY_BYTES` / `DEFAULT_NANO_CPUS`) are `Math.min`-clamped to the operator cap. The config values are validated against `MAX_SESSION_MEM` / `MAX_SESSION_CPU` only at create/PATCH time.

**Consequence:** if an operator **lowers** those env caps after sessions exist (e.g. right-sizing the host), any session whose stored limit exceeds the new cap writes the stale, over-cap value straight to the cgroup on **every respawn** (`startContainer` cold-start or stale-id respawn), silently bypassing the new operator cap until the row is hand-edited. The admin `docker update` path (`ResourceCapsPatchSchema`) is already guarded; only the spawn path was exposed.

## Fix

\`backend/src/dockerManager.ts\` — re-clamp the config caps at spawn so the config path is symmetric with the already-clamped default path:

\`\`\`diff
- Memory: config?.memLimit ?? DEFAULT_MEMORY_BYTES,
- NanoCpus: config?.cpuLimit ?? DEFAULT_NANO_CPUS,
+ Memory: Math.min(config?.memLimit ?? DEFAULT_MEMORY_BYTES, EFFECTIVE_MEM_BYTES_MAX),
+ NanoCpus: Math.min(config?.cpuLimit ?? DEFAULT_NANO_CPUS, EFFECTIVE_CPU_NANO_MAX),
\`\`\`

(`EFFECTIVE_*_MAX` were already imported.)

## Folded-in NIT

\`frontend/src/terminal.ts\` — `encodeURIComponent` the `sessionId` in the WS path for consistency with `api.ts`. Defensive tidiness, not a live fix (sessionId is a server-issued UUID re-validated server-side).

## Testing

- New regression test in \`dockerManager.spawnConfig.test.ts\`: a stored cap above the effective max is clamped to the operator cap at spawn.
- Backend: Biome + \`tsc\` clean, **872 tests pass**.
- Frontend: Biome clean, production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)