### PR TITLE
fix(stats): map a getContainerStats rejection to null in gatherStatsForRunning (#310)

### DIFF
--- a/backend/src/containerStats.ts
+++ b/backend/src/containerStats.ts
@@ -290,9 +290,20 @@ export async function gatherStatsForRunning(
 		}
 		const cid = s.containerId;
 		tasks.push(
-			getContainerStats(docker, cid).then((v) => {
-				out.set(s.sessionId, v);
-			}),
+			getContainerStats(docker, cid).then(
+				(v) => {
+					out.set(s.sessionId, v);
+				},
+				// Defensive: getContainerStats resolves `null` on every
+				// known error path today, so this never fires. But if a
+				// future edit lets it reject, allSettled would silently
+				// drop the row from the map — the admin view would omit the
+				// session entirely instead of rendering `usage: null`. Map
+				// the rejection to the same `null` the resolve path uses.
+				() => {
+					out.set(s.sessionId, null);
+				},
+			),
 		);
 	}
 	await Promise.allSettled(tasks);


### PR DESCRIPTION
Closes #310.

## Problem
The per-session task in `gatherStatsForRunning` chained only a fulfilment handler:

    getContainerStats(docker, cid).then((v) => out.set(s.sessionId, v))

`getContainerStats` resolves `null` on every known error path today, so this is correct. But if a future edit lets it reject, `Promise.allSettled` would silently drop that session from the map — the admin view would omit the session entirely instead of rendering `usage: null` (which the operator can disambiguate via `row.status`).

## Fix
Add a rejection handler to the `.then(...)` that maps to the same `null` the resolve path uses.

## Tests
Defensive-only: the rejection branch is **unreachable today** — `getContainerStats` wraps its whole body (including `docker.getContainer(...)`) in try/catch and always resolves `null` on error. The existing "a single container's failure does NOT stall the others" test covers the resolve-`null` path. Full backend suite passes; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)