### PR TITLE
perf(frontend): append text node instead of textContent += in bootstrap live-tail (#308)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1383,7 +1383,12 @@ function startBootstrapLiveTail(session: SessionInfo, name: string) {
 
 	activeBootstrap = openBootstrapWs(session.sessionId, {
 		onOutput: (chunk) => {
-			pre.textContent += chunk;
+			// Append a text node rather than `pre.textContent += chunk`
+			// (#308): the `+=` form re-reads and re-serialises the entire
+			// accumulated log on every frame, so a verbose hook (npm install
+			// can emit hundreds of KB over the 10-min bootstrap cap) makes
+			// the modal quadratic and janky. Appending a node is O(chunk).
+			pre.appendChild(document.createTextNode(chunk));
 			// Auto-scroll to the bottom so the latest line is visible
 			// — `npm install`-style hooks emit hundreds of lines and
 			// the user expects the tail, not the head.


### PR DESCRIPTION
Closes #308.

## Problem
The bootstrap live-tail appended streamed output with `pre.textContent += chunk`, which re-reads, concatenates, and re-writes the entire accumulated string on every frame. A verbose `postCreate` hook (e.g. `npm install`, which can emit hundreds of KB over the 10-minute bootstrap cap) makes this quadratic, janking the modal as output grows.

## Fix
Append a text node: `pre.appendChild(document.createTextNode(chunk))` — O(chunk) per frame. Behaviourally identical (both append text). The static-render path (`pre.textContent = log`) runs once and is unaffected.

## Verification
`tsc` + `vite build` clean, frontend lint + tests pass (66). No unit harness exists for `main.ts`'s DOM code; the change is a behaviour-preserving micro-optimisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)