### PR TITLE
fix(frontend): keep ports modal open and show errors inline (#190)

### DIFF
--- a/frontend/src/ports.ts
+++ b/frontend/src/ports.ts
@@ -130,8 +130,17 @@ function openPortsModal(): void {
 	const sessionId = activeSessionId;
 	portsModalSessionId = sessionId;
 	portsModalRows = [];
+	// Reset the privileged flag too: a failed/aborted load must not leave a
+	// previous session's `allowPrivilegedPorts=true` in scope (the client-side
+	// privileged-port check reads it). The server still enforces the cap.
+	portsModalPrivilegedAllowed = false;
 	setPortsModalError(null);
 	portsModalPrivilegedHint.hidden = true;
+	// Re-enable the action buttons each open — the error path below disables
+	// them so an unloaded (empty-rows) modal can't be Saved, which would PATCH
+	// `ports: []` and wipe the session's configured ports.
+	portsModalSaveBtn.disabled = false;
+	portsModalAddRowBtn.disabled = false;
 	portsModalTableBody.textContent = "";
 	const loading = document.createElement("tr");
 	const loadingCell = document.createElement("td");
@@ -167,8 +176,15 @@ function openPortsModal(): void {
 			// failure and hid the reason; an inline message stays readable
 			// and lets the user retry by reopening. Clear the "Loading…" row
 			// first so the table doesn't read as an empty port set.
+			//
+			// CRITICAL: disable Save + Add Row. The load failed, so
+			// `portsModalRows` is still []; a Save here would PATCH the whole
+			// set to [] and silently wipe every configured port. The buttons
+			// are re-enabled on the next openPortsModal().
 			portsModalTableBody.textContent = "";
 			setPortsModalError((err as Error).message);
+			portsModalSaveBtn.disabled = true;
+			portsModalAddRowBtn.disabled = true;
 		}
 	})();
 }

--- a/frontend/src/ports.ts
+++ b/frontend/src/ports.ts
@@ -159,11 +159,16 @@ function openPortsModal(): void {
 		} catch (err) {
 			// Same stale-session guard as the success branch above: if the
 			// user already reopened Ports for a different session while this
-			// fetch was in flight, don't toast a stale error or close the
-			// now-current modal out from under them.
+			// fetch was in flight, don't touch the now-current modal.
 			if (portsModalSessionId !== sessionId) return;
-			showToast((err as Error).message, true);
-			closePortsModal();
+			// Keep the modal OPEN and surface the error inline (mirrors the
+			// admin dashboard) instead of closing. Closing made the dialog
+			// "vanish the instant it opened" on any transient GET /ports
+			// failure and hid the reason; an inline message stays readable
+			// and lets the user retry by reopening. Clear the "Loading…" row
+			// first so the table doesn't read as an empty port set.
+			portsModalTableBody.textContent = "";
+			setPortsModalError((err as Error).message);
 		}
 	})();
 }


### PR DESCRIPTION
## Symptom
The exposed-ports modal "closes right after opening."

## Investigation
`openPortsModal` opens the dialog synchronously, then fetches `GET /sessions/:id/ports`. On a non-OK response (`getSessionPorts` throws `"Failed to load ports"`) — or any `apiFetch` rejection — the `catch` called `closePortsModal()`. So **the modal closes on any ports-fetch failure**, and the only trace was a toast that scrolls away.

Ruled out as causes:
- **Not the #312 split**: the ports code was a *verbatim* move in #332 (confirmed by diff); the only logic added was the stale-session guard.
- **Not a broken live binding**: the production bundle references `activeSessionId` as a single shared variable (main reassigns, ports reads) — live binding intact.
- **Not a backend route bug**: `GET /sessions/:id/ports` returns 200 for an owned session; `routes.ports.test.ts` (8 tests) passes.

So a non-OK `/ports` response (e.g. a 401→session-expired, 403/404/500) makes the dialog vanish the instant it opens, hiding the reason. The underlying response status is visible in the browser Network tab.

## Fix
Keep the modal **open** and surface the error **inline** (mirrors the admin dashboard): clear the `Loading…` row and write the message into the modal's error element. The user can read the cause and retry by reopening, instead of the dialog flashing shut.

## Verification
tsc clean, Biome clean, `vite build` green, frontend tests pass (66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)