### PR TITLE
fix(docker): clear port mappings on kill() even when container_id is null (#309)

### DIFF
--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -1655,6 +1655,22 @@ describe("DockerManager.kill port-mapping cleanup (#309)", () => {
 			/DELETE FROM sessions_port_mappings/.test(c[0] as string),
 		);
 		expect(del).toBeDefined();
-		expect(del?.[1]).toEqual(["s1"]);
+		expect(del![1]).toEqual(["s1"]);
+	});
+
+	it("clears port mappings even when the session row is absent (get returns undefined)", async () => {
+		// The other branch the fix closes: reconcile already dropped the
+		// row, so `sessions.get()` resolves undefined and `meta?.containerId`
+		// is false. The clear must still fire.
+		const sessions = makeFakeSessions();
+		(sessions.get as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+		const { dm } = makeDocker({ sessions });
+		dbStubs.d1Query.mockClear();
+		await dm.kill("s1");
+		const del = dbStubs.d1Query.mock.calls.find((c) =>
+			/DELETE FROM sessions_port_mappings/.test(c[0] as string),
+		);
+		expect(del).toBeDefined();
+		expect(del![1]).toEqual(["s1"]);
 	});
 });

--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -1639,3 +1639,22 @@ describe("DockerManager.runPostStart", () => {
 		warnSpy.mockRestore();
 	});
 });
+
+// #309: clearPortMappings must run on kill() even when the session row's
+// container_id is already null (a prior partial teardown / reconcile race).
+// Gating it on a live container_id leaked sessions_port_mappings rows until
+// the next reconcile.
+describe("DockerManager.kill port-mapping cleanup (#309)", () => {
+	it("clears port mappings even when container_id is already null", async () => {
+		const { dm } = makeDocker({ sessions: makeFakeSessions(null) });
+		dbStubs.d1Query.mockClear();
+		await dm.kill("s1");
+		// clearPortMappings issues a DELETE on sessions_port_mappings bound
+		// to the session id — it must fire despite the null container.
+		const del = dbStubs.d1Query.mock.calls.find((c) =>
+			/DELETE FROM sessions_port_mappings/.test(c[0] as string),
+		);
+		expect(del).toBeDefined();
+		expect(del?.[1]).toEqual(["s1"]);
+	});
+});

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -745,19 +745,29 @@ export class DockerManager {
 					`[docker] failed to null container_id for session ${sessionId}: ${(err as Error).message}`,
 				);
 			}
-			// #190 PR 190b — drop runtime port mappings: the host ports
-			// are about to be recycled by the kernel, and the dispatcher
-			// (190c) must NOT proxy a request to a port that's bound to
-			// some other tenant's container in the next moment. Best-
-			// effort because the container is already gone — failing to
-			// clear is a stale-row leak the next spawn / reconcile fixes.
-			try {
-				await clearPortMappings(sessionId);
-			} catch (err) {
-				logger.error(
-					`[docker] failed to clear port mappings for session ${sessionId}: ${(err as Error).message}`,
-				);
-			}
+		}
+
+		// #190 PR 190b — drop runtime port mappings: the host ports are
+		// about to be recycled by the kernel, and the dispatcher (190c)
+		// must NOT proxy a request to a port that's bound to some other
+		// tenant's container in the next moment. Best-effort because the
+		// container is already gone — failing to clear is a stale-row leak
+		// the next spawn / reconcile fixes.
+		//
+		// #309: run this OUTSIDE the `meta?.containerId` guard. A session
+		// whose row already has container_id = null (a prior partial
+		// teardown / reconcile race) can still have lingering
+		// sessions_port_mappings rows; gating the clear on a live
+		// container_id leaked them until the next reconcile. Not a routing
+		// hazard (the dispatcher JOINs on status='running'), just a leak —
+		// but cheap to close here alongside the shared-exec teardown below,
+		// which already runs unconditionally.
+		try {
+			await clearPortMappings(sessionId);
+		} catch (err) {
+			logger.error(
+				`[docker] failed to clear port mappings for session ${sessionId}: ${(err as Error).message}`,
+			);
 		}
 
 		// Destroy any shared exec and per-attach routing for this session.


### PR DESCRIPTION
Closes #309.

## Problem
In `DockerManager.kill()`, the `clearPortMappings(sessionId)` call lived inside the `if (meta?.containerId)` guard. A session whose row already has `container_id = null` (a prior partial teardown / reconcile race) but still has `sessions_port_mappings` rows skipped the clear, so those rows lingered until the next `reconcile()`.

(The original finding also named the shared-exec / `keyOf` teardown, but that already runs unconditionally — only the port-mapping clear was gated.)

## Fix
Move `clearPortMappings` outside the guard so it always runs on `kill`, alongside the shared-exec teardown. `setContainerId(null)` stays inside the guard — no point nulling an already-null id. Not a routing hazard (the dispatcher JOINs on `status='running'`), just a stale-row leak.

## Tests
- New regression: `kill("s1")` with `container_id = null` still issues the `DELETE FROM sessions_port_mappings WHERE session_id = ?` bound to the session id.
- Full backend suite: 879 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)