### PR TITLE
fix(docker): re-check the shared-exec slot after capturePane in attach()

### DIFF
--- a/backend/src/dockerManager.test.ts
+++ b/backend/src/dockerManager.test.ts
@@ -262,6 +262,50 @@ describe("DockerManager shared-exec multiplexing", () => {
 		expect(a2).toHaveBeenCalledWith("hello");
 	});
 
+	// #347 — the LAST client detaching while a joiner's capture-pane is in
+	// flight tears down the shared exec the joiner already awaited. Without
+	// the post-capture re-check, the joiner registers its listener on that
+	// destroyed SharedExec: frozen terminal (no live bytes ever arrive), and
+	// write()/resize() silently no-op because the slot is gone from `shared`.
+	it("respawns when the last client detaches during a joiner's capture-pane (#347)", async () => {
+		const { dm, container } = makeDocker();
+		const received: string[] = [];
+
+		await attachAndFlush(
+			dm,
+			"s1",
+			"a1",
+			80,
+			24,
+			() => {
+				/* noop */
+			},
+			"tab-test",
+		);
+		expect(countAttachExecs(container)).toBe(1);
+
+		// Joiner: start the attach but DON'T await it yet — its capture-pane
+		// one-shots complete on macrotasks (setImmediate in the fake), while
+		// a1's detach teardown runs earlier on the microtask queue. That
+		// reproduces the race interleaving deterministically: the slot is
+		// destroyed while the joiner's capture-pane is still in flight.
+		const joining = dm.attach("s1", "a2", 80, 24, (d) => received.push(d), "tab-test");
+		dm.detach("a1");
+		const result = await joining;
+		result.flushTail();
+
+		// The re-check respawned a fresh shared exec…
+		expect(countAttachExecs(container)).toBe(2);
+		// …and the joiner is live on it: bytes written to the NEW attach
+		// stream reach its listener. Pre-fix this is where it froze — the
+		// listener sat on the destroyed stream and received nothing.
+		const attachExecs = container._execs.filter(isAttachExec);
+		const freshStream = attachExecs[attachExecs.length - 1]!._stream;
+		freshStream.write("post-respawn-bytes");
+		await tick();
+		expect(received.join("")).toContain("post-respawn-bytes");
+	});
+
 	it("serializes concurrent first-attach calls onto a single container.exec()", async () => {
 		const { dm, container } = makeDocker();
 

--- a/backend/src/dockerManager.ts
+++ b/backend/src/dockerManager.ts
@@ -1341,6 +1341,9 @@ export class DockerManager {
 		// half, the wsHandler drop is the auth invariant for the
 		// write-into-someone's-shell half.
 		observe = false,
+		// Internal recursion counter for the #347 teardown re-check below —
+		// callers never pass it.
+		attempt = 0,
 	): Promise<{ handle: ExecHandle; replay: string | null; flushTail: () => void }> {
 		const key = this.targetKey(sessionId, tabId);
 
@@ -1443,6 +1446,38 @@ export class DockerManager {
 		// start), which is more machinery than the lost-bytes symptom
 		// warrants in a terminal product.
 		const snapshot = await this.capturePane(sessionId, tabId);
+
+		// #347 — teardown re-check. Between `await pending` above and the
+		// capture-pane round-trips completing, the LAST remaining client
+		// can detach: its teardown destroys the shared stream and deletes
+		// the slot. Registering on that dead SharedExec would hand this
+		// caller a frozen terminal — no live bytes ever arrive, and
+		// write()/resize() silently no-op because they resolve the attachId
+		// through `this.shared`, where the slot is gone. Detect the
+		// teardown (or a teardown+respawn by a third client — any slot
+		// change invalidates our `s`) and re-run the whole acquisition: a
+		// fresh attach finds the slot empty and respawns, and the stale `s`
+		// carried no listener of ours yet, so there is nothing to unwind.
+		// Bounded: each recursion requires its own detach-during-capture
+		// interleaving; three in a row means the tab is flapping faster
+		// than we can attach — fail loud (wsHandler closes 1011) and let
+		// the client's reconnect-with-backoff (#356) pace the retry.
+		//
+		// The OPPOSITE interleaving — detach's `.then` teardown firing just
+		// AFTER this check passes — is safe without further guarding:
+		// everything from here to `s.listeners.set(attachId, …)` below is
+		// synchronous, so by the time that teardown callback runs it sees
+		// `listeners.size >= 1` and takes the survivors branch instead of
+		// destroying the exec.
+		if (this.shared.get(key) !== pending) {
+			if (attempt >= 2) {
+				throw new Error(`shared exec for ${key} torn down repeatedly during attach`);
+			}
+			logger.info(
+				`[docker] shared exec for ${key} torn down during attach; retrying (attempt ${attempt + 1})`,
+			);
+			return this.attach(sessionId, attachId, cols, rows, onOutput, tabId, observe, attempt + 1);
+		}
 
 		const tail: string[] = [];
 		let armed = true;


### PR DESCRIPTION
Closes #347.

## Summary

`attach()` resolves the shared exec (`await pending`), then awaits `capturePane()` (two `docker exec` round-trips), and only then registers its listener. If the **last** existing client detached inside that window, `detach()` saw `listeners.size === 0`, destroyed the stream, and deleted the slot — the joiner then registered on a dead `SharedExec`: frozen terminal (no live bytes ever arrive), with `write()`/`resize()` silently no-oping because they resolve the attachId through `this.shared`, where the slot is gone. Narrow (two clients, one leaving exactly as another joins) but the other attach races are guarded; this one wasn't.

## Fix

Post-capture re-check: `this.shared.get(key) !== pending` (covers both plain teardown and teardown+respawn by a third client) → re-run the acquisition via bounded recursion (internal `attempt` param, max 3). The stale exec carried no listener of ours yet, so there's nothing to unwind. On exhaustion it throws — wsHandler closes 1011 and the client's reconnect-with-backoff (#360) paces the retry, so "flapping faster than we can attach" degrades gracefully instead of looping server-side.

The **opposite** interleaving (detach's `.then` teardown firing just after the check passes) needs no guard: check-to-`listeners.set` is synchronous, so the late teardown callback sees `listeners.size ≥ 1` and takes the survivors branch. Documented inline.

## Verification

- New regression test reproduces the interleaving deterministically (joiner's capture-pane completes on a macrotask; detach teardown runs first on the microtask queue) and asserts a second shared exec is spawned AND live bytes reach the joiner.
- **Verified red without the fix**: stashing the `dockerManager.ts` change makes exactly this test fail (joiner frozen, no respawn).
- Full backend suite green; Biome + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)