### PR TITLE
fix(idle): don't bump owner's idle timer on non-owner observe reads (#300)

### DIFF
--- a/backend/src/routes.observeLog.test.ts
+++ b/backend/src/routes.observeLog.test.ts
@@ -277,9 +277,11 @@ describe("GET /api/sessions/:id/observe-log", () => {
 		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
 		expect(res.status).toBe(200);
 		await res.text();
-		// Let the res.on("finish") bump listener settle, then assert it
-		// stayed quiet.
-		await new Promise((r) => setTimeout(r, 25));
+		// Deterministically flush past the queued res.on("finish") callback
+		// (a setImmediate yields after the current I/O callbacks) rather than
+		// a fixed delay, which could false-pass under CI load. If a broken
+		// impl bumped, it would have run by now.
+		await new Promise((r) => setImmediate(r));
 		expect(idleSweeperStub.bump).not.toHaveBeenCalled();
 	});
 
@@ -322,7 +324,9 @@ describe("GET /api/sessions/:id/tabs idle-bump (#300)", () => {
 		const res = await fetch(`${baseUrl}/api/sessions/s-1/tabs`);
 		expect(res.status).toBe(200);
 		await res.text();
-		await new Promise((r) => setTimeout(r, 25));
+		// Deterministic flush past the queued finish callback — see the
+		// observe-log non-owner case for why this beats a fixed delay.
+		await new Promise((r) => setImmediate(r));
 		expect(idleSweeperStub.bump).not.toHaveBeenCalled();
 	});
 

--- a/backend/src/routes.observeLog.test.ts
+++ b/backend/src/routes.observeLog.test.ts
@@ -91,6 +91,12 @@ let server: http.Server | null = null;
 let baseUrl = "";
 
 const fakeAssertCanObserve = vi.fn();
+// #300: the idle-bump middleware only mounts when an idleSweeper is wired,
+// so the bump-skip regression tests below need a stub to assert against.
+const idleSweeperStub = {
+	bump: vi.fn(),
+	forget: vi.fn(),
+};
 
 afterEach(async () => {
 	if (server) {
@@ -105,6 +111,8 @@ afterEach(async () => {
 		next();
 	});
 	fakeAssertCanObserve.mockReset();
+	idleSweeperStub.bump.mockReset();
+	idleSweeperStub.forget.mockReset();
 });
 
 async function spinUp(): Promise<void> {
@@ -121,18 +129,24 @@ async function spinUp(): Promise<void> {
 		}),
 	} as unknown as DockerManager;
 	const broadcaster = {} as BootstrapBroadcaster;
-	const router = buildRouter(sessions, docker, broadcaster, {
-		login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
-		register: { ipMax: 1000, ipWindowMs: 60_000 },
-		invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
-		invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
-		invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
-		fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
-		logout: { ipMax: 1000, ipWindowMs: 60_000 },
-		authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
-		adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
-		adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
-	});
+	const router = buildRouter(
+		sessions,
+		docker,
+		broadcaster,
+		{
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesCreate: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesList: { ipMax: 1000, ipWindowMs: 60_000 },
+			invitesRevoke: { ipMax: 1000, ipWindowMs: 60_000 },
+			fileUpload: { ipMax: 1000, ipWindowMs: 60_000 },
+			logout: { ipMax: 1000, ipWindowMs: 60_000 },
+			authStatus: { ipMax: 1000, ipWindowMs: 60_000 },
+			adminStats: { ipMax: 1000, ipWindowMs: 60_000 },
+			adminAction: { ipMax: 1000, ipWindowMs: 60_000 },
+		},
+		idleSweeperStub,
+	);
 	const app = express();
 	app.use(express.json());
 	app.use("/api", router);
@@ -244,6 +258,43 @@ describe("GET /api/sessions/:id/observe-log", () => {
 		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual([]);
+	});
+
+	// #300 regression: a non-owner observer (admin / group-lead) gets a
+	// 200 here, which would otherwise trip the idle-bump middleware and
+	// keep the OWNER's session alive forever — defeating idle auto-stop.
+	it("does NOT bump the idle sweeper when a non-owner observes (#300)", async () => {
+		// caller is "u1" (requireAuth stub); owner is "u-owner".
+		fakeAssertCanObserve.mockResolvedValueOnce({
+			sessionId: "s-1",
+			userId: "u-owner",
+			status: "running",
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
+		expect(res.status).toBe(200);
+		await res.text();
+		// Let the res.on("finish") bump listener settle, then assert it
+		// stayed quiet.
+		await new Promise((r) => setTimeout(r, 25));
+		expect(idleSweeperStub.bump).not.toHaveBeenCalled();
+	});
+
+	it("DOES bump the idle sweeper when the owner reads their own observe-log (#300)", async () => {
+		// caller "u1" is also the owner — their activity legitimately
+		// keeps the session alive.
+		fakeAssertCanObserve.mockResolvedValueOnce({
+			sessionId: "s-1",
+			userId: "u1",
+			status: "running",
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
+		expect(res.status).toBe(200);
+		await res.text();
+		await vi.waitFor(() => {
+			expect(idleSweeperStub.bump).toHaveBeenCalledWith("s-1");
+		});
 	});
 });
 

--- a/backend/src/routes.observeLog.test.ts
+++ b/backend/src/routes.observeLog.test.ts
@@ -127,6 +127,9 @@ async function spinUp(): Promise<void> {
 			sessionsCheckedSinceBoot: 0,
 			errorsSinceBoot: 0,
 		}),
+		// GET /sessions/:id/tabs reads this; the #300 bump-skip tests below
+		// exercise the tabs route too.
+		listTabs: vi.fn(async () => [] as unknown[]),
 	} as unknown as DockerManager;
 	const broadcaster = {} as BootstrapBroadcaster;
 	const router = buildRouter(
@@ -290,6 +293,47 @@ describe("GET /api/sessions/:id/observe-log", () => {
 		});
 		await spinUp();
 		const res = await fetch(`${baseUrl}/api/sessions/s-1/observe-log`);
+		expect(res.status).toBe(200);
+		await res.text();
+		await vi.waitFor(() => {
+			expect(idleSweeperStub.bump).toHaveBeenCalledWith("s-1");
+		});
+	});
+});
+
+// ── GET /api/sessions/:id/tabs idle-bump (#300) ─────────────────────────────
+// The observe UI polls the tab list at the same cadence as the log, so the
+// same skipIdleBump guard applies to this route. Mirrors the observe-log
+// cases above so a regression on the tabs guard is caught independently.
+
+describe("GET /api/sessions/:id/tabs idle-bump (#300)", () => {
+	beforeEach(() => {
+		__resetDispatcherStatsForTests();
+	});
+
+	it("does NOT bump the idle sweeper when a non-owner reads the tab list", async () => {
+		// caller "u1" (requireAuth stub); owner "u-owner".
+		fakeAssertCanObserve.mockResolvedValueOnce({
+			sessionId: "s-1",
+			userId: "u-owner",
+			status: "running",
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-1/tabs`);
+		expect(res.status).toBe(200);
+		await res.text();
+		await new Promise((r) => setTimeout(r, 25));
+		expect(idleSweeperStub.bump).not.toHaveBeenCalled();
+	});
+
+	it("DOES bump the idle sweeper when the owner reads their own tab list", async () => {
+		fakeAssertCanObserve.mockResolvedValueOnce({
+			sessionId: "s-1",
+			userId: "u1",
+			status: "running",
+		});
+		await spinUp();
+		const res = await fetch(`${baseUrl}/api/sessions/s-1/tabs`);
 		expect(res.status).toBe(200);
 		await res.text();
 		await vi.waitFor(() => {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -1534,7 +1534,13 @@ export function buildRouter(
 			// both shapes flow into `handleSessionError`'s standard 404
 			// / 403 emission, so callers get the same status-code
 			// contract the rest of the /sessions/:id reads use.
-			await sessions.assertCanObserve(req.params.id, userId);
+			const meta = await sessions.assertCanObserve(req.params.id, userId);
+			// (#300) A non-owner observer (admin / group-lead) gets a 200
+			// here, which would otherwise trip the idle-bump middleware and
+			// keep the OWNER's session alive — defeating idle auto-stop
+			// (#194) for any session a lead polls. Skip the bump unless the
+			// caller is the owner, so only the owner's own activity counts.
+			if (meta.userId !== userId) res.locals.skipIdleBump = true;
 			const list = await observeLog.listForSession(req.params.id);
 			res.json(list.map(serializeObserveLogEntry));
 		} catch (err) {
@@ -1793,7 +1799,13 @@ export function buildRouter(
 			// Tab CREATE / DELETE further down stay on `assertOwnedBy` —
 			// observability does NOT include the right to mutate tab
 			// state on someone else's session.
-			await sessions.assertCanObserve(req.params.id, userId);
+			const meta = await sessions.assertCanObserve(req.params.id, userId);
+			// (#300) The observe UI polls this endpoint. A non-owner
+			// observer (admin / group-lead) gets a 200, which would trip
+			// the idle-bump middleware and keep the OWNER's session alive
+			// indefinitely, defeating idle auto-stop (#194). Only the
+			// owner's own polling should count as activity.
+			if (meta.userId !== userId) res.locals.skipIdleBump = true;
 			const tabs = await docker.listTabs(req.params.id);
 			res.json(tabs);
 		} catch (err) {


### PR DESCRIPTION
Closes #300.

## Problem
The idle-bump middleware bumps `lastActivity` for every `/sessions/:id` response with `statusCode < 400`. Its documented invariant — a foreign caller gets a 403 from `assertOwnership` *before* the bump, so they can't keep someone else's session alive — holds for ownership routes but **not** the two observe reads:

- `GET /sessions/:id/tabs`
- `GET /sessions/:id/observe-log`

Both gate on `assertCanObserve` and return **200 to a non-owner** (admin / group-lead). The observe UI naturally polls the tab list, so a lead watching a member's session refreshed the owner's `lastActivity` every cycle — and that session could **never be idle-auto-stopped** (#194) regardless of `idle_ttl_seconds`, undermining the cost-control contract the `<400` gate exists to enforce.

## Fix
Both handlers already receive the session meta from `assertCanObserve` (`meta.userId` is the owner). Set `res.locals.skipIdleBump = true` when `meta.userId !== userId`, so only the **owner's own** activity counts. An owner reading their own session still bumps.

## Tests
- New regression tests in `routes.observeLog.test.ts` (wired an `idleSweeper` stub into the harness): a non-owner observe-log read does **not** bump; an owner read **does**.
- Full backend suite: 874 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)