### PR TITLE
fix(ops): bound Docker json-file logs for backend and session containers

### DIFF
--- a/backend/src/dockerManager.spawnConfig.test.ts
+++ b/backend/src/dockerManager.spawnConfig.test.ts
@@ -236,6 +236,21 @@ describe("DockerManager.spawn config-applied", () => {
 		expect(hc.Ulimits).toEqual([{ Name: "nofile", Soft: 65536, Hard: 65536 }]);
 	});
 
+	// #345 — pin the log-rotation cap so a HostConfig refactor can't
+	// silently drop it (unconditional, so the no-config-row spawn is a
+	// sufficient probe).
+	it("always sets a bounded json-file LogConfig (#345)", async () => {
+		const { dm, captured } = makeDmWithCreateCapture();
+		await dm.spawn("sess-1");
+		const hc = captured.opts.HostConfig as {
+			LogConfig: { Type: string; Config: Record<string, string> };
+		};
+		expect(hc.LogConfig).toEqual({
+			Type: "json-file",
+			Config: { "max-size": "10m", "max-file": "3" },
+		});
+	});
+
 	it("applies cpu_limit / mem_limit from the session_configs row", async () => {
 		dbStubs.d1Query.mockResolvedValueOnce({
 			results: [

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -379,6 +379,17 @@ export class DockerManager {
 				// container can raise it back.
 				Ulimits: [{ Name: "nofile", Soft: 65536, Hard: 65536 }],
 				RestartPolicy: { Name: "unless-stopped" },
+				// #345 — bound the json-file log driver. Session containers are
+				// long-lived (they survive stop/start cycles) and their PID 1 /
+				// exec streams can be chatty (Claude TUI repaints, build logs
+				// leaking to the container log via postStart daemons), so an
+				// uncapped log grows in /var/lib/docker/containers/<id>/ until
+				// the host disk fills. 10m × 3 files ≈ 30 MiB worst-case per
+				// session — plenty for post-mortem tails while making the
+				// aggregate bound scale with session count, not with output
+				// volume. Mirrors the `logging:` block on the compose `app`
+				// service (which can't cover spawned containers).
+				LogConfig: { Type: "json-file", Config: { "max-size": "10m", "max-file": "3" } },
 				// Defense-in-depth (issue #15): the image already runs as
 				// unprivileged UID 1000 with no sudo, but we still strip
 				// every Linux capability from the bounding set Docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,16 @@ services:
     networks:
       - sessions-net
     restart: unless-stopped
+    # #345 — bound the json-file driver. Without a cap, backend logs
+    # accumulate in /var/lib/docker/containers/<id>/*-json.log until the
+    # host disk fills. Session containers aren't compose services, so this
+    # block can't cover them — they get the equivalent cap via LogConfig
+    # in DockerManager.spawn().
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
 
   # Build-only helper — the session image needs to exist in Docker's image
   # store before `app` can spawn session containers, but we don't want to


### PR DESCRIPTION
Closes #345.

## Summary

No log rotation existed anywhere: the compose `app` service had no `logging:` block and spawned session containers set no `LogConfig`, so chatty session output (Claude TUI repaints, postStart daemons, build logs) accumulated in `/var/lib/docker/containers/*/*-json.log` without bound — a real disk-fill vector on the self-hosted box since session containers are long-lived.

## Changes

- `docker-compose.yml`: `logging: { json-file, max-size: 10m, max-file: 3 }` on the `app` service.
- `DockerManager.spawn()`: equivalent `LogConfig` on every session container (they aren't compose services, so the compose block can't cover them). 10m × 3 ≈ 30 MiB worst-case per session — plenty for post-mortem tails while the aggregate bound scales with session count, not output volume.
- Like all HostConfig fields, existing session containers pick the cap up on their next full recycle.

## Verification

Biome + tsc green; new spawnConfig test pins the LogConfig (30/30 in that file). Note: `docker compose config` was NOT run (no docker CLI in the dev sandbox) — the compose edit is a plain `logging:` block; worth a `docker compose config -q` on the host before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)