### PR TITLE
fix(bootstrap): bind postCreate to the 10-min wall-clock cap (#301)

### DIFF
--- a/backend/src/bootstrap.test.ts
+++ b/backend/src/bootstrap.test.ts
@@ -424,7 +424,14 @@ describe("runAsyncBootstrap", () => {
 
 		expect(sessionConfigStubs.getSessionConfig).not.toHaveBeenCalled();
 		expect(cloneStubs.runCloneRepo).not.toHaveBeenCalled();
-		expect(spies.runPostCreate).toHaveBeenCalledWith("sess-1", "npm install", expect.any(Function));
+		// #301: postCreate must receive the bootstrap cap's AbortSignal as
+		// its 4th arg so the 10-min wall-clock timer can abort a hung hook.
+		expect(spies.runPostCreate).toHaveBeenCalledWith(
+			"sess-1",
+			"npm install",
+			expect.any(Function),
+			expect.any(AbortSignal),
+		);
 	});
 
 	// A non-zero clone exit must hard-fail the session via the SAME

--- a/backend/src/bootstrap.ts
+++ b/backend/src/bootstrap.ts
@@ -601,16 +601,16 @@ export async function runAsyncBootstrap(
 	}
 
 	// postCreate. May be unset when only config-driven stages were
-	// configured (e.g. clone + agentSeed without a hook). The cap is
-	// still in force for postCreate; runPostCreate doesn't currently
-	// take a signal, but the timer can still abort the in-flight
-	// exec via the same destroy-the-stream mechanism if we extend
-	// the call. For now, postCreate's existing behaviour (no signal)
-	// means a runaway hook isn't aborted by the cap — same shape as
-	// before this PR.
+	// configured (e.g. clone + agentSeed without a hook). The 10-min
+	// wall-clock cap applies here too (#301): the signal is forwarded so
+	// the timer destroys the in-flight exec stream — a hook hanging on a
+	// stalled `npm install` / registry is aborted instead of pinning the
+	// quota slot. As with every other stage, the stream destroy only
+	// unblocks the host-side promise; `failSession` kills the container to
+	// stop the in-container process.
 	if (cfg.postCreateCmd) {
 		const ok = await runStage("postCreate", () =>
-			docker.runPostCreate(sessionId, cfg.postCreateCmd!, onOutput),
+			docker.runPostCreate(sessionId, cfg.postCreateCmd!, onOutput, signal),
 		);
 		if (!ok) return;
 	}

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -991,6 +991,11 @@ export class DockerManager {
 		sessionId: string,
 		cmd: string,
 		onOutput?: (chunk: string) => void,
+		// #301: forward the bootstrap cap's abort signal so a hung
+		// postCreate (e.g. `npm install` against a stalled registry) is
+		// unblocked by the 10-min wall-clock timer like every other stage,
+		// instead of running unbounded and pinning the quota slot.
+		signal?: AbortSignal,
 	): Promise<{ exitCode: number }> {
 		// Thin shim over `streamExec` — postCreate is shell-typed (the
 		// user wrote `npm install && npm test` etc.) so we wrap the
@@ -1001,6 +1006,7 @@ export class DockerManager {
 			{
 				cmd: ["bash", "-c", cmd],
 				workingDir: "/home/developer/workspace",
+				signal,
 			},
 			onOutput,
 		);


### PR DESCRIPTION
Closes #301.

## Problem
Every config-driven bootstrap stage forwards the cap's abort `signal`, but `runPostCreate` didn't take one (the comment at `bootstrap.ts` acknowledged the gap). When the 10-min timer fired during postCreate, `abortController.abort()` ran but nothing destroyed the host-side exec stream, so the promise never settled from the cap.

A postCreate hanging on a stalled `npm install` / registry ran **unbounded and pinned the quota slot** — exactly the scenario the cap exists to prevent. CLAUDE.md states "streamExec is destroyed past 10 min and the session hard-fails."

## Fix
`streamExec` already supports `signal`; `runPostCreate` just wasn't forwarding it.
- Add an optional `signal` param to `runPostCreate` and pass it into `streamExec`.
- Forward `signal` from the bootstrap caller.

On timeout the postCreate exec now rejects with `AbortError` → `runStage`'s catch → `finishWithFail` → `failSession`, which kills the container (stopping the in-container process the host-side stream destroy can't reach).

## Tests
- Updated the postCreate call-shape assertion to require the `AbortSignal` 4th arg (proves the signal is wired).
- The abort→fail→kill path itself is already covered by the existing "runPostCreate throws → flip + kill + broadcast fail" test, which exercises the same `catch → finishWithFail → failSession` route an AbortError rejection takes.
- Full backend suite: 872 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)