### PR TITLE
fix(logger): redact cookie/authorization when logged nested (#305)

### DIFF
--- a/backend/src/logger.test.ts
+++ b/backend/src/logger.test.ts
@@ -40,11 +40,26 @@ describe("logger redaction (#305)", () => {
 	it("redacts a one-level-nested headers.cookie / headers.authorization", () => {
 		const out = captureLog({ headers: { cookie: JWT, authorization: "Bearer SECRET" } });
 		expect(out).not.toMatch(/SECRET/);
+		// Assert the field was censored (not merely absent) — a mis-spelled
+		// path that pino never matches would also satisfy `not.toMatch`.
+		expect(out).toMatch(/\[redacted\]/);
 	});
 
 	it("redacts a two-level-nested req.headers.cookie / req.headers.authorization", () => {
 		const out = captureLog({ req: { headers: { cookie: JWT, authorization: "Bearer SECRET" } } });
 		expect(out).not.toMatch(/SECRET/);
+		expect(out).toMatch(/\[redacted\]/);
+	});
+
+	it("redacts a Set-Cookie response header (top-level and nested under headers)", () => {
+		// setAuthCookie delivers the JWT via Set-Cookie; res.getHeaders()
+		// lowercases the key.
+		const top = captureLog({ "set-cookie": JWT });
+		expect(top).not.toMatch(/eyJhbGciOi/);
+		expect(top).toMatch(/\[redacted\]/);
+		const nested = captureLog({ headers: { "set-cookie": JWT } });
+		expect(nested).not.toMatch(/eyJhbGciOi/);
+		expect(nested).toMatch(/\[redacted\]/);
 	});
 
 	it("does not over-redact a benign numeric `code` field", () => {

--- a/backend/src/logger.test.ts
+++ b/backend/src/logger.test.ts
@@ -1,0 +1,57 @@
+/**
+ * logger.test.ts — redaction coverage (#305).
+ *
+ * pino matches redact paths exactly from the root, so the bare `cookie` /
+ * `authorization` keys only scrub a TOP-LEVEL field. These tests pin that
+ * the JWT-bearing headers are also scrubbed when logged nested (the shape a
+ * future `logger.info({ req })` / `logger.warn({ headers })` would produce),
+ * so the redaction list can't silently regress to top-level-only.
+ */
+
+import { Writable } from "node:stream";
+import { pino } from "pino";
+import { describe, expect, it } from "vitest";
+import { REDACT_PATHS } from "./logger.js";
+
+// Build a logger with the real production redact paths but pointed at a
+// capturing stream, so we assert on exactly what would be serialised.
+function captureLog(obj: unknown): string {
+	let out = "";
+	const sink = new Writable({
+		write(chunk, _enc, cb) {
+			out += chunk.toString();
+			cb();
+		},
+	});
+	const l = pino({ level: "info", redact: { paths: REDACT_PATHS, censor: "[redacted]" } }, sink);
+	l.info(obj as Record<string, unknown>, "test");
+	return out;
+}
+
+describe("logger redaction (#305)", () => {
+	const JWT = "st_token=eyJhbGciOi.SECRET.SIG";
+
+	it("redacts a top-level cookie / authorization", () => {
+		const out = captureLog({ cookie: JWT, authorization: "Bearer SECRET" });
+		expect(out).not.toMatch(/SECRET/);
+		expect(out).toMatch(/\[redacted\]/);
+	});
+
+	it("redacts a one-level-nested headers.cookie / headers.authorization", () => {
+		const out = captureLog({ headers: { cookie: JWT, authorization: "Bearer SECRET" } });
+		expect(out).not.toMatch(/SECRET/);
+	});
+
+	it("redacts a two-level-nested req.headers.cookie / req.headers.authorization", () => {
+		const out = captureLog({ req: { headers: { cookie: JWT, authorization: "Bearer SECRET" } } });
+		expect(out).not.toMatch(/SECRET/);
+	});
+
+	it("does not over-redact a benign numeric `code` field", () => {
+		// Guard the deliberate choice to redact `inviteCode`/`invite_code`
+		// but NOT a bare `code` (HTTP status / error code).
+		const out = captureLog({ code: 503 });
+		expect(out).toMatch(/503/);
+		expect(out).not.toMatch(/\[redacted\]/);
+	});
+});

--- a/backend/src/logger.test.ts
+++ b/backend/src/logger.test.ts
@@ -60,6 +60,22 @@ describe("logger redaction (#305)", () => {
 		const nested = captureLog({ headers: { "set-cookie": JWT } });
 		expect(nested).not.toMatch(/eyJhbGciOi/);
 		expect(nested).toMatch(/\[redacted\]/);
+		// Capital-case bracket paths get their own coverage so a syntax error
+		// in those entries can't survive the suite via a lowercase test value.
+		const topCap = captureLog({ "Set-Cookie": JWT });
+		expect(topCap).not.toMatch(/eyJhbGciOi/);
+		expect(topCap).toMatch(/\[redacted\]/);
+		const nestedCap = captureLog({ headers: { "Set-Cookie": JWT } });
+		expect(nestedCap).not.toMatch(/eyJhbGciOi/);
+		expect(nestedCap).toMatch(/\[redacted\]/);
+	});
+
+	it("redacts a two-level-nested res.headers set-cookie", () => {
+		// `logger.warn({ res: { headers: res.getHeaders() } })` nests
+		// set-cookie one level deeper than the `*[...]` wildcard reaches.
+		const out = captureLog({ res: { headers: { "set-cookie": JWT } } });
+		expect(out).not.toMatch(/eyJhbGciOi/);
+		expect(out).toMatch(/\[redacted\]/);
 	});
 
 	it("does not over-redact a benign numeric `code` field", () => {

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -44,36 +44,55 @@ const transport =
 
 const defaultLevel = isProduction ? "info" : isTest ? "silent" : "debug";
 
+// Redaction acts on field paths, not message-string substrings. Listed
+// here are the known carriers of secret material in this codebase — adding
+// a new auth path that lands a JWT or invite plaintext into a log object
+// should grow this list, not depend on every caller remembering to scrub.
+//
+// Field-name list, not substring match. Picked specifically so a future
+// caller logging `{ code: statusCode }` (HTTP status, error code,
+// anything-but-an-invite-secret) doesn't get silently redacted —
+// `inviteCode` / `invite_code` cover the actual plaintext-bearing fields,
+// and any new secret carrier should land here under its own specific key.
+//
+// Exported so the redaction behaviour can be unit-tested against a captured
+// stream without reaching into the live logger's transport.
+export const REDACT_PATHS = [
+	"password",
+	"passwordHash",
+	"password_hash",
+	"token",
+	"jwt",
+	"jwtSecret",
+	"JWT_SECRET",
+	"inviteCode",
+	"invite_code",
+	"authorization",
+	"Authorization",
+	"cookie",
+	"Cookie",
+	// Nested carriers (#305): pino matches redact paths exactly from the
+	// root, so the bare keys above only scrub a TOP-LEVEL field. A future
+	// caller logging a request/headers object — `logger.info({ req })` or
+	// `logger.warn({ headers })` — would otherwise leak the `st_token` JWT
+	// riding in the Cookie / Authorization header. `*` is a single-level
+	// wildcard, so cover the realistic one-level (`headers.cookie`) and
+	// two-level (`req.headers.cookie`) nestings for the JWT-bearing headers.
+	"*.cookie",
+	"*.Cookie",
+	"*.authorization",
+	"*.Authorization",
+	"req.headers.cookie",
+	"req.headers.Cookie",
+	"req.headers.authorization",
+	"req.headers.Authorization",
+];
+
 export const logger = pino({
 	level: process.env.LOG_LEVEL ?? defaultLevel,
 	transport,
-	// Redaction acts on field paths, not message-string substrings. Listed
-	// here are the known carriers of secret material in this codebase —
-	// adding a new auth path that lands a JWT or invite plaintext into a
-	// log object should grow this list, not depend on every caller
-	// remembering to scrub.
 	redact: {
-		// Field-name list, not substring match. Picked specifically so a
-		// future caller logging `{ code: statusCode }` (HTTP status, error
-		// code, anything-but-an-invite-secret) doesn't get silently
-		// redacted — `inviteCode` / `invite_code` cover the actual
-		// plaintext-bearing fields, and any new secret carrier should
-		// land here under its own specific key.
-		paths: [
-			"password",
-			"passwordHash",
-			"password_hash",
-			"token",
-			"jwt",
-			"jwtSecret",
-			"JWT_SECRET",
-			"inviteCode",
-			"invite_code",
-			"authorization",
-			"Authorization",
-			"cookie",
-			"Cookie",
-		],
+		paths: REDACT_PATHS,
 		censor: "[redacted]",
 	},
 });

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -97,6 +97,11 @@ export const REDACT_PATHS = [
 	'["Set-Cookie"]',
 	'*["set-cookie"]',
 	'*["Set-Cookie"]',
+	// Two-level concrete paths for the response side, mirroring
+	// `req.headers.cookie`: a caller logging `{ res: { headers: ... } }`
+	// nests set-cookie one level deeper than the `*[...]` wildcard reaches.
+	'res.headers["set-cookie"]',
+	'res.headers["Set-Cookie"]',
 ];
 
 export const logger = pino({

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -82,10 +82,21 @@ export const REDACT_PATHS = [
 	"*.Cookie",
 	"*.authorization",
 	"*.Authorization",
+	// Only lowercase for the concrete `req.headers.*` paths: Node lowercases
+	// every incoming HTTP header name, so a capital-C `req.headers.Cookie`
+	// could never match a real request object. (The `*.Cookie` wildcards
+	// above still cover a manually-built object with a capital key.)
 	"req.headers.cookie",
-	"req.headers.Cookie",
 	"req.headers.authorization",
-	"req.headers.Authorization",
+	// The RESPONSE side carries the same JWT: `setAuthCookie` writes it as a
+	// `Set-Cookie` header, so `logger.warn({ headers: res.getHeaders() })`
+	// would leak it. The hyphen needs bracket notation in fast-redact. Node
+	// lowercases response header keys too, so lowercase is the real match;
+	// the capitalised variants guard manually-built objects.
+	'["set-cookie"]',
+	'["Set-Cookie"]',
+	'*["set-cookie"]',
+	'*["Set-Cookie"]',
 ];
 
 export const logger = pino({


### PR DESCRIPTION
Closes #305.

## Verification first
The original finding was marked *needs verification*. Confirmed: **no current call site logs a request/headers object** (all `logger.*` calls use string messages), so this is **defense-in-depth, not a live leak**.

## Problem
pino matches redact paths exactly from the root, so the bare `cookie` / `authorization` / `token` keys only scrub a **top-level** field. A future caller logging a request/headers object — `logger.info({ req })` or `logger.warn({ headers })` (the shape pino's standard req serializer produces) — would leak the `st_token` JWT riding in the Cookie / Authorization header, despite the redaction list appearing to cover it.

## Fix
Add the realistic nestings for the JWT-bearing headers: one-level (`*.cookie`, `*.authorization`, single-level wildcard) and two-level (`req.headers.cookie`, `req.headers.authorization`). Extract `REDACT_PATHS` as an export so the behaviour is unit-testable.

## Tests
New `logger.test.ts` builds a pino instance with the real `REDACT_PATHS` pointed at a capturing stream and asserts the JWT is scrubbed at top / one / two levels of nesting, and that a benign numeric `code` field is **not** over-redacted (guarding the deliberate `inviteCode`-not-`code` choice). Full backend suite: 895 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)