### PR TITLE
fix(session-image): declare truecolor via terminal-features RGB

### DIFF
--- a/session-image/tmux.conf
+++ b/session-image/tmux.conf
@@ -1,8 +1,16 @@
 # ── Shared Terminal — tmux defaults for session containers ───────────────────
 
-# Use 256 colours + true-color (24-bit RGB) passthrough
+# Use 256 colours + true-color (24-bit RGB) passthrough. `terminal-features
+# ... RGB` (tmux >=3.2; image ships 3.4) is the standard capability form; the
+# previous `terminal-overrides ... Tc` was tmux's pre-standard spelling of
+# the same thing. default-terminal deliberately stays xterm-256color rather
+# than the often-recommended tmux-256color: that would depend on the
+# tmux-256color terminfo entry existing in the image (ncurses-term isn't
+# installed) and would change $TERM for every program in the pane, while
+# xterm-256color+RGB yields the same 24-bit output with none of that
+# surface. (#351)
 set -g default-terminal "xterm-256color"
-set -ga terminal-overrides ",xterm-256color:Tc"
+set -as terminal-features ",xterm-256color:RGB"
 
 # Increase scrollback
 set -g history-limit 50000


### PR DESCRIPTION
Closes #351.

## Summary

`tmux.conf` declared 24-bit color with the legacy, non-standard `Tc` flag (`terminal-overrides ",xterm-256color:Tc"`). Replace with the standard capability form: `set -as terminal-features ",xterm-256color:RGB"` (tmux ≥3.2; the image ships 3.4).

**Deliberately NOT switching `default-terminal` to `tmux-256color`** (the other half of the common recommendation): that would require the `tmux-256color` terminfo entry inside the image (`ncurses-term` isn't installed — only `ncurses-base`) and would change `$TERM` for every program in the pane, a much larger behavioral surface. `xterm-256color` + `RGB` yields the same 24-bit output with none of that risk. Rationale is inline in the conf.

## Verification

Ran under the same tmux version the image ships (3.4): `tmux -f session-image/tmux.conf new-session -d` loads with no config errors, and `tmux show -s terminal-features` reports `xterm-256color:RGB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)