### PR TITLE
feat(frontend): mobile extra-keys bar (Esc/Tab/sticky-Ctrl/^C/arrows)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -212,6 +212,32 @@
           </div>
           <div id="terminal-tabs"></div>
           <div id="terminal-container"></div>
+          <!-- Mobile extra-keys bar — the soft keyboard has no Esc/Tab/
+               Ctrl/arrows, which a terminal (vim, tmux, shell history,
+               interrupt) can't live without. Shown only on touch mobile
+               (CSS-gated) while a session is active (JS-gated, rides the
+               same lifecycle as the actions + button). Ctrl is a sticky
+               modifier: tap it, then the next key — bar key or soft-
+               keyboard letter — sends the Ctrl-chord. Wiring and the
+               focus-preservation rationale live in keyBar.ts. -->
+          <div id="key-bar" hidden>
+            <button type="button" data-key="esc">esc</button>
+            <button type="button" data-key="tab">tab</button>
+            <button
+              type="button"
+              data-key="ctrl"
+              id="key-bar-ctrl"
+              aria-pressed="false"
+              title="Sticky Ctrl — applies to the next key"
+            >
+              ctrl
+            </button>
+            <button type="button" data-key="ctrl-c" aria-label="Control C (interrupt)">^C</button>
+            <button type="button" data-key="up" data-repeat aria-label="Arrow up">↑</button>
+            <button type="button" data-key="down" data-repeat aria-label="Arrow down">↓</button>
+            <button type="button" data-key="left" data-repeat aria-label="Arrow left">←</button>
+            <button type="button" data-key="right" data-repeat aria-label="Arrow right">→</button>
+          </div>
         </section>
       </main>
     </div>

--- a/frontend/src/keyBar.ts
+++ b/frontend/src/keyBar.ts
@@ -1,0 +1,126 @@
+/**
+ * keyBar.ts — mobile extra-keys bar (Esc / Tab / Ctrl / ^C / arrows).
+ *
+ * The iOS/Android soft keyboard has none of the keys a terminal lives
+ * on; this bar sits between the terminal and the keyboard and injects
+ * them. Follows the #312 module pattern: imports main.ts's live
+ * bindings, all cross-module reads happen inside functions (TDZ-safe).
+ *
+ * Two design points that are easy to break:
+ *
+ *   - Buttons act on `pointerdown` + preventDefault, NOT `click`.
+ *     Cancelling pointerdown suppresses the compatibility mousedown,
+ *     and focus follows mousedown — so xterm's helper textarea keeps
+ *     focus and the soft keyboard STAYS OPEN while the user taps bar
+ *     keys. A click handler would blur the terminal on every tap and
+ *     bounce the keyboard closed/open.
+ *
+ *   - The sticky-Ctrl state lives HERE, not in terminal.ts. The bar is
+ *     one global widget; terminals are per-tab. Keeping the armed flag
+ *     in the session would desync the button's pressed visual whenever
+ *     the user switched tabs with Ctrl armed. terminal.ts instead
+ *     exposes a `transformInput` hook that every tab's session shares
+ *     (wired in sessionCore.openTab), so whichever terminal receives
+ *     the next keystroke consumes the same armed state the button
+ *     displays.
+ */
+
+import { ctrlifyChar, type SpecialKey } from "./keys.js";
+import { activeSessionId, getActiveTerminal } from "./main.js";
+
+const keyBar = document.getElementById("key-bar")!;
+const ctrlBtn = document.getElementById("key-bar-ctrl") as HTMLButtonElement;
+
+let ctrlArmed = false;
+
+function setCtrlArmed(on: boolean): void {
+	ctrlArmed = on;
+	ctrlBtn.classList.toggle("armed", on);
+	ctrlBtn.setAttribute("aria-pressed", String(on));
+}
+
+/**
+ * transformInput hook shared by every tab's terminal session (wired in
+ * sessionCore.openTab). When Ctrl is armed, the next keyboard chunk is
+ * ctrl-ified and the modifier disarms — including for chunks that have
+ * no control mapping (IME output, multi-char bursts), so the armed
+ * state can't linger past a keystroke the user visibly typed.
+ */
+export function transformKeyInput(data: string): string {
+	if (!ctrlArmed) return data;
+	setCtrlArmed(false);
+	return ctrlifyChar(data);
+}
+
+/** Show the bar only while a session is active — same lifecycle as the
+ *  actions (+) button; called from updateChromeToggle. The `hidden`
+ *  attribute is the JS half; CSS additionally gates display on the
+ *  mobile breakpoint + coarse pointer, so desktop never sees it. */
+export function updateKeyBarVisibility(): void {
+	keyBar.hidden = activeSessionId === null;
+}
+
+function pressKey(key: SpecialKey): void {
+	const term = getActiveTerminal();
+	if (!term) return;
+	const ctrl = ctrlArmed;
+	if (ctrl) setCtrlArmed(false);
+	term.sendSpecialKey(key, { ctrl });
+}
+
+// Hold-to-repeat for the arrow keys (data-repeat buttons): initial
+// delay then steady rate, matching hardware key-repeat feel. Repeats
+// send the PLAIN key — the sticky Ctrl was consumed by the first
+// press, and auto-repeating a modified arrow (word-jump) is more
+// surprising than useful.
+const REPEAT_DELAY_MS = 400;
+const REPEAT_INTERVAL_MS = 80;
+let repeatDelayTimer: ReturnType<typeof setTimeout> | null = null;
+let repeatTimer: ReturnType<typeof setInterval> | null = null;
+
+function stopRepeat(): void {
+	if (repeatDelayTimer !== null) clearTimeout(repeatDelayTimer);
+	if (repeatTimer !== null) clearInterval(repeatTimer);
+	repeatDelayTimer = null;
+	repeatTimer = null;
+}
+
+function startRepeat(key: SpecialKey): void {
+	stopRepeat();
+	repeatDelayTimer = setTimeout(() => {
+		repeatDelayTimer = null;
+		repeatTimer = setInterval(() => {
+			const term = getActiveTerminal();
+			// Tab closed / session switched mid-hold — stop rather than
+			// spray keys at whatever becomes active next.
+			if (!term) {
+				stopRepeat();
+				return;
+			}
+			term.sendSpecialKey(key, { ctrl: false });
+		}, REPEAT_INTERVAL_MS);
+	}, REPEAT_DELAY_MS);
+}
+
+export function initKeyBar(): void {
+	for (const btn of keyBar.querySelectorAll<HTMLButtonElement>("button[data-key]")) {
+		const key = btn.dataset.key!;
+		btn.addEventListener("pointerdown", (ev) => {
+			// Load-bearing: keeps focus (and the soft keyboard) on xterm's
+			// helper textarea — see the module comment.
+			ev.preventDefault();
+			if (key === "ctrl") {
+				setCtrlArmed(!ctrlArmed);
+				return;
+			}
+			pressKey(key as SpecialKey);
+			if (btn.hasAttribute("data-repeat")) startRepeat(key as SpecialKey);
+		});
+		// pointerleave covers the finger sliding off the button mid-hold;
+		// pointercancel covers the OS stealing the gesture (notification
+		// shade pull, app switch).
+		btn.addEventListener("pointerup", stopRepeat);
+		btn.addEventListener("pointerleave", stopRepeat);
+		btn.addEventListener("pointercancel", stopRepeat);
+	}
+}

--- a/frontend/src/keys.test.ts
+++ b/frontend/src/keys.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { ctrlifyChar, specialKeySequence } from "./keys.js";
+
+describe("specialKeySequence", () => {
+	const plain = { appCursor: false, ctrl: false };
+
+	it("encodes the simple keys", () => {
+		expect(specialKeySequence("esc", plain)).toBe("\x1b");
+		expect(specialKeySequence("tab", plain)).toBe("\t");
+		expect(specialKeySequence("ctrl-c", plain)).toBe("\x03");
+	});
+
+	it("encodes arrows as CSI in normal cursor mode", () => {
+		expect(specialKeySequence("up", plain)).toBe("\x1b[A");
+		expect(specialKeySequence("down", plain)).toBe("\x1b[B");
+		expect(specialKeySequence("right", plain)).toBe("\x1b[C");
+		expect(specialKeySequence("left", plain)).toBe("\x1b[D");
+	});
+
+	it("encodes arrows as SS3 in application cursor mode (DECCKM)", () => {
+		const app = { appCursor: true, ctrl: false };
+		expect(specialKeySequence("up", app)).toBe("\x1bOA");
+		expect(specialKeySequence("left", app)).toBe("\x1bOD");
+	});
+
+	it("encodes ctrl-arrows with the CSI modifier form regardless of DECCKM", () => {
+		expect(specialKeySequence("right", { appCursor: false, ctrl: true })).toBe("\x1b[1;5C");
+		// Modified keys have no SS3 encoding — app-cursor mode must not
+		// change the ctrl variant.
+		expect(specialKeySequence("right", { appCursor: true, ctrl: true })).toBe("\x1b[1;5C");
+	});
+
+	it("ignores ctrl for keys with no modified encoding", () => {
+		const ctrl = { appCursor: false, ctrl: true };
+		expect(specialKeySequence("esc", ctrl)).toBe("\x1b");
+		expect(specialKeySequence("tab", ctrl)).toBe("\t");
+		expect(specialKeySequence("ctrl-c", ctrl)).toBe("\x03");
+	});
+});
+
+describe("ctrlifyChar", () => {
+	it("masks letters to C0 codes, case-insensitively", () => {
+		expect(ctrlifyChar("c")).toBe("\x03");
+		expect(ctrlifyChar("C")).toBe("\x03");
+		expect(ctrlifyChar("a")).toBe("\x01");
+		expect(ctrlifyChar("z")).toBe("\x1a");
+	});
+
+	it("maps the @[\\]^_ block", () => {
+		expect(ctrlifyChar("@")).toBe("\x00");
+		expect(ctrlifyChar("[")).toBe("\x1b"); // Ctrl-[ = Esc
+		expect(ctrlifyChar("]")).toBe("\x1d");
+		expect(ctrlifyChar("_")).toBe("\x1f");
+	});
+
+	it("maps space to NUL and ? to DEL", () => {
+		expect(ctrlifyChar(" ")).toBe("\x00");
+		expect(ctrlifyChar("?")).toBe("\x7f");
+	});
+
+	it("passes through unmappable or multi-char input unchanged", () => {
+		expect(ctrlifyChar("ñ")).toBe("ñ");
+		expect(ctrlifyChar("1")).toBe("1");
+		expect(ctrlifyChar("hello")).toBe("hello");
+		expect(ctrlifyChar("")).toBe("");
+	});
+});

--- a/frontend/src/keys.ts
+++ b/frontend/src/keys.ts
@@ -1,0 +1,68 @@
+/**
+ * keys.ts — pure key-sequence helpers for the mobile extra-keys bar.
+ *
+ * Kept free of DOM and xterm imports so the encoding rules are unit-
+ * testable in isolation; terminal.ts supplies the runtime bits (app
+ * cursor mode, the WS pipe) and keyBar.ts supplies the UI state.
+ */
+
+export type SpecialKey = "esc" | "tab" | "up" | "down" | "left" | "right" | "ctrl-c";
+
+const ARROW_FINAL: Record<string, string> = {
+	up: "A",
+	down: "B",
+	right: "C",
+	left: "D",
+};
+
+/**
+ * Byte sequence a real keyboard would produce for `key`.
+ *
+ * Arrows honour DECCKM: normal mode emits CSI (`\x1b[A`), application
+ * cursor mode emits SS3 (`\x1bOA`) — vim/less/htop set the latter and
+ * ignore CSI arrows. Ctrl-modified arrows always use the CSI form with
+ * the xterm modifier parameter (`\x1b[1;5A`); modified keys have no SS3
+ * encoding, applications expect CSI regardless of DECCKM.
+ *
+ * `ctrl` is ignored for the non-arrow keys: Ctrl+Esc / Ctrl+Tab have no
+ * terminal encoding, and ctrl-c already IS a control code.
+ */
+export function specialKeySequence(
+	key: SpecialKey,
+	opts: { appCursor: boolean; ctrl: boolean },
+): string {
+	switch (key) {
+		case "esc":
+			return "\x1b";
+		case "tab":
+			return "\t";
+		case "ctrl-c":
+			return "\x03";
+		default: {
+			const final = ARROW_FINAL[key]!;
+			if (opts.ctrl) return `\x1b[1;5${final}`;
+			return opts.appCursor ? `\x1bO${final}` : `\x1b[${final}`;
+		}
+	}
+}
+
+/**
+ * Transform one soft-keyboard character into its C0 control code, the
+ * way a hardware Ctrl+<key> chord would: letters and the @[\]^_ block
+ * mask to 0x00–0x1f (case-insensitive, so Ctrl+c and Ctrl+C both give
+ * ETX), space maps to NUL (Ctrl+Space, tmux's default prefix-adjacent
+ * binding and emacs set-mark), and `?` maps to DEL (Ctrl+? per the
+ * xterm convention). Anything else — multi-byte IME output, paste
+ * bursts, characters with no control mapping — passes through
+ * unchanged; the caller still disarms its sticky-Ctrl state so the
+ * modifier can't linger armed across an unmappable keystroke.
+ */
+export function ctrlifyChar(data: string): string {
+	if (data.length !== 1) return data;
+	if (data === " ") return "\x00";
+	if (data === "?") return "\x7f";
+	const code = data.toUpperCase().charCodeAt(0);
+	// '@' (0x40) through '_' (0x5f) — the classic Ctrl range.
+	if (code >= 0x40 && code <= 0x5f) return String.fromCharCode(code & 0x1f);
+	return data;
+}

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -2100,3 +2100,55 @@ main:not([data-sidebar-ready]) #sidebar {
     margin-left: auto;
   }
 }
+
+/* ── Mobile extra-keys bar ──────────────────────────────────────
+   Esc/Tab/Ctrl/^C/arrows for soft-keyboard terminals; markup in
+   index.html, wiring + focus-preservation rationale in keyBar.ts.
+   Hidden by default everywhere; shown only when BOTH gates open:
+   the JS `hidden` attribute (session active — same lifecycle as
+   the actions + button) and this media query (mobile breakpoint
+   AND coarse primary pointer, so a narrow DESKTOP window doesn't
+   grow a touch bar it can't use — it has a real keyboard). */
+#key-bar {
+  display: none;
+}
+@media (max-width: 768px) and (pointer: coarse) {
+  #key-bar:not([hidden]) {
+    display: flex;
+  }
+  #key-bar {
+    flex-shrink: 0;
+    gap: 6px;
+    padding: 6px;
+    background: #161b22;
+    border-top: 1px solid #30363d;
+    /* No long-press text-selection magnifier / callout while holding
+       an arrow for key-repeat. */
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+  #key-bar button {
+    flex: 1;
+    min-height: 40px; /* comfortable touch target */
+    background: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #c9d1d9;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.9rem;
+    /* Gestures starting on a key are key presses, never page pans or
+       double-tap zooms. */
+    touch-action: none;
+  }
+  #key-bar button:active {
+    background: #21262d;
+    border-color: #58a6ff;
+  }
+  /* Sticky Ctrl armed state — mirrors aria-pressed, set in keyBar.ts. */
+  #key-bar-ctrl.armed {
+    background: #1f6feb;
+    border-color: #1f6feb;
+    color: #fff;
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -31,6 +31,7 @@ import {
 	type Tab,
 } from "./api.js";
 import { closeInvitesModal } from "./invites.js";
+import { initKeyBar, updateKeyBarVisibility } from "./keyBar.js";
 import { closeMyGroupsModal, closeObserveModal } from "./myGroups.js";
 import {
 	applyResourceCapsToForm,
@@ -737,10 +738,12 @@ export function updateChromeToggle() {
 	if (!s) {
 		chromeToggleBtn.hidden = true;
 		actionsBtn.hidden = true;
+		updateKeyBarVisibility();
 		return;
 	}
 	chromeToggleBtn.hidden = false;
 	actionsBtn.hidden = false;
+	updateKeyBarVisibility();
 	const activeTab = currentTabs.find((t) => t.tabId === currentActiveTabId);
 	// Format: "session › tab". Falls back to just the session name when
 	// no tab is active yet (fresh session, between switches). Using a
@@ -876,5 +879,6 @@ export function getActiveTerminal(): TerminalSession | null {
 
 // ── Init ────────────────────────────────────────────────────────────────────
 
+initKeyBar();
 updateAuthUI();
 initAuth();

--- a/frontend/src/sessionCore.ts
+++ b/frontend/src/sessionCore.ts
@@ -20,6 +20,7 @@ import {
 	TabNotFoundError,
 } from "./api.js";
 import { formatBytes, formatCpuCores, formatCpuPercent } from "./format.js";
+import { transformKeyInput } from "./keyBar.js";
 import {
 	activeSessionId,
 	closingTabs,
@@ -463,6 +464,11 @@ function openTab(tabId: string) {
 				container: pane,
 				sessionId: ownSessionId,
 				tabId,
+				// Sticky-Ctrl from the mobile key bar. One shared transform
+				// across every tab — the armed state lives in keyBar.ts (the
+				// bar is a global widget), so whichever tab receives the next
+				// keystroke consumes the same state the button displays.
+				transformInput: transformKeyInput,
 				onStatus: (status: SessionStatus) => {
 					if (activeSessionId !== ownSessionId) return;
 

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -7,6 +7,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { type IDisposable, type ILink, type ILinkProvider, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+import { type SpecialKey, specialKeySequence } from "./keys.js";
 
 export type SessionStatus = "running" | "stopped" | "terminated" | "disconnected";
 
@@ -27,6 +28,15 @@ export interface TerminalSession {
 	 *  one finalised selection. No-op on desktop, where a mouse drag with
 	 *  the platform modifier already selects (#286). */
 	enterSelectMode(): void;
+	/** Send a named special key (Esc / Tab / arrows / Ctrl-C) to the pty
+	 *  as the byte sequence a hardware keyboard would produce. Arrows
+	 *  honour the terminal's application-cursor-keys mode (DECCKM), which
+	 *  only this layer can see (`term.modes`) — that's why the encoding
+	 *  lives here and not in the key bar. `mods.ctrl` requests the
+	 *  Ctrl-modified variant where one exists (arrows → CSI 1;5x, e.g.
+	 *  word-jump in readline). No-op in observe-mode, matching the
+	 *  suppressed onData input path. */
+	sendSpecialKey(key: SpecialKey, mods?: { ctrl?: boolean }): void;
 }
 
 export type StatusCallback = (status: SessionStatus) => void;
@@ -64,6 +74,19 @@ export function openTerminalSession(opts: {
 	onCopy?: CopyCallback;
 	isActive?: ActivePredicate;
 	/**
+	 * Hook applied to every keyboard-originated input chunk (term.onData)
+	 * before it goes on the wire. The mobile key bar (keyBar.ts) uses
+	 * this for its sticky-Ctrl modifier: the transform lives OUTSIDE the session
+	 * (keyBar.ts owns the armed state) because the bar is a single global
+	 * widget while sessions are per-tab — keeping the state here would
+	 * desync the bar's pressed-Ctrl visual from whichever tab is active.
+	 * NOT applied to paste() (term.paste routes through onData too, but
+	 * bracketed-paste content must never be ctrl-mangled — see the guard
+	 * at the call site) nor to touch-scroll SGR synthesis (those aren't
+	 * keystrokes).
+	 */
+	transformInput?: (data: string) => string;
+	/**
 	 * Read-only observe-mode (#201e). When true:
 	 *   - the WS URL carries `&observe=true` so the backend routes
 	 *     auth via `assertCanObserve` instead of `assertOwnership`;
@@ -95,6 +118,7 @@ export function openTerminalSession(opts: {
 		onRendererFallback,
 		onCopy,
 		isActive,
+		transformInput,
 		observe = false,
 	} = opts;
 	// Fires the fallback notice at most once per TIER, and only when
@@ -706,10 +730,20 @@ export function openTerminalSession(opts: {
 	// in the cleanup path becomes a no-op via the dummy disposable
 	// below (matches the IDisposable contract without an `if (observe)`
 	// branch in the dispose path).
+	// `pasting` gates transformInput: term.paste() feeds the pasted bytes
+	// through this same onData handler (that's how bracketed-paste framing
+	// reaches the wire), and pasted CONTENT must never be ctrl-mangled by
+	// the key bar's sticky modifier — only real keystrokes. Synchronous
+	// flag is sufficient because xterm's paste → onData delivery is
+	// synchronous (coreService.triggerDataEvent inside term.paste).
+	let pasting = false;
 	const inputDisposable: IDisposable = observe
 		? { dispose: () => {} }
 		: term.onData((data) => {
-				send({ type: "input", data });
+				send({
+					type: "input",
+					data: transformInput && !pasting ? transformInput(data) : data,
+				});
 			});
 
 	// ── Touch scroll ────────────────────────────────────────────────────────
@@ -1054,7 +1088,27 @@ export function openTerminalSession(opts: {
 	// bash, zsh, and Claude CLI all do — so multi-line content arrives as
 	// one paste event instead of being executed line-by-line.
 	function paste(text: string) {
-		term.paste(text);
+		// See the `pasting` declaration above the onData handler: the flag
+		// exempts pasted content from the key bar's transformInput hook.
+		pasting = true;
+		try {
+			term.paste(text);
+		} finally {
+			pasting = false;
+		}
+	}
+
+	function sendSpecialKey(key: SpecialKey, mods?: { ctrl?: boolean }) {
+		// Mirrors the onData suppression in observe-mode — the server would
+		// drop the frame anyway; don't spend it.
+		if (observe) return;
+		send({
+			type: "input",
+			data: specialKeySequence(key, {
+				appCursor: term.modes.applicationCursorKeysMode,
+				ctrl: mods?.ctrl ?? false,
+			}),
+		});
 	}
 
 	// Explicit copy of the current selection (actions-menu "Select & copy"
@@ -1146,7 +1200,7 @@ export function openTerminalSession(opts: {
 		term.dispose();
 	}
 
-	return { dispose, setFontSize, paste, copySelection, enterSelectMode };
+	return { dispose, setFontSize, paste, copySelection, enterSelectMode, sendSpecialKey };
 }
 
 // ── Multiline URL link provider ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The iOS/Android soft keyboard has no Esc, Tab, Ctrl, or arrow keys — which makes vim, tmux, shell history, and Ctrl-C interrupt effectively unusable on phones. This adds an extra-keys bar between the terminal and the soft keyboard, shown only on touch mobile while a session is active.

## Design

- **`keys.ts`** (new, pure, unit-tested): sequence encoding. Arrows honour DECCKM — CSI (`\x1b[A`) in normal mode, SS3 (`\x1bOA`) in application-cursor mode (vim/less set it and ignore CSI arrows); Ctrl-arrows always use the CSI modifier form (`\x1b[1;5C`, readline word-jump). `ctrlifyChar` masks the classic `@`–`_` block case-insensitively, space→NUL, `?`→DEL; unmappable input passes through.
- **`terminal.ts`**: `sendSpecialKey(key, {ctrl})` on `TerminalSession` — encoding lives here because only this layer can see `term.modes`. No-op in observe-mode, matching the suppressed input path. New `transformInput` hook on the `onData` pipe; `paste()` is exempted via a synchronous `pasting` flag so bracketed-paste content can never be ctrl-mangled.
- **`keyBar.ts`** (new): owns the **sticky Ctrl** state — tap Ctrl, then the next key (bar key or soft-keyboard letter) sends the chord. State is global to the bar rather than per-terminal because the bar is one widget over many tabs; every tab shares the same `transformInput`, so whichever terminal gets the next keystroke consumes exactly the state the button displays. Arrows hold-to-repeat (400 ms delay, 80 ms rate); repeat stops on pointerup/leave/cancel and if the active tab disappears mid-hold.
- **Focus preservation (load-bearing):** buttons act on `pointerdown` + `preventDefault`, not `click`. Cancelling pointerdown suppresses the compatibility mousedown that focus follows, so xterm's helper textarea keeps focus and **the soft keyboard stays open** while tapping bar keys. A click handler would bounce the keyboard closed on every tap.
- **Visibility:** double-gated — CSS `(max-width: 768px) and (pointer: coarse)` (a narrow desktop window has a real keyboard and doesn't get a touch bar) and the JS `hidden` attribute riding the same active-session lifecycle as the actions `+` button.

## Verification

- `npm run lint`, `npm run build`, `npm test` — green; 9 new unit tests for the sequence/ctrlify encoding (75 total).
- Pending real-device pass on iPhone: keyboard stays open while tapping keys, sticky Ctrl + `c` interrupts, arrows repeat on hold, Esc dismisses vim insert mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)