### PR TITLE
test(ports): cover GET /sessions/:id/ports reachability (#190)

### DIFF
--- a/backend/src/routes.ports.test.ts
+++ b/backend/src/routes.ports.test.ts
@@ -265,3 +265,18 @@ describe("PATCH /sessions/:id/ports", () => {
 		expect(calls.some((c) => /sessions_port_mappings/.test(c[0]))).toBe(false);
 	});
 });
+
+// Reachability of the GET editor endpoint (#190d) — this was previously
+// untested (only PATCH was), which is why a route-registration regression
+// could ship silently.
+describe("GET /sessions/:id/ports (reachability)", () => {
+	it("is reachable through the full buildRouter and returns 200 for the owner", async () => {
+		const { sessions } = makeFakeSessions();
+		await spinUp(sessions);
+		const res = await fetch(`${baseUrl}/api/sessions/sess-1/ports`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { ports: unknown[]; allowPrivilegedPorts: boolean };
+		expect(Array.isArray(body.ports)).toBe(true);
+		expect(typeof body.allowPrivilegedPorts).toBe("boolean");
+	});
+});


### PR DESCRIPTION
`routes.ports.test.ts` only tested **PATCH** `/ports` — the **GET** editor endpoint (#190d) was never tested, so a route-registration regression could ship silently.

Adds a reachability test that hits `GET /api/sessions/:id/ports` through the **full `buildRouter`** and asserts 200 + the `{ports, allowPrivilegedPorts}` shape.

**Diagnostic context:** a user reported a production 404 on this endpoint. This test confirms the route **is** reachable in current `main` (returns 200), so the 404 is a stale backend deploy (the GET endpoint was added in #288), not a code regression.

Full backend suite: 906 passing, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)