### PR TITLE
fix(db): 10s AbortSignal timeout on every d1Query fetch

### DIFF
--- a/backend/src/db.test.ts
+++ b/backend/src/db.test.ts
@@ -95,3 +95,36 @@ describe("d1Query empty-result guard (#304)", () => {
 		);
 	});
 });
+
+// #343: every fetch must carry an abort signal (the 10 s ceiling), and a
+// fired timeout must surface as a sourced D1 error — not undici's generic
+// "The operation was aborted due to timeout", which names neither the
+// dependency nor the statement.
+describe("d1Query timeout (#343)", () => {
+	it("passes an AbortSignal to fetch", async () => {
+		const { d1Query } = await import("./db.js");
+		const fetchMock = mockFetch();
+		await d1Query("SELECT 1");
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+		expect(init.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("rewraps a fired timeout as a sourced error naming D1 and the query", async () => {
+		const { d1Query } = await import("./db.js");
+		// Simulate undici's rejection shape when AbortSignal.timeout fires.
+		(globalThis as { fetch: unknown }).fetch = vi.fn(async () => {
+			throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+		});
+		await expect(d1Query("SELECT * FROM sessions WHERE session_id = ?")).rejects.toThrow(
+			/D1 API timeout after 10000 ms for: SELECT \* FROM sessions/,
+		);
+	});
+
+	it("rethrows non-timeout fetch failures untouched", async () => {
+		const { d1Query } = await import("./db.js");
+		(globalThis as { fetch: unknown }).fetch = vi.fn(async () => {
+			throw new TypeError("fetch failed");
+		});
+		await expect(d1Query("SELECT 1")).rejects.toThrow(/fetch failed/);
+	});
+});

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -57,6 +57,21 @@ export function __resetD1CallsForTests(): void {
 	d1CallsSinceBoot = 0;
 }
 
+// Hard ceiling on every D1 round-trip (#343). Without a signal, a
+// hung-but-accepting endpoint (stalled CF edge, half-open TCP — distinct
+// from a fast connection-refused, which fails immediately) pins each call
+// to undici's default header timeout of ~300 s. Everything hot funnels
+// through d1Query — dispatcher lookups, login, ownership-cache misses,
+// the idle sweeper's SELECT — so during a D1 brown-out those requests
+// would hold sockets for minutes instead of failing fast into their
+// callers' existing catch/degrade paths. 10 s is ~2 orders of magnitude
+// above healthy D1 latency (tens of ms) yet short enough that a wedged
+// dependency surfaces as a burst of sourced errors, not a stalled server.
+// The signal also covers the response BODY reads below — undici ties the
+// whole request lifecycle to it, so a body that stalls mid-stream aborts
+// too.
+const D1_TIMEOUT_MS = 10_000;
+
 /**
  * Execute a single SQL statement against D1.
  * Returns the results array for SELECT, or meta for INSERT/UPDATE/DELETE.
@@ -68,21 +83,37 @@ export async function d1Query<T = Record<string, unknown>>(
 	d1CallsSinceBoot++;
 	const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/d1/database/${DATABASE_ID}/query`;
 
-	const res = await fetch(url, {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${API_TOKEN}`,
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({ sql, params: params ?? [] }),
-	});
+	let data: D1ApiResponse<T>;
+	try {
+		const res = await fetch(url, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${API_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ sql, params: params ?? [] }),
+			signal: AbortSignal.timeout(D1_TIMEOUT_MS),
+		});
 
-	if (!res.ok) {
-		const text = await res.text();
-		throw new Error(`D1 API error (${res.status}): ${text}`);
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`D1 API error (${res.status}): ${text}`);
+		}
+
+		data = (await res.json()) as D1ApiResponse<T>;
+	} catch (err) {
+		// Rewrap the abort as a sourced error: undici surfaces the fired
+		// timeout signal as a DOMException named "TimeoutError", whose
+		// message ("The operation was aborted due to timeout") says nothing
+		// about D1 or the statement. Callers log err.message, so name the
+		// dependency and the query. SQL text only — never params, which can
+		// carry decrypted secret values on the session_configs paths.
+		if (err instanceof DOMException && err.name === "TimeoutError") {
+			throw new Error(`D1 API timeout after ${D1_TIMEOUT_MS} ms for: ${sql.slice(0, 120)}`);
+		}
+		throw err;
 	}
 
-	const data = (await res.json()) as D1ApiResponse<T>;
 	if (!data.success) {
 		throw new Error(`D1 query failed: ${data.errors.map((e) => e.message).join(", ")}`);
 	}


### PR DESCRIPTION
Closes #343.

## Summary

Every D1 call was a bare `fetch` — a hung-but-accepting endpoint (stalled CF edge, half-open TCP; distinct from a fast connection-refused) pinned each call to undici's ~300 s default. Everything hot funnels through `d1Query` (dispatcher `lookupDispatchTarget`, login, ownership-cache misses, the idle sweeper's SELECT), so a D1 brown-out held sockets for minutes instead of failing fast into the callers' existing catch/degrade paths.

## Changes

- `signal: AbortSignal.timeout(10_000)` on the fetch — 10 s is ~2 orders of magnitude above healthy D1 latency (tens of ms) yet short enough that a wedged dependency surfaces as a burst of sourced errors, not a stalled server. The signal covers the response body reads too (undici ties the whole request lifecycle to it).
- A fired timeout is rewrapped as `D1 API timeout after 10000 ms for: <sql…>` — undici's raw `TimeoutError` names neither the dependency nor the statement. SQL text only, never params (they can carry decrypted secret values on the `session_configs` paths).
- Non-timeout fetch failures rethrow untouched.

## Verification

Biome + tsc green; 3 new tests (signal present on fetch, timeout rewrap message, non-timeout passthrough) — `db.test.ts` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)