### PR TITLE
fix(routes): trim + reject whitespace-only username and session name (#307)

### DIFF
--- a/backend/src/rateLimit.test.ts
+++ b/backend/src/rateLimit.test.ts
@@ -469,6 +469,54 @@ describe("auth route rate limiting", () => {
 		});
 	}
 
+	// #307: whitespace-only username is truthy, so `!username` doesn't catch
+	// it; trim-then-check rejects it and trimming is what gets stored / looked
+	// up so register and login agree on the identity.
+	it("register rejects a whitespace-only username with 400, never calls registerUser", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+		const res = await postRegister({ username: "   ", password: "secret123" });
+		expect(res.status).toBe(400);
+		expect(authStubs.registerUser).not.toHaveBeenCalled();
+	});
+
+	it("register trims surrounding whitespace before persisting the username (#307)", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+		const res = await postRegister({ username: "  alice  ", password: "secret123" });
+		expect(res.status).toBe(201);
+		expect(authStubs.registerUser).toHaveBeenCalledWith("alice", "secret123", undefined);
+	});
+
+	it("login trims the username so it matches the stored (trimmed) identity (#307)", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+		authStubs.loginUser.mockImplementation(async () => ({
+			userId: "u1",
+			token: "tok",
+			isAdmin: false,
+		}));
+		const res = await postLogin({ username: "  alice  ", password: "secret123" });
+		expect(res.status).toBe(200);
+		expect(authStubs.loginUser).toHaveBeenCalledWith("alice", "secret123");
+	});
+
+	it("login rejects a whitespace-only username with 400, never calls loginUser", async () => {
+		await spinUp({
+			login: { ipMax: 1000, ipWindowMs: 60_000, usernameMax: 1000, usernameWindowMs: 60_000 },
+			register: { ipMax: 1000, ipWindowMs: 60_000 },
+		});
+		const res = await postLogin({ username: "   ", password: "secret123" });
+		expect(res.status).toBe(400);
+		expect(authStubs.loginUser).not.toHaveBeenCalled();
+	});
+
 	it("login returns 429 after ipMax from one IP — 4th request is blocked", async () => {
 		await spinUp({
 			login: { ipMax: 3, ipWindowMs: 60_000, usernameMax: 1_000, usernameWindowMs: 60_000 },

--- a/backend/src/routes.create.test.ts
+++ b/backend/src/routes.create.test.ts
@@ -189,6 +189,31 @@ describe("POST /sessions — async bootstrap dispatch (PR 185b2b)", () => {
 		bootstrapStubs.runAsyncBootstrap.mockResolvedValue(undefined);
 	});
 
+	// #307: a whitespace-only name is truthy, so `!name` doesn't catch it.
+	it("rejects a whitespace-only name with 400 and does not create a session", async () => {
+		const { sessions, docker, spies } = makeFakes();
+		await spinUp(sessions, docker);
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "   " }),
+		});
+		expect(res.status).toBe(400);
+		expect(spies.create).not.toHaveBeenCalled();
+	});
+
+	it("trims surrounding whitespace before persisting the name (#307)", async () => {
+		const { sessions, docker, spies } = makeFakes();
+		await spinUp(sessions, docker);
+		const res = await fetch(`${baseUrl}/api/sessions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "  my session  " }),
+		});
+		expect(res.status).toBe(201);
+		expect(spies.create).toHaveBeenCalledWith(expect.objectContaining({ name: "my session" }));
+	});
+
 	it("returns 201 with bootstrapping=true and kicks off runAsyncBootstrap when postCreateCmd is set", async () => {
 		const { sessions, docker, spies } = makeFakes();
 		await spinUp(sessions, docker);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -198,7 +198,16 @@ export function buildRouter(
 			res.status(400).json({ error: "username and password (min 6 chars) required" });
 			return;
 		}
-		if (username.length > USERNAME_MAX_LEN) {
+		// Trim and reject whitespace-only (#307): a blank-looking username
+		// would otherwise be stored verbatim and render blank in the sidebar.
+		// Mirrors the trim-then-check convention used for session / group /
+		// template names. The trimmed value is what gets persisted.
+		const trimmedUsername = username.trim();
+		if (!trimmedUsername) {
+			res.status(400).json({ error: "username and password (min 6 chars) required" });
+			return;
+		}
+		if (trimmedUsername.length > USERNAME_MAX_LEN) {
 			res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
 			return;
 		}
@@ -231,7 +240,7 @@ export function buildRouter(
 			trimmedInviteCode = inviteCode.trim();
 		}
 		try {
-			const result = await registerUser(username, password, trimmedInviteCode);
+			const result = await registerUser(trimmedUsername, password, trimmedInviteCode);
 			// JWT goes out as an httpOnly cookie (#18); the response body
 			// keeps the userId for clients that want to address the new
 			// account, but never the raw token.
@@ -265,7 +274,15 @@ export function buildRouter(
 			res.status(400).json({ error: "username and password required" });
 			return;
 		}
-		if (username.length > USERNAME_MAX_LEN) {
+		// Trim to match the stored (trimmed) username from register (#307),
+		// and reject whitespace-only. Used consistently below so the
+		// per-username limiter buckets the same identity register stored.
+		const trimmedUsername = username.trim();
+		if (!trimmedUsername) {
+			res.status(400).json({ error: "username and password required" });
+			return;
+		}
+		if (trimmedUsername.length > USERNAME_MAX_LEN) {
 			res.status(400).json({ error: `username must be at most ${USERNAME_MAX_LEN} characters` });
 			return;
 		}
@@ -280,7 +297,7 @@ export function buildRouter(
 		// the event loop). Without the reservation, a burst of N requests
 		// against the same username could all pass check() and all start
 		// bcrypt before any recordFailure lands, breaking the bound.
-		const check = usernameLimiter.beginAttempt(username);
+		const check = usernameLimiter.beginAttempt(trimmedUsername);
 		if (!check.allowed) {
 			const windowSeconds = Math.ceil(rateLimitConfig.login.usernameWindowMs / 1000);
 			res.setHeader("Retry-After", String(check.retryAfterSeconds));
@@ -299,11 +316,11 @@ export function buildRouter(
 		let result: { userId: string; token: string; isAdmin: boolean; isLead: boolean };
 		try {
 			try {
-				result = await loginUser(username, password);
+				result = await loginUser(trimmedUsername, password);
 			} catch (err) {
 				if (err instanceof InvalidCredentialsError) {
 					// Only bad creds count — infra errors must not lock real users out.
-					usernameLimiter.recordFailure(username);
+					usernameLimiter.recordFailure(trimmedUsername);
 					res.status(401).json({ error: err.message });
 					return;
 				}
@@ -312,7 +329,7 @@ export function buildRouter(
 				res.status(500).json({ error: "Internal server error" });
 				return;
 			}
-			usernameLimiter.reset(username);
+			usernameLimiter.reset(trimmedUsername);
 			setAuthCookie(res, result.token);
 			res.json({
 				userId: result.userId,
@@ -325,7 +342,7 @@ export function buildRouter(
 			// counter but not this slot; pairing it with endAttempt keeps
 			// the invariant that every beginAttempt has exactly one
 			// endAttempt.
-			usernameLimiter.endAttempt(username);
+			usernameLimiter.endAttempt(trimmedUsername);
 		}
 	});
 
@@ -1154,14 +1171,23 @@ export function buildRouter(
 			res.status(400).json({ error: "body.name is required" });
 			return;
 		}
+		// Trim and reject whitespace-only (#307): "   " is truthy so it slips
+		// past the guard above and would render blank in the sidebar. Mirrors
+		// the trim-then-check convention used for group / template names. The
+		// trimmed value is what gets persisted (see sessions.create below).
+		const trimmedName = name.trim();
+		if (!trimmedName) {
+			res.status(400).json({ error: "body.name is required" });
+			return;
+		}
 		// Cap session name at the request boundary. The 100KB express.json
 		// body limit is the only upstream bound otherwise — a 50KB name
 		// would land in D1 verbatim and ride out on every list response.
 		// 64 matches USERNAME_MAX_LEN and the tab-label cap; same shape of
 		// "user-controlled string with no other natural limit" → same cap.
-		// The empty-string case is already handled by the `!name` guard
-		// above; only the upper bound needs to be checked here. See #149.
-		if (name.length > SESSION_NAME_MAX_LEN) {
+		// The empty-string case is already handled by the trim guard above;
+		// only the upper bound needs to be checked here. See #149.
+		if (trimmedName.length > SESSION_NAME_MAX_LEN) {
 			res
 				.status(400)
 				.json({ error: `body.name must be at most ${SESSION_NAME_MAX_LEN} characters` });
@@ -1228,7 +1254,13 @@ export function buildRouter(
 		// the D1 row explicitly on any spawn failure.
 		let meta: Awaited<ReturnType<SessionManager["create"]>> | null = null;
 		try {
-			meta = await sessions.create({ userId, name, cols, rows, envVars: validatedEnvVars });
+			meta = await sessions.create({
+				userId,
+				name: trimmedName,
+				cols,
+				rows,
+				envVars: validatedEnvVars,
+			});
 			// Persist the typed config BEFORE spawning the container. If
 			// docker.spawn fails the rollback in the catch below deletes
 			// the sessions row and ON DELETE CASCADE on session_configs


### PR DESCRIPTION
Closes #307.

## Problem
The register, login, and create-session guards used `if (!x)`, which is truthy for `"   "`. A whitespace-only username or session name slipped past and was persisted verbatim — a blank-looking username could be registered, and a whitespace session name renders blank in the sidebar. Other validators in the same file (group / template names) already trim-then-check.

## Fix
- **register**: trim `username`, reject empty, persist the trimmed value.
- **login**: trim `username` and use it consistently for the per-username rate-limiter key + `loginUser` lookup, so it matches the stored (trimmed) identity register persisted.
- **create session**: trim `name`, reject empty, persist the trimmed value.

## Tests
- `routes.create.test.ts`: whitespace-only name → 400 (no `sessions.create`); surrounding whitespace trimmed before persist.
- `rateLimit.test.ts`: register/login whitespace-only → 400 (no `registerUser`/`loginUser`); surrounding whitespace trimmed in the downstream call.
- Full backend suite: 888 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)