### PR TITLE
fix(db): throw a sourced error when d1Query gets an empty result set (#304)

### DIFF
--- a/backend/src/db.test.ts
+++ b/backend/src/db.test.ts
@@ -69,3 +69,19 @@ describe("d1 call counter (#241b)", () => {
 		expect(getD1CallsSinceBoot()).toBe(1);
 	});
 });
+
+// #304: a `success: true` response with an empty `result` array must throw
+// a sourced error at d1Query, not return undefined and surface later as
+// `Cannot read properties of undefined (reading 'results')` in a caller.
+describe("d1Query empty-result guard (#304)", () => {
+	it("throws a sourced error when result[] is empty despite success:true", async () => {
+		const { d1Query } = await import("./db.js");
+		(globalThis as { fetch: unknown }).fetch = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ result: [], success: true, errors: [] }), { status: 200 }),
+		);
+		await expect(d1Query("SELECT * FROM widgets")).rejects.toThrow(
+			/no result set for: SELECT \* FROM widgets/,
+		);
+	});
+});

--- a/backend/src/db.test.ts
+++ b/backend/src/db.test.ts
@@ -84,4 +84,14 @@ describe("d1Query empty-result guard (#304)", () => {
 			/no result set for: SELECT \* FROM widgets/,
 		);
 	});
+
+	it("throws the same sourced error when the result key is absent entirely", async () => {
+		const { d1Query } = await import("./db.js");
+		(globalThis as { fetch: unknown }).fetch = vi.fn(
+			async () => new Response(JSON.stringify({ success: true, errors: [] }), { status: 200 }),
+		);
+		await expect(d1Query("SELECT * FROM gadgets")).rejects.toThrow(
+			/no result set for: SELECT \* FROM gadgets/,
+		);
+	});
 });

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -96,8 +96,11 @@ export async function d1Query<T = Record<string, unknown>>(
 	// undefined (reading 'results')` in an unrelated module rather than at
 	// the source. The `?.` covers the absent-key case too. Fail loud and
 	// sourced.
+	// `=== undefined` rather than `!first`: `first` is `D1QueryResult | undefined`
+	// (always an object when present), so the precise absent-check reads right
+	// and won't widen the throw surface if the type ever gains a falsy member.
 	const first = data.result?.[0];
-	if (!first) {
+	if (first === undefined) {
 		throw new Error(`D1 returned no result set for: ${sql}`);
 	}
 	return first;

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -87,7 +87,18 @@ export async function d1Query<T = Record<string, unknown>>(
 		throw new Error(`D1 query failed: ${data.errors.map((e) => e.message).join(", ")}`);
 	}
 
-	return data.result[0];
+	// Guard the empty/absent result array. D1's `/query` returns one
+	// `D1QueryResult` per statement, so a single-statement query always
+	// yields `result[0]`. But a malformed `success: true` response with an
+	// empty `result` would otherwise return `undefined` here, and every
+	// caller immediately reads `.results` — surfacing as an opaque
+	// `Cannot read properties of undefined (reading 'results')` in an
+	// unrelated module rather than at the source. Fail loud and sourced.
+	const first = data.result[0];
+	if (!first) {
+		throw new Error(`D1 returned no result set for: ${sql}`);
+	}
+	return first;
 }
 
 /**

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -90,11 +90,13 @@ export async function d1Query<T = Record<string, unknown>>(
 	// Guard the empty/absent result array. D1's `/query` returns one
 	// `D1QueryResult` per statement, so a single-statement query always
 	// yields `result[0]`. But a malformed `success: true` response with an
-	// empty `result` would otherwise return `undefined` here, and every
-	// caller immediately reads `.results` — surfacing as an opaque
-	// `Cannot read properties of undefined (reading 'results')` in an
-	// unrelated module rather than at the source. Fail loud and sourced.
-	const first = data.result[0];
+	// empty (or entirely absent) `result` would otherwise return `undefined`
+	// — or throw on the absent case — and every caller immediately reads
+	// `.results`, surfacing as an opaque `Cannot read properties of
+	// undefined (reading 'results')` in an unrelated module rather than at
+	// the source. The `?.` covers the absent-key case too. Fail loud and
+	// sourced.
+	const first = data.result?.[0];
 	if (!first) {
 		throw new Error(`D1 returned no result set for: ${sql}`);
 	}


### PR DESCRIPTION
Closes #304.

## Problem
After the `success` check, `d1Query` returned `data.result[0]` unconditionally (`db.ts:85-90`). A malformed `success: true` response with an empty/absent `result` array yields `undefined`, and every caller immediately reads `.results` (e.g. `idleSweeper.runSweep`, `groups.fetchRow`, `observeLog.listForSession`). A transient bad D1 response therefore surfaces as an opaque `Cannot read properties of undefined (reading 'results')` in an unrelated module instead of at the source — the same cross-module obscuring `parseD1Utc`'s own throw was written to avoid.

## Fix
Guard `result[0]` and throw `D1 returned no result set for: <sql>` so the failure is loud and attributable.

## Tests
- New regression: a `success: true` + empty `result` response throws the sourced error.
- Full backend suite: 879 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)