### PR TITLE
fix(docker): PidsLimit + nofile ulimit on session containers

### DIFF
--- a/backend/src/dockerManager.spawnConfig.test.ts
+++ b/backend/src/dockerManager.spawnConfig.test.ts
@@ -221,6 +221,21 @@ describe("DockerManager.spawn config-applied", () => {
 		expect(captured.opts.Env).toContain("LEGACY_KEY=legacy");
 	});
 
+	// #344 — Memory/CPU don't bound process count or fds; the claude-review
+	// checklist expects pids to be bounded. Pin the values so a HostConfig
+	// refactor can't silently drop them (they're unconditional, so the
+	// no-config-row spawn is a sufficient probe).
+	it("always sets PidsLimit and a nofile ulimit (fork-bomb / fd-exhaustion bound, #344)", async () => {
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as {
+			PidsLimit: number;
+			Ulimits: Array<{ Name: string; Soft: number; Hard: number }>;
+		};
+		expect(hc.PidsLimit).toBe(1024);
+		expect(hc.Ulimits).toEqual([{ Name: "nofile", Soft: 65536, Hard: 65536 }]);
+	});
+
 	it("applies cpu_limit / mem_limit from the session_configs row", async () => {
 		dbStubs.d1Query.mockResolvedValueOnce({
 			results: [

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -359,6 +359,25 @@ export class DockerManager {
 				// definitions); this keeps the config path symmetric.
 				Memory: Math.min(config?.memLimit ?? DEFAULT_MEMORY_BYTES, EFFECTIVE_MEM_BYTES_MAX),
 				NanoCpus: Math.min(config?.cpuLimit ?? DEFAULT_NANO_CPUS, EFFECTIVE_CPU_NANO_MAX),
+				// #344 — Memory/CPU caps don't bound PROCESS COUNT: a fork bomb
+				// inside a session starves the host's PID space and scheduler
+				// while staying under both cgroup caps. 1024 is far above any
+				// real dev workload in these containers (tmux + node + claude
+				// + a parallel build lands in the low hundreds) yet turns a
+				// fork bomb into an in-container EAGAIN instead of a host
+				// incident. Deliberately a cgroup pids limit and NOT an nproc
+				// ulimit: every session container runs as UID 1000, and
+				// RLIMIT_NPROC counts per-UID across the whole kernel — an
+				// nproc ulimit would let one session's process count exhaust
+				// a SIBLING session's budget. PidsLimit is per-cgroup, so
+				// sessions stay isolated from each other.
+				PidsLimit: 1024,
+				// Companion fd bound. 65536 is generous for dev servers and
+				// file watchers (Vite/watchman-style workloads sit well under
+				// it) while capping a leak well below the dockerd default of
+				// ~1M fds per container. Soft == hard so nothing inside the
+				// container can raise it back.
+				Ulimits: [{ Name: "nofile", Soft: 65536, Hard: 65536 }],
 				RestartPolicy: { Name: "unless-stopped" },
 				// Defense-in-depth (issue #15): the image already runs as
 				// unprivileged UID 1000 with no sudo, but we still strip


### PR DESCRIPTION
Closes #344.

## Summary

The spawn `HostConfig` sets `Memory`/`NanoCpus`/`CapDrop`/`no-new-privileges` but nothing bounds **process count** or **fds** — a fork bomb inside a session starves the host's PID space and scheduler while staying under both cgroup caps. The `claude-review.yml` checklist already lists "pids" as an expected bound; this wires it up.

## Changes

- `PidsLimit: 1024` — far above any real dev workload in these containers (tmux + node + claude + a parallel build lands in the low hundreds) yet turns a fork bomb into an in-container `EAGAIN` instead of a host incident. Deliberately a **cgroup pids limit and not an nproc ulimit**: every session container runs as UID 1000 and `RLIMIT_NPROC` counts per-UID kernel-wide, so an nproc ulimit would let one session exhaust a *sibling* session's budget. PidsLimit is per-cgroup → sessions stay isolated.
- `Ulimits: [{ nofile, 65536/65536 }]` — generous for dev servers and file watchers, well below dockerd's ~1M default; soft == hard so nothing inside can raise it back.

Both are unconditional (not config-driven). Like the other HostConfig fields, existing containers pick this up on their next full recycle (Docker pins HostConfig at create time).

## Verification

Biome + tsc green; new spawnConfig test pins both values so a HostConfig refactor can't silently drop them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)