### PR TITLE
fix(config): reject control chars in git identity email like name (#306)

### DIFF
--- a/backend/src/sessionConfig.test.ts
+++ b/backend/src/sessionConfig.test.ts
@@ -1833,3 +1833,23 @@ describe("encryptAuthCredentials / decryptStoredAuth / redactStoredAuth", () => 
 		expect(redactStoredAuth({})).toBeUndefined();
 	});
 });
+
+// #306: git identity validation. `name` already rejects control chars
+// (INI-corruption guard); `email` must too — they're both written into
+// INI-format ~/.gitconfig by `git config --global`.
+describe("GitIdentitySpec email control-char rejection (#306)", () => {
+	const withEmail = (email: string) => ({ gitIdentity: { name: "Ada", email } });
+
+	it("accepts a normal email", () => {
+		expect(SessionConfigSchema.safeParse(withEmail("ada@example.com")).success).toBe(true);
+	});
+
+	it("rejects an email containing a non-whitespace control byte", () => {
+		// \x01 is not in \s, so it would slip past `[^\s@]+` without the guard.
+		expect(SessionConfigSchema.safeParse(withEmail("a\x01b@example.com")).success).toBe(false);
+	});
+
+	it("rejects an email with a trailing newline (regex $ admits it without the guard)", () => {
+		expect(SessionConfigSchema.safeParse(withEmail("a@b.com\n")).success).toBe(false);
+	});
+});

--- a/backend/src/sessionConfig.ts
+++ b/backend/src/sessionConfig.ts
@@ -427,7 +427,14 @@ const GitIdentitySpec = z
 			.string()
 			.min(1)
 			.max(MAX_GIT_EMAIL_LEN)
-			.refine((e) => GIT_EMAIL_PATTERN.test(e), {
+			// Same control-char guard as `name` (#306). `GIT_EMAIL_PATTERN`
+			// alone admits them: non-whitespace control bytes (\x01-\x08,
+			// \x0e-\x1f, \x7f) aren't in `\s` so they pass `[^\s@]+`, and
+			// without the `m` flag `$` matches before a single trailing `\n`,
+			// so `"a@b\n"` validates. `git config --global user.email` writes
+			// this into INI-format ~/.gitconfig, so close the same
+			// INI-corruption surface `name` already guards.
+			.refine((e) => GIT_EMAIL_PATTERN.test(e) && !CONTROL_CHAR_PATTERN.test(e), {
 				message: "email must be of the form local@domain",
 			}),
 	})


### PR DESCRIPTION
Closes #306.

## Problem
`GitIdentitySpec.name` rejects any control char (the documented `~/.gitconfig` INI-corruption guard), but `email` only ran `GIT_EMAIL_PATTERN` (`/^[^\s@]+@[^\s@]+$/`). Non-whitespace control bytes (`\x01-\x08`, `\x0e-\x1f`, `\x7f`) aren't in `\s`, so they pass `[^\s@]+`; and with no `m` flag, `$` matches before a single trailing `\n`, so `"a@b\n"` validated. `git config --global user.email` writes this into the same INI-format file — a defense-in-depth asymmetry with `name`.

## Fix
Add `&& !CONTROL_CHAR_PATTERN.test(e)` to the email refine.

## Tests
New cases: a normal email passes; an email with an embedded `\x01` is rejected; an email with a trailing newline is rejected. Full backend suite: 891 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)