### PR TITLE
ci(review): raise claude-review --max-turns 20 → 40 for large diffs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,11 +10,12 @@ name: Claude PR Review
 #   This is NOT equivalent to `contents: write` — it does not grant code-push
 #   rights; the resulting token is bounded by the Claude GitHub App's own
 #   install permissions on this repo.
-# - `--max-turns 20` caps iteration blast radius if prompt injection occurs.
-#   Previously 10, bumped after a PR where the agent hit the ceiling before
-#   posting — mostly because permission denials on read-only tools (Read,
-#   Grep, etc.) burnt turns. See the allowlist below for the read-only
-#   tools that were added in the same change.
+# - `--max-turns 40` caps iteration blast radius if prompt injection occurs.
+#   Was 10, then 20; bumped to 40 after large refactor PRs (e.g. the #311
+#   routes.ts split, ~2.6k lines across 8 files) exhausted the budget reading
+#   the full diff before posting — the agent failed with "Reached maximum
+#   number of turns" instead of a verdict. See the allowlist below for the
+#   read-only tools the agent uses.
 # - Allowlist is read-only: only gh/git read commands and read-only fs
 #   tools (Read, Grep, Glob). Nothing that can write, push, or reach
 #   network, so a prompt-injection attack can't pivot beyond influencing
@@ -58,7 +59,7 @@ jobs:
           # so the review lands as a top-level PR comment.
           claude_args: >
             --model claude-sonnet-4-6
-            --max-turns 20
+            --max-turns 40
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*),Read,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
The Claude PR review agent failed on #311 (the routes.ts split, ~2.6k lines across 8 files) with **"Reached maximum number of turns (20)"** — it exhausted its turn budget reading the full diff before it could post a verdict. The pre-rebase run on byte-identical code had completed with LGTM, so this is purely a turn-budget limit on large diffs, not a code issue.

The upcoming #312 (main.ts split, ~5.2k lines) will hit it harder.

Bumps `--max-turns` from 20 to 40 and updates the rationale comment. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)