### PR TITLE
docs: fix stale tmux-'main' and 'SQLite' references

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -72,7 +72,10 @@ jobs:
               Node/Express backend on Proxmox behind a Cloudflare Tunnel.
             - Terminal-server product: each session spawns a Docker container,
               backend relays tmux over WebSocket to xterm.js in the browser.
-            - SQLite on the backend. JWT for auth. Invite-code onboarding.
+            - Persistence is Cloudflare D1: SQLite-flavored but REMOTE over
+              HTTP — every query is a network round-trip and there is no
+              local database file, so local-file/transaction assumptions
+              don't apply. JWT for auth. Invite-code onboarding.
             - Solo repo, no human reviewer — be direct. No praise. No emojis.
             - Threat model: (a) logged-in user trying to escape their container
               or reach another user's session; (b) unauthenticated attacker on

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -272,7 +272,7 @@ Each session runs in a Docker container based on `session-image/Dockerfile`:
 - **Claude CLI:** `@anthropic-ai/claude-code` (globally installed; aliased to `claude --dangerously-skip-permissions` in interactive shells. The container sandbox prevents host compromise / privilege escalation, but **does not protect workspace files from in-session destructive actions** — Claude can run `rm -rf ~/workspace/…` or overwrite a tracked file without asking. Bypass the alias with `\claude` or `command claude` for one call, `unalias claude` for the rest of the shell.)
 - **VS Code CLI:** `code` (standalone) — see [REMOTE-EDITING.md](./REMOTE-EDITING.md)
 - **GitHub CLI:** `gh` (standalone) — auth once with `gh auth login`, then drive PRs / issues / `gh api …` from the session
-- **Terminal:** tmux with a session named `main`, 50k scrollback, mouse support
+- **Terminal:** tmux, 50k scrollback, mouse support. No tmux session exists at container boot (PID 1 is a plain `tail -f /dev/null`) — each browser tab provisions its own tmux session on demand via `tmux new-session -A -s <tabId>` at WS attach
 - **User:** `developer` (UID 1000, unprivileged — no sudo, all Linux capabilities dropped, `no-new-privileges` set)
 - **Workspace:** `/home/developer/workspace` (bind-mounted from `<WORKSPACE_ROOT>/<sessionId>` on the host)
 - **Resources:** Per-session caps come from `session_configs` (`cpu_limit` 0.25–8 cores, `mem_limit` 256 MiB–16 GiB, `idle_ttl_seconds` 60s–24h). Sessions created without explicit caps fall back to the `DEFAULT_NANO_CPUS` (2 cores) / `DEFAULT_MEMORY_BYTES` (2 GiB) constants in `dockerManager.ts`. Idle auto-stop is opt-in (omit `idleTtlSeconds` to disable).


### PR DESCRIPTION
Closes #350.

Two doc statements that no longer match the code (2026-07-03 audit):

- `docs/DEPLOYMENT.md` said each session container runs "tmux with a session named `main`" — `session-image/entrypoint.sh` creates **no** tmux session at boot (PID 1 is `tail -f /dev/null`); each browser tab provisions its own via `tmux new-session -A -s <tabId>` at WS attach.
- `.github/workflows/claude-review.yml` primed the review bot with "SQLite on the backend" — persistence is Cloudflare D1 over HTTP (remote round-trips, no local file), so local-file/transaction assumptions don't apply. Misleading the reviewer here degrades review quality on every PR.

Docs/prompt only — no code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)