### PR TITLE
feat(frontend): WS auto-reconnect with backoff

### DIFF
--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1622,6 +1622,13 @@ main:not([data-sidebar-ready]) #sidebar {
   background: rgba(139, 148, 158, 0.2);
   color: #8b949e;
 }
+/* Synthetic frontend-only state while the WS auto-reconnect loop is
+   retrying (#356) — amber like `stopped` (transient, not an error),
+   distinct from the grey terminal `disconnected` state. */
+#terminal-status-badge.reconnecting {
+  background: rgba(227, 179, 65, 0.2);
+  color: #e3b341;
+}
 #font-size-btn {
   margin-left: auto;
   background: transparent;

--- a/frontend/src/myGroups.ts
+++ b/frontend/src/myGroups.ts
@@ -257,6 +257,16 @@ async function openObserveModal(s: ObservableSession): Promise<void> {
 		// reload suffix here: the observe modal is transient, closing
 		// and reopening it re-attempts the full renderer chain anyway.
 		onRendererFallback: (msg) => showToast(msg),
+		// Auto-reconnect probe (#356), observe-flavoured: getSession is
+		// owner-scoped (404 for a lead), so re-derive "still running"
+		// from the lead-side observable list instead. Matters doubly
+		// here — every observe attach writes an audit row, so doomed
+		// retries against a stopped session would also pollute the
+		// observe log with phantom open→close cycles.
+		canReconnect: async () =>
+			(await fetchMyObservableSessions()).some(
+				(x) => x.sessionId === s.sessionId && x.status === "running",
+			),
 	});
 	activeObserveTerm = term;
 }

--- a/frontend/src/reconnect.test.ts
+++ b/frontend/src/reconnect.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isRetryableCloseCode, MAX_RECONNECT_ATTEMPTS, reconnectDelayMs } from "./reconnect.js";
+
+describe("reconnectDelayMs", () => {
+	// rand() = 0.5 → (0.5*2 - 1) = 0 → zero jitter, pure schedule.
+	const noJitter = () => 0.5;
+
+	it("follows the 1s → 2s → 5s → 10s schedule", () => {
+		expect(reconnectDelayMs(1, noJitter)).toBe(1000);
+		expect(reconnectDelayMs(2, noJitter)).toBe(2000);
+		expect(reconnectDelayMs(3, noJitter)).toBe(5000);
+		expect(reconnectDelayMs(4, noJitter)).toBe(10000);
+	});
+
+	it("caps at the last schedule entry for attempts past the schedule", () => {
+		expect(reconnectDelayMs(5, noJitter)).toBe(10000);
+		expect(reconnectDelayMs(MAX_RECONNECT_ATTEMPTS, noJitter)).toBe(10000);
+		expect(reconnectDelayMs(99, noJitter)).toBe(10000);
+	});
+
+	it("clamps a nonsensical attempt number to the first entry", () => {
+		expect(reconnectDelayMs(0, noJitter)).toBe(1000);
+		expect(reconnectDelayMs(-3, noJitter)).toBe(1000);
+	});
+
+	it("applies at most ±20% jitter", () => {
+		expect(reconnectDelayMs(1, () => 0)).toBe(800); // rand 0 → -20%
+		expect(reconnectDelayMs(1, () => 1)).toBe(1200); // rand 1 → +20%
+		expect(reconnectDelayMs(4, () => 0)).toBe(8000);
+		expect(reconnectDelayMs(4, () => 1)).toBe(12000);
+	});
+});
+
+describe("isRetryableCloseCode", () => {
+	it("never retries deliberate or policy closes", () => {
+		expect(isRetryableCloseCode(1000)).toBe(false); // dispose / clean finish
+		expect(isRetryableCloseCode(1008)).toBe(false); // auth / terminated / invalid tab
+	});
+
+	it("retries transient failure codes", () => {
+		expect(isRetryableCloseCode(1006)).toBe(true); // abnormal (network drop)
+		expect(isRetryableCloseCode(1001)).toBe(true); // going away (restart / tunnel roll)
+		expect(isRetryableCloseCode(1011)).toBe(true); // transient attach failure
+		expect(isRetryableCloseCode(1005)).toBe(true); // no status received
+	});
+});

--- a/frontend/src/reconnect.ts
+++ b/frontend/src/reconnect.ts
@@ -1,0 +1,46 @@
+/**
+ * reconnect.ts — pure policy helpers for terminal WS auto-reconnect (#356).
+ *
+ * Kept free of DOM/WS imports so the backoff schedule and close-code
+ * classification are unit-testable in isolation; terminal.ts owns the
+ * actual socket lifecycle.
+ */
+
+/** Stop retrying after this many consecutive failed attempts — past
+ *  ~40 s of outage the user is better served by the explicit
+ *  "disconnected" state (click the tab to retry) than by a terminal
+ *  that pings the backend forever. */
+export const MAX_RECONNECT_ATTEMPTS = 6;
+
+const DELAY_SCHEDULE_MS = [1000, 2000, 5000, 10000];
+
+/**
+ * Delay before reconnect attempt N (1-based). Follows the schedule
+ * 1s → 2s → 5s → 10s (capped), with ±20% jitter so a fleet of tabs
+ * dropped by the same backend restart / Tunnel roll doesn't stampede
+ * the reconnect in lockstep. `rand` is injectable for tests.
+ */
+export function reconnectDelayMs(attempt: number, rand: () => number = Math.random): number {
+	const idx = Math.min(Math.max(attempt, 1), DELAY_SCHEDULE_MS.length) - 1;
+	const base = DELAY_SCHEDULE_MS[idx]!;
+	const jitter = (rand() * 2 - 1) * 0.2 * base;
+	return Math.round(base + jitter);
+}
+
+/**
+ * Whether a WS close code is worth retrying. Mirrors the backend's
+ * close-code discipline (wsHandler.ts):
+ *
+ *   - 1000 — deliberate close: our own dispose() or a server-side
+ *     clean finish (e.g. "Bootstrap complete"). Never retry.
+ *   - 1008 — policy: auth failure, terminated/failed session, invalid
+ *     path/tab. Retrying re-sends the same rejected request; the
+ *     failure is deterministic. Never retry.
+ *
+ * Everything else — 1006 (network drop, the common mobile-lock case),
+ * 1001 (server going away: backend restart, Tunnel roll), 1011
+ * (transient attach/docker hiccup) — may heal, so retry with backoff.
+ */
+export function isRetryableCloseCode(code: number): boolean {
+	return code !== 1000 && code !== 1008;
+}

--- a/frontend/src/sessionCore.ts
+++ b/frontend/src/sessionCore.ts
@@ -13,6 +13,7 @@ import {
 	createTab,
 	deleteSession,
 	deleteTab,
+	getSession,
 	listSessions,
 	listTabs,
 	startSession,
@@ -469,6 +470,14 @@ function openTab(tabId: string) {
 				// bar is a global widget), so whichever tab receives the next
 				// keystroke consumes the same state the button displays.
 				transformInput: transformKeyInput,
+				// Auto-reconnect probe (#356): consulted before each retry so
+				// a session stopped from another device doesn't get hammered
+				// with doomed attach attempts (the backend has no "stopped"
+				// close code — the exec stream just ends). A thrown probe is
+				// treated as inconclusive by terminal.ts (keep retrying) —
+				// during a Tunnel blip REST is as dead as the WS, and only a
+				// definitive "not running" should abort the loop.
+				canReconnect: async () => (await getSession(ownSessionId)).status === "running",
 				onStatus: (status: SessionStatus) => {
 					if (activeSessionId !== ownSessionId) return;
 
@@ -527,6 +536,22 @@ function openTab(tabId: string) {
 							});
 						}
 						void refreshSessions();
+						return;
+					}
+
+					if (status === "reconnecting") {
+						// Synthetic frontend-only state like "disconnected"
+						// above: fired while terminal.ts retries a dropped WS
+						// with backoff (#356). Badge-only — it must never land
+						// in s.status (same out-of-type footgun documented on
+						// the disconnected branch), and the terminal for this
+						// tab is deliberately NOT torn down: the retry loop
+						// owns the socket, and a successful re-attach repaints
+						// in place. Only the active tab may repaint the shared
+						// badge (same rule as the backend-status path below).
+						if (tabId !== currentActiveTabId) return;
+						terminalStatusBadge.textContent = "reconnecting";
+						terminalStatusBadge.className = "reconnecting";
 						return;
 					}
 

--- a/frontend/src/terminal.ts
+++ b/frontend/src/terminal.ts
@@ -8,8 +8,15 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { type IDisposable, type ILink, type ILinkProvider, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { type SpecialKey, specialKeySequence } from "./keys.js";
+import { isRetryableCloseCode, MAX_RECONNECT_ATTEMPTS, reconnectDelayMs } from "./reconnect.js";
 
-export type SessionStatus = "running" | "stopped" | "terminated" | "disconnected";
+/** "disconnected" and "reconnecting" are frontend-only synthetic states
+ *  (the backend only ever sends "running"): "reconnecting" while the
+ *  auto-reconnect loop (#356) is retrying a dropped socket, then
+ *  "disconnected" once it gives up (or immediately for non-retryable
+ *  closes). Consumers must never write either into a SessionInfo.status
+ *  — see the long rationale in sessionCore's onStatus handler. */
+export type SessionStatus = "running" | "stopped" | "terminated" | "disconnected" | "reconnecting";
 
 export interface TerminalSession {
 	dispose(): void;
@@ -87,6 +94,17 @@ export function openTerminalSession(opts: {
 	 */
 	transformInput?: (data: string) => string;
 	/**
+	 * Authoritative "is this session still worth reconnecting to?" probe
+	 * (#356), consulted before each auto-reconnect attempt. Wired by
+	 * sessionCore against GET /sessions/:id (status === "running").
+	 * Kept as a callback so terminal.ts stays free of api.ts imports.
+	 * Optional: when absent the retry loop runs unconditionally — still
+	 * bounded by MAX_RECONNECT_ATTEMPTS, so the worst case is a handful
+	 * of rejected attaches. A rejection (throw) counts as INCONCLUSIVE
+	 * (keep retrying), not as "stop" — see attemptReconnect.
+	 */
+	canReconnect?: () => Promise<boolean>;
+	/**
 	 * Read-only observe-mode (#201e). When true:
 	 *   - the WS URL carries `&observe=true` so the backend routes
 	 *     auth via `assertCanObserve` instead of `assertOwnership`;
@@ -119,6 +137,7 @@ export function openTerminalSession(opts: {
 		onCopy,
 		isActive,
 		transformInput,
+		canReconnect,
 		observe = false,
 	} = opts;
 	// Fires the fallback notice at most once per TIER, and only when
@@ -641,17 +660,43 @@ export function openTerminalSession(opts: {
 	//
 	// Liveness (post-open) is handled at the protocol layer (ws.ping/pong)
 	// from the server — see backend/src/index.ts heartbeat. Browsers
-	// auto-reply to server pings with no JS hook required, so there is
-	// no `ws.onopen` handler.
-	const wsUrl = buildWsUrl(sessionId, tabId, term.cols, term.rows, observe);
-	const ws = new WebSocket(wsUrl);
+	// auto-reply to server pings with no JS hook required.
+	//
+	// ── Auto-reconnect (#356) ──
+	// A dropped socket (phone lock, Tunnel idle timeout ≈100 s, backend
+	// restart) retries with backoff instead of stranding the tab on
+	// "disconnected" until the user re-clicks it. `ws` is therefore a
+	// reassignable binding: connect() builds a fresh socket per attempt,
+	// and every closure below (send, dispose, handlers) reads the current
+	// one. buildWsUrl runs per-attempt on purpose — term.cols/rows may
+	// have changed since the drop (rotation while offline), and the
+	// replay must be captured at the CURRENT geometry.
 	let disposed = false;
+	let ws: WebSocket;
+	let reconnectAttempts = 0;
+	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-	ws.onmessage = (ev) => {
+	const onWsOpen = () => {
+		if (disposed || reconnectAttempts === 0) return;
+		// Reconnect attach incoming: the backend ships a full capture-pane
+		// replay on every attach, and painting it over the stale pre-drop
+		// content would duplicate the screen. Reset only when a socket
+		// actually OPENS (not per attempt) so failed retries keep the last
+		// good content visible behind the "reconnecting" badge. A fresh
+		// Terminal is what the manual re-click path creates, so reset()
+		// (which also clears modes) matches the established semantics.
+		term.reset();
+	};
+
+	const onWsMessage = (ev: MessageEvent) => {
 		// disposed: post-close frames buffered by the browser or in flight
 		// from the server still fire here, and term.write() throws on a
 		// disposed xterm. Sibling of the onerror/onclose guards below (#93).
 		if (disposed) return;
+		// Any server frame proves the attach is live again — re-arm the
+		// full backoff budget for the NEXT drop. (Cheap assignment; not
+		// worth a first-frame-only flag.)
+		reconnectAttempts = 0;
 		type Msg =
 			| { type: "output"; data: string }
 			| { type: "status"; status: SessionStatus }
@@ -707,19 +752,76 @@ export function openTerminalSession(opts: {
 		}
 	};
 
-	ws.onerror = () => {
+	const onWsError = () => {
 		if (disposed) return;
-		onError("WebSocket connection error");
+		// Console-only. Per spec every `error` is followed by `close`, and
+		// the close handler owns the user-facing signal — historically this
+		// fired a toast too, so one network drop double-toasted ("WebSocket
+		// connection error" + "Connection closed (1006)"). With retries in
+		// the picture it would also toast once per failed attempt.
+		console.warn("[terminal] WebSocket error (close handler decides retry/notice)");
 	};
 
-	ws.onclose = (ev) => {
+	const onWsClose = (ev: CloseEvent) => {
 		// disposed: stale async close from a prior navigate-away — ignore
 		if (disposed) return;
+		if (isRetryableCloseCode(ev.code) && reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+			reconnectAttempts++;
+			// Badge-only synthetic state; the error toast is deliberately
+			// suppressed while retries are in flight — a transient drop that
+			// heals in 1 s shouldn't cost the user a red toast.
+			onStatus("reconnecting");
+			reconnectTimer = setTimeout(() => {
+				reconnectTimer = null;
+				void attemptReconnect();
+			}, reconnectDelayMs(reconnectAttempts));
+			return;
+		}
 		if (ev.code !== 1000) {
 			onError(`Connection closed (${ev.code}): ${ev.reason || "unknown reason"}`);
 		}
 		onStatus("disconnected");
 	};
+
+	const connect = () => {
+		ws = new WebSocket(buildWsUrl(sessionId, tabId, term.cols, term.rows, observe));
+		ws.onopen = onWsOpen;
+		ws.onmessage = onWsMessage;
+		ws.onerror = onWsError;
+		ws.onclose = onWsClose;
+	};
+
+	// One retry attempt: consult the authoritative session status first
+	// (when the caller provided the probe) so we don't burn attach
+	// attempts against a session the owner stopped from another device —
+	// the backend has no "stopped" close code for that case (the exec
+	// stream just ends), so the close code alone can't tell us.
+	const attemptReconnect = async () => {
+		if (disposed) return;
+		if (canReconnect) {
+			// `true` on probe FAILURE is deliberate: during a Tunnel blip
+			// the REST probe is as dead as the WS, and "inconclusive" must
+			// keep the (bounded) retry loop alive. Only a definitive
+			// "session is not running" answer aborts.
+			let ok = true;
+			try {
+				ok = await canReconnect();
+			} catch {
+				/* inconclusive — keep trying */
+			}
+			if (disposed) return; // re-check across the await
+			if (!ok) {
+				// Not an error — the session is simply not running anymore.
+				// Finalize as a plain disconnect: sessionCore tears the pane
+				// down and refreshes the authoritative sidebar state.
+				onStatus("disconnected");
+				return;
+			}
+		}
+		connect();
+	};
+
+	connect();
 
 	// ── Input: xterm → WS ──────────────────────────────────────────────────
 	// In observe-mode (#201e) the backend drops every input frame at
@@ -1051,6 +1153,17 @@ export function openTerminalSession(opts: {
 	// row repaints.
 	const onVisibilityChange = () => {
 		if (document.hidden) return;
+		// Fast-forward a pending reconnect (#356): the dominant mobile flow
+		// is phone-lock → WS dies → user unlocks. iOS freezes JS while
+		// backgrounded, so the backoff timer only starts ticking on resume
+		// — skipping it here makes unlock-to-live-terminal immediate
+		// instead of up-to-10 s. The attempt still routes through
+		// attemptReconnect's canReconnect probe.
+		if (reconnectTimer !== null) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+			void attemptReconnect();
+		}
 		// scheduleFit's rAF will atlas-clear + refresh too, but only if the
 		// fit detects a dimension change. The synchronous pair below covers
 		// the no-change case — tab hidden then restored at the same size,
@@ -1161,6 +1274,15 @@ export function openTerminalSession(opts: {
 	// ── Dispose ─────────────────────────────────────────────────────────────
 	function dispose() {
 		disposed = true;
+		// Cancel any pending auto-reconnect first: past this point `ws`
+		// must stay the final socket (closed below with 1000, which the
+		// retry classifier treats as deliberate). The `disposed` guards in
+		// attemptReconnect/connect make a mid-flight probe harmless, but
+		// clearing here avoids holding the closure alive for up to 10 s.
+		if (reconnectTimer !== null) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
 		// The resize send is debounced on a trailing 100 ms window; if the
 		// user navigates away inside that window the timer would fire after
 		// the socket closes. The `if (disposed) return` guard at the top of


### PR DESCRIPTION
Closes #356.

## Summary

A dropped terminal WS (phone lock, Cloudflare Tunnel idle timeout ≈100 s, backend restart) previously stranded the tab on "disconnected" until the user re-clicked it — felt constantly on mobile, where the socket dies every time the phone locks. Now `terminal.ts` retries with backoff and only falls back to the explicit "disconnected" state when retries are exhausted or the close is known-unretryable.

## Design

- **`reconnect.ts`** (new, pure, unit-tested): backoff schedule 1s→2s→5s→10s (capped) with ±20% jitter (a fleet of tabs dropped by one backend restart shouldn't stampede back in lockstep), `MAX_RECONNECT_ATTEMPTS = 6` (~40 s), and a close-code classifier mirroring `wsHandler.ts`'s discipline: **1000** (deliberate: our dispose, "Bootstrap complete") and **1008** (policy: auth, terminated/failed, invalid tab — deterministic failures) never retry; 1006/1001/1011 do.
- **Reconnect mechanics:** the socket is a reassignable binding built by `connect()`; `buildWsUrl` runs per attempt so the capture-pane replay is requested at the *current* geometry (rotation while offline). `term.reset()` fires when a reconnect socket **opens** — not per attempt — so the incoming replay paints on a clean grid while failed retries keep the last good screen visible behind the badge.
- **New synthetic `"reconnecting"` status** (amber badge, styled like `stopped`): sessionCore keeps it out of `s.status` (same out-of-type footgun documented for `"disconnected"`) and deliberately does **not** tear the pane down mid-retry — the retry loop owns the socket, and the server's `status: "running"` frame on successful re-attach restores the badge. The error toast is suppressed while retries are in flight; a drop that heals in 1 s costs the user nothing.
- **`canReconnect` probe** consulted before each attempt, because the backend has no "stopped" close code (the exec stream just ends — verified in `wsHandler.ts`): owner tabs probe `getSession(id).status === "running"`; the **observe modal** probes the lead-side observable list instead (`getSession` is owner-scoped → 404 for a lead), which matters doubly there since every observe attach writes an audit row and doomed retries would pollute the observe log. Probe **failure is inconclusive** (keep retrying): during a Tunnel blip, REST is as dead as the WS — only a definitive "not running" aborts, which finalizes as a plain disconnect (no error toast) so sessionCore tears down and refreshes the authoritative state.
- **`visibilitychange` fast-forward:** iOS freezes JS while the phone is locked, so the backoff timer only starts ticking on resume; skipping the pending delay on visible makes unlock-to-live-terminal immediate instead of up-to-10 s.
- `ws.onerror` is console-only now — the close handler owns the user-facing signal. This also fixes a pre-existing double-toast (`"WebSocket connection error"` + `"Connection closed (1006)"`) on every network drop.

## Verification

- `npm run lint`, `npm run build`, `npm test` — green; 6 new unit tests (backoff schedule, jitter bounds, clamping, close-code classification; 81 total).
- Manual pass pending: kill the backend mid-session → amber "reconnecting" badge → restart backend within ~40 s → terminal repaints in place; stop a session from a second device → retries stop after the probe, pane tears down cleanly; iPhone lock/unlock → immediate reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)