### PR TITLE
fix(dispatch): don't repopulate cache with rows superseded mid-SELECT (#299)

### DIFF
--- a/backend/src/portMappings.test.ts
+++ b/backend/src/portMappings.test.ts
@@ -370,4 +370,51 @@ describe("lookupDispatchTarget cache (#238)", () => {
 		const got = await lookupDispatchTarget("sess-cl", 3000);
 		expect(got).toBeNull();
 	});
+
+	it("does not cache rows read before a writer invalidated mid-SELECT (#299)", async () => {
+		// Reproduces the read-populate-after-invalidate race: lookup A's
+		// SELECT is in flight (and will return STALE public rows) when an
+		// owner flips the port public->private via setPortMappings. Without
+		// the writeEpoch guard, lookup A would cache.set the stale public
+		// row AFTER the writer's post-write invalidate, serving it as
+		// public/unauthenticated for up to the TTL.
+		let releaseSelect!: () => void;
+		const selectInFlight = new Promise<void>((r) => {
+			releaseSelect = r;
+		});
+		// Lookup A's SELECT: blocks until released, then returns is_public=1.
+		dbStubs.d1Query.mockImplementationOnce(async () => {
+			await selectInFlight;
+			return {
+				results: [sessionRow(3000, "st-stale", 1)],
+				success: true,
+				meta: { changes: 0, duration: 0, last_row_id: 0 },
+			};
+		});
+		const lookupA = lookupDispatchTarget("sess-race", 3000);
+
+		// Writer lands while A's SELECT is in flight (DELETE + INSERT shape
+		// irrelevant here; the point is the invalidateCache → writeEpoch bump).
+		dbStubs.d1Query.mockImplementation(async () => ({
+			results: [],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		await setPortMappings("sess-race", [{ containerPort: 3000, hostPort: 3000, isPublic: false }]);
+
+		// Let A's SELECT resolve with the now-stale public row.
+		releaseSelect();
+		await lookupA;
+
+		// The stale row must NOT have been cached: the next lookup re-fetches
+		// and sees the fresh private value.
+		dbStubs.d1Query.mockImplementationOnce(async () => ({
+			results: [sessionRow(3000, "st-fresh", 0)],
+			success: true,
+			meta: { changes: 0, duration: 0, last_row_id: 0 },
+		}));
+		const after = await lookupDispatchTarget("sess-race", 3000);
+		expect(after?.containerName).toBe("st-fresh");
+		expect(after?.isPublic).toBe(false);
+	});
 });

--- a/backend/src/portMappings.ts
+++ b/backend/src/portMappings.ts
@@ -106,6 +106,9 @@ function invalidateCache(sessionId: string): void {
  *  via the named import path the test file uses. */
 export function __resetDispatchCacheForTests(): void {
 	cache.clear();
+	// Reset the write epoch too so each test gets a genuine clean slate —
+	// the seam's contract is "as if freshly loaded".
+	writeEpoch = 0;
 }
 
 export interface PortMapping {

--- a/backend/src/portMappings.ts
+++ b/backend/src/portMappings.ts
@@ -53,6 +53,15 @@ import { d1Query } from "./db.js";
 // otherwise re-populate the cache from the half-updated table; the
 // post-write invalidate clears that.
 //
+// (#299) Before-and-after still leaves one race: a lookup whose SELECT was
+// ALREADY IN FLIGHT (holding rows read before the write) can `cache.set`
+// those stale rows AFTER the writer's post-write invalidate — re-publishing
+// them for up to the TTL. The security-relevant case is a port the owner
+// just flipped `public:true -> false` via PATCH /ports staying cached as
+// public (unauthenticated) for 30 s. `invalidateCache` therefore also bumps
+// a monotonic `writeEpoch`; `lookupDispatchTarget` snapshots it before its
+// SELECT and skips the populate if it moved across the await.
+//
 // TTL is the safety net for the unusual case where someone mutates the
 // table out-of-band (e.g. a manual SQL edit during debugging) — bounded
 // at 30 s so an operator running an experiment doesn't have to restart
@@ -76,8 +85,18 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>();
 
+// Monotonic write counter (#299) — see the cache header comment. A single
+// global counter, not per-session: an invalidate for an unrelated session
+// also makes an in-flight lookup skip its populate, but that only costs an
+// occasional extra D1 round-trip (the data wasn't actually stale), and
+// writes are session-lifecycle events (spawn / stop / kill / reconcile /
+// PATCH ports) — rare next to dispatch reads. The global counter keeps the
+// bookkeeping to one number with no per-session memory growth.
+let writeEpoch = 0;
+
 function invalidateCache(sessionId: string): void {
 	cache.delete(sessionId);
+	writeEpoch++;
 }
 
 /** Test seam: drop every cached entry. The dispatcher tests that swap
@@ -209,6 +228,13 @@ export async function lookupDispatchTarget(
 		// a paired `clearPortMappings` invalidation having fired.
 		cache.delete(sessionId);
 	}
+	// Snapshot the write epoch BEFORE the await (#299). If any writer
+	// invalidates while the SELECT below is in flight, `writeEpoch` moves and
+	// we skip the cache populate — the rows we just read may already be
+	// superseded (e.g. a public->private flip that landed mid-SELECT). Read
+	// here, while still synchronous, so no writer can interleave before the
+	// snapshot.
+	const epochAtRead = writeEpoch;
 	// Fetch the FULL set of dispatch targets for this session in one
 	// round-trip. Same JOIN as before, minus the per-port WHERE clause —
 	// the per-port lookup is satisfied from the populated map below. This
@@ -241,7 +267,14 @@ export async function lookupDispatchTarget(
 			ownerUserId: row.user_id,
 		});
 	}
-	cache.set(sessionId, { byContainerPort, expiresAt: now + CACHE_TTL_MS });
+	// Only populate if no writer invalidated during the SELECT above. A moved
+	// epoch means a setPortMappings/clearPortMappings landed mid-flight and
+	// these rows may be stale; skipping the set just makes the next lookup
+	// re-fetch (the result we return to THIS caller is still served — it's
+	// at worst as fresh as a request that arrived a moment earlier).
+	if (writeEpoch === epochAtRead) {
+		cache.set(sessionId, { byContainerPort, expiresAt: now + CACHE_TTL_MS });
+	}
 	return byContainerPort.get(containerPort) ?? null;
 }
 


### PR DESCRIPTION
Closes #299.

## Problem
`lookupDispatchTarget` populates the dispatch-target cache **after** an awaited SELECT. The "invalidate before AND after" in `setPortMappings`/`clearPortMappings` only defends a lookup that *starts* its SELECT inside the DELETE→INSERT window — **not** a lookup whose SELECT is already in flight (holding rows read before the write) and whose `cache.set` lands *after* the writer's post-write invalidate.

That in-flight lookup re-publishes stale rows for up to `CACHE_TTL_MS` (30 s). The security-relevant case: a port the owner just flipped `public:true → false` via `PATCH /ports` can stay cached as **public / unauthenticated for 30 s** under the concurrent traffic a live dev-server proxy reliably has — contradicting the documented "applied immediately on a running session" guarantee.

## Fix
- `invalidateCache` bumps a monotonic `writeEpoch`.
- `lookupDispatchTarget` snapshots `writeEpoch` synchronously before its SELECT and only `cache.set`s if it's unchanged across the await. A moved epoch means a writer landed mid-flight, so the rows may be stale — skipping the populate just makes the next lookup re-fetch. The in-flight caller still gets its result (at worst as fresh as a request that arrived a moment earlier).
- A single **global** counter (not per-session) keeps the bookkeeping to one number with no per-session memory growth. An unrelated session's write only costs an occasional extra D1 round-trip, and writes are session-lifecycle events (spawn/stop/kill/reconcile/PATCH ports) — rare next to dispatch reads.

## Tests
- New regression test holds a lookup's SELECT in flight, runs `setPortMappings` (public→private), then resolves the now-stale public row and asserts it was **not** cached (the next lookup re-fetches and sees the fresh private value).
- Full backend suite: 873 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)