### PR TITLE
fix(ws): tear down docker listener when socket closes during attach() (#298)

### DIFF
--- a/backend/src/wsHandler.test.ts
+++ b/backend/src/wsHandler.test.ts
@@ -33,6 +33,7 @@ afterAll(() => {
 interface FakeWs {
 	readyState: number;
 	on: ReturnType<typeof vi.fn>;
+	off: ReturnType<typeof vi.fn>;
 	close: ReturnType<typeof vi.fn>;
 	send: ReturnType<typeof vi.fn>;
 }
@@ -41,6 +42,9 @@ function makeFakeWs(): FakeWs {
 	return {
 		readyState: 1, // WebSocket.OPEN — sendMsg() gates on this
 		on: vi.fn(),
+		// `off` mirrors the real ws EventEmitter alias; the handler swaps
+		// its setup-phase 'close' listener for the steady-state teardown.
+		off: vi.fn(),
 		close: vi.fn(),
 		send: vi.fn(),
 	};
@@ -268,6 +272,58 @@ describe("handleWsConnection geometry from URL", () => {
 	});
 });
 
+// ── Close during the attach() window (#298) ──────────────────────────────
+// Regression guard: if the socket closes WHILE docker.attach() (or the
+// observe-row INSERT) is still awaiting, the teardown handlers aren't
+// registered yet and Node won't replay the already-emitted 'close'. The
+// handler must record the early close and run detach() once attach()
+// resolves — otherwise the shared exec fd and the idle-sweeper-bumping
+// outputListener leak forever.
+
+describe("handleWsConnection close-during-attach (#298)", () => {
+	it("detaches when the socket closes during the attach() await", async () => {
+		const ws = makeFakeWs();
+		const sessions = {
+			assertOwnership: vi.fn().mockResolvedValue({ status: "running", cols: 80, rows: 24 }),
+			updateConnected: vi.fn().mockResolvedValue(undefined),
+		} as unknown as SessionManager;
+		// Deferred attach: lets the test close the socket mid-await before
+		// resolving, reproducing the race window.
+		let resolveAttach!: (v: { replay: null; flushTail: () => void }) => void;
+		const docker = {
+			attach: vi.fn(
+				() =>
+					new Promise((r) => {
+						resolveAttach = r;
+					}),
+			),
+			detach: vi.fn(),
+		} as unknown as DockerManager;
+		const req = makeReq("/ws/sessions/s-1?tab=tab-1", true);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		handleWsConnection(ws as any, req as any, sessions, docker);
+		await vi.waitFor(() => {
+			expect(docker.attach).toHaveBeenCalled();
+		});
+
+		// Socket closes mid-attach: invoke the only 'close' listener
+		// registered so far (the setup-phase flag-setter) and flip
+		// readyState as the real transport would.
+		const earlyClose = ws.on.mock.calls.find((c) => c[0] === "close");
+		expect(earlyClose).toBeDefined();
+		(earlyClose![1] as () => void)();
+		ws.readyState = 3; // WebSocket.CLOSED
+
+		resolveAttach({ replay: null, flushTail: () => {} });
+
+		await vi.waitFor(() => {
+			expect(docker.detach).toHaveBeenCalled();
+		});
+		// The message handler must never be wired up for a dead socket.
+		expect(ws.on.mock.calls.some((c) => c[0] === "message")).toBe(false);
+	});
+});
+
 // ── Observe-mode (#201d) ─────────────────────────────────────────────────
 // `?observe=true` opts into a read-only attach gated on `assertCanObserve`.
 // The WS handler must: switch the auth call, pass `observe: true` to
@@ -378,11 +434,13 @@ describe("handleWsConnection observe-mode (#201d)", () => {
 			"s-1", // session
 			"owner-bob", // owner (denormalised at insert)
 		);
-		// Simulate WS close — handler is registered via ws.on("close", …).
-		// Find the close handler from the on() mock calls and invoke it.
-		const closeCall = ws.on.mock.calls.find((c) => c[0] === "close");
-		expect(closeCall).toBeDefined();
-		(closeCall![1] as () => void)();
+		// Simulate WS close. Two "close" listeners are registered: the
+		// setup-phase flag-setter (swapped off after attach) and the
+		// steady-state teardown. Invoke the LAST one — the real teardown
+		// that flips the audit row.
+		const closeCalls = ws.on.mock.calls.filter((c) => c[0] === "close");
+		expect(closeCalls.length).toBeGreaterThan(0);
+		(closeCalls.at(-1)![1] as () => void)();
 		// recordObserveEnd is fire-and-forget (the WS-close path doesn't
 		// await it; the SQL idempotency is the safety net). waitFor
 		// polls until the microtask the close handler scheduled lands.

--- a/backend/src/wsHandler.ts
+++ b/backend/src/wsHandler.ts
@@ -245,6 +245,55 @@ export function handleWsConnection(
 			sendMsg(ws, { type: "output", data });
 		};
 
+		// `observeLogId` + `teardown` are declared before the attach()
+		// await so the close/error handlers registered below — which must
+		// be in place to catch a socket that closes DURING setup — can
+		// reference them. teardown is idempotent (the `tornDown` guard):
+		// 'close' and 'error' can both fire for one socket, and the
+		// post-setup readyState re-check can invoke it a third time.
+		//
+		// Close + error both run the same teardown:
+		//   - detach() releases the docker-layer listener.
+		//   - For observe attaches, recordObserveEnd() flips the audit
+		//     row's `ended_at`. The UPDATE is idempotent (WHERE
+		//     ended_at IS NULL), so a duplicate call is a no-op. Errors
+		//     during the D1 UPDATE are logged and swallowed: a transient
+		//     at close time shouldn't crash teardown or leak via
+		//     uncaughtException.
+		let observeLogId: string | null = null;
+		let tornDown = false;
+		const teardown = (reason: "close" | "error", logCtx: string): void => {
+			if (tornDown) return;
+			tornDown = true;
+			docker.detach(attachId);
+			if (observeLogId !== null) {
+				recordObserveEnd(observeLogId).catch((err) => {
+					logger.warn(
+						`[ws] observe-log end failed on ${reason}: ${(err as Error).message} ` +
+							`(log=${observeLogId} session=${sessionId})`,
+					);
+				});
+			}
+			logger.info(`[ws] user=${userId} detached from session=${sessionId} (${logCtx})`);
+		};
+
+		// The teardown handlers are registered only AFTER attach() resolves
+		// (below), because detach() before attach() has registered its
+		// bufferedListener would race the listener insert and re-leak it.
+		// But a socket can close DURING the attach()/recordObserveStart
+		// awaits — and Node's EventEmitter does not replay a 'close' that
+		// fired before its listener existed. So during setup we only RECORD
+		// that the socket went away; the real detach runs after attach()
+		// resolves via the closedDuringSetup/readyState check below. Without
+		// this, a close mid-attach orphaned the docker listener forever:
+		// the shared exec fd leaked and the leaked outputListener kept
+		// bumping the idle-sweeper, so the session could never be auto-stopped.
+		let closedDuringSetup = false;
+		const onSetupClose = () => {
+			closedDuringSetup = true;
+		};
+		ws.on("close", onSetupClose);
+
 		// attach() hands back `flushTail` — until we call it, the listener
 		// installed inside attach() piles incoming live bytes into a local
 		// array instead of forwarding them. This lets us guarantee the
@@ -281,18 +330,37 @@ export function handleWsConnection(
 		//     and an unaudited observe would defeat the whole point
 		//     of the trail. detach() to release the listener +
 		//     re-throw so the catch block runs ws.close(1011).
-		let observeLogId: string | null = null;
-		if (isObserverNotOwner) {
+		// Skip the audit-row INSERT if the socket already went away during
+		// attach() — no point recording an observe we'd immediately have to
+		// close, and it avoids a D1 round-trip on a dead connection.
+		if (isObserverNotOwner && !closedDuringSetup) {
 			try {
 				observeLogId = await recordObserveStart(userId, sessionId, session.userId);
 			} catch (err) {
-				docker.detach(attachId);
+				teardown("error", "observe-start failed");
 				throw err;
 			}
 			logger.info(
 				`[ws] observe attach logged: observer=${userId} session=${sessionId} ` +
 					`owner=${session.userId} log=${observeLogId}`,
 			);
+		}
+
+		// Setup is done: attach() has registered its listener and any
+		// observe row exists. Swap the record-only close handler for the
+		// real teardown, then settle the race — if the socket closed at any
+		// point during setup (flag) or is simply no longer OPEN, tear down
+		// now, because the freshly-registered 'close' handler will NOT fire
+		// for a 'close' event that already emitted.
+		ws.off("close", onSetupClose);
+		ws.on("close", () => teardown("close", "close"));
+		ws.on("error", (err) => {
+			logger.error(`[ws] error on session=${sessionId}: ${err.message}`);
+			teardown("error", `error: ${err.message}`);
+		});
+		if (closedDuringSetup || ws.readyState !== WebSocket.OPEN) {
+			teardown("close", "closed-during-setup");
+			return;
 		}
 
 		sendMsg(ws, { type: "status", status: "running" });
@@ -350,35 +418,6 @@ export function handleWsConnection(
 					}
 					break;
 			}
-		});
-
-		// Close + error both run the same teardown:
-		//   - detach() releases the docker-layer listener.
-		//   - For observe attaches, recordObserveEnd() flips the audit
-		//     row's `ended_at`. The UPDATE is idempotent (WHERE
-		//     ended_at IS NULL), so if both 'close' and 'error' fire
-		//     for the same socket — common during dirty teardowns —
-		//     the second call is a no-op. Errors during the D1 UPDATE
-		//     are logged and swallowed: a transient at close time
-		//     shouldn't crash the teardown or leak via
-		//     uncaughtException.
-		const teardown = (reason: "close" | "error", logCtx: string): void => {
-			docker.detach(attachId);
-			if (observeLogId !== null) {
-				recordObserveEnd(observeLogId).catch((err) => {
-					logger.warn(
-						`[ws] observe-log end failed on ${reason}: ${(err as Error).message} ` +
-							`(log=${observeLogId} session=${sessionId})`,
-					);
-				});
-			}
-			logger.info(`[ws] user=${userId} detached from session=${sessionId} (${logCtx})`);
-		};
-
-		ws.on("close", () => teardown("close", "close"));
-		ws.on("error", (err) => {
-			logger.error(`[ws] error on session=${sessionId}: ${err.message}`);
-			teardown("error", `error: ${err.message}`);
 		});
 	})().catch((err) => {
 		if (err instanceof NotFoundError) {


### PR DESCRIPTION
Closes #298.

## Problem
The close/error teardown handlers in `handleWsConnection` were registered only **after** `await docker.attach()` (and, for observers, the `recordObserveStart` INSERT) resolved. `attach()` inserts its `bufferedListener` into `s.listeners` *during* that await window. If the socket closed mid-await — a clean client navigation, or the heartbeat `terminate()` — Node's EventEmitter never replays the already-emitted `close` to the listener registered later, so `teardown`/`detach` never ran.

Consequences:
- The leaked listener kept `s.listeners.size` above 0, so the shared `docker exec` stream/fd was never released — an authed owner could loop connect/close-mid-attach to exhaust the process fd table.
- The leaked `outputListener` kept calling `idleSweeper.bump()` on every tmux byte, so **idle auto-stop (#194) could never reap that session**.
- A narrower sub-window (close during `recordObserveStart`) left an `ended_at IS NULL` observe audit row open forever.

## Fix
- Declare an idempotent `teardown` (guarded by `tornDown`) and `observeLogId` **before** the `attach()` await.
- During setup, register a **record-only** `close` handler (`closedDuringSetup` flag). We can't `detach()` directly in an early handler — that would race the listener insert inside `attach()` and re-leak it.
- After `attach()` resolves and any observe row exists, swap in the real teardown handlers and settle the race: if `closedDuringSetup || ws.readyState !== OPEN`, tear down immediately and return (the freshly-registered handler won't fire for an already-emitted `close`).
- Skip the observe-row INSERT entirely if the socket already went away during attach.

## Tests
- New regression test (`close-during-attach (#298)`) resolves a deferred `attach()` only after closing the socket mid-await, and asserts `detach()` runs and no message handler is wired up.
- Updated the `FakeWs` mock with `off` (real `ws` EventEmitter alias) and fixed the observe-close test to invoke the steady-state `close` listener.
- Full backend suite: 873 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)